### PR TITLE
fix prometheus scraping

### DIFF
--- a/install-bundles/install-bundle-gcp-identity/0-cnrm-system.yaml
+++ b/install-bundles/install-bundle-gcp-identity/0-cnrm-system.yaml
@@ -654,7 +654,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/version: 1.74.0
-    prometheus.io/port: "8888"
+    prometheus.io/port: "48797"
     prometheus.io/scrape: "true"
   labels:
     cnrm.cloud.google.com/monitored: "true"

--- a/install-bundles/install-bundle-namespaced/0-cnrm-system.yaml
+++ b/install-bundles/install-bundle-namespaced/0-cnrm-system.yaml
@@ -585,7 +585,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/version: 1.74.0
-    prometheus.io/port: "8888"
+    prometheus.io/port: "48797"
     prometheus.io/scrape: "true"
   labels:
     cnrm.cloud.google.com/monitored: "true"

--- a/install-bundles/install-bundle-workload-identity/0-cnrm-system.yaml
+++ b/install-bundles/install-bundle-workload-identity/0-cnrm-system.yaml
@@ -655,7 +655,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/version: 1.74.0
-    prometheus.io/port: "8888"
+    prometheus.io/port: "48797"
     prometheus.io/scrape: "true"
   labels:
     cnrm.cloud.google.com/monitored: "true"


### PR DESCRIPTION
This fixes a regression introduced with 1.46.0. Prometheus uses services to discover pods, but does still scrape the pods directly, not the service. Therefore the annotation has to contain the target port.