### PR TITLE
Tell dependabot to ignore some k8s releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,22 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+    - dependency-name: k8s.io/*
+      # Ignore major and minor versions for dependencies updates
+      # Allow patches and security updates.
+      # We expect we will stick pick up k8s major versions via controller-runtime.
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: gomod
     directory: /mockgcp
     schedule:
       interval: daily
+    ignore:
+    - dependency-name: k8s.io/*
+      # Ignore major and minor versions for dependencies updates
+      # Allow patches and security updates.
+      # We expect we will stick pick up k8s major versions via controller-runtime.
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
This will let us pick up patch releases and remind us when 1.29 is
released.
