### PR TITLE
refactor: stop using inject framework in controller-runtime

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -255,7 +255,8 @@ func NewHarness(t *testing.T, ctx context.Context) *Harness {
 	if len(webhooks) > 0 {
 		server := mgr.GetWebhookServer()
 		for _, cfg := range webhooks {
-			server.Register(cfg.Path, &webhook.Admission{Handler: cfg.Handler})
+			handler := cfg.HandlerFunc(mgr)
+			server.Register(cfg.Path, &webhook.Admission{Handler: handler})
 		}
 	}
 

--- a/pkg/test/controller/reconcile.go
+++ b/pkg/test/controller/reconcile.go
@@ -79,7 +79,8 @@ func startTestManager(env *envtest.Environment, testType test.TestType, whCfgs [
 	if testType == test.IntegrationTestType {
 		server := mgr.GetWebhookServer()
 		for _, cfg := range whCfgs {
-			server.Register(cfg.Path, &webhook.Admission{Handler: cfg.Handler})
+			handler := cfg.HandlerFunc(mgr)
+			server.Register(cfg.Path, &webhook.Admission{Handler: handler})
 		}
 	}
 	stop := startMgr(mgr, log.Fatalf)

--- a/pkg/webhook/abandon_on_uninstall_webhook.go
+++ b/pkg/webhook/abandon_on_uninstall_webhook.go
@@ -17,6 +17,7 @@ package webhook
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -24,6 +25,12 @@ import (
 // managed by KCC is deleted, the accompanying controller is set to abandon any resources that are
 // attempted to be deleted.
 type abandonOnCRDUninstallWebhook struct{}
+
+func NewAbandonOnCRDUninstallWebhook() HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &abandonOnCRDUninstallWebhook{}
+	}
+}
 
 // This webhook is now a no-op and will soon be removed as deletiondefender does not need this layer of protection any
 // longer. The reason to keep it for now is that the operator does not yet remove the old webhook registration. The

--- a/pkg/webhook/generic_defaulter.go
+++ b/pkg/webhook/generic_defaulter.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -36,8 +37,10 @@ import (
 type genericDefaulter struct {
 }
 
-func NewGenericDefaulter() *genericDefaulter {
-	return &genericDefaulter{}
+func NewGenericDefaulter() HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &genericDefaulter{}
+	}
 }
 
 func (a *genericDefaulter) Handle(ctx context.Context, req admission.Request) admission.Response {

--- a/pkg/webhook/iam_defaulter.go
+++ b/pkg/webhook/iam_defaulter.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -40,10 +41,12 @@ type iamDefaulter struct {
 }
 
 func NewIAMDefaulter(smLoader *servicemappingloader.ServiceMappingLoader,
-	serviceMetadataLoader metadata.ServiceMetadataLoader) *iamDefaulter {
-	return &iamDefaulter{
-		smLoader:              smLoader,
-		serviceMetadataLoader: serviceMetadataLoader,
+	serviceMetadataLoader metadata.ServiceMetadataLoader) HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &iamDefaulter{
+			smLoader:              smLoader,
+			serviceMetadataLoader: serviceMetadataLoader,
+		}
 	}
 }
 

--- a/pkg/webhook/iam_validator.go
+++ b/pkg/webhook/iam_validator.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -44,11 +45,13 @@ type iamValidatorHandler struct {
 
 func NewIAMValidatorHandler(smLoader *servicemappingloader.ServiceMappingLoader,
 	serviceMetadataLoader metadata.ServiceMetadataLoader,
-	schemaLoader dclschemaloader.DCLSchemaLoader) *iamValidatorHandler {
-	return &iamValidatorHandler{
-		smLoader:              smLoader,
-		serviceMetadataLoader: serviceMetadataLoader,
-		schemaLoader:          schemaLoader,
+	schemaLoader dclschemaloader.DCLSchemaLoader) HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &iamValidatorHandler{
+			smLoader:              smLoader,
+			serviceMetadataLoader: serviceMetadataLoader,
+			schemaLoader:          schemaLoader,
+		}
 	}
 }
 

--- a/pkg/webhook/immutable_fields_validator.go
+++ b/pkg/webhook/immutable_fields_validator.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -63,12 +64,14 @@ var (
 	allowedResponse = admission.ValidationResponse(true, "admission controller passed")
 )
 
-func NewImmutableFieldsValidatorHandler(smLoader *servicemappingloader.ServiceMappingLoader, dclSchemaLoader dclschemaloader.DCLSchemaLoader, serviceMetadataLoader dclmetadata.ServiceMetadataLoader) *immutableFieldsValidatorHandler {
-	return &immutableFieldsValidatorHandler{
-		smLoader:              smLoader,
-		tfResourceMap:         provider.ResourceMap(),
-		dclSchemaLoader:       dclSchemaLoader,
-		serviceMetadataLoader: serviceMetadataLoader,
+func NewImmutableFieldsValidatorHandler(smLoader *servicemappingloader.ServiceMappingLoader, dclSchemaLoader dclschemaloader.DCLSchemaLoader, serviceMetadataLoader dclmetadata.ServiceMetadataLoader) HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &immutableFieldsValidatorHandler{
+			smLoader:              smLoader,
+			tfResourceMap:         provider.ResourceMap(),
+			dclSchemaLoader:       dclSchemaLoader,
+			serviceMetadataLoader: serviceMetadataLoader,
+		}
 	}
 }
 

--- a/pkg/webhook/immutable_fields_validator_test.go
+++ b/pkg/webhook/immutable_fields_validator_test.go
@@ -1529,7 +1529,7 @@ func TestChangesOnImmutableFieldsForDCLResource(t *testing.T) {
 	}
 }
 
-func assertImmutableFieldsValidatorResult(t *testing.T, v *immutableFieldsValidatorHandler, provider *schema.Provider, testCase TestCase) {
+func assertImmutableFieldsValidatorResult(t *testing.T, _ HandlerFunc, provider *schema.Provider, testCase TestCase) {
 	r, ok := provider.ResourcesMap[testCase.TFSchemaName]
 	if !ok {
 		t.Errorf("couldn't get the schema for %v", testCase.TFSchemaName)
@@ -1617,7 +1617,7 @@ func TestChangesOnImmutableResourceIDField(t *testing.T) {
 	}
 }
 
-func newImmutableFieldsValidatorHandler(t *testing.T) *immutableFieldsValidatorHandler {
+func newImmutableFieldsValidatorHandler(t *testing.T) HandlerFunc {
 	t.Helper()
 	smLoader, err := servicemappingloader.New()
 	if err != nil {

--- a/pkg/webhook/no_unknown_fields_validator.go
+++ b/pkg/webhook/no_unknown_fields_validator.go
@@ -29,7 +29,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -38,19 +38,13 @@ type noUnknownFieldsValidatorHandler struct {
 	smLoader *servicemappingloader.ServiceMappingLoader
 }
 
-// noUnknownFieldsValidatorHandler implements inject.Client.
-var _ inject.Client = &noUnknownFieldsValidatorHandler{}
-
-func NewNoUnknownFieldsValidatorHandler(smLoader *servicemappingloader.ServiceMappingLoader) *noUnknownFieldsValidatorHandler {
-	return &noUnknownFieldsValidatorHandler{
-		smLoader: smLoader,
+func NewNoUnknownFieldsValidatorHandler(smLoader *servicemappingloader.ServiceMappingLoader) HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &noUnknownFieldsValidatorHandler{
+			client:   mgr.GetClient(),
+			smLoader: smLoader,
+		}
 	}
-}
-
-// InjectClient injects the client into the noUnknownFieldsValidatorHandler
-func (a *noUnknownFieldsValidatorHandler) InjectClient(c client.Client) error {
-	a.client = c
-	return nil
 }
 
 func (a *noUnknownFieldsValidatorHandler) Handle(ctx context.Context, req admission.Request) admission.Response {

--- a/pkg/webhook/resource_validator.go
+++ b/pkg/webhook/resource_validator.go
@@ -22,26 +22,17 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type resourceValidatorHandler struct {
-	client client.Client
 }
 
-// resourceValidatorHandler implements inject.Client.
-var _ inject.Client = &resourceValidatorHandler{}
-
-func NewResourceValidatorHandler() *resourceValidatorHandler {
-	return &resourceValidatorHandler{}
-}
-
-// InjectClient injects the client into the noUnknownFieldsValidatorHandler
-func (a *resourceValidatorHandler) InjectClient(c client.Client) error {
-	a.client = c
-	return nil
+func NewResourceValidatorHandler() HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &resourceValidatorHandler{}
+	}
 }
 
 func (a *resourceValidatorHandler) Handle(ctx context.Context, req admission.Request) admission.Response {

--- a/pkg/webhook/types.go
+++ b/pkg/webhook/types.go
@@ -17,6 +17,8 @@ package webhook
 import (
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -24,7 +26,7 @@ type WebhookConfig struct {
 	Type           webhookType
 	Name           string
 	Path           string
-	Handler        admission.Handler
+	HandlerFunc    func(mgr manager.Manager) admission.Handler
 	FailurePolicy  admissionregistration.FailurePolicyType
 	ObjectSelector *metav1.LabelSelector
 	Rules          []admissionregistration.RuleWithOperations
@@ -37,3 +39,8 @@ const (
 	Mutating   webhookType = "Mutating"
 	Validating webhookType = "Validating"
 )
+
+func (c *WebhookConfig) BuildAdmission(mgr manager.Manager) *webhook.Admission {
+	handler := c.HandlerFunc(mgr)
+	return &webhook.Admission{Handler: handler}
+}


### PR DESCRIPTION
The inject framework has been removed, so we need this to continue to
update controller-runtime.
