### PR TITLE
Add prerequisites info to attached cluster resource reference doc

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -60,12 +60,13 @@ Note: Before using this resource, make sure you review and complete the steps in
 </table>
 
 ## Prerequisites
-We need to prepare the target cluster to be attached to make sure the Multi-cloud service connects to the target cluster.
-That requires an install-agent to be deployed into the target cluster.
+Before you can use this resource, you must prepare the target cluster
+so that the multi-cloud service can connect to the target cluster.
+To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:
 
 Steps to deploy the install-agent into target cluster:
 
-1. Get the manifest yaml file for the install-agent
+1. Get the manifest yaml file for the install-agent:
 
 `gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
 
@@ -73,7 +74,7 @@ Example command:
 
 `gcloud container attached clusters generate-install-manifest kcc-attached-cluster  --location=us-west1 --platform-version=1.25.0-gke.5 --output-file=manifest.yaml`
 
-2. Checkout the target cluster and get kubeconfig context
+2. Check out the target cluster and get the kubeconfig context:
 
 EKS cluster: `aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER`
 
@@ -81,13 +82,13 @@ AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
 
 `export KUBECONFIG_CONTEXT=$(kubectl config current-context)`
 
-3. Apply manifest yaml to target cluster
+3. Apply the `manifest.yaml` file to the target cluster:
 
-`kubectl use-context $KUBECONFIG_CONTEXT` (optional, previous aws/az command should already switch context)
+(optional, previous aws/az command should already switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
 
 `kubectl apply -f manifest.yaml`
 
-You should see below logs:
+You should see the following logs:
 
 ```
  namespace/gke-install created
@@ -96,10 +97,10 @@ You should see below logs:
  deployment.apps/gke-multicloud-agent created
 ```
 
-4. Switch back to the GKE cluster with KCC installed
+4. Switch back to the GKE cluster with Config Connector installed:
 
-Run `kubectl config get-contexts` to see all context that configured, should be at least two contexts show up here:
-one associates to the target cluster, one associates to your GKE cluster with KCC installed.
+Run `kubectl config get-contexts` to see all configured contexts. You should see at least two contexts:
+one associated with the target cluster, and one associated with the GKE cluster with Config Connector installed.
 
 Run `kubectl config use-context GKE_CONTEXT` to switch back to the GKE context.
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -64,8 +64,6 @@ Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.
 To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:
 
-Steps to deploy the install-agent into target cluster:
-
 1. Get the manifest yaml file for the install-agent:
 
 `gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
@@ -84,7 +82,7 @@ AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
 
 3. Apply the `manifest.yaml` file to the target cluster:
 
