### PR TITLE
Add permission requirements to SecretManagerSecret documentation

### DIFF
--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -616,7 +616,7 @@ update to date, we need to add the new CRDs and samples to existing doc.
     `https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances`).
     Add an additional paragraph/table if needed.
 1.  Update the URL in "Before you begin" section, points to the "Prerequisites" or 
-    "Before you begin" section in the service guide. This Make sure that the URL
+    "Before you begin" section in the service guide. Make sure that the URL
     is working by adding the partial URL to
     `https://cloud.google.com` (i.e.
     `https://cloud.google.com/spanner/docs/create-query-database-console#before`).

--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -615,6 +615,11 @@ update to date, we need to add the new CRDs and samples to existing doc.
     `https://cloud.google.com` (i.e.
     `https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances`).
     Add an additional paragraph/table if needed.
+1.  Update the URL in "Before you begin" section, points to the "Prerequisites" or 
+    "Before you begin" section in the service guide. This Make sure that the URL
+    is working by adding the partial URL to
+    `https://cloud.google.com` (i.e.
+    `https://cloud.google.com/spanner/docs/create-query-database-console#before`).
 1.  Update
     [scripts/generate-google3-docs/resource-reference/overview.md](scripts/generate-google3-docs/resource-reference/overview.md)
     by adding a row for your resource to the resource table. Note you need to

