### PR TITLE
Enable observed state in CRD generation via allowlist

### DIFF
--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -74,6 +74,15 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 	for k, v := range statusJSONSchema.Properties {
 		openAPIV3Schema.Properties["status"].Properties[k] = v
 	}
+	if _, ok := k8s.ObservedStateAllowlist[resource]; ok {
+		trueValue := true
+		stateJSONSchema := apiextensions.JSONSchemaProps{
+			Type:                   "object",
+			Description:            "The observed state of the underlying GCP resource.",
+			XPreserveUnknownFields: &trueValue,
+		}
+		openAPIV3Schema.Properties["status"].Properties["observedState"] = stateJSONSchema
+	}
 
 	group := strings.ToLower(sm.Spec.Name) + "." + ApiDomain
 

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -157,6 +157,14 @@ var (
 		// KCC no longer supports GameServicesRealm CRD as of v1.101.0.
 		"GameServicesRealm": true,
 	}
+
+	// ObservedStateAllowlist is a map containing a list of resources that
+	// should have the observed state enabled in the status.
+	// The keys in the list are Terraform resource names, and the values should
+	// be 'true'. E.g. "google_storage_bucket": true.
+	// This allowlist should be removed once all resources supports the observed
+	// state.
+	ObservedStateAllowlist = map[string]bool{}
 )
 
 func FormatAnnotation(annotationName string) string {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/309651922

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
