### PR TITLE
Update test configuration to use new test EKS cluster

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/create.yaml
@@ -25,7 +25,7 @@ spec:
   description: "Test attached cluster"
   distribution: "eks"
   oidcConfig:
-    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/917F5DD7A27C5CA2B2B626B94C0752B37
+    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/17F5DD7A27C5CA2B2B626B94C0752B37
   platformVersion: 1.25.0-gke.5
   fleet:
     projectRef:

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/create.yaml
@@ -25,7 +25,7 @@ spec:
   description: "Test attached cluster"
   distribution: "eks"
   oidcConfig:
-    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/92DAEF534054AF3146823C35D9F14010
+    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/917F5DD7A27C5CA2B2B626B94C0752B37
   platformVersion: 1.25.0-gke.5
   fleet:
     projectRef:

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedcluster/update.yaml
@@ -25,7 +25,7 @@ spec:
   description: "Test attached cluster update"
   distribution: "eks"
   oidcConfig:
-    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/92DAEF534054AF3146823C35D9F14010
+    issuerUrl: https://oidc.eks.us-west-2.amazonaws.com/id/17F5DD7A27C5CA2B2B626B94C0752B37
   platformVersion: 1.25.0-gke.5
   fleet:
     projectRef:


### PR DESCRIPTION
### Change description

The previous test EKS cluster created under partner team account got deleted by the Janitor job. To avoid this, we need to specify a "do not delete" tag when creating AWS resources.

In this task, I created a new EKS cluster with the same cluster name, deployed the install-agent into that cluster, need to update the configuration in KCC test yaml file to make sure it's using the newly created EKS cluster. Otherwise test will fail because previous EKS cluster no longer exists.

Fixes b/303108135

### Tests you have done
Dynamic test passed: https://screenshot.googleplex.com/ASJgop8f77GmEZd.png

Commands:
`source scripts/shared-vars-public.sh`
export env variables if there's any
`go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests containerattached -timeout 900s`

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
