### PR TITLE
Enable dependabot for operator Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,7 @@ updates:
     directory: /build/webhook
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: /operator
+    schedule:
+      interval: daily


### PR DESCRIPTION
Follow up of #910. Enable dependabot on operator/Dockerfile as well.