### PR TITLE
Update display name variable to match current GKE docs

### DIFF
--- a/samples/tutorials/hardening-your-cluster/service-account.yaml
+++ b/samples/tutorials/hardening-your-cluster/service-account.yaml
@@ -17,5 +17,5 @@ kind: IAMServiceAccount
 metadata:
   name: [SA_NAME]
 spec:
-  displayName: [SA_NAME]
+  displayName: [DISPLAY_NAME]
 # [END configconnector_hardening_your_cluster_service_account]


### PR DESCRIPTION
In https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa, we're splitting the display name and service account name variables. 

This PR updates the ConfigConnector yaml to match the gcloud command. 