### PR TITLE
Fix ResourceReference fields that are not ResourceReferences

### DIFF
--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"contrib.go.opencensus.io/exporter/prometheus"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"go.opencensus.io/stats/view"
 )
 

--- a/scripts/generate-go-crd-clients/generate-types-file_test.go
+++ b/scripts/generate-go-crd-clients/generate-types-file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/scripts/generate-go-crd-clients/generate-types-file_test.go
+++ b/scripts/generate-go-crd-clients/generate-types-file_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/fielddesc"
+)
+
+func TestIsResourceField(ot *testing.T) {
+	testCases := []struct {
+		name     string
+		field    fielddesc.FieldDescription
+		expected bool
+	}{
+		{
+			// This field has the Ref suffix, and the expected children.
+			name: "reference-field",
+			field: fielddesc.FieldDescription{
+				ShortName: "ThisIsARef",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "external",
+					},
+					{
+						ShortName: "namespace",
+					},
+					{
+						ShortName: "name",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			// This field does not have the Ref name suffix.
+			name: "not-reference-field",
+			field: fielddesc.FieldDescription{
+				ShortName: "NotRefField",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "other",
+					},
+					{
+						ShortName: "children",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			// This field has the Ref name suffix, but does not match the expected children fields.
+			// refer to the v1alpha1.SecretKeyReference struct at pkg/apis/core/v1alpha1/krm_types.go
+			name: "secret-key-ref",
+			field: fielddesc.FieldDescription{
+				ShortName: "SecretKeyRef",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "name",
+					},
+					{
+						ShortName: "key",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		ot.Run(tc.name, func(t *testing.T) {
+			actual := isResourceReference(tc.field)
+			if tc.expected && !actual {
+				t.Errorf("expected field to be resource ref: %+v", tc.field)
+			} else if !tc.expected && actual {
+				t.Errorf("expected field to not be resource ref: %+v", tc.field)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR modifies the type generate code to fix an assumption relating to ResourceReference fields.

Fixes #598 

The PR has 3 commits:
- ResourceReference must have the Ref name and expected children.
  - This commit modifies the `isResourceReference` code so that a ResourceReference field must have the expected `Ref` name suffix, and the expected children. Both checks must be true for the field to be a resource reference.
- Add test for isResourceReference
  - This commit adds a unit-test file that tests the behavior of `isResourceReference`.
- Generated changes from 'make test'
  - This commit includes the generated changes from running `make test`.

Note that I couldn't actually run the tests locally since they assume `kubebuilder` is installed in `/usr/local/kubebuilder`:
```
❯ go test -v ./scripts/generate-go-crd-clients -run TestIsResourceField
{"severity":"error","timestamp":"2023-04-25T12:33:09.738-0400","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":0,"error":"fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"}
{"severity":"error","timestamp":"2023-04-25T12:33:09.738-0400","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":1,"error":"fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"}
{"severity":"error","timestamp":"2023-04-25T12:33:09.739-0400","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":2,"error":"fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"}
{"severity":"error","timestamp":"2023-04-25T12:33:09.740-0400","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":3,"error":"fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"}
{"severity":"error","timestamp":"2023-04-25T12:33:09.741-0400","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":4,"error":"fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"}
FAIL    github.com/GoogleCloudPlatform/k8s-config-connector/scripts/generate-go-crd-clients     0.183s
FAIL
```

I have `kubebuilder` installed, but my installation did not include an `etcd` binary.
```
❯ command -v kubebuilder
/usr/bin/kubebuilder

❯ kubebuilder version
Version: main.version{KubeBuilderVersion:"3.9.0", KubernetesVendor:"1.26.0", GitCommit:"26f605e889b2215120f73ea42b081efac99f5162", BuildDate:"2023-01-16T17:21:30Z", GoOs:"linux", GoArch:"amd64"}
```
