### PR TITLE
fix gcp-sql-user.yaml password

### DIFF
--- a/apps/wordpress/charts/wordpress-gcp/templates/gcp-sql-user.yaml
+++ b/apps/wordpress/charts/wordpress-gcp/templates/gcp-sql-user.yaml
@@ -6,4 +6,5 @@ spec:
   instanceRef:
     name: {{ required "instanceName is required!" .Values.database.instanceName }}
   host: "%"
-  password: {{ required "password is required!" .Values.database.password }}
+  password: 
+    value: {{ required "password is required!" .Values.database.password }}


### PR DESCRIPTION
According to the specification of [SQLUser](https://cloud.google.com/config-connector/docs/reference/resources#spec_75), the `password` field is a `oneof` field. A `value` field should be enough for the sample app use case.