### PR TITLE
github ci: mock tests should not need gcloud CLI

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -63,8 +63,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21.3'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
       - name: 'Run mock tests'
         run: |
           ./scripts/github-actions/ga-mock-test.sh


### PR DESCRIPTION
Stop installing the gcloud CLI, so we can validate that it is not a
requirement for the mock tests.
