### PR TITLE
tests: update urlMap tests

### DIFF
--- a/config/samples/resources/computeurlmap/regional-compute-url-map-l7-ilb-path/compute_v1beta1_computeurlmap.yaml
+++ b/config/samples/resources/computeurlmap/regional-compute-url-map-l7-ilb-path/compute_v1beta1_computeurlmap.yaml
@@ -61,7 +61,7 @@ spec:
                 name: computeurlmap-dep
             retryPolicy:
               numRetries: 4
-              retryTimeout:
+              perTryTimeout:
                 seconds: "30"
               retryConditions:
                 - "5xx"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeurlmap/regionalcomputeurlmap/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeurlmap/regionalcomputeurlmap/create.yaml
@@ -63,7 +63,7 @@ spec:
                 name: computebackendservice-${uniqueId}
             retryPolicy:
               numRetries: 4
-              retryTimeout:
+              perTryTimeout:
                 seconds: "30"
               retryConditions:
                 - "5xx"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeurlmap/regionalcomputeurlmap/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeurlmap/regionalcomputeurlmap/update.yaml
@@ -63,7 +63,7 @@ spec:
                 name: computebackendservice-${uniqueId}
             retryPolicy:
               numRetries: 4
-              retryTimeout:
+              perTryTimeout:
                 seconds: "30"
               retryConditions:
                 - "5xx"

--- a/samples/resources/computeurlmap/regional-compute-url-map-l7-ilb-path/compute_v1beta1_computeurlmap.yaml
+++ b/samples/resources/computeurlmap/regional-compute-url-map-l7-ilb-path/compute_v1beta1_computeurlmap.yaml
@@ -61,7 +61,7 @@ spec:
                 name: computeurlmap-dep
             retryPolicy:
               numRetries: 4
-              retryTimeout:
+              perTryTimeout:
                 seconds: "30"
               retryConditions:
                 - "5xx"

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeurlmap.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeurlmap.md
@@ -5637,7 +5637,7 @@ spec:
                 name: computeurlmap-dep
             retryPolicy:
               numRetries: 4
-              retryTimeout:
+              perTryTimeout:
                 seconds: "30"
               retryConditions:
                 - "5xx"


### PR DESCRIPTION
Some samples/fixtures were using a field that isn't valid against the
schema.
