### PR TITLE
Add missing info into Add new resource through TF doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ operator/config/autopilot-manager/manager_image_patch.yaml
 
 # Test binary, build with 'go test -c'
 *.test
+*.build
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,21 @@ can run it locally on your dev machine with the steps below.
     down the replica to 0.
 2.  Run `make run` and inspect the output logs.
 
+#### Test your changes
+
+If you are adding a new resource, you need to follow the steps in [NewResourceFromTerraform.md](NewResourceFromTerraform.md)
+to make code changes, add test data, and run the tests for your resource.
+
+If you are working on a existing resource, test yaml should exist under
+./pkg/test/resourcefixture/testdata/basic, you can run the test command directly
+to make sure the test can still pass. Example command:
+
+```bash
+   # Export the environment variables needed in the dynamic tests if you haven't done it.
+   TEST_FOLDER_ID=123456789 go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests cloudschedulerjob -timeout 900s
+ ```
+Replace `cloudschedulerjob` with your test target.
+
 ### Submit a Pull Request
 
 At this point you already knows how to make changes and verify it in your local

--- a/README.ConfigureResourceReferences.md
+++ b/README.ConfigureResourceReferences.md
@@ -148,7 +148,7 @@ Here is an example configuration:
 
 1.  `tfField`: TF field which references a GCP resource. In the above
     example, it's `disk.source_snapshot_encryption_key.kms_key_service_account`.
