### PR TITLE
mockgcp: replace uuid with apimachinery uuid

### DIFF
--- a/mockgcp/common/operations/operations.go
+++ b/mockgcp/common/operations/operations.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	pb "google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/prototext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
@@ -45,7 +45,7 @@ func NewOperationsService(storage storage.Storage) *Operations {
 func (s *Operations) NewLRO(ctx context.Context) (*pb.Operation, error) {
 	now := time.Now()
 	millis := now.UnixMilli()
-	id := uuid.New()
+	id := string(uuid.NewUUID())
 
 	op := &pb.Operation{}
 

--- a/mockgcp/go.mod
+++ b/mockgcp/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/iam v1.1.1
 	cloud.google.com/go/longrunning v0.5.1
 	github.com/golang/protobuf v1.5.3
-	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	google.golang.org/api v0.126.0
 	google.golang.org/genproto v0.0.0-20230815205213-6bfd019c3878
@@ -30,6 +29,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect


### PR DESCRIPTION
It's a wrapper around the same library, but it avoids a go.mod
dependency - and we're already using apimachinery.
