### PR TITLE
Support the configuration of the partial observed state in TF-based CRDs

### DIFF
--- a/pkg/apis/core/v1alpha1/servicemapping_types.go
+++ b/pkg/apis/core/v1alpha1/servicemapping_types.go
@@ -181,6 +181,13 @@ type ResourceConfig struct {
 	// It must be set when V1alpha1ToV1beta1 is set to `true`. It must be
 	// `v1alpha1` when first set.
 	StorageVersion *string `json:"storageVersion,omitempty"`
+
+	// ObservedFields specifies which `spec` fields should be exposed under
+	// `status.observedState` in the CRD, and in the CR after a successful
+	// reconciliation.
+	// The fields should be snake case paths in TF. For example,
+	// `master_auth.client_certificate`.
+	ObservedFields *[]string `json:"observedFields,omitempty"`
 }
 
 type IAMConfig struct {

--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -71,6 +71,7 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 	if err != nil {
 		return nil, fmt.Errorf("error renaming status fields with reserved names for %#v: %v", statusJSONSchema, err)
 	}
+	populateObservedState(resourceConfig, specJSONSchema, statusJSONSchema)
 	for k, v := range statusJSONSchema.Properties {
 		openAPIV3Schema.Properties["status"].Properties[k] = v
 	}
@@ -448,4 +449,55 @@ func cleanupDeprecatedFieldDescription(description string) string {
 	return strings.ReplaceAll(description,
 		"is deprecated and will be removed in a future major release",
 		"is deprecated")
+}
+
+func populateObservedState(rc *corekccv1alpha1.ResourceConfig, spec *apiextensions.JSONSchemaProps, status *apiextensions.JSONSchemaProps) {
+	if rc.ObservedFields == nil || len(*rc.ObservedFields) == 0 {
+		return
+	}
+	observedStateJSONSchema := apiextensions.JSONSchemaProps{
+		Type:        "object",
+		Description: "The observed state of the underlying GCP resource.",
+		Properties:  make(map[string]apiextensions.JSONSchemaProps),
+	}
+	for _, path := range *rc.ObservedFields {
+		populateObservedField(strings.Split(path, "."), spec, &observedStateJSONSchema)
+	}
+	status.Properties["observedState"] = observedStateJSONSchema
+}
+
+func populateObservedField(observedFieldPath []string, sourceSchema *apiextensions.JSONSchemaProps, observedFieldParent *apiextensions.JSONSchemaProps) apiextensions.JSONSchemaProps {
+	field := text.SnakeCaseToLowerCamelCase(observedFieldPath[0])
+	if len(observedFieldPath) > 1 {
+		subSchema := sourceSchema.Properties[field]
+		switch subSchema.Type {
+		case "array":
+			// TODO(b/): Support the use case when the observed field is a subfield under an array.
+			panic(fmt.Errorf("observed fields under an array is not supported"))
+		case "object":
+			objSchema := apiextensions.JSONSchemaProps{
+				Type:        "object",
+				Description: subSchema.Description,
+				Properties:  make(map[string]apiextensions.JSONSchemaProps),
+			}
+			observedFieldParent.Properties[field] = populateObservedField(observedFieldPath[1:], &subSchema, &objSchema)
+			return *observedFieldParent
+		default:
+			panic(fmt.Errorf("error parsing observed field %v: cannot iterate into type that is not object or array of objects", observedFieldPath))
+		}
+	}
+
+	subSchema := sourceSchema.Properties[field]
+	switch subSchema.Type {
+	case "array":
+		// TODO(b/): Support the use case when the observed field is an array.
+		panic(fmt.Errorf("observed fields of an array is not supported"))
+	case "object":
+		// TODO(b/): Support the use case when the observed field is an object.
+		panic(fmt.Errorf("observed fields of an object is not supported"))
+	default:
+		observedFieldParent.Properties[field] = *subSchema.DeepCopy()
+	}
+
+	return *observedFieldParent
 }

--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -472,7 +472,7 @@ func populateObservedField(observedFieldPath []string, sourceSchema *apiextensio
 		subSchema := sourceSchema.Properties[field]
 		switch subSchema.Type {
 		case "array":
-			// TODO(b/): Support the use case when the observed field is a subfield under an array.
+			// TODO(b/312581557): Support the use case when the observed field is a subfield under an array.
 			panic(fmt.Errorf("observed fields under an array is not supported"))
 		case "object":
 			objSchema := apiextensions.JSONSchemaProps{
@@ -490,10 +490,10 @@ func populateObservedField(observedFieldPath []string, sourceSchema *apiextensio
 	subSchema := sourceSchema.Properties[field]
 	switch subSchema.Type {
 	case "array":
-		// TODO(b/): Support the use case when the observed field is an array.
+		// TODO(b/312581569): Support the use case when the observed field is an array.
 		panic(fmt.Errorf("observed fields of an array is not supported"))
 	case "object":
-		// TODO(b/): Support the use case when the observed field is an object.
+		// TODO(b/312581569): Support the use case when the observed field is an object.
 		panic(fmt.Errorf("observed fields of an object is not supported"))
 	default:
 		observedFieldParent.Properties[field] = *subSchema.DeepCopy()


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/309651922

* Added `observedFields` to the ResourceConfig to enable the configuration of fields exposed in the partial observed state for TF-based CRDs.
* Added the logic to generate the `status` with an `observedState` object containing the fields under `observedFields` in the TF-based CRDs.
  * The current implementation focuses on the main use case that the observed field is not under an array, and itself is not an object or array field.
* Added/Updated the unit tests to ensure `observedFields` is not empty when set, and the fields under `observedFields` have no duplicates and are all valid fields in TF schema.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
- Configured the `observedFields` locally in the service mapping and verified the CRD is generated correctly:

Diff in config/servicemappings/container.yaml
```
@@ -40,6 +40,8 @@ spec:
         - remove_default_node_pool
       mutableButUnreadableFields:
         - min_master_version
+      observedFields:
+        - master_auth.client_certificate
       containers:
         - type: project
           tfField: project
```
Diff in config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
```
@@ -1808,6 +1808,24 @@ spec:
                   current reported status reflects the most recent desired state of
                   the resource.
                 type: integer
+              observedState:
+                description: The observed state of the underlying GCP resource.
+                properties:
+                  masterAuth:
+                    description: DEPRECATED. Basic authentication was removed for
+                      GKE cluster versions >= 1.19. The authentication information
+                      for accessing the Kubernetes master. Some values in this block
+                      are only returned by the API if your service account has permission
+                      to get credentials for your GKE cluster. If you see an unexpected
+                      diff unsetting your client cert, ensure you have the container.clusters.getCredentials
+                      permission.
+                    properties:
+                      clientCertificate:
+                        description: Base64 encoded public certificate used by clients
+                          to authenticate to the cluster endpoint.
+                        type: string
+                    type: object
+                type: object
               operation:
                 type: string
               selfLink:
```