-    Note that it is snack case, and it should be a path if it has parent fields.
+    Note that it is snake case, and it should be a path if it has parent fields.
 1.  `description`: description of the tfField, can be found in the
     [Terraform documentation](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs).
     If the referenced KCC kind is not supported, prepend `Only external field is

--- a/README.ConfigureResourceReferences.md
+++ b/README.ConfigureResourceReferences.md
@@ -1,0 +1,185 @@
+# Overview
+
+The following guidelines will help you identify potential reference fields and
+configure them in service mappings.
+
+## What is a reference field?
+
+In KCC, we have the concept of
+[resource references](https://cloud.google.com/config-connector/docs/how-to/creating-resource-references).
+Users can specify the value of a resource reference field by referencing other
+resources.
+
+A reference field is a field whose value is coming from another GCP resource.
+The common cases of such values are:
+
+*   Resource ID of another GCP resource
+*   Relative resource name of another GCP resource
+*   Self link of another GCP resource
+*   A service-generated value of another GCP resource
+
+## Identify which fields should be turned into reference fields
+
+You might already look at the
+[Terraform resource documentation](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs)
+when researching the resource. You can also take a look at the API documentation
+if needed.
+
+For example, to learn the fields in PubSubTopic, you will need to go through the
+fields under Arguments Reference section in
+[google_pubsub_topic](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/pubsub_topic),
+and you may need check the
+[REST API doc](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics)
+and the
+[tutorial doc](https://cloud.google.com/pubsub/docs/create-topic#managing_topics).
+
+After you have a basic understanding of the fields for the target resource, some
+approaches would help you identify whether the field is mapping to a GCP
+resource.
+
+1.  In the GCP tutorial for the target resource, if another GCP resource is
+    required before creating the target resource, and if the value of a field in
+    the other GCP resource is needed when creating the target resource, then we
+    know the field is likely a reference field. Note down the field name and the
+    other GCP resource name.
+1.  In the TF sample for the target resource, if the value of a field is an
+    attribute reference of another TF resource, then we know the field is likely
+    a reference field. Note down the field name and the other TF resource type
+    name. E.g. the `key_ring` fields mentioned in the
+    [cmek sample for PubSubTopic](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/pubsub_topic#example-usage---pubsub-topic-cmek).
+1.  Be aware of field name mentioning: `name`, `id`, `link`, `email`,
+    `service_account`, resource names under the same API of the target resource,
+    or field description mentioning `refer`, `GCP`/`google`/`cloud` resources,
+    `url`, `uri`, etc. Once you see these keywords, it's very likely that this
+    field references to gcp resource. Double-check the GCP tutorial and/or TF
+    documentation to confirm.
+
+Figure out the referenced GCP resource through reading the field description. If
+you are still unsure, contact the API team for more information. Once it's
+determined, note down the field name and the referenced GCP resource name.
+
+## Identify whether the referenced resource is TF-based or DCL-based
+
+### Turn GCP resource name or TF type name into KCC kind name
+
+Before moving on, you need to turn the referenced TF type/GCP resource names
+you've noted down into KCC kind names. Ask the KCC team for help if you still
+can't figure them out with the following instructions.
+
+1.  If you know the TF type name, you can do project-scoped search in your local
+    repository with the TF type name. If you find a hit in a service mapping
+    yaml file (under either the `config/servicemappings/` folder or the
+    `scripts/resource-autogen/generated/servicemappings/`), the corresponding
+    `kind` field in the same resource config should be the KCC kind.
+
+1.  If you know the GCP resource name, you can either use the search widget to
+    find the corresponding TF type in
+    [Terraform doc](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs)
+    with the GCP resource name, then figure out the KCC kind name following the
+    step above; or you can use the search widget to find the corresponding KCC
+    kind directly in
+    [KCC reference doc](https://cloud.google.com/config-connector/docs/reference/overview).
+
+1.  If you can't find a KCC kind with the steps above, it's possible that the
+    referenced resource is not supported in KCC. Reach out to the KCC team is
+    you are unsure. If you've determined that the KCC kind is not supported in
+    KCC, skip the next couple of sections and go to
+    [Configure reference resource in the service mappings](#configure-reference-in-the-service-mappings).
+
+### Determine whether the referenced resource is TF-based or DCL-based
+
+Based on the KCC kind names of the references you figured above, follow the
+steps to identify the referenced resource is DCL or TF based.
+
+1.  Search for the KCC kind name of the referenced resource on the
+    [crds folder](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/master/crds).
+
+1.  Open the CRD file containing the KCC kind name, search for `dcl2crd` and
+    `tf2crd` labels (only one should exist for a particular CRD).
+
+    1.  If `cnrm.cloud.google.com/dcl2crd: "true"` is found, then it is a
+        DCL-based resource.
+
+    1.  If `cnrm.cloud.google.com/tf2crd: "true"` is found, then it is a
+        TF-based resource.
+
+## Identify whether the reference field is a string field or a field of other types (list, etc)
+
+Check the TF schema of the target resource in the TF provider to determine the
+type of the reference field. The URL of file is in the format of
+`https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/services/[servicename]/resource_[tf_type_name_without_google_prefix].go`.
+You can find a `Type` field for each argument, and two most common types are
+`schema.TypeString` and `schema.TypeList`.
+
+1.  If the field is a string, follow
+    [Configure reference resource in the service mappings](#configure-reference-in-the-service-mappings)
+    to continue configuring the resource reference.
+1.  If the field is a list:
+
+    1.  If the field is not required, mark it as an ignored field following
+        [this example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/b746248cd5a9b30669380513de8fdc6b4c43018d/config/servicemappings/cloudbuild.yaml#L204).
+    1.  If the field is required, reach out to the KCC team for further
+        discussion.
+
+1.  If the field is neither a string nor a list, reach out to the KCC team for
+    further discussion.
+
+## Configure reference resource in the service mappings
+
+Based on the information identified in above sections, configure the service
+mapping file by providing values for the required fields. Fields can be found in
+[service mapping types](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/b746248cd5a9b30669380513de8fdc6b4c43018d/pkg/apis/core/v1alpha1/servicemapping_types.go#L242)
+
+Here is an example configuration:
+```
+- tfField: disk.source_snapshot_encryption_key.kms_key_service_account
+  key: kmsKeyServiceAccountRef
+  description: |-
+    The service account being used for the encryption request for the
+    given KMS key. If absent, the Compute Engine default service account
+    is used.
+  gvk:
+    kind: IAMServiceAccount
+    version: v1beta1
+    group: iam.cnrm.cloud.google.com
+  targetField: email
+```
+
+1.  `tfField`: TF field which has reference to other GCP resources. In above
+    example, it's `disk.source_snapshot_encryption_key.kms_key_service_account`.
+    Note that it is snack case, and it should be a path if it has parent fields.
+1.  `description`: description of the tfField, can be found in the
+    [Terraform documentation](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs).
+    If the referenced KCC kind is not supported, prepend `Only external field is
+    supported to configure the reference.` and a newline in the description.
+    Here is an
+    [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/b746248cd5a9b30669380513de8fdc6b4c43018d/config/servicemappings/cloudbuild.yaml#L135).
+1.  `key`: the key of the resource being referenced, the convention is to name
+    it as `{tfFieldNameInCamelCase}Ref`. Note here we only need the TF field
+    name, no need to include parent fields. Example name:
+    `kmsKeyServiceAccountRef`.
+1.  `targetField`: the referenced resource's Terraform field that will be
+    extracted and set as the value of the tfField. In the example above, the
+    value of the TF field
+    `disk.source_snapshot_encryption_key.kms_key_service_account` (whose
+    corresponding field
+    `spec.disk.sourceSnapshotEncryptionKey.KmsKeyServiceAccountRef` is a
+    reference field in KCC) should be the value of the TF field `email` in the
+    corresponding TF type of the `IAMServiceAccount` KCC kind.
+1.  `gvk`: Group,Version,Kind of the resource being referenced. Note that an
+    alpha only resource cannot be referenced from a v1beta1 resource. After
+    an alpha resource is promoted to beta, we can reference to the beta
+    version of the resource.
+
+    To identify alpha resources that should not be referenced by a stable
+    v1beta1 resource:
+
+    1.  Check the CRD of the referenced resource in
+        [crds folder](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/master/crds).
+    1.  Search for the value of `cnrm.cloud.google.com/stability-level` in the
+        CRD, if it is `alpha`, then it is an alpha resource; otherwise, it
+        contains a stable v1beta1 version.
+
+1.  `dclBasedResource`: set to `true` if the referenced resource is a DCL-based
+    resource; Do not need to set this field if it not a DCL-based resource (just
+    like the example).

--- a/README.ConfigureResourceReferences.md
+++ b/README.ConfigureResourceReferences.md
@@ -5,12 +5,11 @@ configure them in service mappings.
 
 ## What is a reference field?
 
-In KCC, we have the concept of
-[resource references](https://cloud.google.com/config-connector/docs/how-to/creating-resource-references).
-Users can specify the value of a resource reference field by referencing other
-resources.
+Config Connector uses the concept of
+[resource references](https://cloud.google.com/config-connector/docs/how-to/creating-resource-references),
+which lets you specify the value of a resource reference field by referencing other resources.
 
-A reference field is a field whose value is coming from another GCP resource.
+A reference field is a field whose value comes from another Google Cloud resource.
 The common cases of such values are:
 
 *   Resource ID of another GCP resource
@@ -20,51 +19,51 @@ The common cases of such values are:
 
 ## Identify which fields should be turned into reference fields
 
-You might already look at the
+You want to look at the
 [Terraform resource documentation](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs)
-when researching the resource. You can also take a look at the API documentation
+when researching the resource. You can also look at the API documentation
 if needed.
 
-For example, to learn the fields in PubSubTopic, you will need to go through the
-fields under Arguments Reference section in
+For example, to learn the fields in PubSubTopic, you should check the
+fields under the Arguments Reference section in
 [google_pubsub_topic](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/pubsub_topic),
-and you may need check the
+You might also need to check the
 [REST API doc](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics)
 and the
 [tutorial doc](https://cloud.google.com/pubsub/docs/create-topic#managing_topics).
 
-After you have a basic understanding of the fields for the target resource, some
-approaches would help you identify whether the field is mapping to a GCP
-resource.
+After you have a basic understanding of the fields for the target resource, these
+approaches can help you identify whether the field maps to a Google Cloud
+resource:
 
 1.  In the GCP tutorial for the target resource, if another GCP resource is
     required before creating the target resource, and if the value of a field in
-    the other GCP resource is needed when creating the target resource, then we
-    know the field is likely a reference field. Note down the field name and the
+    the other GCP resource is needed when creating the target resource, then
+    the field is likely a reference field. Make a note of the field name and the
     other GCP resource name.
 1.  In the TF sample for the target resource, if the value of a field is an
-    attribute reference of another TF resource, then we know the field is likely
-    a reference field. Note down the field name and the other TF resource type
-    name. E.g. the `key_ring` fields mentioned in the
+    attribute reference of another TF resource, then the field is likely
+    a reference field. Make a note of the field name and the other TF resource type
+    name, for example the `key_ring` fields mentioned in the
     [cmek sample for PubSubTopic](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/pubsub_topic#example-usage---pubsub-topic-cmek).
-1.  Be aware of field name mentioning: `name`, `id`, `link`, `email`,
+1.  If the field name includes: `name`, `id`, `link`, `email`,
     `service_account`, resource names under the same API of the target resource,
-    or field description mentioning `refer`, `GCP`/`google`/`cloud` resources,
-    `url`, `uri`, etc. Once you see these keywords, it's very likely that this
-    field references to gcp resource. Double-check the GCP tutorial and/or TF
-    documentation to confirm.
+    or field descriptions include `refer`, `GCP`/`google`/`cloud` resources,
+    `url`, `uri`, and so on. These keywords indicate it's likely that these
+    fields reference Google Cloud resources. Double-check the Google Cloud tutorial
+    and the Terraform documentation to confirm.
 
-Figure out the referenced GCP resource through reading the field description. If
-you are still unsure, contact the API team for more information. Once it's
-determined, note down the field name and the referenced GCP resource name.
+Figure out the referenced GCP resource through reading the field description.
+Once it's determined, note down the field name and the referenced GCP resource name.
 
 ## Identify whether the referenced resource is TF-based or DCL-based
 
 ### Turn GCP resource name or TF type name into KCC kind name
 
-Before moving on, you need to turn the referenced TF type/GCP resource names
-you've noted down into KCC kind names. Ask the KCC team for help if you still
-can't figure them out with the following instructions.
+Before you can identify what the resource is based on, you must convert
+the Google Cloud resource name or Terraform type name into a
+Config Connector kind name. Create a Github question in this repo for help
+if you still can't find the Config Connector kind name after following these steps:
 
 1.  If you know the TF type name, you can do project-scoped search in your local
     repository with the TF type name. If you find a hit in a service mapping
@@ -75,36 +74,38 @@ can't figure them out with the following instructions.
 1.  If you know the GCP resource name, you can either use the search widget to
     find the corresponding TF type in
     [Terraform doc](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs)
-    with the GCP resource name, then figure out the KCC kind name following the
-    step above; or you can use the search widget to find the corresponding KCC
-    kind directly in
+    with the GCP resource name. Then you can find the KCC kind name by following
+    the first step above. Alternatively, you can use the search widget to find the
+    corresponding KCC kind directly in
     [KCC reference doc](https://cloud.google.com/config-connector/docs/reference/overview).
 
 1.  If you can't find a KCC kind with the steps above, it's possible that the
-    referenced resource is not supported in KCC. Reach out to the KCC team is
-    you are unsure. If you've determined that the KCC kind is not supported in
-    KCC, skip the next couple of sections and go to
+    referenced resource is not supported in KCC. Create a Github question in this repo
+    to clarify. If you've determined that the KCC kind is not supported in
+    KCC, skip ahead to
     [Configure reference resource in the service mappings](#configure-reference-in-the-service-mappings).
 
-### Determine whether the referenced resource is TF-based or DCL-based
+### Determine whether the referenced resource is TF-based(Terraform) or DCL-based(Declarative Client Library)
 
-Based on the KCC kind names of the references you figured above, follow the
-steps to identify the referenced resource is DCL or TF based.
+Based on the KCC kind names of the references that you identified above, follow these
+steps to identify if the referenced resource is DCL or TF-based:
 
 1.  Search for the KCC kind name of the referenced resource on the
     [crds folder](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/master/crds).
 
-1.  Open the CRD file containing the KCC kind name, search for `dcl2crd` and
-    `tf2crd` labels (only one should exist for a particular CRD).
+1.  Open the CRD file containing the KCC kind name. Search for `dcl2crd` and
+    `tf2crd` labels. There should be only one label for each CRD.
 
-    1.  If `cnrm.cloud.google.com/dcl2crd: "true"` is found, then it is a
+    1.  If the resource has the `cnrm.cloud.google.com/dcl2crd: "true"` label, it's a
         DCL-based resource.
 
-    1.  If `cnrm.cloud.google.com/tf2crd: "true"` is found, then it is a
+    1.  If the resource has the `cnrm.cloud.google.com/tf2crd: "true"` label, it's a
         TF-based resource.
 
-## Identify whether the reference field is a string field or a field of other types (list, etc)
+## Identify the reference field type
 
+Next, you identify the type of the reference field. In most cases,
+the reference field is a string field, but could be another type like a list.
 Check the TF schema of the target resource in the TF provider to determine the
 type of the reference field. The URL of file is in the format of
 `https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/services/[servicename]/resource_[tf_type_name_without_google_prefix].go`.
@@ -118,15 +119,15 @@ You can find a `Type` field for each argument, and two most common types are
 
     1.  If the field is not required, mark it as an ignored field following
         [this example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/b746248cd5a9b30669380513de8fdc6b4c43018d/config/servicemappings/cloudbuild.yaml#L204).
-    1.  If the field is required, reach out to the KCC team for further
-        discussion.
+    1.  If the field is required, create a Github question in this repo for
+        further discussion.
 
-1.  If the field is neither a string nor a list, reach out to the KCC team for
-    further discussion.
+1.  If the field isn't a string or a list, create a Github question in this repo
+    for further discussion.
 
 ## Configure reference resource in the service mappings
 
-Based on the information identified in above sections, configure the service
+Based on the information identified in the above sections, configure the service
 mapping file by providing values for the required fields. Fields can be found in
 [service mapping types](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/b746248cd5a9b30669380513de8fdc6b4c43018d/pkg/apis/core/v1alpha1/servicemapping_types.go#L242)
 
@@ -145,7 +146,7 @@ Here is an example configuration:
   targetField: email
 ```
 
