### PR TITLE
Fix secret key ref

### DIFF
--- a/pkg/clients/generated/apis/k8s/v1alpha1/types.go
+++ b/pkg/clients/generated/apis/k8s/v1alpha1/types.go
@@ -59,23 +59,14 @@ type Condition struct {
 type ResourceRef struct {
 	/* The external name of the referenced resource */
 	External string `json:"external,omitempty"`
+	/* APIVersion of the referenced resource */
+	APIVersion string `json:"apiVersion,omitempty"`
 	/* Kind of the referent. */
 	Kind string `json:"kind,omitempty"`
 	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */
 	Name string `json:"name,omitempty"`
 	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
 	Namespace string `json:"namespace,omitempty"`
-}
-
-type IAMResourceRef struct {
-	/* Kind of the referenced resource */
-	Kind string `json:"kind"`
-	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
-	Namespace string `json:"namespace,omitempty"`
-	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */
-	Name string `json:"name,omitempty"`
-	/* APIVersion of the referenced resource */
-	APIVersion string `json:"apiVersion,omitempty"`
-	/* The external name of the referenced resource */
-	External string `json:"external,omitempty"`
+	/* Key in the referenced secret to select. */
+	Key string `json:"key,omitempty"`
 }

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"go.opencensus.io/stats/view"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"

--- a/scripts/generate-go-crd-clients/generate-types-file_test.go
+++ b/scripts/generate-go-crd-clients/generate-types-file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/scripts/generate-go-crd-clients/generate-types-file_test.go
+++ b/scripts/generate-go-crd-clients/generate-types-file_test.go
@@ -76,7 +76,7 @@ func TestIsResourceField(ot *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/scripts/generate-go-crd-clients/generate-types-file_test.go
+++ b/scripts/generate-go-crd-clients/generate-types-file_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/fielddesc"
+)
+
+func TestIsResourceField(ot *testing.T) {
+	testCases := []struct {
+		name     string
+		field    fielddesc.FieldDescription
+		expected bool
+	}{
+		{
+			// This field has the Ref suffix, and the expected children.
+			name: "reference-field",
+			field: fielddesc.FieldDescription{
+				ShortName: "ThisIsARef",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "external",
+					},
+					{
+						ShortName: "namespace",
+					},
+					{
+						ShortName: "name",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			// This field does not have the Ref name suffix.
+			name: "not-reference-field",
+			field: fielddesc.FieldDescription{
+				ShortName: "NotRefField",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "other",
+					},
+					{
+						ShortName: "children",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			// This field has the Ref name suffix, but does not match the expected children fields.
+			// refer to the v1alpha1.SecretKeyReference struct at pkg/apis/core/v1alpha1/krm_types.go
+			name: "secret-key-ref",
+			field: fielddesc.FieldDescription{
+				ShortName: "SecretKeyRef",
+				Children: []fielddesc.FieldDescription{
+					{
+						ShortName: "name",
+					},
+					{
+						ShortName: "key",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		ot.Run(tc.name, func(t *testing.T) {
+			actual := isResourceReference(tc.field)
+			if tc.expected && !actual {
+				t.Errorf("expected field to be resource ref: %+v", tc.field)
+			} else if !tc.expected && actual {
+				t.Errorf("expected field to not be resource ref: %+v", tc.field)
+			}
+		})
+	}
+}

--- a/scripts/generate-go-crd-clients/k8s/v1alpha1/types.go
+++ b/scripts/generate-go-crd-clients/k8s/v1alpha1/types.go
@@ -59,23 +59,14 @@ type Condition struct {
 type ResourceRef struct {
 	/* The external name of the referenced resource */
 	External string `json:"external,omitempty"`
+	/* APIVersion of the referenced resource */
+	APIVersion string `json:"apiVersion,omitempty"`
 	/* Kind of the referent. */
 	Kind string `json:"kind,omitempty"`
 	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */
 	Name string `json:"name,omitempty"`
 	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
 	Namespace string `json:"namespace,omitempty"`
-}
-
-type IAMResourceRef struct {
-	/* Kind of the referenced resource */
-	Kind string `json:"kind"`
-	/* Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ */
-	Namespace string `json:"namespace,omitempty"`
-	/* Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names */
-	Name string `json:"name,omitempty"`
-	/* APIVersion of the referenced resource */
-	APIVersion string `json:"apiVersion,omitempty"`
-	/* The external name of the referenced resource */
-	External string `json:"external,omitempty"`
+	/* Key in the secret to select from */
+	Key string `json:"key,omitempty"`
 }


### PR DESCRIPTION
cc @diviner524 


### TODO:
- [x] cherry pick the generation fix in #848 
- [x] I think the changes are to aggressive, here're what I'm gonna change:
  - [x] keep all ResourceRef
  - [x] ResourceRef will have all the possible fields in a reference `kind, apiVersion, key, name, namespace, external`. There will be some redundant fields for some type, but it won't hurt.
- [ ] generate client code again, fix conflicts.
- [ ] Resolve the rest problems.

### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes #598 
Fixes #1010 
Continues #848

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
