### PR TITLE
mockgcp: Support returning values from LROs

### DIFF
--- a/mockgcp/mockcertificatemanager/v1.go
+++ b/mockgcp/mockcertificatemanager/v1.go
@@ -121,8 +121,8 @@ func (s *CertificateManagerV1) DeleteCertificate(ctx context.Context, req *pb.De
 
 	fqn := name.String()
 
-	kind := (&pb.Certificate{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, kind, fqn); err != nil {
+	deletedObj := &pb.Certificate{}
+	if err := s.storage.Delete(ctx, fqn, deletedObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "certificate %q not found", name)
 		} else {
@@ -221,8 +221,8 @@ func (s *CertificateManagerV1) DeleteCertificateMap(ctx context.Context, req *pb
 
 	fqn := name.String()
 
-	kind := (&pb.CertificateMap{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, kind, fqn); err != nil {
+	oldObj := &pb.CertificateMap{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "certificate map %q not found", name)
 		} else {
@@ -322,8 +322,8 @@ func (s *CertificateManagerV1) DeleteDnsAuthorization(ctx context.Context, req *
 
 	fqn := name.String()
 
-	kind := (&pb.DnsAuthorization{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, kind, fqn); err != nil {
+	oldObj := &pb.DnsAuthorization{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "dns authorization %q not found", name)
 		} else {
@@ -422,8 +422,8 @@ func (s *CertificateManagerV1) DeleteCertificateMapEntry(ctx context.Context, re
 
 	fqn := name.String()
 
-	kind := (&pb.CertificateMapEntry{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, kind, fqn); err != nil {
+	deletedObj := &pb.CertificateMapEntry{}
+	if err := s.storage.Delete(ctx, fqn, deletedObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "certificate map entry %q not found", name)
 		} else {

--- a/mockgcp/mockcloudfunctions/v1.go
+++ b/mockgcp/mockcloudfunctions/v1.go
@@ -122,8 +122,8 @@ func (s *CloudFunctionsV1) DeleteFunction(ctx context.Context, req *pb.DeleteFun
 
 	fqn := name.String()
 
-	kind := (&pb.CloudFunction{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, kind, fqn); err != nil {
+	oldObj := &pb.CloudFunction{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "function %q not found", name)
 		} else {

--- a/mockgcp/mockgkemulticloud/attachedcluster.go
+++ b/mockgcp/mockgkemulticloud/attachedcluster.go
@@ -125,8 +125,8 @@ func (s *GKEMulticloudV1) DeleteAttachedCluster(ctx context.Context, req *pb.Del
 
 	fqn := name.String()
 
-	attachedClusterKind := (&pb.AttachedCluster{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, attachedClusterKind, fqn); err != nil {
+	oldObj := &pb.AttachedCluster{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "attachedCluster %q not found", name)
 		} else {

--- a/mockgcp/mockiam/serviceaccounts.go
+++ b/mockgcp/mockiam/serviceaccounts.go
@@ -135,8 +135,8 @@ func (s *ServerV1) DeleteServiceAccount(ctx context.Context, req *pb.DeleteServi
 	}
 
 	fqn := name.String()
-	serviceAccountKind := (&pb.ServiceAccount{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, serviceAccountKind, fqn); err != nil {
+	deletedObj := &pb.ServiceAccount{}
+	if err := s.storage.Delete(ctx, fqn, deletedObj); err != nil {
 		return nil, status.Errorf(codes.Internal, "error deleting serviceaccount: %v", err)
 	}
 

--- a/mockgcp/mocknetworkservices/networkservices.go
+++ b/mockgcp/mocknetworkservices/networkservices.go
@@ -124,8 +124,8 @@ func (s *NetworkServicesServer) DeleteMesh(ctx context.Context, req *pb.DeleteMe
 
 	fqn := name.String()
 
-	meshKind := (&pb.Mesh{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, meshKind, fqn); err != nil {
+	deletedObj := &pb.Mesh{}
+	if err := s.storage.Delete(ctx, fqn, deletedObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "mesh %q not found", name)
 		} else {

--- a/mockgcp/mockprivateca/capool.go
+++ b/mockgcp/mockprivateca/capool.go
@@ -119,8 +119,8 @@ func (s *PrivateCAV1) DeleteCaPool(ctx context.Context, req *pb.DeleteCaPoolRequ
 
 	fqn := name.String()
 
-	caPoolKind := (&pb.CaPool{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, caPoolKind, fqn); err != nil {
+	oldObj := &pb.CaPool{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "caPool %q not found", name)
 		} else {

--- a/mockgcp/mocksecretmanager/secrets.go
+++ b/mockgcp/mocksecretmanager/secrets.go
@@ -107,8 +107,8 @@ func (s *SecretsV1) DeleteSecret(ctx context.Context, req *pb.DeleteSecretReques
 
 	fqn := name.String()
 
-	secretKind := (&pb.Secret{}).ProtoReflect().Descriptor()
-	if err := s.storage.Delete(ctx, secretKind, fqn); err != nil {
+	oldObj := &pb.Secret{}
+	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "secret %q not found", name)
 		} else {

--- a/mockgcp/pkg/storage/interfaces.go
+++ b/mockgcp/pkg/storage/interfaces.go
@@ -31,7 +31,7 @@ type Storage interface {
 	// List returns all matching objects
 	List(ctx context.Context, kind protoreflect.Descriptor, options ListOptions, callback func(obj proto.Message) error) error
 	// Deleting deletes the object, returning a not found error if it does not exist.
-	Delete(ctx context.Context, kind protoreflect.Descriptor, fqn string) error
+	Delete(ctx context.Context, fqn string, dest proto.Message) error
 }
 
 // ListOptions restricts the objects returned by a List

--- a/mockgcp/pkg/storage/memory.go
+++ b/mockgcp/pkg/storage/memory.go
@@ -78,18 +78,20 @@ func (s *typeStorage) Create(ctx context.Context, fqn string, create proto.Messa
 }
 
 // Delete deletes the object, returning a not found error if it does not exist.
-func (s *InMemoryStorage) Delete(ctx context.Context, kind protoreflect.Descriptor, fqn string) error {
-	return s.getTypeStorage(kind.FullName()).Delete(ctx, fqn)
+func (s *InMemoryStorage) Delete(ctx context.Context,  fqn string, dest proto.Message) error {
+	kind := dest.ProtoReflect().Descriptor()
+	return s.getTypeStorage(kind.FullName()).Delete(ctx, fqn, dest)
 }
 
-func (s *typeStorage) Delete(ctx context.Context, fqn string) error {
+func (s *typeStorage) Delete(ctx context.Context, fqn string, dest proto.Message) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	_, found := s.byKey[fqn]
+	existing, found := s.byKey[fqn]
 	if !found {
 		return apierrors.NewNotFound(schema.GroupResource{}, fqn)
 	}
+	proto.Merge(dest, existing)
 	delete(s.byKey, fqn)
 	return nil
 }


### PR DESCRIPTION
Some clients rely on the value in the LRO; by supporting this we can
also clean up the API for delete.
