### PR TITLE
Fix "certificate" typo in description

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagercertificatemapentries.certificatemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagercertificatemapentries.certificatemanager.cnrm.cloud.google.com.yaml
@@ -102,7 +102,7 @@ spec:
                   selecting a proper certificate.
                 type: string
               mapRef:
-                description: A map entry that is inputted into the cetrificate map.
+                description: A map entry that is inputted into the certificate map.
                 oneOf:
                 - not:
                     required:
@@ -306,7 +306,7 @@ spec:
                   selecting a proper certificate.
                 type: string
               mapRef:
-                description: A map entry that is inputted into the cetrificate map.
+                description: A map entry that is inputted into the certificate map.
                 oneOf:
                 - not:
                     required:

--- a/config/servicemappings/certificatemanager.yaml
+++ b/config/servicemappings/certificatemanager.yaml
@@ -120,7 +120,7 @@ spec:
         - tfField: map
           key: mapRef
           description: |-
-            A map entry that is inputted into the cetrificate map.
+            A map entry that is inputted into the certificate map.
           gvk:
             kind: CertificateManagerCertificateMap
             version: v1beta1

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemapentry_types.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemapentry_types.go
@@ -48,7 +48,7 @@ type CertificateManagerCertificateMapEntrySpec struct {
 	// +optional
 	Hostname *string `json:"hostname,omitempty"`
 
-	/* A map entry that is inputted into the cetrificate map. */
+	/* A map entry that is inputted into the certificate map. */
 	MapRef v1alpha1.ResourceRef `json:"mapRef"`
 
 	/* Immutable. A predefined matcher for particular cases, other than SNI selection. */

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagercertificatemapentry.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagercertificatemapentry.md
@@ -183,7 +183,7 @@ selecting a proper certificate.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}A map entry that is inputted into the cetrificate map.{% endverbatim %}</p>
+            <p>{% verbatim %}A map entry that is inputted into the certificate map.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
This makes it into the docs.
