### PR TITLE
tests: Verify the object observedGeneration

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -348,15 +348,16 @@ func (t *Harness) waitForCRDReady(obj client.Object) {
 			logger.Info("Error getting resource", "kind", kind, "id", id, "error", err)
 			return false, err
 		}
-		conditions := dynamic.GetConditions(t.T, u)
-		for _, condition := range conditions {
+		objectStatus := dynamic.GetObjectStatus(t.T, u)
+		// CRDs do not have observedGeneration
+		for _, condition := range objectStatus.Conditions {
 			if condition.Type == "Established" && condition.Status == "True" {
 				logger.Info("crd is ready", "kind", kind, "id", id)
 				return true, nil
 			}
 		}
 		// This resource is not completely ready. Let's keep polling.
-		logger.Info("CRD is not ready", "kind", kind, "id", id, "conditions", conditions)
+		logger.Info("CRD is not ready", "kind", kind, "id", id, "conditions", objectStatus.Conditions)
 		return false, nil
 	}); err != nil {
 		t.Errorf("error while polling for ready on %v %v: %v", kind, id, err)

--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourceactuation"
 	dclextension "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/extension"
 	dclmetadata "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
@@ -250,8 +249,7 @@ func validateCreate(t *testing.T, testContext testrunner.TestContext, systemCont
 
 	// Check that condition is ready and "UpToDate" event was recorded
 	// TODO: (eventually) check default fields are propagated correctly
-	conditions := dynamic.GetConditions(t, reconciledUnstruct)
-	testcontroller.AssertReadyCondition(t, conditions)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	verifyResourceIDIfSupported(t, systemContext, resourceContext, reconciledUnstruct, initialUnstruct)
@@ -389,8 +387,7 @@ func testUpdate(t *testing.T, testContext testrunner.TestContext, systemContext 
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.Updating)
 
 	// Check if condition is ready and update event was recorded
-	conditions := dynamic.GetConditions(t, reconciledUnstruct)
-	testcontroller.AssertReadyCondition(t, conditions)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	// Check observedGeneration matches with the pre-reconcile generation
@@ -638,8 +635,7 @@ func testReconcileAcquire(t *testing.T, testContext testrunner.TestContext, syst
 	}
 
 	// Check that condition is ready and "UpToDate" event was recorded
-	conditions := dynamic.GetConditions(t, reconciledUnstruct)
-	testcontroller.AssertReadyCondition(t, conditions)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	// Check observedGeneration matches with the pre-reconcile generation

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
@@ -119,7 +119,7 @@ func testReconcileResourceLevelCreate(t *testing.T, mgr manager.Manager, k8sAudi
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sAuditConfig, preReconcileGeneration)
 }
@@ -212,7 +212,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, mgr manager.Manager, k8sAudi
 		t.Fatalf("error retrieving GCP audit config: %v", err)
 	}
 	assertSameAuditConfigs(t, newK8sAuditConfig, gcpAuditConfig)
-	testcontroller.AssertReadyCondition(t, newK8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, newK8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &newK8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sAuditConfig, preReconcileGeneration)
 }
@@ -291,7 +291,7 @@ func testReconcileResourceLevelNoChanges(t *testing.T, mgr manager.Manager, k8sA
 	if k8sAuditConfig.GetResourceVersion() != newK8sAuditConfig.GetResourceVersion() {
 		t.Errorf("reconcile that was expected to be a no-op resulted in a write to the API server")
 	}
-	testcontroller.AssertReadyCondition(t, newK8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, newK8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &newK8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sAuditConfig, preReconcileGeneration)
 }
@@ -354,7 +354,7 @@ func testReconcileResourceLevelDelete(t *testing.T, mgr manager.Manager, k8sAudi
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	if err := kubeClient.Delete(context.TODO(), k8sAuditConfig); err != nil {
 		t.Fatalf("error deleting k8s resource: %v", err)
@@ -433,7 +433,7 @@ func testReconcileResourceLevelDeleteParentFirst(t *testing.T, mgr manager.Manag
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 
 	// First, delete the parent resource of the IAMAuditConfig
@@ -516,7 +516,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sAud
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sAuditConfig, preReconcileGeneration)
 }

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
@@ -317,7 +317,7 @@ func testReconcileResourceLevelCreate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
 	assertPolicy(t, k8sPartialPolicy, existingPolicy, gcpPolicy, iamClient)
-	testcontroller.AssertReadyCondition(t, k8sPartialPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPartialPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &k8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPartialPolicy, preReconcileGeneration)
 }
@@ -341,7 +341,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("error retrieving GCP policy: %v", err)
 	}
 	assertPolicy(t, newK8sPartialPolicy, existingPolicy, gcpPolicy, iamClient)
-	testcontroller.AssertReadyCondition(t, newK8sPartialPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, newK8sPartialPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &newK8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sPartialPolicy, preReconcileGeneration)
 }
@@ -545,7 +545,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPar
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPartialPolicy), k8sPartialPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPartialPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPartialPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &k8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPartialPolicy, preReconcileGeneration)
 }

--- a/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
+++ b/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
@@ -181,7 +181,7 @@ func testReconcileResourceLevelCreate(t *testing.T, kubeClient client.Client, k8
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicy), k8sPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &k8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicy, preReconcileGeneration)
 }
@@ -204,7 +204,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("error retrieving GCP policy: %v", err)
 	}
 	testiam.AssertSamePolicy(t, newK8sPolicy, gcpPolicy)
-	testcontroller.AssertReadyCondition(t, newK8sPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, newK8sPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &newK8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sPolicy, preReconcileGeneration)
 }
@@ -400,7 +400,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPol
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicy), k8sPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicy.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPolicy)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &k8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicy, preReconcileGeneration)
 }

--- a/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
@@ -170,7 +170,7 @@ func testPolicyMemberCreateDelete(t *testing.T, mgr manager.Manager, k8sPolicyMe
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicyMember), k8sPolicyMember); err != nil {
 		t.Fatalf("unexpected error getting resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicyMember.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPolicyMember)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMPolicyMemberGVK.Kind, &k8sPolicyMember.ObjectMeta, k8s.UpToDate)
 	if err := kubeClient.Delete(context.TODO(), k8sPolicyMember); err != nil {
 		t.Fatalf("error deleting policy member: %v", err)
@@ -257,7 +257,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPol
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicyMember), k8sPolicyMember); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicyMember.Status.Conditions)
+	testcontroller.AssertReadyCondition(t, k8sPolicyMember)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMPolicyMemberGVK.Kind, &k8sPolicyMember.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicyMember, preReconcileGeneration)
 }


### PR DESCRIPTION
This is more accurate, and means we don't have to rely on waiting and
hoping for a reconcile.
