### PR TITLE
Skipping problematic reinstall of gcloud if setup.

### DIFF
--- a/scripts/environment-setup/gcp-setup.sh
+++ b/scripts/environment-setup/gcp-setup.sh
@@ -45,15 +45,20 @@ if [[ ! $(gcloud beta container clusters list | grep ${CLUSTER_NAME}) ]]; then
         --workload-pool=${PROJECT_ID}.svc.id.goog
 fi
 
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-    | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+GCLOUD_PKG="google-cloud-sdk-gke-gcloud-auth-plugin"
+if apt list $GCLOUD_PKG --installed | grep $GCLOUD_PKG; then
+    printf "GCloud already installed, skipping install"
+else
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key \
-    --keyring /usr/share/keyrings/cloud.google.gpg add -
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key \
+        --keyring /usr/share/keyrings/cloud.google.gpg add -
 
-sudo apt-get update && sudo apt-get install google-cloud-cli
+    sudo apt-get update && sudo apt-get install google-cloud-cli
 
-sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+    sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
+fi
 
 # Configure kubectl to communicate with the cluster.
 gcloud container clusters get-credentials ${CLUSTER_NAME}


### PR DESCRIPTION
I see an error on the apt install if I already have the package installed.
Added a check to skip the relevant apt install if the package is already installed.