### PR TITLE
Adding spec.region field to SQLInstance example

### DIFF
--- a/resources/sqlinstance/postgres-sql-instance/sql_v1alpha3_sqlinstance.yaml
+++ b/resources/sqlinstance/postgres-sql-instance/sql_v1alpha3_sqlinstance.yaml
@@ -4,5 +4,6 @@ metadata:
   name: postgres-sql-instance-sample
 spec:
   databaseVersion: POSTGRES_9_6
+  region: us-central1
   settings:
     tier: db-custom-16-61440 # see https://cloud.google.com/sql/docs/postgres/create-instance


### PR DESCRIPTION
If you do not specify the `spec.region` in a SQLInstance, you will get the following error:

```
"error":"Update call failed: Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'."
```