-1.  `tfField`: TF field which has reference to other GCP resources. In above
+1.  `tfField`: TF field which references a GCP resource. In the above
     example, it's `disk.source_snapshot_encryption_key.kms_key_service_account`.
     Note that it is snack case, and it should be a path if it has parent fields.
 1.  `description`: description of the tfField, can be found in the

--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -197,11 +197,15 @@ ServiceMappings file. Add the `ResourceConfig` for your resource:
         - remove_default_node_pool
     ```
 
-1. Add `mutableButUnreadableFields` if necessary. Fields may not be existent in the underlying GCP resource,
+1. Add `mutableButUnreadableFields` if necessary. Fields may not exist in the underlying GCP resource,
    but are returned by Terraform on read and it's mutable. We need to add them into the `mutableButUnreadableFields`
    list in the service mapping. The difference between `mutableButUnreadableFields` and `directives` is,
-   The `mutableButUnreadableFields` fields will still be a part of resource CDR spec, they are unreadable but the 
-   value of the fields can be modified.
+   The `mutableButUnreadableFields` fields will still be a part of resource CRD spec, they are unreadable but the 
+   value of the fields can be modified. Similarly, you'll need to look at Terraform resource documentation,
+   Google Cloud API documentation, and the [pkg/apis/core/servicemapping_types](pkg/apis/core/servicemapping_types)
+   documentation to determine if any fields are `mutableButUnreadableFields`. An example is `password` field. It is
+   mutable because users may update their password through the API. However, GCP resource usually will not return the
+   `password` value for security considerations.
 
    ```yaml
     - name: google_container_cluster
