### PR TITLE
Use valueTemplate instead of targetField for AlloyDB networkRef

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbclusters.alloydb.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbclusters.alloydb.cnrm.cloud.google.com.yaml
@@ -332,10 +332,10 @@ spec:
                       If set, the instance IPs for this cluster will be created in the allocated range.
                     type: string
                   networkRef:
-                    description: "Only `external` field is supported to configure
-                      the reference.\n\n(Required) The relative resource name of the
-                      VPC network on which \nthe instance can be accessed. It is specified
-                      in the following form: \nprojects/{projectNumber}/global/networks/{network_id}."
+                    description: |-
+                      (Required) The relative resource name of the VPC network on which
+                      the instance can be accessed. It is specified in the following form:
+                      projects/{project}/global/networks/{network_id}.
                     oneOf:
                     - not:
                         required:
@@ -352,7 +352,8 @@ spec:
                       - external
                     properties:
                       external:
-                        description: 'Allowed value: The `selfLink` field of a `ComputeNetwork`
+                        description: 'Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`,
+                          where {{value}} is the `name` field of a `ComputeNetwork`
                           resource.'
                         type: string
                       name:
@@ -364,10 +365,10 @@ spec:
                     type: object
                 type: object
               networkRef:
-                description: "Only `external` field is supported to configure the
-                  reference.\n\n(Required) The relative resource name of the VPC network
-                  on which \nthe instance can be accessed. It is specified in the
-                  following form: \nprojects/{projectNumber}/global/networks/{network_id}."
+                description: |-
+                  (Required) The relative resource name of the VPC network on which
+                  the instance can be accessed. It is specified in the following form:
+                  projects/{project}/global/networks/{network_id}.
                 oneOf:
                 - not:
                     required:
@@ -384,8 +385,8 @@ spec:
                   - external
                 properties:
                   external:
-                    description: 'Allowed value: The `selfLink` field of a `ComputeNetwork`
-                      resource.'
+                    description: 'Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`,
+                      where {{value}} is the `name` field of a `ComputeNetwork` resource.'
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -949,10 +950,10 @@ spec:
                       If set, the instance IPs for this cluster will be created in the allocated range.
                     type: string
                   networkRef:
-                    description: "Only `external` field is supported to configure
-                      the reference.\n\n(Required) The relative resource name of the
-                      VPC network on which \nthe instance can be accessed. It is specified
-                      in the following form: \nprojects/{projectNumber}/global/networks/{network_id}."
+                    description: |-
+                      (Required) The relative resource name of the VPC network on which
+                      the instance can be accessed. It is specified in the following form:
+                      projects/{project}/global/networks/{network_id}.
                     oneOf:
                     - not:
                         required:
@@ -969,7 +970,8 @@ spec:
                       - external
                     properties:
                       external:
-                        description: 'Allowed value: The `selfLink` field of a `ComputeNetwork`
+                        description: 'Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`,
+                          where {{value}} is the `name` field of a `ComputeNetwork`
                           resource.'
                         type: string
                       name:
@@ -981,10 +983,10 @@ spec:
                     type: object
                 type: object
               networkRef:
-                description: "Only `external` field is supported to configure the
-                  reference.\n\n(Required) The relative resource name of the VPC network
-                  on which \nthe instance can be accessed. It is specified in the
-                  following form: \nprojects/{projectNumber}/global/networks/{network_id}."
+                description: |-
+                  (Required) The relative resource name of the VPC network on which
+                  the instance can be accessed. It is specified in the following form:
+                  projects/{project}/global/networks/{network_id}.
                 oneOf:
                 - not:
                     required:
@@ -1001,8 +1003,8 @@ spec:
                   - external
                 properties:
                   external:
-                    description: 'Allowed value: The `selfLink` field of a `ComputeNetwork`
-                      resource.'
+                    description: 'Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`,
+                      where {{value}} is the `name` field of a `ComputeNetwork` resource.'
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'

--- a/config/servicemappings/alloydb.yaml
+++ b/config/servicemappings/alloydb.yaml
@@ -97,37 +97,33 @@ spec:
         - tfField: automated_backup_policy.encryption_config.kms_key_name
           description: "(Optional) The fully-qualified resource name of the KMS key. Each Cloud KMS key is regionalized and has the following format: projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY_NAME]."
           key: kmsKeyNameRef
-          gvk: 
+          gvk:
             group: kms.cnrm.cloud.google.com
             version: v1beta1
             kind: KMSCryptoKey
           targetField: self_link
         - tfField: network
           description: |-
-            Only `external` field is supported to configure the reference.
-
-            (Required) The relative resource name of the VPC network on which 
-            the instance can be accessed. It is specified in the following form: 
-            projects/{projectNumber}/global/networks/{network_id}.
-          key: networkRef
-          gvk: 
-            group: compute.cnrm.cloud.google.com
-            version: v1beta1
-            kind: ComputeNetwork
-          targetField: self_link
-        - tfField: network_config.network
-          description: |-
-            Only `external` field is supported to configure the reference.
-
-            (Required) The relative resource name of the VPC network on which 
-            the instance can be accessed. It is specified in the following form: 
-            projects/{projectNumber}/global/networks/{network_id}.
+            (Required) The relative resource name of the VPC network on which
+            the instance can be accessed. It is specified in the following form:
+            projects/{project}/global/networks/{network_id}.
           key: networkRef
           gvk:
             group: compute.cnrm.cloud.google.com
             version: v1beta1
             kind: ComputeNetwork
