### PR TITLE
Update IAMResourceRef

### DIFF
--- a/pkg/clients/generated/apis/k8s/v1alpha1/types.go
+++ b/pkg/clients/generated/apis/k8s/v1alpha1/types.go
@@ -69,7 +69,7 @@ type ResourceRef struct {
 
 type IAMResourceRef struct {
 	/* Kind of the referenced resource */
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
 	Namespace string `json:"namespace,omitempty"`
 	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */


### PR DESCRIPTION
`serviceAccountRef` or `serviceIdentityRef` do not accept a `kind` attribute in IAMPartialPolicy