### PR TITLE
Remove existing folder to avoid generating symbolic link loop

### DIFF
--- a/scripts/generate-go-crd-clients/generate-clients.sh
+++ b/scripts/generate-go-crd-clients/generate-clients.sh
@@ -28,6 +28,7 @@ go run ./scripts/generate-go-crd-clients
 make fmt # Fix up the formatting and headers
 
 # HACK: Some of the kubernetes generation tools still run better in GOPATH
+rm -rf ${REPO_ROOT}/.build/go/src/github.com/GoogleCloudPlatform/k8s-config-connector
 mkdir -p "${REPO_ROOT}/.build/go/src/github.com/GoogleCloudPlatform"
 ln -sf "${REPO_ROOT}" "${REPO_ROOT}/.build/go/src/github.com/GoogleCloudPlatform/k8s-config-connector" 
 export GOPATH="${REPO_ROOT}/.build/go"


### PR DESCRIPTION
### Change description

There was an extra symbolic link generated after running `make generate-go-client`.

Example:

```
shuxiancai@shuxian:~/go/src/github.com/diviner524/k8s-config-connector$ ls -l k8s-config-connector
lrwxrwxrwx 1 shuxiancai primarygroup 83 Oct 16 23:28 k8s-config-connector -> /usr/local/google/home/shuxiancai/go/src/github.com/diviner524/k8s-config-connector
```

The fix removes this symbolic link loop.

Fixes #

### Tests you have done

Tried `make generate-go-client` after the fix, the symbolic link is no longer there.

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