-(optional, previous aws/az command should already switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
+(Optional if you used the previous command to switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
 
 `kubectl apply -f manifest.yaml`
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -7,6 +7,8 @@
 
 
 
+Note: Before using this resource, make sure you review and complete the steps in Prerequisites section.
+
 <table>
 <thead>
 <tr>
@@ -56,6 +58,50 @@
 </tr>
 </tbody>
 </table>
+
+## Prerequisites
+We need to prepare the target cluster to be attached to make sure the Multi-cloud service connects to the target cluster.
+That requires an install-agent to be deployed into the target cluster.
+
+Steps to deploy the install-agent into target cluster:
+
+1. Get the manifest yaml file for the install-agent
+
+`gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
+
+Example command:
+
+`gcloud container attached clusters generate-install-manifest kcc-attached-cluster  --location=us-west1 --platform-version=1.25.0-gke.5 --output-file=manifest.yaml`
+
+2. Checkout the target cluster and get kubeconfig context
+
+EKS cluster: `aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER`
+
+AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
+
+`export KUBECONFIG_CONTEXT=$(kubectl config current-context)`
+
+3. Apply manifest yaml to target cluster
+
+`kubectl use-context $KUBECONFIG_CONTEXT` (optional, previous aws/az command should already switch context)
+
+`kubectl apply -f manifest.yaml`
+
+You should see below logs:
+
+```
+ namespace/gke-install created
+ serviceaccount/gke-install-agent created
+ clusterrolebinding.rbac.authorization.k8s.io/multicloud-install-agent-admin created
+ deployment.apps/gke-multicloud-agent created
+```
+
+4. Switch back to the GKE cluster with KCC installed
+
+Run `kubectl config get-contexts` to see all context that configured, should be at least two contexts show up here:
+one associates to the target cluster, one associates to your GKE cluster with KCC installed.
+
+Run `kubectl config use-context GKE_CONTEXT` to switch back to the GKE context.
 
 ## Custom Resource Definition Properties
 

--- a/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
@@ -57,8 +57,6 @@ Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.
 To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:
 
-Steps to deploy the install-agent into target cluster:
-
 1. Get the manifest yaml file for the install-agent:
 
 `gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
@@ -77,7 +75,7 @@ AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
 
 3. Apply the `manifest.yaml` file to the target cluster:
 
-(optional, previous aws/az command should already switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
+(Optional if you used the previous command to switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
 
 `kubectl apply -f manifest.yaml`
 

--- a/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
@@ -53,12 +53,13 @@ Note: Before using this resource, make sure you review and complete the steps in
 </table>
 
 ## Prerequisites
-We need to prepare the target cluster to be attached to make sure the Multi-cloud service connects to the target cluster.
-That requires an install-agent to be deployed into the target cluster.
+Before you can use this resource, you must prepare the target cluster
+so that the multi-cloud service can connect to the target cluster.
+To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:
 
 Steps to deploy the install-agent into target cluster:
 
-1. Get the manifest yaml file for the install-agent
+1. Get the manifest yaml file for the install-agent:
 
 `gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
 
@@ -66,7 +67,7 @@ Example command:
 
 `gcloud container attached clusters generate-install-manifest kcc-attached-cluster  --location=us-west1 --platform-version=1.25.0-gke.5 --output-file=manifest.yaml`
 
-2. Checkout the target cluster and get kubeconfig context
+2. Check out the target cluster and get the kubeconfig context:
 
 EKS cluster: `aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER`
 
@@ -74,13 +75,13 @@ AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
 
 `export KUBECONFIG_CONTEXT=$(kubectl config current-context)`
 
-3. Apply manifest yaml to target cluster
+3. Apply the `manifest.yaml` file to the target cluster:
 
-`kubectl use-context $KUBECONFIG_CONTEXT` (optional, previous aws/az command should already switch context)
+(optional, previous aws/az command should already switch context) `kubectl use-context $KUBECONFIG_CONTEXT`
 
 `kubectl apply -f manifest.yaml`
 
-You should see below logs:
+You should see the following logs:
 
 ```
  namespace/gke-install created
@@ -89,10 +90,10 @@ You should see below logs:
  deployment.apps/gke-multicloud-agent created
 ```
 
-4. Switch back to the GKE cluster with KCC installed
+4. Switch back to the GKE cluster with Config Connector installed:
 
-Run `kubectl config get-contexts` to see all context that configured, should be at least two contexts show up here:
-one associates to the target cluster, one associates to your GKE cluster with KCC installed.
+Run `kubectl config get-contexts` to see all configured contexts. You should see at least two contexts:
+one associated with the target cluster, and one associated with the GKE cluster with Config Connector installed.
 
 Run `kubectl config use-context GKE_CONTEXT` to switch back to the GKE context.
 

--- a/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
@@ -6,6 +6,8 @@
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
 
+Note: Before using this resource, make sure you review and complete the steps in Prerequisites section.
+
 <table>
 <thead>
 <tr>
@@ -49,6 +51,50 @@
 </tr>
 </tbody>
 </table>
+
+## Prerequisites
+We need to prepare the target cluster to be attached to make sure the Multi-cloud service connects to the target cluster.
+That requires an install-agent to be deployed into the target cluster.
+
+Steps to deploy the install-agent into target cluster:
+
+1. Get the manifest yaml file for the install-agent
+
+`gcloud container attached clusters generate-install-manifest my-cluster  --location=GOOGLE_CLOUD_REGION --platform-version=PLATFORM_VERSION --output-file=manifest.yaml`
+
+Example command:
+
+`gcloud container attached clusters generate-install-manifest kcc-attached-cluster  --location=us-west1 --platform-version=1.25.0-gke.5 --output-file=manifest.yaml`
+
+2. Checkout the target cluster and get kubeconfig context
+
+EKS cluster: `aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER`
+
+AKS cluster: `az aks get-credentials -n $CLUSTER -g $AZURE_RESOURCE_GROUP`
+
+`export KUBECONFIG_CONTEXT=$(kubectl config current-context)`
+
+3. Apply manifest yaml to target cluster
+
+`kubectl use-context $KUBECONFIG_CONTEXT` (optional, previous aws/az command should already switch context)
+
+`kubectl apply -f manifest.yaml`
+
+You should see below logs:
+
+```
+ namespace/gke-install created
+ serviceaccount/gke-install-agent created
+ clusterrolebinding.rbac.authorization.k8s.io/multicloud-install-agent-admin created
+ deployment.apps/gke-multicloud-agent created
+```
+
+4. Switch back to the GKE cluster with KCC installed
+
+Run `kubectl config get-contexts` to see all context that configured, should be at least two contexts show up here:
+one associates to the target cluster, one associates to your GKE cluster with KCC installed.
+
+Run `kubectl config use-context GKE_CONTEXT` to switch back to the GKE context.
 
 {{template "resource.tmpl" .}}
 {{template "endnote.tmpl" .}}


### PR DESCRIPTION
### Change description

As a follow up of https://cnrm-review.git.corp.google.com/c/cnrm/+/65520, add missing prerequisites info to attached cluster resource public doc.

Fixes b/302729344

### Tests you have done

No test needed, this is doc update.


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
