### PR TITLE
e2e: speed up tests

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -60,6 +60,19 @@ type Harness struct {
 	restConfig *rest.Config
 }
 
+// ForSubtest returns a harness scoped to a subtest (created by t.Run).
+func (h *Harness) ForSubtest(t *testing.T) *Harness {
+	ctx, cancel := context.WithCancel(h.Ctx)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	subHarness := *h
+	subHarness.T = t
+	subHarness.Ctx = ctx
+	return &subHarness
+}
+
 type httpRoundTripperKeyType int
 
 // httpRoundTripperKey is the key value for http.RoundTripper in a context.Context

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -55,6 +55,8 @@ func TestAllInSeries(t *testing.T) {
 		cancel()
 	})
 
+	testHarness := create.NewHarness(t, ctx)
+
 	t.Run("samples", func(t *testing.T) {
 		samples := create.LoadSamples(t, project)
 
@@ -65,7 +67,7 @@ func TestAllInSeries(t *testing.T) {
 			t.Run(s.Name, func(t *testing.T) {
 				create.MaybeSkip(t, s.Name, s.Resources)
 
-				h := create.NewHarness(t, ctx)
+				h := testHarness.ForSubtest(t)
 
 				cleanupResources := true
 
@@ -112,7 +114,7 @@ func TestAllInSeries(t *testing.T) {
 			t.Run(s.Name, func(t *testing.T) {
 				create.MaybeSkip(t, s.Name, s.Resources)
 
-				h := create.NewHarness(t, ctx)
+				h := testHarness.ForSubtest(t)
 
 				cleanupResources := true
 


### PR DESCRIPTION
We share a kube-apiserver instance rather than bringing it up for each
test, and we reduce some critical polling intervals.
