### PR TITLE
Patch the change to send SdkPipeline parameters via environment fields in DataflowFlexTemplateJob

### DIFF
--- a/hack/terraform-overrides/dataflow_flex_template_job_environment_fields.patch
+++ b/hack/terraform-overrides/dataflow_flex_template_job_environment_fields.patch
@@ -1,0 +1,372 @@
+diff --git a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+index f96b5dbed..f03427d07 100644
+--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
++++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+@@ -6,6 +6,7 @@ import (
+ 	"context"
+ 	"fmt"
+ 	"log"
++	"strconv"
+ 	"strings"
+ 	"time"
+ 
+@@ -111,6 +112,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 				Optional: true,
+ 				// ForceNew applies to both stream and batch jobs
+ 				ForceNew:    true,
++				Computed:    true,
+ 				Description: `The initial number of Google Compute Engine instances for the job.`,
+ 			},
+ 
+@@ -119,6 +121,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 				Optional: true,
+ 				// ForceNew applies to both stream and batch jobs
+ 				ForceNew:    true,
++				Computed:    true,
+ 				Description: `The maximum number of Google Compute Engine instances to be made available to your pipeline during execution, from 1 to 1000.`,
+ 			},
+ 
+@@ -146,12 +149,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 			"sdk_container_image": {
+ 				Type:        schema.TypeString,
+ 				Optional:    true,
++				Computed:    true,
+ 				Description: `Docker registry location of container image to use for the 'worker harness. Default is the container for the version of the SDK. Note this field is only valid for portable pipelines.`,
+ 			},
+ 
+ 			"network": {
+ 				Type:             schema.TypeString,
+ 				Optional:         true,
++				Computed:         true,
+ 				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+ 				Description:      `The network to which VMs will be assigned. If it is not provided, "default" will be used.`,
+ 			},
+@@ -159,6 +164,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 			"subnetwork": {
+ 				Type:             schema.TypeString,
+ 				Optional:         true,
++				Computed:         true,
+ 				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+ 				Description:      `The subnetwork to which VMs will be assigned. Should be of the form "regions/REGION/subnetworks/SUBNETWORK".`,
+ 			},
+@@ -166,12 +172,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 			"machine_type": {
+ 				Type:        schema.TypeString,
+ 				Optional:    true,
++				Computed:    true,
+ 				Description: `The machine type to use for the job.`,
+ 			},
+ 
+ 			"kms_key_name": {
+ 				Type:        schema.TypeString,
+ 				Optional:    true,
++				Computed:    true,
+ 				Description: `The name for the Cloud KMS key for the job. Key format is: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`,
+ 			},
+ 
+@@ -202,12 +210,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
+ 			"autoscaling_algorithm": {
+ 				Type:        schema.TypeString,
+ 				Optional:    true,
++				Computed:    true,
+ 				Description: `The algorithm to use for autoscaling`,
+ 			},
+ 
+ 			"launcher_machine_type": {
+ 				Type:        schema.TypeString,
+ 				Optional:    true,
++				Computed:    true,
+ 				Description: `The machine type to use for launching the job. The default is n1-standard-1.`,
+ 			},
+ 
+@@ -240,7 +250,7 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
+ 		return err
+ 	}
+ 
+-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
++	env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -249,7 +259,7 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
+ 		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
+ 			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
+ 			JobName:              d.Get("name").(string),
+-			Parameters:           tpgresource.ExpandStringMap(d, "parameters"),
++			Parameters:           updatedParameters,
+ 			Environment:          &env,
+ 		},
+ 	}
+@@ -275,29 +285,92 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
+ 	return resourceDataflowFlexTemplateJobRead(d, meta)
+ }
+ 
+-func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_tpg.Config) (dataflow.FlexTemplateRuntimeEnvironment, error) {
++func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_tpg.Config) (dataflow.FlexTemplateRuntimeEnvironment, map[string]string, error) {
++
++	updatedParameters := tpgresource.ExpandStringMap(d, "parameters")
+ 
+ 	additionalExperiments := tpgresource.ConvertStringSet(d.Get("additional_experiments").(*schema.Set))
+ 
++	var autoscalingAlgorithm string
++	autoscalingAlgorithm, updatedParameters = dataflowFlexJobTypeTransferVar("autoscaling_algorithm", "autoscalingAlgorithm", updatedParameters, d)
++
++	var numWorkers int
++	if p, ok := d.GetOk("parameters.numWorkers"); ok {
++		number, err := strconv.Atoi(p.(string))
++		if err != nil {
++			return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("parameters.numWorkers must have a valid integer assigned to it, current value is %s", p.(string))
++		}
++		delete(updatedParameters, "numWorkers")
++		numWorkers = number
++	} else {
++		if v, ok := d.GetOk("num_workers"); ok {
++			numWorkers = v.(int)
++		}
++	}
++
++	var maxNumWorkers int
++	if p, ok := d.GetOk("parameters.maxNumWorkers"); ok {
++		number, err := strconv.Atoi(p.(string))
++		if err != nil {
++			return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
++		}
++		delete(updatedParameters, "maxNumWorkers")
++		maxNumWorkers = number
++	} else {
++		if v, ok := d.GetOk("max_workers"); ok {
++			maxNumWorkers = v.(int)
++		}
++	}
++
++	network, updatedParameters := dataflowFlexJobTypeTransferVar("network", "network", updatedParameters, d)
++
++	serviceAccountEmail, updatedParameters := dataflowFlexJobTypeTransferVar("service_account_email", "serviceAccountEmail", updatedParameters, d)
++
++	subnetwork, updatedParameters := dataflowFlexJobTypeTransferVar("subnetwork", "subnetwork", updatedParameters, d)
++
++	tempLocation, updatedParameters := dataflowFlexJobTypeTransferVar("temp_location", "tempLocation", updatedParameters, d)
++
++	stagingLocation, updatedParameters := dataflowFlexJobTypeTransferVar("staging_location", "stagingLocation", updatedParameters, d)
++
++	machineType, updatedParameters := dataflowFlexJobTypeTransferVar("machine_type", "workerMachineType", updatedParameters, d)
++
++	kmsKeyName, updatedParameters := dataflowFlexJobTypeTransferVar("kms_key_name", "kmsKeyName", updatedParameters, d)
++
++	ipConfiguration, updatedParameters := dataflowFlexJobTypeTransferVar("ip_configuration", "ipConfiguration", updatedParameters, d)
++
++	var enableStreamingEngine bool
++	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
++		delete(updatedParameters, "enableStreamingEngine")
++		enableStreamingEngine = p.(bool)
++	} else {
++		if v, ok := d.GetOk("enable_streaming_engine"); ok {
++			enableStreamingEngine = v.(bool)
++		}
++	}
++
++	sdkContainerImage, updatedParameters := dataflowFlexJobTypeTransferVar("sdk_container_image", "sdkContainerImage", updatedParameters, d)
++
++	launcherMachineType, updatedParameters := dataflowFlexJobTypeTransferVar("launcher_machine_type", "launcherMachineType", updatedParameters, d)
++
+ 	env := dataflow.FlexTemplateRuntimeEnvironment{
+ 		AdditionalUserLabels:  tpgresource.ExpandStringMap(d, "labels"),
+-		AutoscalingAlgorithm:  d.Get("autoscaling_algorithm").(string),
+-		NumWorkers:            int64(d.Get("num_workers").(int)),
+-		MaxWorkers:            int64(d.Get("max_workers").(int)),
+-		Network:               d.Get("network").(string),
+-		ServiceAccountEmail:   d.Get("service_account_email").(string),
+-		Subnetwork:            d.Get("subnetwork").(string),
+-		TempLocation:          d.Get("temp_location").(string),
+-		StagingLocation:       d.Get("staging_location").(string),
+-		MachineType:           d.Get("machine_type").(string),
+-		KmsKeyName:            d.Get("kms_key_name").(string),
+-		IpConfiguration:       d.Get("ip_configuration").(string),
+-		EnableStreamingEngine: d.Get("enable_streaming_engine").(bool),
++		AutoscalingAlgorithm:  autoscalingAlgorithm,
++		NumWorkers:            int64(numWorkers),
++		MaxWorkers:            int64(maxNumWorkers),
++		Network:               network,
++		ServiceAccountEmail:   serviceAccountEmail,
++		Subnetwork:            subnetwork,
++		TempLocation:          tempLocation,
++		StagingLocation:       stagingLocation,
++		MachineType:           machineType,
++		KmsKeyName:            kmsKeyName,
++		IpConfiguration:       ipConfiguration,
++		EnableStreamingEngine: enableStreamingEngine,
+ 		AdditionalExperiments: additionalExperiments,
+-		SdkContainerImage:     d.Get("sdk_container_image").(string),
+-		LauncherMachineType:   d.Get("launcher_machine_type").(string),
++		SdkContainerImage:     sdkContainerImage,
++		LauncherMachineType:   launcherMachineType,
+ 	}
+-	return env, nil
++	return env, updatedParameters, nil
+ }
+ 
+ // resourceDataflowFlexTemplateJobRead reads a Flex Template Job resource.
+@@ -368,7 +441,7 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
+ 	if err := d.Set("num_workers", optionsMap["numWorkers"]); err != nil {
+ 		return fmt.Errorf("Error setting num_workers: %s", err)
+ 	}
+-	if err := d.Set("max_workers", optionsMap["maxWorkers"]); err != nil {
++	if err := d.Set("max_workers", optionsMap["maxNumWorkers"]); err != nil {
+ 		return fmt.Errorf("Error setting max_workers: %s", err)
+ 	}
+ 	if err := d.Set("staging_location", optionsMap["stagingLocation"]); err != nil {
+@@ -453,7 +526,7 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
+ 
+ 	tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
+ 
+-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
++	env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -469,7 +542,7 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
+ 
+ 			ContainerSpecGcsPath:  d.Get("container_spec_gcs_path").(string),
+ 			JobName:               d.Get("name").(string),
+-			Parameters:            tpgresource.ExpandStringMap(d, "parameters"),
++			Parameters:            updatedParameters,
+ 			TransformNameMappings: tnamemapping,
+ 			Environment:           &env,
+ 			Update:                true,
+@@ -582,6 +655,100 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
+ }
+ 
+ func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
++
++	err := dataflowFlexJobTypeParameterOverride("autoscaling_algorithm", "autoscalingAlgorithm", d)
++	if err != nil {
++		return err
++	}
++
++	if p, ok := d.GetOk("parameters.numWorkers"); ok {
++		if d.HasChange("num_workers") {
++			e := d.Get("num_workers")
++			return fmt.Errorf("Error setting num_workers, value is supplied twice: num_workers=%d, parameters.numWorkers=%d", e.(int), p.(int))
++		} else {
++			p := d.Get("parameters.numWorkers")
++			number, err := strconv.Atoi(p.(string))
++			if err != nil {
++				return fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
++			}
++			d.SetNew("num_workers", number)
++		}
++	}
++
++	if p, ok := d.GetOk("parameters.maxNumWorkers"); ok {
++		if d.HasChange("max_workers") {
++			e := d.Get("max_workers")
++			return fmt.Errorf("Error setting max_workers, value is supplied twice: max_workers=%d, parameters.maxNumWorkers=%d", e.(int), p.(int))
++		} else {
++			p := d.Get("parameters.maxNumWorkers")
++			number, err := strconv.Atoi(p.(string))
++			if err != nil {
++				return fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
++			}
++			d.SetNew("max_workers", number)
++		}
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("network", "network", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("service_account_email", "serviceAccountEmail", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("subnetwork", "subnetwork", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("temp_location", "tempLocation", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("staging_location", "stagingLocation", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("machine_type", "workerMachineType", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("kms_key_name", "kmsKeyName", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("ip_configuration", "ipConfiguration", d)
++	if err != nil {
++		return err
++	}
++
++	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
++		if d.HasChange("enable_streaming_engine") {
++			e := d.Get("enable_streaming_engine")
++			return fmt.Errorf("Error setting enable_streaming_engine, value is supplied twice: enable_streaming_engine=%t, parameters.enableStreamingEngine=%t", e.(bool), p.(bool))
++		} else {
++			p := d.Get("parameters.enableStreamingEngine")
++			d.SetNew("enable_streaming_engine", p.(string))
++		}
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("sdk_container_image", "sdkContainerImage", d)
++	if err != nil {
++		return err
++	}
++
++	err = dataflowFlexJobTypeParameterOverride("launcher_machine_type", "launcherMachineType", d)
++	if err != nil {
++		return err
++	}
++
+ 	// All non-virtual fields are ForceNew for batch jobs
+ 	if d.Get("type") == "JOB_TYPE_BATCH" {
+ 		resourceSchema := ResourceDataflowFlexTemplateJob().Schema
+@@ -604,3 +771,35 @@ func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.Resou
+ 
+ 	return nil
+ }
++
++func dataflowFlexJobTypeTransferVar(ename, pname string, updatedParameters map[string]string, d *schema.ResourceData) (string, map[string]string) {
++
++	pstring := fmt.Sprintf("parameters.%s", pname)
++
++	if p, ok := d.GetOk(pstring); ok {
++		delete(updatedParameters, pname)
++		return p.(string), updatedParameters
++	} else {
++		if v, ok := d.GetOk(ename); ok {
++			return v.(string), updatedParameters
++		} else {
++			return "", updatedParameters
++		}
++	}
++}
++
++func dataflowFlexJobTypeParameterOverride(ename, pname string, d *schema.ResourceDiff) error {
++
++	pstring := fmt.Sprintf("parameters.%s", pname)
++
++	if p, ok := d.GetOk(pstring); ok {
++		if d.HasChange(ename) {
++			e := d.Get(ename)
++			return fmt.Errorf("Error setting %s, value is supplied twice: %s=\"%s\", %s=\"%s\"", ename, ename, e.(string), pstring, p.(string))
++		} else {
++			p := d.Get(pstring)
++			d.SetNew(ename, p.(string))
++		}
++	}
++	return nil
++}

--- a/hack/terraform-overrides/dataflow_flex_template_job_max_workers.patch
+++ b/hack/terraform-overrides/dataflow_flex_template_job_max_workers.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+index f96b5dbed..cfa21a2f8 100644
+--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
++++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+@@ -368,7 +368,7 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
+ 	if err := d.Set("num_workers", optionsMap["numWorkers"]); err != nil {
+ 		return fmt.Errorf("Error setting num_workers: %s", err)
+ 	}
+-	if err := d.Set("max_workers", optionsMap["maxWorkers"]); err != nil {
++	if err := d.Set("max_workers", optionsMap["maxNumWorkers"]); err != nil {
+ 		return fmt.Errorf("Error setting max_workers: %s", err)
+ 	}
+ 	if err := d.Set("staging_location", optionsMap["stagingLocation"]); err != nil {

--- a/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/update.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataflow.cnrm.cloud.google.com/v1beta1
+kind: DataflowFlexTemplateJob
+metadata:
+  annotations:
+    cnrm.cloud.google.com/on-delete: "cancel"
+  labels:
+    label-one: "value-one"
+  name: dataflowflextemplatejob-${uniqueId}
+spec:
+  region: us-central1
+  # This is a public, Google-maintained Dataflow Job flex template of a batch job
+  containerSpecGcsPath: gs://dataflow-templates/2020-08-31-00_RC00/flex/PubSub_Avro_to_BigQuery
+  parameters:
+    # This is maintained by us.
+    schemaPath: gs://config-connector-samples/dataflowflextemplate/numbers.avsc
+    inputSubscription: projects/${projectId}/subscriptions/pubsubsubscription-${uniqueId}
+    outputTopic: projects/${projectId}/topics/pubsubtopic1-${uniqueId}
+    outputTableSpec: ${projectId}:bigquerydataset${uniqueId}.bigquerytable${uniqueId}
+    createDisposition: CREATE_NEVER

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -102,8 +102,12 @@ apply-patches:
 	# Don't remove resource on read just because the job is in a terminal
 	# state. Instead, wait for the user to explicitly remove it.
 	git apply ../hack/terraform-overrides/dataflow_flex_template_job.patch
-	# Fix the issue that the max_workers read from the job is always 0.
-	git apply ../hack/terraform-overrides/dataflow_flex_template_job_max_workers.patch
+	# Make the same changes in
+	# https://github.com/hashicorp/terraform-provider-google-beta/pull/6357
+	# to update google_dataflow_flex_template_job to send SdkPipeline parameters
+	# via environment block fields, and to fix the issue that the returned
+    # maxWorkers was always 0.
+	git apply ../hack/terraform-overrides/dataflow_flex_template_job_environment_fields.patch
 	# Adds support for TF imports for google_compute_instance_from_template
 	git apply ../hack/terraform-overrides/compute_instance_from_template_import.patch
 	# The `StorageBucketAccessControl.get` call returns 400 when its entity

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -102,6 +102,8 @@ apply-patches:
 	# Don't remove resource on read just because the job is in a terminal
 	# state. Instead, wait for the user to explicitly remove it.
 	git apply ../hack/terraform-overrides/dataflow_flex_template_job.patch
+	# Fix the issue that the max_workers read from the job is always 0.
+	git apply ../hack/terraform-overrides/dataflow_flex_template_job_max_workers.patch
 	# Adds support for TF imports for google_compute_instance_from_template
 	git apply ../hack/terraform-overrides/compute_instance_from_template_import.patch
 	# The `StorageBucketAccessControl.get` call returns 400 when its entity

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -111,6 +112,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Optional: true,
 				// ForceNew applies to both stream and batch jobs
 				ForceNew:    true,
+				Computed:    true,
 				Description: `The initial number of Google Compute Engine instances for the job.`,
 			},
 
@@ -119,6 +121,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Optional: true,
 				// ForceNew applies to both stream and batch jobs
 				ForceNew:    true,
+				Computed:    true,
 				Description: `The maximum number of Google Compute Engine instances to be made available to your pipeline during execution, from 1 to 1000.`,
 			},
 
@@ -146,12 +149,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 			"sdk_container_image": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `Docker registry location of container image to use for the 'worker harness. Default is the container for the version of the SDK. Note this field is only valid for portable pipelines.`,
 			},
 
 			"network": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 				Description:      `The network to which VMs will be assigned. If it is not provided, "default" will be used.`,
 			},
@@ -159,6 +164,7 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 			"subnetwork": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 				Description:      `The subnetwork to which VMs will be assigned. Should be of the form "regions/REGION/subnetworks/SUBNETWORK".`,
 			},
@@ -166,12 +172,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 			"machine_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The machine type to use for the job.`,
 			},
 
 			"kms_key_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The name for the Cloud KMS key for the job. Key format is: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`,
 			},
 
@@ -202,12 +210,14 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 			"autoscaling_algorithm": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The algorithm to use for autoscaling`,
 			},
 
 			"launcher_machine_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The machine type to use for launching the job. The default is n1-standard-1.`,
 			},
 
@@ -240,7 +250,7 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
+	env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
 	if err != nil {
 		return err
 	}
@@ -249,7 +259,7 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
 			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
 			JobName:              d.Get("name").(string),
-			Parameters:           tpgresource.ExpandStringMap(d, "parameters"),
+			Parameters:           updatedParameters,
 			Environment:          &env,
 		},
 	}
@@ -275,29 +285,92 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 	return resourceDataflowFlexTemplateJobRead(d, meta)
 }
 
