### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ configuration, and more importantly **tooling**. For example, the same
 customization or templating tool can be used to manage test vs. production
 versions of an application across both Kubernetes and GCP.
 
-This repository contains full Config Connector source code. This inlcudes
+This repository contains full Config Connector source code. This includes
 controllers, CRDs, install bundles, and sample resource configurations.
 
 ## Usage


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "inlcudes" to "includes" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.