### PR TITLE
AlloyDB: Update/Add test cases and samples to reflect modifications as per TF Provider 4.84.0

### DIFF
--- a/config/samples/resources/alloydbbackup/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbbackup/alloydb_v1beta1_alloydbcluster.yaml
@@ -18,7 +18,8 @@ metadata:
   name: alloydbbackup-dep
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbbackup-dep
+  networkConfig:
+    networkRef: 
+      name: alloydbbackup-dep
   projectRef:
     external: ${PROJECT_ID?}

--- a/config/samples/resources/alloydbcluster/regular-cluster/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/alloydb_v1beta1_alloydbcluster.yaml
@@ -15,11 +15,36 @@
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
 metadata:
-  name: alloydbinstance-dep-primary
+  name: alloydbcluster-sample-regular
 spec:
-  location: us-central1
+  location: us-east1
   networkConfig:
     networkRef: 
-      name: alloydbinstance-dep-primary
+      name: alloydbcluster-dep-regular
   projectRef:
     external: ${PROJECT_ID?}
+  automatedBackupPolicy:
+    backupWindow: 3600s
+    encryptionConfig:
+      kmsKeyNameRef: 
+        name: alloydbcluster-dep-regular
+    enabled: true
+    labels:
+      source: kcc
+    location: us-east1
+    timeBasedRetention:
+      retentionPeriod: 43200s
+    weeklySchedule:
+      daysOfWeek: [MONDAY]
+      startTimes: 
+        - hours: 4
+          minutes: 0
+          seconds: 0
+          nanos: 0
+  encryptionConfig:
+    kmsKeyNameRef: 
+      name: alloydbcluster-dep-regular
+  initialUser:
+    user: "postgres"
+    password:
+      value: "postgres"

--- a/config/samples/resources/alloydbcluster/regular-cluster/compute_v1beta1_computeaddress.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/compute_v1beta1_computeaddress.yaml
@@ -4,23 +4,22 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: alloydbcluster-dep-regular
+  prefixLength: 16
+  purpose: VPC_PEERING

--- a/config/samples/resources/alloydbcluster/regular-cluster/compute_v1beta1_computenetwork.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/compute_v1beta1_computenetwork.yaml
@@ -4,23 +4,17 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
 metadata:
-  name: alloydbinstance-${uniqueId}
-spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  name: alloydbcluster-dep-regular
+
+

--- a/config/samples/resources/alloydbcluster/regular-cluster/iam_v1beta1_iampartialpolicy.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/iam_v1beta1_iampartialpolicy.yaml
@@ -4,23 +4,26 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  resourceRef:
+    apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    kind: KMSCryptoKey
+    name: alloydbcluster-dep-regular
+  bindings:
+    - role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+      members:
+        - memberFrom:
+            serviceIdentityRef:
+              name: alloydbcluster-dep-regular

--- a/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmscryptokey.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmscryptokey.yaml
@@ -4,23 +4,20 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: kms.cnrm.cloud.google.com/v1beta1
+kind: KMSCryptoKey
 metadata:
-  name: alloydbinstance-${uniqueId}
+  labels:
+    source: kcc-alloydbcluster-sample
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  keyRingRef:
+    name: alloydbcluster-dep-regular

--- a/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmskeyring.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmskeyring.yaml
@@ -17,4 +17,4 @@ kind: KMSKeyRing
 metadata:
   name: alloydbcluster-dep-regular
 spec:
-  location: us-central1
+  location: us-east1

--- a/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmskeyring.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/kms_v1beta1_kmskeyring.yaml
@@ -4,23 +4,17 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: kms.cnrm.cloud.google.com/v1beta1
+kind: KMSKeyRing
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  location: us-central1

--- a/config/samples/resources/alloydbcluster/regular-cluster/servicenetworking_v1beta1_servicenetworkingconnection.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/servicenetworking_v1beta1_servicenetworkingconnection.yaml
@@ -4,23 +4,21 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  networkRef:
+    name: alloydbcluster-dep-regular
+  reservedPeeringRanges:
+  - external: alloydbcluster-dep-regular
+  service: servicenetworking.googleapis.com