-func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_tpg.Config) (dataflow.FlexTemplateRuntimeEnvironment, error) {
+func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_tpg.Config) (dataflow.FlexTemplateRuntimeEnvironment, map[string]string, error) {
+
+	updatedParameters := tpgresource.ExpandStringMap(d, "parameters")
 
 	additionalExperiments := tpgresource.ConvertStringSet(d.Get("additional_experiments").(*schema.Set))
 
+	var autoscalingAlgorithm string
+	autoscalingAlgorithm, updatedParameters = dataflowFlexJobTypeTransferVar("autoscaling_algorithm", "autoscalingAlgorithm", updatedParameters, d)
+
+	var numWorkers int
+	if p, ok := d.GetOk("parameters.numWorkers"); ok {
+		number, err := strconv.Atoi(p.(string))
+		if err != nil {
+			return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("parameters.numWorkers must have a valid integer assigned to it, current value is %s", p.(string))
+		}
+		delete(updatedParameters, "numWorkers")
+		numWorkers = number
+	} else {
+		if v, ok := d.GetOk("num_workers"); ok {
+			numWorkers = v.(int)
+		}
+	}
+
+	var maxNumWorkers int
+	if p, ok := d.GetOk("parameters.maxNumWorkers"); ok {
+		number, err := strconv.Atoi(p.(string))
+		if err != nil {
+			return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
+		}
+		delete(updatedParameters, "maxNumWorkers")
+		maxNumWorkers = number
+	} else {
+		if v, ok := d.GetOk("max_workers"); ok {
+			maxNumWorkers = v.(int)
+		}
+	}
+
+	network, updatedParameters := dataflowFlexJobTypeTransferVar("network", "network", updatedParameters, d)
+
+	serviceAccountEmail, updatedParameters := dataflowFlexJobTypeTransferVar("service_account_email", "serviceAccountEmail", updatedParameters, d)
+
+	subnetwork, updatedParameters := dataflowFlexJobTypeTransferVar("subnetwork", "subnetwork", updatedParameters, d)
+
+	tempLocation, updatedParameters := dataflowFlexJobTypeTransferVar("temp_location", "tempLocation", updatedParameters, d)
+
+	stagingLocation, updatedParameters := dataflowFlexJobTypeTransferVar("staging_location", "stagingLocation", updatedParameters, d)
+
+	machineType, updatedParameters := dataflowFlexJobTypeTransferVar("machine_type", "workerMachineType", updatedParameters, d)
+
+	kmsKeyName, updatedParameters := dataflowFlexJobTypeTransferVar("kms_key_name", "kmsKeyName", updatedParameters, d)
+
+	ipConfiguration, updatedParameters := dataflowFlexJobTypeTransferVar("ip_configuration", "ipConfiguration", updatedParameters, d)
+
+	var enableStreamingEngine bool
+	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
+		delete(updatedParameters, "enableStreamingEngine")
+		enableStreamingEngine = p.(bool)
+	} else {
+		if v, ok := d.GetOk("enable_streaming_engine"); ok {
+			enableStreamingEngine = v.(bool)
+		}
+	}
+
+	sdkContainerImage, updatedParameters := dataflowFlexJobTypeTransferVar("sdk_container_image", "sdkContainerImage", updatedParameters, d)
+
+	launcherMachineType, updatedParameters := dataflowFlexJobTypeTransferVar("launcher_machine_type", "launcherMachineType", updatedParameters, d)
+
 	env := dataflow.FlexTemplateRuntimeEnvironment{
 		AdditionalUserLabels:  tpgresource.ExpandStringMap(d, "labels"),
-		AutoscalingAlgorithm:  d.Get("autoscaling_algorithm").(string),
-		NumWorkers:            int64(d.Get("num_workers").(int)),
-		MaxWorkers:            int64(d.Get("max_workers").(int)),
-		Network:               d.Get("network").(string),
-		ServiceAccountEmail:   d.Get("service_account_email").(string),
-		Subnetwork:            d.Get("subnetwork").(string),
-		TempLocation:          d.Get("temp_location").(string),
-		StagingLocation:       d.Get("staging_location").(string),
-		MachineType:           d.Get("machine_type").(string),
-		KmsKeyName:            d.Get("kms_key_name").(string),
-		IpConfiguration:       d.Get("ip_configuration").(string),
-		EnableStreamingEngine: d.Get("enable_streaming_engine").(bool),
+		AutoscalingAlgorithm:  autoscalingAlgorithm,
+		NumWorkers:            int64(numWorkers),
+		MaxWorkers:            int64(maxNumWorkers),
+		Network:               network,
+		ServiceAccountEmail:   serviceAccountEmail,
+		Subnetwork:            subnetwork,
+		TempLocation:          tempLocation,
+		StagingLocation:       stagingLocation,
+		MachineType:           machineType,
+		KmsKeyName:            kmsKeyName,
+		IpConfiguration:       ipConfiguration,
+		EnableStreamingEngine: enableStreamingEngine,
 		AdditionalExperiments: additionalExperiments,
-		SdkContainerImage:     d.Get("sdk_container_image").(string),
-		LauncherMachineType:   d.Get("launcher_machine_type").(string),
+		SdkContainerImage:     sdkContainerImage,
+		LauncherMachineType:   launcherMachineType,
 	}
