### PR TITLE
Record and verify HTTP requests

### DIFF
--- a/mockgcp/common/httpmux/errors.go
+++ b/mockgcp/common/httpmux/errors.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpmux
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+)
+
+type wrappedStatus struct {
+	Error *wrappedError `json:"error,omitempty"`
+}
+
+type wrappedError struct {
+	Code    int            `json:"code,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Status  string         `json:"status,omitempty"`
+	Errors  []errorDetails `json:"errors,omitempty"`
+}
+
+type errorDetails struct {
+	Domain  string `json:"domain,omitempty"`
+	Message string `json:"message,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// customErrorHandler wraps errors in an error blockk
+func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+	s := status.Convert(err)
+	// pb := s.Proto()
+
+	w.Header().Del("Trailer")
+	w.Header().Del("Transfer-Encoding")
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	httpStatusCode := runtime.HTTPStatusFromCode(s.Code())
+	wrapped := &wrappedStatus{
+		Error: &wrappedError{
+			Code:    httpStatusCode,
+			Message: s.Message(),
+		},
+	}
+
+	switch s.Code() {
+	case codes.PermissionDenied:
+		wrapped.Error.Status = "PERMISSION_DENIED"
+	case codes.AlreadyExists:
+		wrapped.Error.Status = "ALREADY_EXISTS"
+	case codes.NotFound:
+		wrapped.Error.Status = "NOT_FOUND"
+		wrapped.Error.Errors = append(wrapped.Error.Errors, errorDetails{
+			Domain:  "global",
+			Message: wrapped.Error.Message,
+			Reason:  "notFound",
+		})
+	}
+
+	buf, merr := json.Marshal(wrapped)
+	if merr != nil {
+		klog.Warningf("Failed to marshal error message %q: %v", s, merr)
+		runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
+		return
+	}
+
+	if err := addGCPHeaders(ctx, w, nil); err != nil {
+		klog.Warningf("unexpected error from header filter: %v", err)
+	}
+
+	w.WriteHeader(httpStatusCode)
+	if _, err := w.Write(buf); err != nil {
+		klog.Warningf("Failed to write response: %v", err)
+	}
+
+}

--- a/mockgcp/common/httpmux/mux.go
+++ b/mockgcp/common/httpmux/mux.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpmux
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/klog/v2"
+)
+
+// NewServeMux constructs an http server with our error handling etc
+func NewServeMux(ctx context.Context, conn *grpc.ClientConn, handlers ...func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error) (*runtime.ServeMux, error) {
+	marshaler := &runtime.HTTPBodyMarshaler{
+		Marshaler: &runtime.JSONPb{
+			MarshalOptions: protojson.MarshalOptions{
+				EmitUnpopulated: false,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+			},
+		},
+	}
+
+	outgoingHeaderMatcher := func(key string) (string, bool) {
+		switch key {
+		case "content-type":
+			return "", false
+		default:
+			klog.Warningf("unknown grpc metadata header %q", key)
+			return "", false
+		}
+	}
+
+	mux := runtime.NewServeMux(
+		runtime.WithErrorHandler(customErrorHandler),
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, marshaler),
+		runtime.WithOutgoingHeaderMatcher(outgoingHeaderMatcher),
+		runtime.WithForwardResponseOption(addGCPHeaders),
+	)
+
+	for _, handler := range handlers {
+		if err := handler(ctx, mux, conn); err != nil {
+			return nil, err
+		}
+	}
+
+	return mux, nil
+}
+
+func addGCPHeaders(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
+	if w.Header().Get("Content-Type") == "application/json" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	}
+	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Server", "ESF")
+	w.Header()["Vary"] = []string{"Origin", "X-Origin", "Referer"}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	w.Header().Set("X-Xss-Protection", "0")
+
+	return nil
+}

--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -265,6 +265,10 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		response := &http.Response{}
 		response.Body = ioutil.NopCloser(&body)
 		response.Header = w.header
+		if w.statusCode == 0 {
+			w.statusCode = 200
+		}
+		response.Status = fmt.Sprintf("%d %s", w.statusCode, http.StatusText(w.statusCode))
 		response.StatusCode = w.statusCode
 		return response, nil
 	}