-          targetField: self_link
+          valueTemplate: projects/{{project}}/global/networks/{{value}}
+        - tfField: network_config.network
+          description: |-
+            (Required) The relative resource name of the VPC network on which
+            the instance can be accessed. It is specified in the following form:
+            projects/{project}/global/networks/{network_id}.
+          key: networkRef
+          gvk:
+            group: compute.cnrm.cloud.google.com
+            version: v1beta1
+            kind: ComputeNetwork
+          valueTemplate: projects/{{project}}/global/networks/{{value}}
         - tfField: restore_backup_source.backup_name
           description: "(Required) The name of the backup that this cluster is restored from."
           key: backupNameRef

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbcluster_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbcluster_types.go
@@ -110,11 +110,9 @@ type ClusterNetworkConfig struct {
 	// +optional
 	AllocatedIpRange *string `json:"allocatedIpRange,omitempty"`
 
-	/* Only `external` field is supported to configure the reference.
-
-	(Required) The relative resource name of the VPC network on which
+	/* (Required) The relative resource name of the VPC network on which
 	the instance can be accessed. It is specified in the following form:
-	projects/{projectNumber}/global/networks/{network_id}. */
+	projects/{project}/global/networks/{network_id}. */
 	// +optional
 	NetworkRef *v1alpha1.ResourceRef `json:"networkRef,omitempty"`
 }
@@ -218,11 +216,9 @@ type AlloyDBClusterSpec struct {
 	// +optional
 	NetworkConfig *ClusterNetworkConfig `json:"networkConfig,omitempty"`
 
-	/* Only `external` field is supported to configure the reference.
-
-	(Required) The relative resource name of the VPC network on which
+	/* (Required) The relative resource name of the VPC network on which
 	the instance can be accessed. It is specified in the following form:
-	projects/{projectNumber}/global/networks/{network_id}. */
+	projects/{project}/global/networks/{network_id}. */
 	// +optional
 	NetworkRef *v1alpha1.ResourceRef `json:"networkRef,omitempty"`
 

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/dependencies.yaml
@@ -28,8 +28,9 @@ spec:
     password:
       value: alloydb-pg
   location: us-west1
-  networkRef:
-    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
+  networkConfig:
+    networkRef:
+      name: computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
 ---

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
@@ -655,11 +655,9 @@ If set, the instance IPs for this cluster will be created in the allocated range
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}Only `external` field is supported to configure the reference.
-
-(Required) The relative resource name of the VPC network on which 
-the instance can be accessed. It is specified in the following form: 
-projects/{projectNumber}/global/networks/{network_id}.{% endverbatim %}</p>
+            <p>{% verbatim %}(Required) The relative resource name of the VPC network on which
+the instance can be accessed. It is specified in the following form:
+projects/{project}/global/networks/{network_id}.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -669,7 +667,7 @@ projects/{projectNumber}/global/networks/{network_id}.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Allowed value: The `selfLink` field of a `ComputeNetwork` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`, where {{value}} is the `name` field of a `ComputeNetwork` resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -699,11 +697,9 @@ projects/{projectNumber}/global/networks/{network_id}.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}Only `external` field is supported to configure the reference.
-
-(Required) The relative resource name of the VPC network on which 
-the instance can be accessed. It is specified in the following form: 
-projects/{projectNumber}/global/networks/{network_id}.{% endverbatim %}</p>
+            <p>{% verbatim %}(Required) The relative resource name of the VPC network on which
+the instance can be accessed. It is specified in the following form:
+projects/{project}/global/networks/{network_id}.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -713,7 +709,7 @@ projects/{projectNumber}/global/networks/{network_id}.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Allowed value: The `selfLink` field of a `ComputeNetwork` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}Allowed value: string of the format `projects/{{project}}/global/networks/{{value}}`, where {{value}} is the `name` field of a `ComputeNetwork` resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Change description

Configure the service mapping for AlloyDB to enable networkRef. The previous configuration (self_link) was not working, which gives error like below:

```
malformed network path: \"[https://www.googleapis.com/compute/v1/projects/foo/global/networks/default\](https://www.googleapis.com/compute/v1/projects/foo/global/networks/default%5C)"",
```

The valueTemplate format avoids the full URL being passed as the value for network field.

Fixes b/305866115

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests basicalloydbinstance -timeout 9000s 2>&1 | tee ~/tmp/log2.txt


--- PASS: TestCreateNoChangeUpdateDelete (1.33s)
    --- PASS: TestCreateNoChangeUpdateDelete/basic-basicalloydbinstance (1975.80s)
PASS
{"severity":"info","timestamp":"2023-10-19T23:39:00.077Z","msg":"Stopping and waiting for non leader election runnables"}
{"severity":"info","timestamp":"2023-10-19T23:39:00.078Z","msg":"Stopping and waiting for leader election runnables"}
{"severity":"info","timestamp":"2023-10-19T23:39:00.078Z","msg":"Stopping and waiting for caches"}
{"severity":"info","timestamp":"2023-10-19T23:39:00.078Z","msg":"Stopping and waiting for webhooks"}
{"severity":"info","timestamp":"2023-10-19T23:39:00.078Z","logger":"controller-runtime.webhook","msg":"shutting down webhook server"}
{"severity":"info","timestamp":"2023-10-19T23:39:00.078Z","msg":"Wait completed, proceeding to shutdown the manager"}
ok      github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      1990.160s
