### PR TITLE
Set kind json key to omitempty for IAMResourceRef type

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_iamauditconfigs.iam.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_iamauditconfigs.iam.cnrm.cloud.google.com.yaml
@@ -92,8 +92,6 @@ spec:
                     type: string
                   namespace:
                     type: string
-                required:
-                - kind
                 type: object
               service:
                 description: 'Immutable. Required. The service for which to enable

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ replace github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp => ./mockgcp
 
 require (
 	cloud.google.com/go/profiler v0.1.0
-	github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp v0.0.0-00010101000000-000000000000
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.44.0
+	github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp v0.0.0-00010101000000-000000000000
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30
 	github.com/blang/semver v3.5.1+incompatible

--- a/pkg/apis/iam/v1beta1/krm_types.go
+++ b/pkg/apis/iam/v1beta1/krm_types.go
@@ -23,7 +23,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 // go-clients have an accurate representation of this struct.
 // ResourceReference defines a relationship to another resource
 type ResourceReference struct {
-	Kind       string `json:"kind"`
+	Kind       string `json:"kind,omitempty"`
 	Namespace  string `json:"namespace,omitempty"`
 	Name       string `json:"name,omitempty"`
 	APIVersion string `json:"apiVersion,omitempty"`

--- a/pkg/clients/generated/apis/k8s/v1alpha1/types.go
+++ b/pkg/clients/generated/apis/k8s/v1alpha1/types.go
@@ -69,7 +69,7 @@ type ResourceRef struct {
 
 type IAMResourceRef struct {
 	/* Kind of the referenced resource */
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
 	Namespace string `json:"namespace,omitempty"`
 	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"contrib.go.opencensus.io/exporter/prometheus"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"go.opencensus.io/stats/view"
 )
 

--- a/scripts/generate-go-crd-clients/k8s/v1alpha1/types.go
+++ b/scripts/generate-go-crd-clients/k8s/v1alpha1/types.go
@@ -69,7 +69,7 @@ type ResourceRef struct {
 
 type IAMResourceRef struct {
 	/* Kind of the referenced resource */
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
 	Namespace string `json:"namespace,omitempty"`
 	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */


### PR DESCRIPTION
`serviceAccountRef` or `serviceIdentityRef` do not accept a `kind` attribute in IAMPartialPolicy

Related to [#822](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/822)