--- a/mockgcp/mockiam/service.go
+++ b/mockgcp/mockiam/service.go
@@ -22,10 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/iam/admin/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 )
 
 // MockService represents a mocked IAM service.
@@ -63,10 +63,5 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux := runtime.NewServeMux()
-	if err := pb.RegisterIAMHandler(ctx, mux, conn); err != nil {
-		return nil, err
-	}
-
-	return mux, nil
+	return httpmux.NewServeMux(ctx, conn, pb.RegisterIAMHandler)
 }

--- a/pkg/cli/gcpclient/client_integration_test.go
+++ b/pkg/cli/gcpclient/client_integration_test.go
@@ -84,7 +84,7 @@ func init() {
 			return inner
 		}
 		outputDir := filepath.Join(artifacts, "http-logs")
-		t := test.NewHTTPRecorder(inner.Transport, outputDir)
+		t := test.NewHTTPRecorder(inner.Transport, test.NewDirectoryEventSink(outputDir))
 		return &http.Client{Transport: t}
 	}
 	transport_tpg.OAuth2HTTPClientTransformer = func(ctx context.Context, inner *http.Client) *http.Client {
@@ -93,7 +93,7 @@ func init() {
 			return inner
 		}
 		outputDir := filepath.Join(artifacts, "http-logs")
-		t := test.NewHTTPRecorder(inner.Transport, outputDir)
+		t := test.NewHTTPRecorder(inner.Transport, test.NewDirectoryEventSink(outputDir))
 		return &http.Client{Transport: t}
 	}
 }

--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -88,7 +88,7 @@ func init() {
 			log.Info("env var ARTIFACTS is not set; will not record http log")
 		} else {
 			outputDir := filepath.Join(artifacts, "http-logs")
-			t := test.NewHTTPRecorder(ret.Transport, outputDir)
+			t := test.NewHTTPRecorder(ret.Transport, test.NewDirectoryEventSink(outputDir))
 			ret = &http.Client{Transport: t}
 		}
 		return ret

--- a/pkg/controller/mocktests/secretmanager_secret_test.go
+++ b/pkg/controller/mocktests/secretmanager_secret_test.go
@@ -65,7 +65,7 @@ func TestSecretManagerSecretVersion(t *testing.T) {
 	} else {
 		outputDir := filepath.Join(artifacts, "http-logs")
 
-		roundTripper = test.NewHTTPRecorder(mockCloud, outputDir)
+		roundTripper = test.NewHTTPRecorder(mockCloud, test.NewDirectoryEventSink(outputDir))
 	}
 
 	gcpHTTPClient := &http.Client{Transport: roundTripper}

