### PR TITLE
Validate the name for webhook timeout customization CRs.

### DIFF
--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -48,3 +48,15 @@ patchesJson6902:
     kind: CustomResourceDefinition
     name: controllerresources.customize.core.cnrm.cloud.google.com
   path: controllerresources_required_fields_patch.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+  path: validate_validatingwebhookconfigurationcustomizations_name_patch.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+  path: validate_mutatingwebhookconfigurationcustomizations_name_patch.yaml

--- a/operator/config/crd/validate_mutatingwebhookconfigurationcustomizations_name_patch.yaml
+++ b/operator/config/crd/validate_mutatingwebhookconfigurationcustomizations_name_patch.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      enum:
+        - mutating-webhook
+      type: string

--- a/operator/config/crd/validate_validatingwebhookconfigurationcustomizations_name_patch.yaml
+++ b/operator/config/crd/validate_validatingwebhookconfigurationcustomizations_name_patch.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      enum:
+        - validating-webhook
+        - abandon-on-uninstall
+      type: string


### PR DESCRIPTION
Validate the name for `ValidatingWebhookConfigurationCustomization` and `MutatingWebhookConfigurationCustomization` custom resource.

CRD diff introduced by this PR:
https://www.diffchecker.com/LW515tRH/

Fixes #879, b/296128049