### PR TITLE
Mark CertificateManager group as supported in mockgcp

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -291,38 +291,30 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 	if os.Getenv("E2E_GCP_TARGET") == "mock" {
 		for _, resource := range resources {
 			gvk := resource.GroupVersionKind()
-			switch gvk.GroupKind() {
-			case schema.GroupKind{Group: "certificatemanager.cnrm.cloud.google.com", Kind: "CertificateManagerCertificate"}:
-			case schema.GroupKind{Group: "certificatemanager.cnrm.cloud.google.com", Kind: "CertificateManagerCertificateMap"}:
-			case schema.GroupKind{Group: "certificatemanager.cnrm.cloud.google.com", Kind: "CertificateManagerDNSAuthorization"}:
-				// ok
 
+			switch gvk.Group {
+			case "certificatemanager.cnrm.cloud.google.com":
+				continue
+			}
+
+			switch gvk.GroupKind() {
 			case schema.GroupKind{Group: "cloudfunctions.cnrm.cloud.google.com", Kind: "CloudFunctionsFunction"}:
-				// ok
 
 			case schema.GroupKind{Group: "containerattached.cnrm.cloud.google.com", Kind: "ContainerAttachedCluster"}:
-				// ok
 
 			case schema.GroupKind{Group: "iam.cnrm.cloud.google.com", Kind: "IAMServiceAccount"}:
-				// ok
 
 			case schema.GroupKind{Group: "networkservices.cnrm.cloud.google.com", Kind: "NetworkServicesMesh"}:
-				// ok
 
 			case schema.GroupKind{Group: "privateca.cnrm.cloud.google.com", Kind: "PrivateCACAPool"}:
-				// ok
 
 			case schema.GroupKind{Group: "secretmanager.cnrm.cloud.google.com", Kind: "SecretManagerSecret"}:
-				// ok
 			case schema.GroupKind{Group: "secretmanager.cnrm.cloud.google.com", Kind: "SecretManagerSecretVersion"}:
-				// ok
 
 			case schema.GroupKind{Group: "", Kind: "Secret"}:
-				// ok
 
 			case schema.GroupKind{Group: "serviceusage.cnrm.cloud.google.com", Kind: "Service"}:
 			case schema.GroupKind{Group: "serviceusage.cnrm.cloud.google.com", Kind: "ServiceIdentity"}:
-				// ok
 
 			default:
 				t.Skipf("gk %v not suppported by mock gcp; skipping", gvk.GroupKind())

--- a/mockgcp/mockcertificatemanager/names.go
+++ b/mockgcp/mockcertificatemanager/names.go
@@ -119,3 +119,36 @@ func (s *MockService) parseDNSAuthorizationName(name string) (*dnsAuthorizationN
 		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
 	}
 }
+
+type certificateMapEntryName struct {
+	Project                 *projects.ProjectData
+	Location                string
+	CertificateMap          string
+	CertificateMapEntryName string
+}
+
+func (n *certificateMapEntryName) String() string {
+	return "projects/" + n.Project.ID + "/locations/" + n.Location + "/certificateMaps/" + n.CertificateMap + "/certificateMapEntries/" + n.CertificateMapEntryName
+}
+
+func (s *MockService) parseCertificateMapEntryName(name string) (*certificateMapEntryName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "certificateMaps" && tokens[6] == "certificateMapEntries" {
+		project, err := s.projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &certificateMapEntryName{
+			Project:                 project,
+			Location:                tokens[3],
+			CertificateMap:          tokens[5],
+			CertificateMapEntryName: tokens[7],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}


### PR DESCRIPTION
We can start to mark whole groups as being supported now in mockgcp, rather than doing it for each type.