--- a/pkg/test/eventsink.go
+++ b/pkg/test/eventsink.go
@@ -1,0 +1,173 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+// An EventSink listens for various events we are able to capture during tests,
+// currently just http requests/responses.
+type EventSink interface {
+	AddHTTPEvent(ctx context.Context, entry *LogEntry)
+}
+
+type httpEventSinkType int
+
+var httpEventSinkKey httpEventSinkType
+
+// EventSinksFromContext gets the EventSink listeners attached to the passed context.
+func EventSinksFromContext(ctx context.Context) []EventSink {
+	v := ctx.Value(httpEventSinkKey)
+	if v == nil {
+		return nil
+	}
+	return v.([]EventSink)
+}
+
+// AddSinkToContext attaches the sinks to the returned context.
+func AddSinkToContext(ctx context.Context, sinks ...EventSink) context.Context {
+	var eventSinks []EventSink
+	v := ctx.Value(httpEventSinkKey)
+	if v != nil {
+		eventSinks = v.([]EventSink)
+	}
+	eventSinks = append(eventSinks, sinks...)
+	return context.WithValue(ctx, httpEventSinkKey, eventSinks)
+}
+
+func NewMemoryEventSink() *MemoryEventSink {
+	return &MemoryEventSink{}
+}
+
+// MemoryEventSink is an EventSink that stores events in memory
+type MemoryEventSink struct {
+	mutex      sync.Mutex
+	HTTPEvents []*LogEntry `json:"httpEvents,omitempty"`
+}
+
+func (s *MemoryEventSink) AddHTTPEvent(ctx context.Context, entry *LogEntry) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.HTTPEvents = append(s.HTTPEvents, entry)
+}
+
+func (s *MemoryEventSink) FormatHTTP() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	var eventStrings []string
+	for _, entry := range s.HTTPEvents {
+		s := entry.FormatHTTP()
+		eventStrings = append(eventStrings, s)
+	}
+	return strings.Join(eventStrings, "\n---\n\n")
+}
+
+func (s *MemoryEventSink) PrettifyJSON(mutators ...JSONMutator) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, entry := range s.HTTPEvents {
+		entry.PrettifyJSON(mutators...)
+	}
+}
+
+func (s *MemoryEventSink) RemoveHTTPResponseHeader(key string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, entry := range s.HTTPEvents {
+		entry.Response.RemoveHeader(key)
+	}
+}
+
+func (s *MemoryEventSink) RemoveRequests(pred func(e *LogEntry) bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	var keep []*LogEntry
+	for _, entry := range s.HTTPEvents {
+		if !pred(entry) {
+			keep = append(keep, entry)
+		}
+	}
+	s.HTTPEvents = keep
+}
+
+type DirectoryEventSink struct {
+	outputDir string
+
+	// mutex to avoid concurrent writes to the same file
+	mutex sync.Mutex
+}
+
+func NewDirectoryEventSink(outputDir string) *DirectoryEventSink {
+	return &DirectoryEventSink{outputDir: outputDir}
+}
+
+func (r *DirectoryEventSink) AddHTTPEvent(ctx context.Context, entry *LogEntry) {
+	// Write to a log file
+	t := TestFromContext(ctx)
+	testName := "unknown"
+	if t != nil {
+		testName = t.Name()
+	}
+	dirName := sanitizePath(testName)
+	p := filepath.Join(r.outputDir, dirName, "requests.log")
+
+	if err := r.writeToFile(p, entry); err != nil {
+		klog.Fatalf("error writing http event: %v", err)
+	}
+}
+
+func (r *DirectoryEventSink) writeToFile(p string, entry *LogEntry) error {
+	b, err := yaml.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	// Just in case we are writing to the same file concurrently
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", filepath.Dir(p), err)
+	}
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open file %q: %w", p, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(b); err != nil {
+		return fmt.Errorf("failed to write to file %q: %w", p, err)
+	}
+	delimeter := "\n\n---\n\n"
+	if _, err := f.Write([]byte(delimeter)); err != nil {
+		return fmt.Errorf("failed to write to file %q: %w", p, err)
+	}
+
+	return nil
+}

--- a/pkg/test/http_recorder.go
+++ b/pkg/test/http_recorder.go
@@ -16,18 +16,16 @@ package test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path/filepath"
+	"sort"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/yaml"
 )
 
 type LogEntry struct {
@@ -52,15 +50,13 @@ type Response struct {
 }
 
 type HTTPRecorder struct {
-	outputDir string
-	inner     http.RoundTripper
+	inner http.RoundTripper
 
-	// mutex to avoid concurrent writes to the same file
-	mutex sync.Mutex
+	eventSinks []EventSink
 }
 
-func NewHTTPRecorder(inner http.RoundTripper, outputDir string) *HTTPRecorder {
-	rt := &HTTPRecorder{outputDir: outputDir, inner: inner}
+func NewHTTPRecorder(inner http.RoundTripper, eventSinks ...EventSink) *HTTPRecorder {
+	rt := &HTTPRecorder{inner: inner, eventSinks: eventSinks}
 	return rt
 }
 
@@ -127,39 +123,10 @@ func (r *HTTPRecorder) record(entry *LogEntry, req *http.Request, resp *http.Res
 		}
 	}
 
+	// If we have event sink(s), write to that sink also
 	ctx := req.Context()
-	t := TestFromContext(ctx)
-	testName := "unknown"
-	if t != nil {
-		testName = t.Name()
-	}
-	dirName := sanitizePath(testName)
-	p := filepath.Join(r.outputDir, dirName, "requests.log")
-
-	b, err := yaml.Marshal(entry)
-	if err != nil {
-		return fmt.Errorf("failed to marshal data: %w", err)
-	}
-
-	// Just in case we are writing to the same file concurrently
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
-		return fmt.Errorf("failed to create directory %q: %w", filepath.Dir(p), err)
-	}
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open file %q: %w", p, err)
-	}
-	defer f.Close()
-
-	if _, err := f.Write(b); err != nil {
-		return fmt.Errorf("failed to write to file %q: %w", p, err)
-	}
-	delimeter := "\n\n---\n\n"
-	if _, err := f.Write([]byte(delimeter)); err != nil {
-		return fmt.Errorf("failed to write to file %q: %w", p, err)
+	for _, eventSink := range r.eventSinks {
+		eventSink.AddHTTPEvent(ctx, entry)
 	}
 
 	return nil
@@ -175,4 +142,99 @@ func sanitizePath(s string) string {
 		}
 	}
 	return out.String()
