### PR TITLE
Fix set blockOwnerDeletion failures for OwnerReferencesPermissionEnforcement enabled clusters

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -119,6 +119,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors/finalizers
+  verbs:
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings


### PR DESCRIPTION
Fixes  #434

If [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller is enabled, such as on OpenShift, ConfigConnector operator would fail with error `forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on`

This PR ensures that operator's manager role has sufficient permission to update finalizer on a configconnector resource which will then allow us to set blockOwnerDeletion on resources created via Reconcile of a ConfigConnector.