--- a/config/samples/resources/alloydbcluster/regular-cluster/serviceusage_v1beta1_serviceidentity.yaml
+++ b/config/samples/resources/alloydbcluster/regular-cluster/serviceusage_v1beta1_serviceidentity.yaml
@@ -4,23 +4,19 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-regular
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  projectRef:
+    external: ${PROJECT_ID?}
+  resourceID: alloydb.googleapis.com

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbbackup.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbbackup.yaml
@@ -4,23 +4,21 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+kind: AlloyDBBackup
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbcluster-dep-restoredfrombackup
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  clusterNameRef: 
+    name: alloydbcluster-dep-restoredfrombackup
+  location: us-central1
+  projectRef:
+    external: ${PROJECT_ID?}

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbbackup.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbbackup.yaml
@@ -19,6 +19,6 @@ metadata:
 spec:
   clusterNameRef: 
     name: alloydbcluster-dep-restoredfrombackup
-  location: us-central1
+  location: us-east1
   projectRef:
     external: ${PROJECT_ID?}

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbcluster.yaml
@@ -15,35 +15,27 @@
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
 metadata:
-  name: alloydbcluster-sample
+  name: alloydbcluster-dep-restoredfrombackup
 spec:
-  location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbcluster-dep
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: alloydbcluster-dep-restoredfrombackup
   projectRef:
     external: ${PROJECT_ID?}
-  automatedBackupPolicy:
-    backupWindow: 3600s
-    encryptionConfig:
-      kmsKeyNameRef: 
-        name: alloydbcluster-dep
-    enabled: true
-    labels:
-      source: kcc
-    location: us-central1
-    timeBasedRetention:
-      retentionPeriod: 43200s
-    weeklySchedule:
-      daysOfWeek: [MONDAY]
-      startTimes: 
-        - hours: 4
-          minutes: 0
-          seconds: 0
-          nanos: 0
-  encryptionConfig:
-    kmsKeyNameRef: 
-      name: alloydbcluster-dep
-  initialUser:
-    user: "postgres"
-    password:
-      value: "postgres"
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbcluster-sample-restoredfrombackup
+spec:
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: alloydbcluster-dep-restoredfrombackup
+  projectRef:
+    external: ${PROJECT_ID?}
+  restoreBackupSource:
+    backupNameRef:
+      name: alloydbcluster-dep-restoredfrombackup
+  

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbinstance.yaml
@@ -12,18 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPartialPolicy
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-restoredfrombackup
 spec:
-  resourceRef:
-    apiVersion: kms.cnrm.cloud.google.com/v1beta1
-    kind: KMSCryptoKey
-    name: alloydbcluster-dep
-  bindings:
-    - role: roles/cloudkms.cryptoKeyEncrypterDecrypter
-      members:
-        - memberFrom:
-            serviceIdentityRef:
-              name: alloydbcluster-dep
+  clusterRef: 
+    name: alloydbcluster-dep-restoredfrombackup
+  instanceType: PRIMARY

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/compute_v1beta1_computeaddress.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/compute_v1beta1_computeaddress.yaml
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kms.cnrm.cloud.google.com/v1beta1
-kind: KMSKeyRing
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-restoredfrombackup
 spec:
-  location: us-central1
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: alloydbcluster-dep-restoredfrombackup
+  prefixLength: 16
+  purpose: VPC_PEERING

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/compute_v1beta1_computenetwork.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/compute_v1beta1_computenetwork.yaml
@@ -4,23 +4,17 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
 metadata:
-  name: alloydbinstance-${uniqueId}
-spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  name: alloydbcluster-dep-restoredfrombackup
+
+

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/servicenetworking_v1beta1_servicenetworkingconnection.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/servicenetworking_v1beta1_servicenetworkingconnection.yaml
@@ -15,10 +15,10 @@
 apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
 kind: ServiceNetworkingConnection
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-restoredfrombackup
 spec:
   networkRef:
-    name: alloydbcluster-dep
+    name: alloydbcluster-dep-restoredfrombackup
   reservedPeeringRanges:
-  - external: alloydbcluster-dep
+  - external: alloydbcluster-dep-restoredfrombackup
   service: servicenetworking.googleapis.com

--- a/config/samples/resources/alloydbinstance/read-instance/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbinstance/read-instance/alloydb_v1beta1_alloydbcluster.yaml
@@ -18,7 +18,8 @@ metadata:
   name: alloydbinstance-dep-read
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbinstance-dep-read
+  networkConfig:
+    networkRef: 
+      name: alloydbinstance-dep-read
   projectRef:
     external: ${PROJECT_ID?}

