### PR TITLE
tests: if we run the controller once then the object does not converge

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -249,7 +249,7 @@ func validateCreate(t *testing.T, testContext testrunner.TestContext, systemCont
 
 	// Check that condition is ready and "UpToDate" event was recorded
 	// TODO: (eventually) check default fields are propagated correctly
-	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct, preReconcileGeneration)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	verifyResourceIDIfSupported(t, systemContext, resourceContext, reconciledUnstruct, initialUnstruct)
@@ -387,7 +387,7 @@ func testUpdate(t *testing.T, testContext testrunner.TestContext, systemContext 
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.Updating)
 
 	// Check if condition is ready and update event was recorded
-	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct, preReconcileGeneration)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	// Check observedGeneration matches with the pre-reconcile generation
@@ -635,7 +635,7 @@ func testReconcileAcquire(t *testing.T, testContext testrunner.TestContext, syst
 	}
 
 	// Check that condition is ready and "UpToDate" event was recorded
-	testcontroller.AssertReadyCondition(t, reconciledUnstruct)
+	testcontroller.AssertReadyCondition(t, reconciledUnstruct, preReconcileGeneration)
 	testcontroller.AssertEventRecordedforUnstruct(t, kubeClient, reconciledUnstruct, k8s.UpToDate)
 
 	// Check observedGeneration matches with the pre-reconcile generation

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
@@ -119,7 +119,7 @@ func testReconcileResourceLevelCreate(t *testing.T, mgr manager.Manager, k8sAudi
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sAuditConfig, preReconcileGeneration)
 }
@@ -212,7 +212,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, mgr manager.Manager, k8sAudi
 		t.Fatalf("error retrieving GCP audit config: %v", err)
 	}
 	assertSameAuditConfigs(t, newK8sAuditConfig, gcpAuditConfig)
-	testcontroller.AssertReadyCondition(t, newK8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, newK8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &newK8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sAuditConfig, preReconcileGeneration)
 }
@@ -291,7 +291,7 @@ func testReconcileResourceLevelNoChanges(t *testing.T, mgr manager.Manager, k8sA
 	if k8sAuditConfig.GetResourceVersion() != newK8sAuditConfig.GetResourceVersion() {
 		t.Errorf("reconcile that was expected to be a no-op resulted in a write to the API server")
 	}
-	testcontroller.AssertReadyCondition(t, newK8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, newK8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &newK8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sAuditConfig, preReconcileGeneration)
 }
@@ -345,6 +345,7 @@ func testReconcileResourceLevelDelete(t *testing.T, mgr manager.Manager, k8sAudi
 	if err := kubeClient.Create(context.TODO(), k8sAuditConfig); err != nil {
 		t.Fatalf("error creating k8s resource: %v", err)
 	}
+	preReconcileGeneration := k8sAuditConfig.GetGeneration()
 	reconciler.ReconcileObjectMeta(k8sAuditConfig.ObjectMeta, iamv1beta1.IAMAuditConfigGVK.Kind, expectedReconcileResult, nil)
 	gcpAuditConfig, err := tfIamClient.GetAuditConfig(context.TODO(), k8sAuditConfig)
 	if err != nil {
@@ -354,7 +355,7 @@ func testReconcileResourceLevelDelete(t *testing.T, mgr manager.Manager, k8sAudi
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	if err := kubeClient.Delete(context.TODO(), k8sAuditConfig); err != nil {
 		t.Fatalf("error deleting k8s resource: %v", err)
@@ -424,6 +425,7 @@ func testReconcileResourceLevelDeleteParentFirst(t *testing.T, mgr manager.Manag
 	if err := kubeClient.Create(context.TODO(), k8sAuditConfig); err != nil {
 		t.Fatalf("error creating k8s resource: %v", err)
 	}
+	preReconcileGeneration := k8sAuditConfig.GetGeneration()
 	reconciler.ReconcileObjectMeta(k8sAuditConfig.ObjectMeta, iamv1beta1.IAMAuditConfigGVK.Kind, expectedReconcileResult, nil)
 	gcpAuditConfig, err := tfIamClient.GetAuditConfig(context.TODO(), k8sAuditConfig)
 	if err != nil {
@@ -433,7 +435,7 @@ func testReconcileResourceLevelDeleteParentFirst(t *testing.T, mgr manager.Manag
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 
 	// First, delete the parent resource of the IAMAuditConfig
@@ -516,7 +518,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sAud
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sAuditConfig)
+	testcontroller.AssertReadyCondition(t, k8sAuditConfig, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sAuditConfig, preReconcileGeneration)
 }

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
@@ -317,7 +317,7 @@ func testReconcileResourceLevelCreate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
 	assertPolicy(t, k8sPartialPolicy, existingPolicy, gcpPolicy, iamClient)
-	testcontroller.AssertReadyCondition(t, k8sPartialPolicy)
+	testcontroller.AssertReadyCondition(t, k8sPartialPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &k8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPartialPolicy, preReconcileGeneration)
 }
@@ -341,7 +341,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("error retrieving GCP policy: %v", err)
 	}
 	assertPolicy(t, newK8sPartialPolicy, existingPolicy, gcpPolicy, iamClient)
-	testcontroller.AssertReadyCondition(t, newK8sPartialPolicy)
+	testcontroller.AssertReadyCondition(t, newK8sPartialPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &newK8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sPartialPolicy, preReconcileGeneration)
 }
@@ -545,7 +545,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPar
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPartialPolicy), k8sPartialPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPartialPolicy)
+	testcontroller.AssertReadyCondition(t, k8sPartialPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPartialPolicyGVK.Kind, &k8sPartialPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPartialPolicy, preReconcileGeneration)
 }

