### PR TITLE
Add annotation for gcp-sql-instance

### DIFF
--- a/apps/wordpress/charts/wordpress-gcp/templates/gcp-sql-instance.yaml
+++ b/apps/wordpress/charts/wordpress-gcp/templates/gcp-sql-instance.yaml
@@ -2,6 +2,7 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: {{ required "instanceName is required!" .Values.database.instanceName }}
+  cnrm.cloud.google.com/project-id: {{ required "projectId is required!" .Values.google.projectId }}
 spec:
   databaseVersion: {{ required "version is required!" .Values.database.version }}
   region: {{ required "region is required!" .Values.google.region }}


### PR DESCRIPTION
Got error when install the wordpress sample app:
```
wordpress$ kubectl describe sqlinstance wp-db
Name:         wp-db
Namespace:    default
Labels:       <none>
Annotations:  cnrm.cloud.google.com/management-conflict-prevention-policy: resource
              cnrm.cloud.google.com/project-id: default
API Version:  sql.cnrm.cloud.google.com/v1beta1
Kind:         SQLInstance
Metadata:
  .......
Status:
  Conditions:
    Last Transition Time:  2020-03-10T19:46:57Z
    Message:               Update call failed: error fetching live state: error reading underlying resource: Error reading SQL Database Instance "wp-db": googleapi: Error 400: Project specified in the request is invalid., errorInvalidProject
    Reason:                UpdateFailed
    Status:                False
    Type:                  Ready
```
The gcp-sql-instance template should have the project ID annotation to avoid invalid project ID error.