### PR TITLE
Fix alloydb test cases

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/basicalloydbbackup/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/basicalloydbbackup/dependencies.yaml
@@ -15,11 +15,9 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: default
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: computenetwork-${uniqueId}
 spec:
-  description: Default network for the project
+  autoCreateSubnetworks: false
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
@@ -27,11 +25,11 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   initialUser:
-    password: 
+    password:
       value: alloydb-pg
   location: us-east1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkRef:
+    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
   resourceID: alloydbcluster${uniqueId}
@@ -44,7 +42,7 @@ spec:
   location: global
   addressType: INTERNAL
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   prefixLength: 16
   purpose: VPC_PEERING
   resourceID: computeaddress${uniqueId}
@@ -55,7 +53,7 @@ metadata:
   name: servicenetworkingconnection-${uniqueId}
 spec:
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   reservedPeeringRanges:
   - name: computeaddress-${uniqueId}
   service: servicenetworking.googleapis.com
@@ -65,7 +63,7 @@ kind: AlloyDBInstance
 metadata:
   name: alloydbinstance-${uniqueId}
 spec:
-  clusterRef: 
+  clusterRef:
     name: alloydbcluster-${uniqueId}
   instanceType: PRIMARY
   machineConfig:

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/create.yaml
@@ -17,7 +17,8 @@ kind: AlloyDBBackup
 metadata:
   name: alloydbbackup-${uniqueId}
 spec:
-  clusterName: "projects/${projectId}/locations/us-east1/clusters/alloydbcluster${uniqueId}"
+  clusterNameRef:
+    external: "projects/${projectId}/locations/us-east1/clusters/alloydbcluster${uniqueId}"
   location: us-east1
   encryptionConfig:
     kmsKeyNameRef: 

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/dependencies.yaml
@@ -15,11 +15,9 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: default
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: computenetwork-${uniqueId}
 spec:
-  description: Default network for the project
+  autoCreateSubnetworks: false
 ---
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: ServiceIdentity
@@ -38,11 +36,11 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   initialUser:
-    password: 
+    password:
       value: alloydb-pg
   location: us-east1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkRef:
+    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
   resourceID: alloydbcluster${uniqueId}
@@ -55,7 +53,7 @@ spec:
   location: global
   addressType: INTERNAL
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   prefixLength: 16
   purpose: VPC_PEERING
   resourceID: computeaddress${uniqueId}
@@ -66,9 +64,9 @@ metadata:
   name: servicenetworkingconnection-${uniqueId}
 spec:
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   reservedPeeringRanges:
-  - external: computeaddress${uniqueId}
+  - name: computeaddress-${uniqueId}
   service: servicenetworking.googleapis.com
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/dependencies.yaml
@@ -15,11 +15,9 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: default
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: computenetwork-${uniqueId}
 spec:
-  description: Default network for the project
+  autoCreateSubnetworks: false
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
@@ -27,11 +25,11 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   initialUser:
-    password: 
+    password:
       value: alloydb-pg
   location: us-west1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkRef:
+    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
 ---
@@ -43,7 +41,7 @@ spec:
   location: global
   addressType: INTERNAL
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   prefixLength: 16
   purpose: VPC_PEERING
 ---
@@ -53,7 +51,7 @@ metadata:
   name: servicenetworkingconnection-${uniqueId}
 spec:
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   reservedPeeringRanges:
   - name: computeaddress-${uniqueId}
   service: servicenetworking.googleapis.com

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/fullalloydbinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/fullalloydbinstance/dependencies.yaml
@@ -15,11 +15,9 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: default
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: computenetwork-${uniqueId}
 spec:
-  description: Default network for the project
+  autoCreateSubnetworks: false
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
@@ -27,11 +25,11 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   initialUser:
-    password: 
+    password:
       value: alloydb-pg
   location: us-west1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkRef:
+    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
   resourceID: alloydbcluster${uniqueId}
@@ -44,7 +42,7 @@ spec:
   location: global
   addressType: INTERNAL
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   prefixLength: 16
   purpose: VPC_PEERING
   resourceID: computeaddress${uniqueId}
@@ -55,7 +53,7 @@ metadata:
   name: servicenetworkingconnection-${uniqueId}
 spec:
   networkRef:
-    name: default
+    name: computenetwork-${uniqueId}
   reservedPeeringRanges:
-  - external: computeaddress${uniqueId}
+  - name: computeaddress-${uniqueId}
   service: servicenetworking.googleapis.com


### PR DESCRIPTION
### Change description

This is to fix the failing test cases from alloydb. Use non-default network to avoid error:

Error waiting for Create Service Networking Connection: Error code 6, message: A tenant resource with tag "projects/940811646928/global/networks/default" already exists on this tenancy unit.

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/305866115

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Local tests shows the test cases are now passing when running together:
$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests "fullalloydbbackup|basicalloydbbackup|fullalloydbinstance" -timeout 9000s 2>&1 | tee ~/tmp/log2.txt

--- PASS: TestCreateNoChangeUpdateDelete (6.94s)
    --- PASS: TestCreateNoChangeUpdateDelete/basic-fullalloydbbackup (1219.55s)
    --- PASS: TestCreateNoChangeUpdateDelete/basic-basicalloydbbackup (1221.71s)
    --- PASS: TestCreateNoChangeUpdateDelete/basic-fullalloydbinstance (2959.40s)
PASS