--- a/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
+++ b/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
@@ -181,7 +181,7 @@ func testReconcileResourceLevelCreate(t *testing.T, kubeClient client.Client, k8
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicy), k8sPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicy)
+	testcontroller.AssertReadyCondition(t, k8sPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &k8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicy, preReconcileGeneration)
 }
@@ -204,7 +204,7 @@ func testReconcileResourceLevelUpdate(t *testing.T, kubeClient client.Client, k8
 		t.Fatalf("error retrieving GCP policy: %v", err)
 	}
 	testiam.AssertSamePolicy(t, newK8sPolicy, gcpPolicy)
-	testcontroller.AssertReadyCondition(t, newK8sPolicy)
+	testcontroller.AssertReadyCondition(t, newK8sPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &newK8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, newK8sPolicy, preReconcileGeneration)
 }
@@ -400,7 +400,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPol
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicy), k8sPolicy); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicy)
+	testcontroller.AssertReadyCondition(t, k8sPolicy, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMPolicyGVK.Kind, &k8sPolicy.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicy, preReconcileGeneration)
 }

--- a/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
@@ -170,7 +170,7 @@ func testPolicyMemberCreateDelete(t *testing.T, mgr manager.Manager, k8sPolicyMe
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicyMember), k8sPolicyMember); err != nil {
 		t.Fatalf("unexpected error getting resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicyMember)
+	testcontroller.AssertReadyCondition(t, k8sPolicyMember, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMPolicyMemberGVK.Kind, &k8sPolicyMember.ObjectMeta, k8s.UpToDate)
 	if err := kubeClient.Delete(context.TODO(), k8sPolicyMember); err != nil {
 		t.Fatalf("error deleting policy member: %v", err)
@@ -257,7 +257,7 @@ func testReconcileResourceLevelAcquire(t *testing.T, mgr manager.Manager, k8sPol
 	if err := kubeClient.Get(context.TODO(), k8s.GetNamespacedName(k8sPolicyMember), k8sPolicyMember); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
-	testcontroller.AssertReadyCondition(t, k8sPolicyMember)
+	testcontroller.AssertReadyCondition(t, k8sPolicyMember, preReconcileGeneration)
 	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMPolicyMemberGVK.Kind, &k8sPolicyMember.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sPolicyMember, preReconcileGeneration)
 }

--- a/pkg/test/controller/condition.go
+++ b/pkg/test/controller/condition.go
@@ -22,8 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// AssertReadyCondition checks that the given statuc.onditions slice contains a Ready condition.
-func AssertReadyCondition(t *testing.T, object runtime.Object) {
+// AssertReadyCondition checks that the given status.conditions slice contains a Ready condition.
+// It waits for the specified observedGeneration (or later).
+func AssertReadyCondition(t *testing.T, object runtime.Object, minObservedGeneration int64) {
 	t.Helper()
 
 	gvk := object.GetObjectKind().GroupVersionKind()
@@ -38,8 +39,8 @@ func AssertReadyCondition(t *testing.T, object runtime.Object) {
 	if objectStatus.ObservedGeneration == nil {
 		t.Fatalf("resource %v does not yet have status.observedGeneration", objectID)
 	}
-	if *objectStatus.ObservedGeneration < objectStatus.Generation {
-		t.Fatalf("resource %v status.observedGeneration is behind current generation", objectID)
+	if *objectStatus.ObservedGeneration < minObservedGeneration {
+		t.Fatalf("resource %v status.observedGeneration %v is behind minObservedGeneration %v", objectID, *objectStatus.ObservedGeneration, minObservedGeneration)
 	}
 
 	if len(objectStatus.Conditions) != 1 {


### PR DESCRIPTION
Because we only run the reconcile method of the controller once in
some tests, we can't expect that the object has converged fully
(observedGeneration == generation); that needs another reconciliation.
In these tests, we wait only for the observedGeneration to include the
generation before reconciliation.