--- a/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbcluster.yaml
@@ -4,23 +4,22 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+kind: AlloyDBCluster
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbinstance-dep-zonal
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  location: us-central1
+  networkConfig:
+    networkRef: 
+      name: alloydbinstance-dep-zonal
+  projectRef:
+    external: ${PROJECT_ID?}

--- a/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbinstance.yaml
@@ -4,23 +4,22 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBInstance
 metadata:
-  name: alloydbinstance-${uniqueId}
+  name: alloydbinstance-sample-zonal
 spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
+  clusterRef: 
+    name: alloydbinstance-dep-zonal
+  availabilityType: ZONAL
   instanceType: PRIMARY
   machineConfig:
     cpuCount: 2

--- a/config/samples/resources/alloydbinstance/zonal-instance/compute_v1beta1_computeaddress.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/compute_v1beta1_computeaddress.yaml
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeNetwork
+kind: ComputeAddress
 metadata:
-  name: alloydbcluster-dep
-
-
+  name: alloydbinstance-dep-zonal
+spec:
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: alloydbinstance-dep-zonal
+  prefixLength: 16
+  purpose: VPC_PEERING

--- a/config/samples/resources/alloydbinstance/zonal-instance/compute_v1beta1_computenetwork.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/compute_v1beta1_computenetwork.yaml
@@ -4,23 +4,17 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
-kind: AlloyDBInstance
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
 metadata:
-  name: alloydbinstance-${uniqueId}
-spec:
-  clusterRef:
-    name: alloydbcluster-${uniqueId}
-  availabilityType: REGIONAL
-  instanceType: PRIMARY
-  machineConfig:
-    cpuCount: 2
+  name: alloydbinstance-dep-zonal
+
+

--- a/config/samples/resources/alloydbinstance/zonal-instance/servicenetworking_v1beta1_servicenetworkingconnection.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/servicenetworking_v1beta1_servicenetworkingconnection.yaml
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
-kind: ServiceIdentity
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbinstance-dep-zonal
 spec:
-  projectRef:
-    external: ${PROJECT_ID?}
-  resourceID: alloydb.googleapis.com
+  networkRef:
+    name: alloydbinstance-dep-zonal
+  reservedPeeringRanges:
+  - external: alloydbinstance-dep-zonal
+  service: servicenetworking.googleapis.com

--- a/config/servicemappings/alloydb.yaml
+++ b/config/servicemappings/alloydb.yaml
@@ -67,6 +67,8 @@ spec:
         labels: labels
       resourceID:
         targetField: cluster_id
+      mutableButUnreadableFields:
+        - initial_user
       hierarchicalReferences:
         - type: project
           key: projectRef

