### PR TITLE
github CI: upload artifacts directory

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -70,6 +70,12 @@ jobs:
           ./scripts/github-actions/ga-mock-test.sh
         env:
           GOPATH: /home/runner/go
+          ARTIFACTS: /tmp/artifacts
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: /tmp/artifacts/
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/pkg/test/http_recorder.go
+++ b/pkg/test/http_recorder.go
@@ -26,8 +26,8 @@ import (
 	"time"
 	"unicode"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 type LogEntry struct {
@@ -96,7 +96,7 @@ func (r *HTTPRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if recordErr := r.record(&entry, req, response); recordErr != nil {
-		klog.Warningf("failed to record HTTP request: %v", err)
+		klog.Warningf("failed to record HTTP request: %v", recordErr)
 	}
 
 	return response, err


### PR DESCRIPTION
This lets us see richer and more structured output than we get with
just the logfile.