@@ -411,7 +415,6 @@ section under the Appendix.
 
     ```bash
        # Export the environment variables needed in the dynamic tests if you haven't done it.
-       source scripts/shared-vars.sh
        TEST_FOLDER_ID=123456789 go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests cloudschedulerjob -timeout 900s
     ```
 
@@ -575,7 +578,7 @@ go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -ru
 ```
 Replace the environment variables to real values before running the tests.
 
-Prow job will automatically run these tests in a newly created project. If this is
+The sample tests will be run periodically in a newly created project through internal CI/CD pipeline. If this is
 not feasible for your resource, for example, your resource requires a custom project with special setup,
 you can skip the test by adding it to the
 `testDisabledList` map in

--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -197,6 +197,34 @@ ServiceMappings file. Add the `ResourceConfig` for your resource:
         - remove_default_node_pool
     ```
 
+1. Add `mutableButUnreadableFields` if necessary. Fields may not be existent in the underlying GCP resource,
+   but are returned by Terraform on read and it's mutable. We need to add them into the `mutableButUnreadableFields`
+   list in the service mapping. The difference between `mutableButUnreadableFields` and `directives` is,
+   The `mutableButUnreadableFields` fields will still be a part of resource CDR spec, they are unreadable but the 
+   value of the fields can be modified.
+
+   ```yaml
+    - name: google_container_cluster
+      kind: ContainerCluster
+      ...
+      mutableButUnreadableFields:
+         - min_master_version
+    ```
+
+1. Add `ignoredFields` if necessary. Fields can't be supported or will result in the suboptimal UX (e.g.
+   multi-kind reference in the legacy style) due to lack of feature support, and we need to ignore the fields right now:
+   Add the fields into the `ignoredFields` list in the service mapping, file a GitHub issue to support this field,
+   and add a TODO with the issue ID right above the entry in the ignoredFields list.
+
+    ```yaml
+    - name: google_container_cluster
+      kind: ContainerCluster
+      ...
+      ignoredFields:
+          # TODO: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/000
+          - node_pool
+    ```
+
 1.  Fill out the `resourceAvailableInAssetInventory`. Set to false.
 
 1.  Add `hierarchicalReferences` if they exist. Determine if the corresonding