-	return env, nil
+	return env, updatedParameters, nil
 }
 
 // resourceDataflowFlexTemplateJobRead reads a Flex Template Job resource.
@@ -453,7 +526,7 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
 
 	tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
 
-	env, err := resourceDataflowFlexJobSetupEnv(d, config)
+	env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
 	if err != nil {
 		return err
 	}
@@ -469,7 +542,7 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
 
 			ContainerSpecGcsPath:  d.Get("container_spec_gcs_path").(string),
 			JobName:               d.Get("name").(string),
-			Parameters:            tpgresource.ExpandStringMap(d, "parameters"),
+			Parameters:            updatedParameters,
 			TransformNameMappings: tnamemapping,
 			Environment:           &env,
 			Update:                true,
@@ -582,6 +655,100 @@ func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interfac
 }
 
 func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+
+	err := dataflowFlexJobTypeParameterOverride("autoscaling_algorithm", "autoscalingAlgorithm", d)
+	if err != nil {
+		return err
+	}
+
+	if p, ok := d.GetOk("parameters.numWorkers"); ok {
+		if d.HasChange("num_workers") {
+			e := d.Get("num_workers")
+			return fmt.Errorf("Error setting num_workers, value is supplied twice: num_workers=%d, parameters.numWorkers=%d", e.(int), p.(int))
+		} else {
+			p := d.Get("parameters.numWorkers")
+			number, err := strconv.Atoi(p.(string))
+			if err != nil {
+				return fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
+			}
+			d.SetNew("num_workers", number)
+		}
+	}
+
+	if p, ok := d.GetOk("parameters.maxNumWorkers"); ok {
+		if d.HasChange("max_workers") {
+			e := d.Get("max_workers")
+			return fmt.Errorf("Error setting max_workers, value is supplied twice: max_workers=%d, parameters.maxNumWorkers=%d", e.(int), p.(int))
+		} else {
+			p := d.Get("parameters.maxNumWorkers")
+			number, err := strconv.Atoi(p.(string))
+			if err != nil {
+				return fmt.Errorf("parameters.maxNumWorkers must have a valid integer assigned to it, current value is %s", p.(string))
+			}
+			d.SetNew("max_workers", number)
+		}
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("network", "network", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("service_account_email", "serviceAccountEmail", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("subnetwork", "subnetwork", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("temp_location", "tempLocation", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("staging_location", "stagingLocation", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("machine_type", "workerMachineType", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("kms_key_name", "kmsKeyName", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("ip_configuration", "ipConfiguration", d)
+	if err != nil {
+		return err
+	}
+
+	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
+		if d.HasChange("enable_streaming_engine") {
+			e := d.Get("enable_streaming_engine")
+			return fmt.Errorf("Error setting enable_streaming_engine, value is supplied twice: enable_streaming_engine=%t, parameters.enableStreamingEngine=%t", e.(bool), p.(bool))
+		} else {
+			p := d.Get("parameters.enableStreamingEngine")
+			d.SetNew("enable_streaming_engine", p.(string))
+		}
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("sdk_container_image", "sdkContainerImage", d)
+	if err != nil {
+		return err
+	}
+
+	err = dataflowFlexJobTypeParameterOverride("launcher_machine_type", "launcherMachineType", d)
+	if err != nil {
+		return err
+	}
+
 	// All non-virtual fields are ForceNew for batch jobs
 	if d.Get("type") == "JOB_TYPE_BATCH" {
 		resourceSchema := ResourceDataflowFlexTemplateJob().Schema
@@ -602,5 +769,37 @@ func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.Resou
 		}
 	}
 
+	return nil
+}
+
+func dataflowFlexJobTypeTransferVar(ename, pname string, updatedParameters map[string]string, d *schema.ResourceData) (string, map[string]string) {
+
+	pstring := fmt.Sprintf("parameters.%s", pname)
+
+	if p, ok := d.GetOk(pstring); ok {
+		delete(updatedParameters, pname)
+		return p.(string), updatedParameters
+	} else {
+		if v, ok := d.GetOk(ename); ok {
+			return v.(string), updatedParameters
+		} else {
+			return "", updatedParameters
+		}
+	}
+}
+
+func dataflowFlexJobTypeParameterOverride(ename, pname string, d *schema.ResourceDiff) error {
+
+	pstring := fmt.Sprintf("parameters.%s", pname)
+
+	if p, ok := d.GetOk(pstring); ok {
+		if d.HasChange(ename) {
+			e := d.Get(ename)
+			return fmt.Errorf("Error setting %s, value is supplied twice: %s=\"%s\", %s=\"%s\"", ename, ename, e.(string), pstring, p.(string))
+		} else {
+			p := d.Get(pstring)
+			d.SetNew(ename, p.(string))
+		}
+	}
 	return nil
 }

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
@@ -368,7 +368,7 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("num_workers", optionsMap["numWorkers"]); err != nil {
 		return fmt.Errorf("Error setting num_workers: %s", err)
 	}
-	if err := d.Set("max_workers", optionsMap["maxWorkers"]); err != nil {
+	if err := d.Set("max_workers", optionsMap["maxNumWorkers"]); err != nil {
 		return fmt.Errorf("Error setting max_workers: %s", err)
 	}
 	if err := d.Set("staging_location", optionsMap["stagingLocation"]); err != nil {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/304563477

Added a patch to send SdkPipeline parameters via environment block fields and to fix the issue that the retrieved maxWorkers was always 0.

The patch is identical with the fix in TF: https://github.com/GoogleCloudPlatform/magic-modules/pull/9031

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Created a streaming job using the DataflowFlexTemplateJob on a locally built KCC and the resource status became UpToDate and stayed to be UpToDate.