--- a/pkg/snippet/snippetgeneration/snippetgeneration.go
+++ b/pkg/snippet/snippetgeneration/snippetgeneration.go
@@ -32,6 +32,7 @@ import (
 // generation for resources that have multiple samples. It is a map of
 // 'resource samples directory name' -> 'sample subdirectory name'.
 var preferredSampleForResource = map[string]string{
+	"alloydbcluster":                    "regular-cluster",
 	"alloydbinstance":                   "primary-instance",
 	"bigqueryjob":                       "query-bigquery-job",
 	"bigtableappprofile":                "multicluster-bigtable-app-profile",

--- a/pkg/test/resourcefixture/contexts/alloydb_context.go
+++ b/pkg/test/resourcefixture/contexts/alloydb_context.go
@@ -25,4 +25,14 @@ func init() {
 		ResourceKind: "AlloyDBBackup",
 		SkipUpdate:   true,
 	}
+
+	resourceContextMap["restorebackupalloydbcluster"] = ResourceContext{
+		ResourceKind: "AlloyDBCluster",
+		SkipUpdate:   true,
+	}
+
+	resourceContextMap["zonalalloydbinstance"] = ResourceContext{
+		ResourceKind: "AlloyDBInstance",
+		SkipUpdate:   true,
+	}
 }

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
@@ -18,8 +18,16 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkConfig:
+    networkRef: 
+      name: default
+ 
   projectRef:
     external: ${projectId}
+
+  initialUser:
+    user: postgres
+    password:
+      value: postgres
+
   resourceID: alloydbcluster${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
@@ -18,8 +18,10 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkConfig:
+    networkRef: 
+      name: default
+
   projectRef:
     external: ${projectId}
   automatedBackupPolicy:

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/create.yaml
@@ -18,11 +18,17 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${projectId}/global/networks/default
+  networkConfig:
+    networkRef: 
+      name: computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
 
+  initialUser:
+    user: postgres
+    password:
+      value: postgres
+      
   automatedBackupPolicy:
     backupWindow: 7200s
     enabled: true

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/dependencies.yaml
@@ -15,11 +15,9 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: default
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: computenetwork-${uniqueId}
 spec:
-  description: Default network for the project
+  autoCreateSubnetworks: false
 ---
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: ServiceIdentity

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/update.yaml
@@ -18,11 +18,12 @@ metadata:
   name: alloydbcluster-${uniqueId}
 spec:
   location: us-central1
-  networkRef:
-    external: projects/${projectId}/global/networks/default
+  networkConfig:
+    networkRef:
+      name: computenetwork-${uniqueId}
   projectRef:
     external: ${projectId}
-  
+
   automatedBackupPolicy:
     backupWindow: 3600s
     enabled: true
@@ -36,3 +37,6 @@ spec:
           minutes: 0
           seconds: 0
           nanos: 0
+
+  continuousBackupConfig:
+    enabled: false

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/restorebackupalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/restorebackupalloydbcluster/create.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeAddress
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
 metadata:
-  name: alloydbcluster-dep
+  name: restored-alloydbcluster-${uniqueId}
 spec:
-  location: global
-  addressType: INTERNAL
-  networkRef:
-    name: alloydbcluster-dep
-  prefixLength: 16
-  purpose: VPC_PEERING
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: computenetwork-${uniqueId}
+  projectRef:
+    external: ${projectId}
+  restoreBackupSource:
+    backupNameRef:
+      name: alloydbbackup-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/restorebackupalloydbcluster/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/restorebackupalloydbcluster/dependencies.yaml
@@ -1,0 +1,77 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: computenetwork-${uniqueId}
+spec:
+  autoCreateSubnetworks: false
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbcluster-${uniqueId}
+spec:
+  location: us-east1
+  networkRef:
+    external: projects/${projectId}/global/networks/computenetwork-${uniqueId}
+  projectRef:
+    external: ${projectId}
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: computeaddress-${uniqueId}
+spec:
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: computenetwork-${uniqueId}
+  prefixLength: 16
+  purpose: VPC_PEERING
+  resourceID: computeaddress${uniqueId}
+---
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
+metadata:
+  name: servicenetworkingconnection-${uniqueId}
+spec:
+  networkRef:
+    name: computenetwork-${uniqueId}
+  reservedPeeringRanges:
+  - name: computeaddress-${uniqueId}
+  service: servicenetworking.googleapis.com
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
+metadata:
+  name: alloydbinstance-${uniqueId}
+spec:
+  clusterRef:
+    name: alloydbcluster-${uniqueId}
+  instanceType: PRIMARY
+  machineConfig:
+    cpuCount: 2
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBBackup
+metadata:
+  name: alloydbbackup-${uniqueId}
+spec:
+  clusterNameRef: 
+    name: alloydbcluster-${uniqueId}
+  location: us-east1
+  projectRef:
+    external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbinstance/update.yaml
@@ -19,7 +19,8 @@ metadata:
   name: alloydbinstance-${uniqueId}
 spec:
   clusterRef: 
-    name: alloydbcluster-${uniqueId}   
+    name: alloydbcluster-${uniqueId}
+  availabilityType: REGIONAL
   instanceType: PRIMARY
   databaseFlags:
     enable_google_adaptive_autovacuum: "off"

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/zonalalloydbinstance/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/zonalalloydbinstance/create.yaml
@@ -4,20 +4,23 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# external: projects/${projectId}/locations/us-west1/clusters/alloydbcluster-${uniqueId}
 
-apiVersion: kms.cnrm.cloud.google.com/v1beta1
-kind: KMSCryptoKey
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
 metadata:
-  labels:
-    source: kcc-alloydbcluster-sample
-  name: alloydbcluster-dep
+  name: alloydbinstance-${uniqueId}
 spec:
-  keyRingRef:
-    name: alloydbcluster-dep
+  clusterRef:
+    name: alloydbcluster-${uniqueId}
+  availabilityType: ZONAL
+  instanceType: PRIMARY
+  machineConfig:
+    cpuCount: 2

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/zonalalloydbinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/zonalalloydbinstance/dependencies.yaml
@@ -1,0 +1,58 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: computenetwork-${uniqueId}
+spec:
+  autoCreateSubnetworks: false
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbcluster-${uniqueId}
+spec:
+  initialUser:
+    password:
+      value: alloydb-pg
+  location: us-west1
+  networkConfig:
+    networkRef:
+      name: computenetwork-${uniqueId}
+  projectRef:
+    external: ${projectId}
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: computeaddress-${uniqueId}
+spec:
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: computenetwork-${uniqueId}
+  prefixLength: 16
+  purpose: VPC_PEERING
+---
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
+metadata:
+  name: servicenetworkingconnection-${uniqueId}
+spec:
+  networkRef:
+    name: computenetwork-${uniqueId}
+  reservedPeeringRanges:
+  - name: computeaddress-${uniqueId}
+  service: servicenetworking.googleapis.com

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbbackup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbbackup.md
@@ -445,8 +445,9 @@ metadata:
   name: alloydbbackup-dep
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbbackup-dep
+  networkConfig:
+    networkRef: 
+      name: alloydbbackup-dep
   projectRef:
     external: ${PROJECT_ID?}
 ---

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
@@ -1190,7 +1190,7 @@ uid: string
 
 ## Sample YAML(s)
 
-### Typical Use Case
+### Regular Cluster
 ```yaml
 # Copyright 2023 Google LLC
 #
@@ -1209,22 +1209,23 @@ uid: string
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster
 metadata:
-  name: alloydbcluster-sample
+  name: alloydbcluster-sample-regular
 spec:
-  location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbcluster-dep
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: alloydbcluster-dep-regular
   projectRef:
     external: ${PROJECT_ID?}
   automatedBackupPolicy:
     backupWindow: 3600s
     encryptionConfig:
       kmsKeyNameRef: 
-        name: alloydbcluster-dep
+        name: alloydbcluster-dep-regular
     enabled: true
     labels:
       source: kcc
-    location: us-central1
+    location: us-east1
     timeBasedRetention:
       retentionPeriod: 43200s
     weeklySchedule:
@@ -1236,7 +1237,7 @@ spec:
           nanos: 0
   encryptionConfig:
     kmsKeyNameRef: 
-      name: alloydbcluster-dep
+      name: alloydbcluster-dep-regular
   initialUser:
     user: "postgres"
     password:
@@ -1245,72 +1246,165 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeAddress
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   location: global
   addressType: INTERNAL
   networkRef:
-    name: alloydbcluster-dep
+    name: alloydbcluster-dep-regular
   prefixLength: 16
   purpose: VPC_PEERING
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   resourceRef:
     apiVersion: kms.cnrm.cloud.google.com/v1beta1
     kind: KMSCryptoKey
-    name: alloydbcluster-dep
+    name: alloydbcluster-dep-regular
   bindings:
     - role: roles/cloudkms.cryptoKeyEncrypterDecrypter
       members:
         - memberFrom:
             serviceIdentityRef:
-              name: alloydbcluster-dep
+              name: alloydbcluster-dep-regular
 ---
 apiVersion: kms.cnrm.cloud.google.com/v1beta1
 kind: KMSCryptoKey
 metadata:
   labels:
     source: kcc-alloydbcluster-sample
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   keyRingRef:
-    name: alloydbcluster-dep
+    name: alloydbcluster-dep-regular
 ---
 apiVersion: kms.cnrm.cloud.google.com/v1beta1
 kind: KMSKeyRing
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   location: us-central1
 ---
 apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
 kind: ServiceNetworkingConnection
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   networkRef:
-    name: alloydbcluster-dep
+    name: alloydbcluster-dep-regular
   reservedPeeringRanges:
-  - external: alloydbcluster-dep
+  - external: alloydbcluster-dep-regular
   service: servicenetworking.googleapis.com
 ---
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: ServiceIdentity
 metadata:
-  name: alloydbcluster-dep
+  name: alloydbcluster-dep-regular
 spec:
   projectRef:
     external: ${PROJECT_ID?}
   resourceID: alloydb.googleapis.com
+```
+
+### Restored From Backup Cluster
+```yaml
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+spec:
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: alloydbcluster-dep-restoredfrombackup
+  projectRef:
+    external: ${PROJECT_ID?}
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbcluster-sample-restoredfrombackup
+spec:
+  location: us-east1
+  networkConfig:
+    networkRef: 
+      name: alloydbcluster-dep-restoredfrombackup
+  projectRef:
+    external: ${PROJECT_ID?}
+  restoreBackupSource:
+    backupNameRef:
+      name: alloydbcluster-dep-restoredfrombackup
+  
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBBackup
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+spec:
+  clusterNameRef: 
+    name: alloydbcluster-dep-restoredfrombackup
+  location: us-central1
+  projectRef:
+    external: ${PROJECT_ID?}
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+spec:
+  clusterRef: 
+    name: alloydbcluster-dep-restoredfrombackup
+  instanceType: PRIMARY
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+spec:
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: alloydbcluster-dep-restoredfrombackup
+  prefixLength: 16
+  purpose: VPC_PEERING
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+---
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
+metadata:
+  name: alloydbcluster-dep-restoredfrombackup
+spec:
+  networkRef:
+    name: alloydbcluster-dep-restoredfrombackup
+  reservedPeeringRanges:
+  - external: alloydbcluster-dep-restoredfrombackup
+  service: servicenetworking.googleapis.com
 ```
 
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
@@ -1291,7 +1291,7 @@ kind: KMSKeyRing
 metadata:
   name: alloydbcluster-dep-regular
 spec:
-  location: us-central1
+  location: us-east1
 ---
 apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
 kind: ServiceNetworkingConnection
@@ -1365,7 +1365,7 @@ metadata:
 spec:
   clusterNameRef: 
     name: alloydbcluster-dep-restoredfrombackup
-  location: us-central1
+  location: us-east1
   projectRef:
     external: ${PROJECT_ID?}
 ---

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
@@ -434,8 +434,9 @@ metadata:
   name: alloydbinstance-dep-primary
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbinstance-dep-primary
+  networkConfig:
+    networkRef: 
+      name: alloydbinstance-dep-primary
   projectRef:
     external: ${PROJECT_ID?}
 ---
@@ -515,8 +516,9 @@ metadata:
   name: alloydbinstance-dep-read
 spec:
   location: us-central1
-  networkRef: 
-    external: projects/${PROJECT_ID?}/global/networks/alloydbinstance-dep-read
+  networkConfig:
+    networkRef: 
+      name: alloydbinstance-dep-read
   projectRef:
     external: ${PROJECT_ID?}
 ---
@@ -546,6 +548,75 @@ spec:
     name: alloydbinstance-dep-read
   reservedPeeringRanges:
   - name: alloydbinstance-dep-read
+  service: servicenetworking.googleapis.com
+```
+
+### Zonal Instance
+```yaml
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
+metadata:
+  name: alloydbinstance-sample-zonal
+spec:
+  clusterRef: 
+    name: alloydbinstance-dep-zonal
+  availabilityType: ZONAL
+  instanceType: PRIMARY
+  machineConfig:
+    cpuCount: 2
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydbinstance-dep-zonal
+spec:
+  location: us-central1
+  networkConfig:
+    networkRef: 
+      name: alloydbinstance-dep-zonal
+  projectRef:
+    external: ${PROJECT_ID?}
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: alloydbinstance-dep-zonal
+spec:
+  location: global
+  addressType: INTERNAL
+  networkRef:
+    name: alloydbinstance-dep-zonal
+  prefixLength: 16
+  purpose: VPC_PEERING
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: alloydbinstance-dep-zonal
+---
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
+metadata:
+  name: alloydbinstance-dep-zonal
+spec:
+  networkRef:
+    name: alloydbinstance-dep-zonal
+  reservedPeeringRanges:
+  - external: alloydbinstance-dep-zonal
   service: servicenetworking.googleapis.com
 ```
 


### PR DESCRIPTION
### Change description

Addresses the following for AlloyDB Resources
1. Use networkConfig field instead of networkRef(deprecated) for AlloyDBCluster
2. Add initialUser field to "mutableButNotReadable" section in the servicemapping config for AllouDBCluster
3. Add test case and sample for AlloyDBCluster which is restored from backup
4. Add test case and sample for zonal AlloyDBInstance

Fixes b/308577459

### Tests you have done

Executed make ready-pr

Ran tests for all test cases
go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests alloydb -timeout 7200s
Output Summary of test run at https://paste.googleplex.com/5879544559960064

- [Yes] Run `make ready-pr` to ensure this PR is ready for review.
- [Yes] Perform necessary E2E testing for changed resources.