--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -610,16 +610,17 @@ update to date, we need to add the new CRDs and samples to existing doc.
 1.  Change the values for "Service name" (there are **two**, one for 'Google
     Cloud Service Name' and one for 'Config Connector Service Name'), "Service
     Documentation", "REST Resource Name", and "REST Resource Documentation"
-    accordingly. Make sure that the URL in "REST Resource Documentation" points
-    to a working document by adding the partial URL to
-    `https://cloud.google.com` (i.e.
-    `https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances`).
-    Add an additional paragraph/table if needed.
-1.  Update the URL in "Before you begin" section, points to the "Prerequisites" or 
-    "Before you begin" section in the service guide. Make sure that the URL
-    is working by adding the partial URL to
-    `https://cloud.google.com` (i.e.
-    `https://cloud.google.com/spanner/docs/create-query-database-console#before`).
+    accordingly. Make sure that the partial URL in "REST Resource Documentation" points
+    to a working document when prepending `https://cloud.google.com` to the partial URL.
+    For example, if the partial URL is updated to `/spanner/docs/reference/rest/v1/projects.instances`,
+    verify if `https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances `is a working URL. 
+    Add additional paragraph/table if needed.
+1.  If additional setup is necessary before the newly added resource can be applied successfully, 
+    and the setup can't be done via the Config Connector resources or features, add a "Prerequisites" section to explain
+    the prerequisites steps,
+    E.g. [scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md](scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md)
+    and
+    [scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md](scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md)
 1.  Update
     [scripts/generate-google3-docs/resource-reference/overview.md](scripts/generate-google3-docs/resource-reference/overview.md)
     by adding a row for your resource to the resource table. Note you need to

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -57,10 +57,7 @@
 </tbody>
 </table>
 
-## Before you begin
-
-Please review and complete <a href="/anthos/clusters/docs/multi-cloud/attached/eks/how-to/attach-cluster">Prerequisites</a>
-section in service documentation.
+## Prerequisites
 
 Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -7,8 +7,6 @@
 
 
 
-Note: Before using this resource, make sure you review and complete the steps in Prerequisites section.
-
 <table>
 <thead>
 <tr>
@@ -59,7 +57,11 @@ Note: Before using this resource, make sure you review and complete the steps in
 </tbody>
 </table>
 
-## Prerequisites
+## Before you begin
+
+Please review and complete <a href="/anthos/clusters/docs/multi-cloud/attached/eks/how-to/attach-cluster">Prerequisites</a>
+section in service documentation.
+
 Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.
 To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
@@ -75,8 +75,10 @@
 </table>
 
 ## Prerequisites
-Before you can use this resource, assign the Secret Manager Admin role (roles/secretmanager.admin) on the project, folder, or organization.
-The required permission ‘secretmanager.versions.access’ is included in this role.
+
+Before you can use this resource, assign the Secret Manager Admin role
+(roles/secretmanager.admin) on the project, folder, or organization. The
+required permission ‘secretmanager.versions.access’ is included in this role.
 
 ## Custom Resource Definition Properties
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
@@ -74,6 +74,10 @@
 </tbody>
 </table>
 
+## Prerequisites
+Before you can use this resource, assign the Secret Manager Admin role (roles/secretmanager.admin) on the project, folder, or organization.
+The required permission ‘secretmanager.versions.access’ is included in this role.
+
 ## Custom Resource Definition Properties
 
 

--- a/scripts/generate-google3-docs/resource-reference/overview.md
+++ b/scripts/generate-google3-docs/resource-reference/overview.md
@@ -13,6 +13,10 @@ version. If you are using a different version, you can find each version's
 Custom Resource Definitions in the GitHub repository. For example, this
 [link contains CRDs for version 1.89.0](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/v1.89.0/crds).
 
+Please review <a href="/config-connector/docs/best-practices">Best Practice for Config Connector</a> for best practices.
+
+Please review <a href="/config-connector/docs/troubleshooting">Troubleshooting Config Connector</a> for common issues.
+
 <div>
 <devsite-filter>
   <input type="text" placeholder="Type a keyword to filter the list of resources">

--- a/scripts/generate-google3-docs/resource-reference/overview.md
+++ b/scripts/generate-google3-docs/resource-reference/overview.md
@@ -13,8 +13,10 @@ version. If you are using a different version, you can find each version's
 Custom Resource Definitions in the GitHub repository. For example, this
 [link contains CRDs for version 1.89.0](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/v1.89.0/crds).
 
-Note: Please review <a href="/config-connector/docs/best-practices">Best Practice for {{product_name_short}}</a> for best practices.
-And <a href="/config-connector/docs/troubleshooting">Troubleshooting {{product_name_short}}</a> for common issues.
+Note: Please review <a href="/config-connector/docs/best-practices">best
+practices</a> and
+<a href="/config-connector/docs/troubleshooting">troubleshooting</a> common
+issues for {{product_name_short}}.
 
 <div>
 <devsite-filter>
@@ -817,7 +819,8 @@ And <a href="/config-connector/docs/troubleshooting">Troubleshooting {{product_n
 </devsite-filter>
 </div>
 
-The following resources are not supported in {{product_name_short}} starting from the corresponding version:
+The following resources are not supported in {{product_name_short}} starting
+from the corresponding version:
 
 <div>
 <table>

--- a/scripts/generate-google3-docs/resource-reference/overview.md
+++ b/scripts/generate-google3-docs/resource-reference/overview.md
@@ -13,9 +13,8 @@ version. If you are using a different version, you can find each version's
 Custom Resource Definitions in the GitHub repository. For example, this
 [link contains CRDs for version 1.89.0](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/v1.89.0/crds).
 
-Please review <a href="/config-connector/docs/best-practices">Best Practice for Config Connector</a> for best practices.
-
-Please review <a href="/config-connector/docs/troubleshooting">Troubleshooting Config Connector</a> for common issues.
+Note: Please review <a href="/config-connector/docs/best-practices">Best Practice for {{product_name_short}}</a> for best practices.
+And <a href="/config-connector/docs/troubleshooting">Troubleshooting {{product_name_short}}</a> for common issues.
 
 <div>
 <devsite-filter>

--- a/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
@@ -50,10 +50,7 @@
 </tbody>
 </table>
 
-## Before you begin
-
-Please review and complete <a href="/anthos/clusters/docs/multi-cloud/attached/eks/how-to/attach-cluster">Prerequisites</a>
-section in service documentation.
+## Prerequisites
 
 Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.

--- a/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/containerattached_containerattachedcluster.tmpl
@@ -6,8 +6,6 @@
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
 
-Note: Before using this resource, make sure you review and complete the steps in Prerequisites section.
-
 <table>
 <thead>
 <tr>
@@ -52,7 +50,11 @@ Note: Before using this resource, make sure you review and complete the steps in
 </tbody>
 </table>
 
-## Prerequisites
+## Before you begin
+
+Please review and complete <a href="/anthos/clusters/docs/multi-cloud/attached/eks/how-to/attach-cluster">Prerequisites</a>
+section in service documentation.
+
 Before you can use this resource, you must prepare the target cluster
 so that the multi-cloud service can connect to the target cluster.
 To prepare the cluster, follow the steps to deploy an install-agent into the target cluster:

--- a/scripts/generate-google3-docs/resource-reference/templates/secretmanager_secretmanagersecret.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/secretmanager_secretmanagersecret.tmpl
@@ -50,8 +50,10 @@
 </table>
 
 ## Prerequisites
-Before you can use this resource, assign the Secret Manager Admin role (roles/secretmanager.admin) on the project, folder, or organization.
-The required permission ‘secretmanager.versions.access’ is included in this role.
+
+Before you can use this resource, assign the Secret Manager Admin role
+(roles/secretmanager.admin) on the project, folder, or organization. The
+required permission ‘secretmanager.versions.access’ is included in this role.
 
 {{template "resource.tmpl" .}}
 {{template "endnote.tmpl" .}}

--- a/scripts/generate-google3-docs/resource-reference/templates/secretmanager_secretmanagersecret.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/secretmanager_secretmanagersecret.tmpl
@@ -49,6 +49,10 @@
 </tbody>
 </table>
 
+## Prerequisites
+Before you can use this resource, assign the Secret Manager Admin role (roles/secretmanager.admin) on the project, folder, or organization.
+The required permission ‘secretmanager.versions.access’ is included in this role.
+
 {{template "resource.tmpl" .}}
 {{template "endnote.tmpl" .}}
 {% endblock %}


### PR DESCRIPTION
### Change description

This is a sample PR to add permission requirements to ConfigConnector documentation. It only applies to one doc for now, once approval, same pattern will be applied to all docs.

The idea is to have a new "before you begin" section in each resource doc, service owner should be able to identify the requirements and add there. Every resource should at least have a link to point to the service documentation "before you begin" or "prerequisites" section, including any pre-setup, grant permissions, enable apis, etc.

I also added the link to "best practice" and "troubleshooting", in the KCC resource overview page. So users can more easily find solutions to common questions.

Fixes b/291854102

### Tests you have done
The doc should now look like: 
overview: https://screenshot.googleplex.com/AL4qA6A5Qf4JgHb.png
attached cluster resource: https://screenshot.googleplex.com/6JbhdXH2FRt4jiy.png


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
