### PR TITLE
TF patch: pass context to Terraform request

### DIFF
--- a/hack/terraform-overrides/send_request_with_context.patch
+++ b/hack/terraform-overrides/send_request_with_context.patch
@@ -1,0 +1,25 @@
+diff --git a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go
+index 300a756ab..b5dcf8e2c 100644
+--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go
++++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go
+@@ -4,6 +4,7 @@ package transport
+ 
+ import (
+ 	"bytes"
++	"context"
+ 	"encoding/json"
+ 	"fmt"
+ 	"log"
+@@ -66,7 +67,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
+ 			if err != nil {
+ 				return err
+ 			}
+-			req, err := http.NewRequest(opt.Method, u, &buf)
++			ctx := opt.Config.Context
++			if ctx == nil {
++				ctx = context.Background()
++			}
++			req, err := http.NewRequestWithContext(ctx, opt.Method, u, &buf)
+ 			if err != nil {
+ 				return err
+ 			}

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -292,3 +292,6 @@ apply-patches:
 	git apply ../hack/terraform-overrides/alloydb-user-tf-5.4.0.patch
 	# Add edgecontainer resources (TODO) Remove the patch once TF update to v5.1.0
 	git apply ../hack/terraform-overrides/edgecontainer.patch
+    # Pass non-empty golang context to http request, to get the test info from context of http request
+    # Related bug b/309633764
+	git apply ../hack/terraform-overrides/send_request_with_context.patch

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/transport.go
@@ -4,6 +4,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -66,7 +67,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 			if err != nil {
 				return err
 			}
-			req, err := http.NewRequest(opt.Method, u, &buf)
+			ctx := opt.Config.Context
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			req, err := http.NewRequestWithContext(ctx, opt.Method, u, &buf)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Change description

Pass context to Terraform request. Previous PR: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1000

Evidence: https://screenshot.googleplex.com/gGUWwTkS2iM4aMh

Note: There is still an "unknown" folder, due to Terraform design, some resources, like bigquerytable, iampolicy, etc, they are not using Terraform `sendRequest()` method, to process and send request. We are not able to modify the code to pass current test context into the request. More details: https://docs.google.com/document/d/17ipukWhYa0FCmapGpLH_yPxNpALfNWbFHw3jiOEGeWY/edit#heading=h.7ljxi7p6idva

### Tests you have done
Integration test:
`go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests pubsub -timeout 300s`

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