@@ -242,6 +270,17 @@ ServiceMappings file. Add the `ResourceConfig` for your resource:
 
 1.  Run `make manifests`.
 1.  Run `git status`. Verify that there is a new CRD in `config/crds`.
+
+Note that you need to run `make manifests` every time when you update the service mapping file, and check the crd has 
+been updated accordingly. 
+
+### Run Unit Tests
+
+```
+make test
+```
+
+Ensure all tests pass.
 
 # Add the Service to Testing and Release
 
@@ -336,14 +375,45 @@ section under the Appendix.
 
 ## Run Tests
 
-1.  Run your newly added resource's test cases in `pkg/controller/dynamic`,
-    replacing `spannerinstance` with the name of your resource:
+1.  Set `[test-target]` to the kind (in all lower-case letters) in the following
+    command to run all the tests for your resource.
+
+    ```bash
+    go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests [test-target] -timeout 900s
+    ```
+
+    If you have multiple test cases and just want
+    to run a single test case of your resource, you can set `[test-target]` to a
+    specific test case folder name. For example:
 
     ```
-    go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests spannerinstance
+    pkg/test/resourcefixture/testdata/basic
+    ├── pubsub
+    |   ├── v1beta1
+    |       ├── pubsubsubscription
+    |           ├── basicpubsubsubscription
+    |               └── create.yaml
+    |               └── dependencies.yaml
+    |               └── update.yaml
+    |           ├── bigquerypubsubsubscription
+    |               └── create.yaml
+    |               └── dependencies.yaml
+    |               └── update.yaml
     ```
 
