### PR TITLE
Add least privilege role file

### DIFF
--- a/samples/tutorials/hardening-your-cluster/policy-least-privilege.yaml
+++ b/samples/tutorials/hardening-your-cluster/policy-least-privilege.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# [START configconnector_hardening_your_cluster_least_privilege]
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: policy-least-privilege
+spec:
+  member: serviceAccount:[SA_NAME]@[PROJECT_ID].iam.gserviceaccount.com
+  role: roles/container.nodeServiceAccount
+  resourceRef:
+    kind: Project
+    name: [PROJECT_ID]
+# [END configconnector_hardening_your_cluster_object_viewer]


### PR DESCRIPTION
We're updating the hardening guide to use the newly added `roles/container.nodeServiceAccount` least privilege IAM role. This file binds that role to the new service account