### PR TITLE
docs: Start removing verbatim tags

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesslevel.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesslevel.md
@@ -639,7 +639,7 @@ custom access levels - https://cloud.google.com/access-context-manager/docs/cust
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbcluster.md
@@ -896,7 +896,7 @@ projects/{project}/global/networks/{network_id}.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/artifactregistry/artifactregistryrepository.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/artifactregistry/artifactregistryrepository.md
@@ -694,7 +694,7 @@ Repository. Upstream policies cannot be set on a standard repository.{% endverba
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerydataset.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerydataset.md
@@ -634,7 +634,7 @@ LOGICAL is the default if this flag isn't specified.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigqueryjob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigqueryjob.md
@@ -1436,7 +1436,7 @@ Creation, truncation and append actions occur as one atomic update upon job comp
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
@@ -1056,7 +1056,7 @@ view:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtableappprofile.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtableappprofile.md
@@ -231,7 +231,7 @@ It is unsafe to send these requests to the same table/row/column in multiple clu
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtablegcpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtablegcpolicy.md
@@ -314,7 +314,7 @@ tableRef:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtableinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtableinstance.md
@@ -323,7 +323,7 @@ this cluster must be granted the cloudkms.cryptoKeyEncrypterDecrypter role on th
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtabletable.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigtable/bigtabletable.md
@@ -242,7 +242,7 @@ splitKeys:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/billingbudgets/billingbudgetsbudget.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/billingbudgets/billingbudgetsbudget.md
@@ -698,7 +698,7 @@ Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/wo
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/binaryauthorization/binaryauthorizationattestor.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/binaryauthorization/binaryauthorizationattestor.md
@@ -302,7 +302,7 @@ Allowed value: The Google Cloud resource name of a `ContainerAnalysisNote` resou
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagercertificate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagercertificate.md
@@ -675,7 +675,7 @@ Leaf certificate comes first, followed by intermediate ones if any.{% endverbati
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildtrigger.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildtrigger.md
@@ -2766,7 +2766,7 @@ Only populated on get requests.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudfunctions/cloudfunctionsfunction.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudfunctions/cloudfunctionsfunction.md
@@ -596,7 +596,7 @@ Allowed value: The Google Cloud resource name of a `VPCAccessConnector` resource
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudscheduler/cloudschedulerjob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudscheduler/cloudschedulerjob.md
@@ -597,7 +597,7 @@ Allowed value: The Google Cloud resource name of a `PubSubTopic` resource (forma
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
@@ -2244,7 +2244,7 @@ failed request. Default is 30 seconds. Valid range is [1, 86400].{% endverbatim 
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computedisk.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computedisk.md
@@ -1147,7 +1147,7 @@ create the disk. Provide this when creating the disk.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computefirewall.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computefirewall.md
@@ -599,7 +599,7 @@ instances on the specified network.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
@@ -1062,7 +1062,7 @@ are valid.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeimage.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeimage.md
@@ -529,7 +529,7 @@ Reference link: https://cloud.google.com/compute/docs/reference/rest/v1/images.{
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstance.md
@@ -1963,7 +1963,7 @@ Must be from 0 to 315,576,000,000 inclusive.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstancegroup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstancegroup.md
@@ -267,7 +267,7 @@ zone: string
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstancetemplate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeinstancetemplate.md
@@ -1870,7 +1870,7 @@ Must be from 0 to 315,576,000,000 inclusive.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenodegroup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenodegroup.md
@@ -409,7 +409,7 @@ config in the project map.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenodetemplate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenodetemplate.md
@@ -231,7 +231,7 @@ nodes will experience outages while maintenance is applied. Possible values: ["R
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computereservation.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computereservation.md
@@ -300,7 +300,7 @@ affinity for any reservation. Defaults to false.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeresourcepolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeresourcepolicy.md
@@ -546,7 +546,7 @@ with RFC1035.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouter.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouter.md
@@ -314,7 +314,7 @@ attachments (interconnectAttachments).{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouternat.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouternat.md
@@ -750,7 +750,7 @@ Defaults to 30s if not set.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouterpeer.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computerouterpeer.md
@@ -527,7 +527,7 @@ side of the BGP session.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesecuritypolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesecuritypolicy.md
@@ -1047,7 +1047,7 @@ used.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeserviceattachment.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeserviceattachment.md
@@ -423,7 +423,7 @@ Allowed value: The `selfLink` field of a `ComputeForwardingRule` resource.{% end
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesnapshot.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesnapshot.md
@@ -542,7 +542,7 @@ RFC 4648 base64 to either encrypt or decrypt this resource.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesslcertificate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesslcertificate.md
@@ -260,7 +260,7 @@ The chain must include at least one intermediate cert.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesubnetwork.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computesubnetwork.md
@@ -425,7 +425,7 @@ If not specified IPV4_ONLY will be used. Possible values: ["IPV4_ONLY", "IPV4_IP
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeurlmap.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeurlmap.md
@@ -5358,7 +5358,7 @@ service.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computevpntunnel.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computevpntunnel.md
@@ -515,7 +515,7 @@ created.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/configcontroller/configcontrollerinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/configcontroller/configcontrollerinstance.md
@@ -432,7 +432,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -3814,7 +3814,7 @@ Enables workload identity.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containernodepool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containernodepool.md
@@ -1777,7 +1777,7 @@ for running workloads on sole tenant nodes.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containeranalysis/containeranalysisnote.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containeranalysis/containeranalysisnote.md
@@ -1165,7 +1165,7 @@ vulnerability:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataproc/dataproccluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataproc/dataproccluster.md
@@ -2544,7 +2544,7 @@ Allowed value: The Google Cloud resource name of a `StorageBucket` resource (for
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataproc/dataprocworkflowtemplate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataproc/dataprocworkflowtemplate.md
@@ -3158,7 +3158,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpdeidentifytemplate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpdeidentifytemplate.md
@@ -6920,7 +6920,7 @@ Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/wo
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpjobtrigger.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpjobtrigger.md
@@ -2354,7 +2354,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpstoredinfotype.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dlp/dlpstoredinfotype.md
@@ -570,7 +570,7 @@ Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/wo
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnsmanagedzone.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnsmanagedzone.md
@@ -620,7 +620,7 @@ while private zones are visible only to Virtual Private Cloud resources. Default
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnspolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnspolicy.md
@@ -266,7 +266,7 @@ Defaults to no logging if not set.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/eventarc/eventarctrigger.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/eventarc/eventarctrigger.md
@@ -667,7 +667,7 @@ Allowed value: The Google Cloud resource name of a `PubSubTopic` resource (forma
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeature.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeature.md
@@ -295,7 +295,7 @@ Allowed value: The Google Cloud resource name of a `GKEHubMembership` resource (
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamaccessboundarypolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamaccessboundarypolicy.md
@@ -289,7 +289,7 @@ This can be used e.g. in UIs which allow to enter the expression.{% endverbatim 
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamauditconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamauditconfig.md
@@ -282,7 +282,7 @@ service: string
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampartialpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampartialpolicy.md
@@ -930,7 +930,7 @@ resourceRef:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicy.md
@@ -903,7 +903,7 @@ resourceRef:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicymember.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicymember.md
@@ -879,7 +879,7 @@ role: string
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamworkforcepoolprovider.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamworkforcepoolprovider.md
@@ -424,7 +424,7 @@ Allowed value: The Google Cloud resource name of an `IAMWorkforcePool` resource 
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamworkloadidentitypoolprovider.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iamworkloadidentitypoolprovider.md
@@ -348,7 +348,7 @@ Allowed value: The Google Cloud resource name of an `IAMWorkloadIdentityPool` re
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformconfig.md
@@ -1070,7 +1070,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformoauthidpconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformoauthidpconfig.md
@@ -263,7 +263,7 @@ responseType:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformtenantoauthidpconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformtenantoauthidpconfig.md
@@ -309,7 +309,7 @@ Allowed value: The Google Cloud resource name of an `IdentityPlatformTenant` res
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmscryptokey.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmscryptokey.md
@@ -260,7 +260,7 @@ See the [algorithm reference](https://cloud.google.com/kms/docs/reference/rest/v
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogsink.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogsink.md
@@ -578,7 +578,7 @@ folderRef, or organizationRef may be specified.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/memcache/memcacheinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/memcache/memcacheinstance.md
@@ -444,7 +444,7 @@ provided, all zones will be used.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringalertpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringalertpolicy.md
@@ -1422,7 +1422,7 @@ whichever is smaller.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringdashboard.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringdashboard.md
@@ -6659,7 +6659,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringnotificationchannel.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringnotificationchannel.md
@@ -379,7 +379,7 @@ to a different credential configuration in the config will require an apply to u
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringuptimecheckconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringuptimecheckconfig.md
@@ -569,7 +569,7 @@ Allowed value: The Google Cloud resource name of a `MonitoringGroup` resource (f
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkconnectivity/networkconnectivityspoke.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkconnectivity/networkconnectivityspoke.md
@@ -546,7 +546,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityauthorizationpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityauthorizationpolicy.md
@@ -408,7 +408,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityclienttlspolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityclienttlspolicy.md
@@ -322,7 +322,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityservertlspolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networksecurity/networksecurityservertlspolicy.md
@@ -333,7 +333,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicesendpointpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicesendpointpolicy.md
@@ -427,7 +427,7 @@ Allowed value: The Google Cloud resource name of a `NetworkSecurityServerTLSPoli
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicesgrpcroute.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicesgrpcroute.md
@@ -671,7 +671,7 @@ Allowed value: The Google Cloud resource name of a `ComputeBackendService` resou
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicestcproute.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/networkservices/networkservicestcproute.md
@@ -441,7 +441,7 @@ Allowed value: The Google Cloud resource name of a `ComputeBackendService` resou
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/osconfig/osconfigguestpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/osconfig/osconfigguestpolicy.md
@@ -1561,7 +1561,7 @@ Allowed value: The Google Cloud resource name of a `StorageBucket` resource (for
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/osconfig/osconfigospolicyassignment.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/osconfig/osconfigospolicyassignment.md
@@ -1825,7 +1825,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacapool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacapool.md
@@ -938,7 +938,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificate.md
@@ -1030,7 +1030,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificateauthority.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificateauthority.md
@@ -1050,7 +1050,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificatetemplate.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privateca/privatecacertificatetemplate.md
@@ -763,7 +763,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/pubsub/pubsubsubscription.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/pubsub/pubsubsubscription.md
@@ -783,7 +783,7 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/pubsub/pubsubtopic.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/pubsub/pubsubtopic.md
@@ -293,7 +293,7 @@ and is not a valid configuration.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/recaptchaenterprise/recaptchaenterprisekey.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/recaptchaenterprise/recaptchaenterprisekey.md
@@ -356,7 +356,7 @@ Allowed value: The Google Cloud resource name of a `Project` resource (format: `
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/redis/redisinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/redis/redisinstance.md
@@ -701,7 +701,7 @@ range associated with the private service access connection, or "auto".{% endver
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/resourcemanager/resourcemanagerpolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/resourcemanager/resourcemanagerpolicy.md
@@ -417,7 +417,7 @@ projectRef, folderRef, or organizationRef may be specified.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runjob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runjob.md
@@ -1468,7 +1468,7 @@ subnetwork with the same name with the network will be used.{% endverbatim %}</p
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runservice.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runservice.md
@@ -1842,7 +1842,7 @@ subnetwork with the same name with the network will be used.{% endverbatim %}</p
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
@@ -484,7 +484,7 @@ An object containing a list of "key": value pairs. Example:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
@@ -249,7 +249,7 @@ disabled rather than deleted. Default is 'DELETE'. Possible values are:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sourcerepo/sourcereporepository.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sourcerepo/sourcereporepository.md
@@ -250,7 +250,7 @@ account.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerdatabase.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerdatabase.md
@@ -285,7 +285,7 @@ update the database's version_retention_period.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
@@ -1479,7 +1479,7 @@ Specifying this field has no-ops; it's recommended to remove this field from you
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqluser.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqluser.md
@@ -341,7 +341,7 @@ type: string
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/storage/storagebucket.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/storage/storagebucket.md
@@ -758,7 +758,7 @@ Enables Bucket PolicyOnly access to a bucket.{% endverbatim %}</p>
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/storagetransfer/storagetransferjob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/storagetransfer/storagetransferjob.md
@@ -1072,7 +1072,7 @@ transferSpec:
 </table>
 
 
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 
 
 ### Status

--- a/scripts/generate-google3-docs/resource-reference/templates/shared/resource.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/shared/resource.tmpl
@@ -43,7 +43,7 @@
 </table>
 
 {{ if .SpecDescriptionContainsRequiredIfParentPresent }}
-<p>{% verbatim %}* Field is required when parent field is specified{% endverbatim %}</p>
+<p>* Field is required when parent field is specified</p>
 {{ end }}
 
 ### Status


### PR DESCRIPTION
The verbatim tags are not valid HTML/markdown, and we don't really need them.

This PR removes a first (simple) case