-    Ensure they are successful.
+    ```bash
+    go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests basicpubsubsubscription -timeout 900s
+    ```
+
+1.  If the dynamic test data contains constant placeholder
+    strings, e.g. "TEST_FOLDER_ID", you need to set them as env variables
+    first as follows:
+
+    ```bash
+       # Export the environment variables needed in the dynamic tests if you haven't done it.
+       source scripts/shared-vars.sh
+       TEST_FOLDER_ID=123456789 go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests cloudschedulerjob -timeout 900s
+    ```
 
 ## Optionally Add the Resource to Test Contexts
 
@@ -394,6 +464,11 @@ To disable the acquire and update test:
 If the test takes more than 10 minutes to finish, add it to
 LONG_RUNNING_CRUD_TESTS_REGEX in
 [./scripts/shared-vars-public.sh](./scripts/shared-vars-public.sh).
+
+## Optionally enable GCP services API endpoints
+
+Check the SUPPORTED_SERVICES in [./scripts/shared-vars-public.sh](./scripts/shared-vars-public.sh)
+to make sure the GCP services for your resource is in the list, if not, you need to add it into the list.
 
 ## Resource skeleton test cases
 
@@ -488,6 +563,24 @@ samples are created for that resource.
 1.  Follow the sample guidelines [here](README.Samples.md) and create sample(s)
     for the resource.
 