+}
+
+func (e *LogEntry) FormatHTTP() string {
+	var b strings.Builder
+	b.WriteString(e.Request.FormatHTTP())
+	b.WriteString(e.Response.FormatHTTP())
+	return b.String()
+}
+
+func (r *Request) FormatHTTP() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s %s\n", r.Method, r.URL))
+	var keys []string
+	for k := range r.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range r.Header[k] {
+			b.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+		}
+	}
+	b.WriteString("\n")
+	if r.Body != "" {
+		b.WriteString(r.Body)
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}
+
+func (r *Response) FormatHTTP() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s\n", r.Status))
+	var keys []string
+	for k := range r.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range r.Header[k] {
+			b.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+		}
+	}
+	b.WriteString("\n")
+	if r.Body != "" {
+		b.WriteString(r.Body)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+type JSONMutator func(obj map[string]any)
+
+func (r *LogEntry) PrettifyJSON(mutators ...JSONMutator) {
+	r.Request.PrettifyJSON(mutators...)
+	r.Response.PrettifyJSON(mutators...)
+}
+
+func (r *Response) PrettifyJSON(mutators ...JSONMutator) {
+	r.Body = prettifyJSON(r.Body, mutators...)
+}
+
+func (r *Request) PrettifyJSON(mutators ...JSONMutator) {
+	r.Body = prettifyJSON(r.Body, mutators...)
+}
+
+func prettifyJSON(s string, mutators ...JSONMutator) string {
+	if s == "" {
+		return s
+	}
+
+	obj := make(map[string]any)
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		klog.Fatalf("error from json.Unmarshal(%q): %v", s, err)
+		return s
+	}
+
+	for _, mutator := range mutators {
+		mutator(obj)
+	}
+
+	b, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		klog.Fatalf("error from json.MarshalIndent: %v", err)
+		return s
+	}
+	return string(b)
+}
+
+func (r *Response) RemoveHeader(key string) {
+	r.Header.Del(key)
+}
+
+func (r *Request) RemoveHeader(key string) {
+	r.Header.Del(key)
 }

--- a/pkg/test/resourcefixture/testdata/basic/iam/v1beta1/iamserviceaccount/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/iam/v1beta1/iamserviceaccount/_http.log
@@ -1,0 +1,276 @@
+POST https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+{
+  "accountId": "gsa-${uniqueId}",
+  "serviceAccount": {
+    "displayName": "ExampleGSA"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+PATCH https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+{
+  "serviceAccount": {
+    "displayName": "ExampleGSA2",
+    "etag": "abcdef0123A="
+  },
+  "updateMask": "display_name"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA2",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "ExampleGSA2",
+  "email": "gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+DELETE https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/gsa-${uniqueId}@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.21.4 gdcl/0.139.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}


### PR DESCRIPTION
~WIP: Builds on #870.~

Demonstrates how we can export and verify the HTTP requests using golden-testing.

One gotcha is that sometimes we poll for resources, so we need to implement some basic request normalization (e.g. collapsing redundant queries for the same object)