### PR TITLE
Fix attached cluster dynamic test

### DIFF
--- a/pkg/test/controller/k8s.go
+++ b/pkg/test/controller/k8s.go
@@ -175,7 +175,7 @@ func ReplaceTestVars(t *testing.T, b []byte, uniqueId string, project testgcp.GC
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.InterconnectTestProject), testgcp.GetInterconnectTestProject(t), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.HighCPUQuotaTestProject), testgcp.GetHighCpuQuotaTestProject(t), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.RecaptchaEnterpriseTestProject), testgcp.GetRecaptchaEnterpriseTestProject(t), -1)
-	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCAttachedClusterProject.Key), testgcp.TestAttachedClusterName.Get(), -1)
+	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCAttachedClusterProject.Key), testgcp.TestKCCAttachedClusterProject.Get(), -1)
 	return []byte(s)
 }
 


### PR DESCRIPTION
### Change description

Test failed due to a typo in getting env variable.

Fixes b/312873271

### Tests you have done

Dynamic test passed locally

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
