### PR TITLE
Group http-log by test name-DCL resource

### DIFF
--- a/pkg/test/resourcefixture/test_runner.go
+++ b/pkg/test/resourcefixture/test_runner.go
@@ -49,6 +49,7 @@ func runTestCase(ctx context.Context, t *testing.T, fixture ResourceFixture, tes
 	}
 	t.Run(FormatTestName(fixture), func(t *testing.T) {
 		t.Parallel()
+		ctx = test.WithContext(ctx, t)
 		testCaseFunc(ctx, t, fixture)
 		// note, this function, runTestCase(...) almost always returns before testCaseFunc(...) returns
 	})


### PR DESCRIPTION
### Change description

Pass test info into context. 
Current stage there's no value in context, we initialize it with context.TODO() and never pass any values to it. That would not give us any useful information during test run. 

In this simple code change, I pass the test information(including the test name) to the request context so that we can obtain the test name when writing to the HTTP log.

But I noticed that only works for DCL resources, evidence: https://screenshot.googleplex.com/8jqqFJAuuJ7VpRG.png; I suspect the context gets dropped somewhere when we call Terraform [Apply](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go#L833). In addition, the test context actually depends on how we set up the test, if we drop the current test context in any method, we may lose it.

Another option would be to not run test in parallel, and save current test information into a global variable. But our tests would be very slow. We are in a discussion about how to achieve this and minimize the impact on testing speed.

b/304550821

### Tests you have done

no changed resources in this PR

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
