### PR TITLE
Add tests for exporting resources

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -100,7 +100,7 @@ func RunCreateDeleteTest(t *Harness, unstructs []*unstructured.Unstructured, cle
 	waitForReady(t, unstructs)
 	// Clean up resources on success or if cleanupResources flag is true
 	if cleanupResources {
-		cleanup(t, unstructs)
+		DeleteResources(t, unstructs)
 	}
 }
 
@@ -175,7 +175,7 @@ func waitForReadySingleResource(t *Harness, wg *sync.WaitGroup, u *unstructured.
 	t.Errorf("%v, final status: %+v", baseMsg, objectStatus)
 }
 
-func cleanup(t *Harness, unstructs []*unstructured.Unstructured) {
+func DeleteResources(t *Harness, unstructs []*unstructured.Unstructured) {
 	logger := log.FromContext(t.Ctx)
 
 	for _, u := range unstructs {

--- a/pkg/cli/cmd/apply.go
+++ b/pkg/cli/cmd/apply.go
@@ -36,11 +36,12 @@ var (
 		Short:  "Apply a KRM resource configuration file to Google Cloud Platform backend",
 		Long:   `Apply a KRM resource configuration file to Google Cloud Platform backend`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if err := parameters.Validate(&applyParams, os.Stdin); err != nil {
 				return err
 			}
 			rootCmd.SilenceUsage = true
-			return apply.Execute(&applyParams, os.Stdout)
+			return apply.Execute(ctx, &applyParams, os.Stdout)
 		},
 		Args: cobra.NoArgs,
 	}

--- a/pkg/cli/cmd/apply/execute.go
+++ b/pkg/cli/cmd/apply/execute.go
@@ -15,6 +15,7 @@
 package apply
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -25,8 +26,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 )
 
-func Execute(params *parameters.Parameters, output io.Writer) error {
-	tfProvider, err := tf.NewProvider(params.OAuth2Token)
+func Execute(ctx context.Context, params *parameters.Parameters, output io.Writer) error {
+	tfProvider, err := tf.NewProvider(ctx, params.OAuth2Token)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/bulkexport/execute.go
+++ b/pkg/cli/cmd/bulkexport/execute.go
@@ -37,7 +37,7 @@ func Execute(ctx context.Context, params *parameters.Parameters) error {
 	if err != nil {
 		return err
 	}
-	tfProvider, err := tf.NewProvider(params.OAuth2Token)
+	tfProvider, err := tf.NewProvider(ctx, params.OAuth2Token)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func Execute(ctx context.Context, params *parameters.Parameters) error {
 		return err
 	}
 	defer assetStream.Close()
-	yamlStream, err := outputstream.NewResourceByteStream(params, assetStream)
+	yamlStream, err := outputstream.NewResourceByteStream(tfProvider, params, assetStream)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/bulkexport/outputstream/outputstream.go
+++ b/pkg/cli/cmd/bulkexport/outputstream/outputstream.go
@@ -25,26 +25,21 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/outputsink"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/serviceclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/stream"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/tf"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func NewResourceByteStream(params *parameters.Parameters, assetStream stream.AssetStream) (stream.ByteStream, error) {
-	provider, err := tf.NewProvider(params.OAuth2Token)
-	if err != nil {
-		return nil, err
-	}
+func NewResourceByteStream(tfProvider *schema.Provider, params *parameters.Parameters, assetStream stream.AssetStream) (stream.ByteStream, error) {
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
 		return nil, fmt.Errorf("error creating service mapping loader: %v", err)
 	}
-	unstructuredStream, err := NewUnstructuredStream(params, assetStream, provider, smLoader)
+	unstructuredStream, err := NewUnstructuredStream(params, assetStream, tfProvider, smLoader)
 	if err != nil {
 		return nil, err
 	}
-	return stream.NewByteStream(outputsink.ResourceFormat(params.ResourceFormat), unstructuredStream, smLoader, provider)
+	return stream.NewByteStream(outputsink.ResourceFormat(params.ResourceFormat), unstructuredStream, smLoader, tfProvider)
 }
 
 func NewUnstructuredStream(params *parameters.Parameters, assetStream stream.AssetStream, provider *schema.Provider, smLoader *servicemappingloader.ServiceMappingLoader) (stream.UnstructuredStream, error) {

--- a/pkg/cli/cmd/export.go
+++ b/pkg/cli/cmd/export.go
@@ -66,7 +66,7 @@ var (
 )
 
 func init() {
-	commonparams.AddOAuth2TokenParam(exportCmd, &exportParams.OAuth2Token)
+	commonparams.AddOAuth2TokenParam(exportCmd, &exportParams.GCPAccessToken)
 	commonparams.AddIAMFormatParam(exportCmd, &exportParams.IAMFormat)
 	commonparams.AddFilterDeletedIAMMembersParam(exportCmd, &exportParams.FilterDeletedIAMMembers)
 	commonparams.AddOutputParam(exportCmd, &exportParams.Output)

--- a/pkg/cli/cmd/export/execute.go
+++ b/pkg/cli/cmd/export/execute.go
@@ -26,15 +26,17 @@ import (
 )
 
 func Execute(ctx context.Context, params *parameters.Parameters) error {
-	byteStream, err := outputstream.NewResourceByteStream(params)
+	tfProvider, err := tf.NewProvider(ctx, params.GCPAccessToken)
+	if err != nil {
+		return err
+	}
+
+	byteStream, err := outputstream.NewResourceByteStream(tfProvider, params)
 	if err != nil {
 		return err
 	}
 	recoverableStream := stream.NewRecoverableByteStream(byteStream)
-	tfProvider, err := tf.NewProvider(params.OAuth2Token)
-	if err != nil {
-		return err
-	}
+
 	outputSink, err := outputsink.New(tfProvider, params.Output, outputsink.ResourceFormat(params.ResourceFormat))
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/export/outputstream/outputstream.go
+++ b/pkg/cli/cmd/export/outputstream/outputstream.go
@@ -23,26 +23,21 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/gcpclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/outputsink"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/stream"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/tf"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func NewResourceByteStream(params *parameters.Parameters) (stream.ByteStream, error) {
-	provider, err := tf.NewProvider(params.OAuth2Token)
-	if err != nil {
-		return nil, err
-	}
+func NewResourceByteStream(tfProvider *schema.Provider, params *parameters.Parameters) (stream.ByteStream, error) {
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
 		return nil, fmt.Errorf("error creating service mapping loader: %v", err)
 	}
-	unstructuredStream, err := NewUnstructuredStream(params, provider, smLoader)
+	unstructuredStream, err := NewUnstructuredStream(params, tfProvider, smLoader)
 	if err != nil {
 		return nil, err
 	}
-	return stream.NewByteStream(outputsink.ResourceFormat(params.ResourceFormat), unstructuredStream, smLoader, provider)
+	return stream.NewByteStream(outputsink.ResourceFormat(params.ResourceFormat), unstructuredStream, smLoader, tfProvider)
 }
 
 func NewUnstructuredStream(params *parameters.Parameters, provider *schema.Provider, smLoader *servicemappingloader.ServiceMappingLoader) (stream.UnstructuredStream, error) {

--- a/pkg/cli/cmd/export/outputstream/outputstream_test.go
+++ b/pkg/cli/cmd/export/outputstream/outputstream_test.go
@@ -39,8 +39,8 @@ func TestNewUnstructuredStreamWithPolicyMemberIAMOption(t *testing.T) {
 
 func testNewUnstructuredStreamWithIAMOption(t *testing.T, iamFormatOption string, instanceOfExpectedType interface{}) {
 	params := parameters.Parameters{
-		IAMFormat:   iamFormatOption,
-		OAuth2Token: "dummyToken",
+		IAMFormat:      iamFormatOption,
+		GCPAccessToken: "dummyToken",
 	}
 	unstructuredStream, err := outputstream.NewUnstructuredStream(&params, tfprovider.NewOrLogFatal(tfprovider.UnitTestConfig()),
 		testservicemappingloader.New(t))

--- a/pkg/cli/cmd/export/parameters/parameters.go
+++ b/pkg/cli/cmd/export/parameters/parameters.go
@@ -21,11 +21,14 @@ import (
 type Parameters struct {
 	IAMFormat               string
 	FilterDeletedIAMMembers bool
-	OAuth2Token             string
-	Output                  string
-	ResourceFormat          string
-	URI                     string
-	Verbose                 bool
+
+	// GCPAccessToken is the (optional) static authentication token to use for GCP authentication.
+	GCPAccessToken string
+
+	Output         string
+	ResourceFormat string
+	URI            string
+	Verbose        bool
 }
 
 func Validate(p *Parameters) error {

--- a/pkg/cli/cmd/printresources/resourcedescription/resourcedescription.go
+++ b/pkg/cli/cmd/printresources/resourcedescription/resourcedescription.go
@@ -15,6 +15,7 @@
 package resourcedescription
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -36,6 +37,8 @@ type ResourceDescription struct {
 }
 
 func GetAll() ([]ResourceDescription, error) {
+	ctx := context.TODO()
+
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
 		return nil, fmt.Errorf("error creating service mapping loader: %w", err)
@@ -43,7 +46,7 @@ func GetAll() ([]ResourceDescription, error) {
 	// tfprovider.New(...) configures the provider which requires valid access credentials. This is unnecessary
 	// for the purposes of getting the schema information. To get around this but not create a new codepath for creating
 	// a google provider, pass in an invalid, placeholder oauth2 token.
-	tfProvider, err := tf.NewProvider("invalid token")
+	tfProvider, err := tf.NewProvider(ctx, "invalid token")
 	if err != nil {
 		return nil, fmt.Errorf("error creating tf provider: %w", err)
 	}

--- a/pkg/cli/gcpclient/quick_test.go
+++ b/pkg/cli/gcpclient/quick_test.go
@@ -98,7 +98,7 @@ func newDependencies(t *testing.T) (gcpclient.Client, *servicemappingloader.Serv
 		return nil, nil, nil, nil, fmt.Errorf("error loading service mappings: %v", err)
 	}
 	config := tfprovider.Config{
-		AccessToken: "", // <- insert a valid oauth2 token here
+		GCPAccessToken: "", // <- insert a valid oauth2 token here
 	}
 	tfProvider, err := tfprovider.New(ctx, config)
 	if err != nil {

--- a/pkg/cli/tf/tf.go
+++ b/pkg/cli/tf/tf.go
@@ -22,11 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func NewProvider(oauth2Token string) (*schema.Provider, error) {
-	ctx := context.TODO()
-
+func NewProvider(ctx context.Context, gcpAccessToken string) (*schema.Provider, error) {
 	config := tfprovider.Config{
-		AccessToken: oauth2Token,
+		GCPAccessToken: gcpAccessToken,
 	}
 	p, err := tfprovider.New(ctx, config)
 	if err != nil {

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -55,9 +55,9 @@ type Config struct {
 	// Currently only used in tests.
 	HTTPClient *http.Client
 
-	// AccessToken allows configuration of a static access token.
+	// GCPAccessToken allows configuration of a static access token for accessing GCP.
 	// Currently only used in tests.
-	AccessToken string
+	GCPAccessToken string
 }
 
 // Creates a new controller-runtime manager.Manager and starts all of the KCC controllers pointed at the
@@ -88,7 +88,7 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	tfCfg := tfprovider.NewConfig()
 	tfCfg.UserProjectOverride = config.UserProjectOverride
 	tfCfg.BillingProject = config.BillingProject
-	tfCfg.AccessToken = config.AccessToken
+	tfCfg.GCPAccessToken = config.GCPAccessToken
 
 	provider, err := tfprovider.New(ctx, tfCfg)
 	if err != nil {

--- a/pkg/test/resourcefixture/resourcefixture.go
+++ b/pkg/test/resourcefixture/resourcefixture.go
@@ -51,6 +51,7 @@ const (
 type ResourceFixture struct {
 	GVK          schema.GroupVersionKind
 	Name         string
+	SourceDir    string
 	Create       []byte
 	Update       []byte
 	Dependencies []byte
@@ -133,10 +134,11 @@ func loadResourceFixture(t *testing.T, testName string, testType TestType, dir, 
 	}
 
 	rf := ResourceFixture{
-		Name:   testName,
-		GVK:    gvk,
-		Create: createConfig,
-		Type:   testType,
+		Name:      testName,
+		SourceDir: dir,
+		GVK:       gvk,
+		Create:    createConfig,
+		Type:      testType,
 	}
 
 	if updateFile != "" {

--- a/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/service/export.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/service/export.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: runtimeconfig.googleapis.com
+spec:
+  projectRef:
+    external: example-project-id
+  resourceID: runtimeconfig.googleapis.com
+...

--- a/pkg/tf/provider/provider.go
+++ b/pkg/tf/provider/provider.go
@@ -30,9 +30,9 @@ import (
 
 // Config holds additional configuration for the google TF provider
 type Config struct {
-	// AccessToken is the access_token to be passed to the TF provider (if non-empty),
+	// GCPAccessToken is the access_token to be passed to the TF provider (if non-empty),
 	// allowing use of a non-default OAuth2 identity
-	AccessToken string
+	GCPAccessToken string
 
 	// Scopes is the list of OAuth2 scopes to be passed to the TF provider,
 	// allowing use of non-default OAuth2 scopes. If none are specified, then
@@ -64,7 +64,7 @@ func UnitTestConfig() Config {
 			// read Google Drive files.
 			"https://www.googleapis.com/auth/drive.readonly",
 		),
-		AccessToken: "dummyToken",
+		GCPAccessToken: "dummyToken",
 	}
 }
 
@@ -83,8 +83,8 @@ func NewConfig() Config {
 func New(ctx context.Context, config Config) (*tfschema.Provider, error) {
 	googleProvider := provider.Provider()
 	cfgMap := map[string]interface{}{}
-	if config.AccessToken != "" {
-		cfgMap["access_token"] = config.AccessToken
+	if config.GCPAccessToken != "" {
+		cfgMap["access_token"] = config.GCPAccessToken
 	}
 
 	cfgMap["scopes"] = config.Scopes


### PR DESCRIPTION
We need to plumb through the context so we can use this in our mocks, and then we add a test for exporting resources.

Currently just one test (for serviceusage), because it requires some mapping to the export "URI".