### PR TITLE
Switch prometheus-to-sd from k8s.gcr.io to gke.gcr.io for private GKE cluster

### DIFF
--- a/config/samples/resources/binaryauthorizationpolicy/default-policy/binaryauthorization_v1beta1_binaryauthorizationpolicy.yaml
+++ b/config/samples/resources/binaryauthorizationpolicy/default-policy/binaryauthorization_v1beta1_binaryauthorizationpolicy.yaml
@@ -22,7 +22,7 @@ spec:
   admissionWhitelistPatterns:
     - namePattern: "gcr.io/google_containers/*"
     - namePattern: "gcr.io/google-containers/*"
-    - namePattern: "k8s.gcr.io/*"
+    - namePattern: "registry.k8s.io/*"
     - namePattern: "gke.gcr.io/*"
     - namePattern: "gcr.io/stackdriver-agents/*"
   defaultAdmissionRule:

--- a/operator/config/gke-addon/image_configmap.yaml
+++ b/operator/config/gke-addon/image_configmap.yaml
@@ -5,7 +5,7 @@ data:
   cnrm.recorder: gcr.io/gke-release/cnrm/recorder:411c879
   cnrm.unmanageddetector: gcr.io/gke-release/cnrm/unmanageddetector:411c879
   cnrm.webhook: gcr.io/gke-release/cnrm/webhook:411c879
-  prom-to-sd: k8s.gcr.io/prometheus-to-sd:v0.9.1
+  prom-to-sd: gke.gcr.io/prometheus-to-sd:v0.9.1
 kind: ConfigMap
 metadata:
   annotations:

--- a/operator/pkg/test/controller/manifest.go
+++ b/operator/pkg/test/controller/manifest.go
@@ -106,7 +106,7 @@ spec:
         image: gcr.io/gke-release/cnrm/controller:4af93f1
         name: manager
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: k8s.gcr.io/prometheus-to-sd:v0.9.1
+        image: gke.gcr.io/prometheus-to-sd:v0.9.1
         name: prom-to-sd
 `}
 

--- a/operator/scripts/update-kcc-manifest/manager_sidecar_patch.yaml
+++ b/operator/scripts/update-kcc-manifest/manager_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: k8s.gcr.io/prometheus-to-sd:v0.9.1
+    image: gke.gcr.io/prometheus-to-sd:v0.9.1
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/scripts/update-kcc-manifest/recorder_sidecar_patch.yaml
+++ b/operator/scripts/update-kcc-manifest/recorder_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:48797?whitelisted=applied_resources_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: k8s.gcr.io/prometheus-to-sd:v0.9.1
+    image: gke.gcr.io/prometheus-to-sd:v0.9.1
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/samples/resources/binaryauthorizationpolicy/default-policy/binaryauthorization_v1beta1_binaryauthorizationpolicy.yaml
+++ b/samples/resources/binaryauthorizationpolicy/default-policy/binaryauthorization_v1beta1_binaryauthorizationpolicy.yaml
@@ -22,7 +22,7 @@ spec:
   admissionWhitelistPatterns:
     - namePattern: "gcr.io/google_containers/*"
     - namePattern: "gcr.io/google-containers/*"
-    - namePattern: "k8s.gcr.io/*"
+    - namePattern: "registry.k8s.io/*"
     - namePattern: "gke.gcr.io/*"
     - namePattern: "gcr.io/stackdriver-agents/*"
   defaultAdmissionRule:

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/binaryauthorization/binaryauthorizationpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/binaryauthorization/binaryauthorizationpolicy.md
@@ -567,7 +567,7 @@ spec:
   admissionWhitelistPatterns:
     - namePattern: "gcr.io/google_containers/*"
     - namePattern: "gcr.io/google-containers/*"
-    - namePattern: "k8s.gcr.io/*"
+    - namePattern: "registry.k8s.io/*"
     - namePattern: "gke.gcr.io/*"
     - namePattern: "gcr.io/stackdriver-agents/*"
   defaultAdmissionRule:


### PR DESCRIPTION
As per Kubernetes [announcement](https://kubernetes.io/blog/2023/03/10/image-registry-redirect/) , registry switched from k8s.gcr.io to registry.k8s.io which not authorized in private cluster , perhaps is possible to have conditional setting for  prometheus-to-sd image based on cluster type