### PR TITLE
Enable dependabot for docker and gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: /mockgcp
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/builder
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/deletiondefender
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/manager
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/recorder
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/unmanageddetector
+    schedule:
+      interval: daily
+  - package-ecosystem: docker
+    directory: /build/webhook
+    schedule:
+      interval: daily

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -14,7 +14,7 @@
 
 # This Dockerfile builds an image containing builds of all the binaries built
 # from source (manager, webhook, etc.)
-FROM golang:1.21 AS builder
+FROM golang:1.21.3 AS builder
 
 # Copy in the Go source code
 WORKDIR /go/src/github.com/GoogleCloudPlatform/k8s-config-connector

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -15,7 +15,7 @@
 # This Dockefile builds a thin image containing the manager binary
 
 # Build the manager binary
-FROM golang:1.21 AS builder
+FROM golang:1.21.3 AS builder
 
 # Copy in the Go source code
 WORKDIR /go/src/github.com/GoogleCloudPlatform/k8s-config-connector


### PR DESCRIPTION
Also tie to specific versions of golang image in our Dockerfile (where
we use them directly), if dependabot is going to keep them up to date.