+## Run/Disable Sample Tests
+
+In addition to the integration tests run using
+[pkg/test/testdata/resourcefixture](pkg/test/testdata/resourcefixture), KCC has
+tests for resource samples. These tests can be run manually as follows (example
+given is for one of CloudSchedulerJob's samples):
+
+```bash
+go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests scheduler-job-pubsub
+```
+Replace the environment variables to real values before running the tests.
+
+Prow job will automatically run these tests in a newly created project. If this is
+not feasible for your resource, for example, your resource requires a custom project with special setup,
+you can skip the test by adding it to the
+`testDisabledList` map in
+[config/tests/samples/create/samples_test.go](config/tests/samples/create/samples_test.go).
+
 ## Cloud Code Snippets
 
 We have a script that generates snippet files for Cloud Code using our samples.
@@ -506,6 +599,11 @@ update to date, we need to add the new CRDs and samples to existing doc.
     [scripts/generate-google3-docs/resource-reference/templates](scripts/generate-google3-docs/resource-reference/templates),
     and name it like `spanner_spannerinstance.tmpl`, (i.e.,
     <service>_<kind>.tmpl).
+1.  Some resources need additional messages in the doc, for example, in
+    [BigQueryDataset](https://cloud.google.com/config-connector/docs/reference/resource-docs/bigquery/bigquerydataset)
+    there's a warning message. If you want to add message for your resource, similar to
+    [bigquery_bigquerydataset.tmpl](scripts/generate-google3-docs/resource-reference/templates/bigquery_bigquerydataset.tmpl),
+    add the message into the tmpl file.
 1.  Change the values for "Service name" (there are **two**, one for 'Google
     Cloud Service Name' and one for 'Config Connector Service Name'), "Service
     Documentation", "REST Resource Name", and "REST Resource Documentation"

--- a/README.UpdatingTerraformProvider.md
+++ b/README.UpdatingTerraformProvider.md
@@ -35,10 +35,10 @@
         1.  (Optional) Consider adding the reference fields in testdata and
             samples if it is an important ask from users or belongs to a
             core user case.
-    1.  Fields may not be existent in the underlying GCP resource, and we need
+    1.  Fields may not exist in the underlying GCP resource, and we need
         to turn them into directives: Add the fields into the `directives` list
         in the service mapping. `directives` fields do not exist in resource CRD.
-    1.  Fields may not be existent in the underlying GCP resource, but are returned
+    1.  Fields may not exist in the underlying GCP resource, but are returned
         by Terraform on read, we need to add them into the `mutableButUnreadableFields`
         list in the service mapping. The fields are unreadable but the spec value of
         the fields can be modified.

--- a/README.UpdatingTerraformProvider.md
+++ b/README.UpdatingTerraformProvider.md
@@ -37,7 +37,11 @@
             core user case.
     1.  Fields may not be existent in the underlying GCP resource, and we need
         to turn them into directives: Add the fields into the `directives` list
-        in the service mapping.
+        in the service mapping. `directives` fields do not exist in resource CRD.
+    1.  Fields may not be existent in the underlying GCP resource, but are returned
+        by Terraform on read, we need to add them into the `mutableButUnreadableFields`
+        list in the service mapping. The fields are unreadable but the spec value of
+        the fields can be modified.
     1.  Fields can't be supported or will result in the suboptimal UX (e.g.
         multi-kind reference in the legacy style) due to lack of feature
         support, and we need to ignore the fields right now: Add the fields into


### PR DESCRIPTION
### Change description

Add missing info into Add new resource through TF doc

Fixes b/301450585

### Tests you have done

Doc update, no e2e test is needed.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
