### PR TITLE
Generate clients without requiring GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ Session.vim
 
 # always skip vendored files
 /vendor
+.build

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ fmt:
 	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg cmd scripts config/tests
 	# 04bfe4ee9ca5764577b029acc6a1957fd1997153 includes fix to not log "Skipped" for each skipped file
 	GOFLAGS= go run github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153 -c "Google LLC" -l apache \
-	-ignore "vendor/**" -ignore "third_party/**" \
+	-ignore ".build/**" -ignore "vendor/**" -ignore "third_party/**" \
 	-ignore "config/crds/**" -ignore "config/cloudcodesnippets/**" \
 	-ignore "**/*.html" -ignore "config/installbundle/components/clusterroles/cnrm_admin.yaml" \
 	-ignore "config/installbundle/components/clusterroles/cnrm_viewer.yaml" \
@@ -179,17 +179,9 @@ install: manifests
 deploy-controller: docker-build docker-push
 	kustomize build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
-
-# Generate strong-typed definitions for existing CRDs
-.PHONY: client-types
-client-types:
-	go run ./scripts/generate-go-crd-clients
-	make fmt
-
 # Generate CRD go clients
 .PHONY: generate-go-client
-generate-go-client: client-types
-	go generate ./pkg/clients/generated/...
+generate-go-client:
 	./scripts/generate-go-crd-clients/generate-clients.sh
 
 # Generate google3 docs

--- a/scripts/generate-go-crd-clients/generate-clients.sh
+++ b/scripts/generate-go-crd-clients/generate-clients.sh
@@ -20,8 +20,28 @@ set -o pipefail
 
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-source ${REPO_ROOT}/scripts/shared-vars-public.sh
-cd "${REPO_ROOT}/pkg/clients/generated/"
+cd "${REPO_ROOT}"
+
+# Generate strong-typed definitions for existing CRDs
+echo "Generating go types"
+go run ./scripts/generate-go-crd-clients
+make fmt # Fix up the formatting and headers
+
+# HACK: Some of the kubernetes generation tools still run better in GOPATH
+mkdir -p "${REPO_ROOT}/.build/go/src/github.com/GoogleCloudPlatform"
+ln -sf "${REPO_ROOT}" "${REPO_ROOT}/.build/go/src/github.com/GoogleCloudPlatform/k8s-config-connector" 
+export GOPATH="${REPO_ROOT}/.build/go"
+
+GOPATH_REPO_ROOT="${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-config-connector"
+
+# Generate deepcopy etc
+echo "Generating deepcopy for go types"
+cd "${GOPATH_REPO_ROOT}"
+go generate ./pkg/clients/generated/...
+
+# Generate the clients
+echo "Generating clients"
+cd "${GOPATH_REPO_ROOT}/pkg/clients/generated/"
 
 # Extract API & version names
 API_DIRS=(apis/*/*/)
@@ -35,7 +55,7 @@ done
 printf -v JOINED '%s,' "${API_VERSIONS[@]:1}"
 JOINED="${JOINED}${API_VERSIONS[0]}"
 
-go run ${REPO_ROOT}/scripts/client-gen/main.go --clientset-name versioned --input-base github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis --input ${JOINED} --output-base ../ --output-package github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/client/clientset -h ${REPO_ROOT}/hack/boilerplate_client_alpha.go.txt
+go run ${GOPATH_REPO_ROOT}/scripts/client-gen/main.go --clientset-name versioned --input-base github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis --input ${JOINED} --output-base ../ --output-package github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/client/clientset -h ${GOPATH_REPO_ROOT}/hack/boilerplate_client_alpha.go.txt
 
 # Clients are generated in a temp github.com/ folder where we pull the
 # generated files out into a cleared pkg/client/ folder


### PR DESCRIPTION
Some of the kubernetes generators still work better with GOPATH; we
can create a temporary directory structure to keep them happy.
