### PR TITLE
Remove usage of binauthz in samples as it is no longer supported

### DIFF
--- a/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeaturemembership.yaml
+++ b/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeaturemembership.yaml
@@ -42,8 +42,6 @@ spec:
       logDeniesEnabled: true
       templateLibraryInstalled: true
       auditIntervalSeconds: "20"
-    binauthz:
-      enabled: true
     hierarchyController:
       enabled: true
       enablePodTreeLabels: true

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/create.yaml
@@ -33,6 +33,3 @@ spec:
         policyDir: "config-connector"
         syncWaitSecs: "20"
         syncRev: "HEAD"
-    # binauthz is intentionally set to an empty struct, which means caller wants
-    # to install Binauthz without parameters.
-    binauthz: {}

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/update.yaml
@@ -41,8 +41,6 @@ spec:
       logDeniesEnabled: true
       templateLibraryInstalled: true
       auditIntervalSeconds: "20"
-    binauthz:
-      enabled: true
     hierarchyController:
       enabled: true
       enablePodTreeLabels: true

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
@@ -890,8 +890,6 @@ spec:
       logDeniesEnabled: true
       templateLibraryInstalled: true
       auditIntervalSeconds: "20"
-    binauthz:
-      enabled: true
     hierarchyController:
       enabled: true
       enablePodTreeLabels: true


### PR DESCRIPTION
### Change description

Remove binauthz from sample as it is no longer support.
Fixes b/307983504

### Tests you have done

This sample test is currently disabled.

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/f8961f9694dda6124095cbc2addad4e201790aea/config/tests/samples/create/samples_test.go#L171

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
