### PR TITLE
tests: refactor sample loading to defer substitution

### DIFF
--- a/config/tests/samples/create/contents_test.go
+++ b/config/tests/samples/create/contents_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package create
 
 import (
@@ -15,11 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-var matchEverythingRegex = regexp.MustCompile(".*")
-
 func TestNames(t *testing.T) {
-	project := testgcp.GetDefaultProject(t)
-	samples := loadSamplesOntoUnstructs(t, matchEverythingRegex, project)
+	project := testgcp.GCPProject{
+		ProjectID:     "tests-testnames",
+		ProjectNumber: 1234567890,
+	}
+	samples := LoadAllSamples(t, project)
 	for _, s := range samples {
 		for _, r := range s.Resources {
 			validateResourceName(t, s.Name, r)
@@ -29,12 +27,12 @@ func TestNames(t *testing.T) {
 
 func TestLicenses(t *testing.T) {
 	beginsWithCopyrightRegex := regexp.MustCompile("^# Copyright 20[0-9]{2} Google LLC.*")
-	samples := mapSampleNamesToFilePaths(t, matchEverythingRegex)
-	for sampleName, files := range samples {
-		for _, f := range files {
+	sampleKeys := ListAllSamples(t)
+	for _, sampleKey := range sampleKeys {
+		for _, f := range sampleKey.files {
 			b := test.MustReadFile(t, f)
 			if !beginsWithCopyrightRegex.Match(b) {
-				t.Errorf("file '%v' in sample '%v' does not contain a license header", f, sampleName)
+				t.Errorf("file '%v' in sample '%v' does not contain a license header", f, sampleKey.Name)
 			}
 		}
 	}

--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -16,8 +16,8 @@ package create
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path"
+	"io/fs"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,7 +36,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang-collections/go-datastructures/queue"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -236,65 +235,85 @@ func waitForDeleteToComplete(t *Harness, wg *sync.WaitGroup, u *unstructured.Uns
 	}
 }
 
-// LoadSamples loads all the samples
-func LoadSamples(t *testing.T, project testgcp.GCPProject) []Sample {
+// LoadAllSamples loads all the samples.
+func LoadAllSamples(t *testing.T, project testgcp.GCPProject) []Sample {
 	matchEverything := regexp.MustCompile(".*")
-	return loadSamplesOntoUnstructs(t, matchEverything, project)
+	return LoadMatchingSamples(t, matchEverything, project)
 }
 
-func loadSamplesOntoUnstructs(t *testing.T, regex *regexp.Regexp, project testgcp.GCPProject) []Sample {
+// LoadMatchingSamples loads the samples that match the regex
+func LoadMatchingSamples(t *testing.T, regex *regexp.Regexp, project testgcp.GCPProject) []Sample {
+	sampleKeys := ListMatchingSamples(t, regex)
+	var samples []Sample
+	for _, sampleKey := range sampleKeys {
+		sample := loadSampleOntoUnstructs(t, sampleKey, project)
+		samples = append(samples, sample)
+	}
+	return samples
+}
+
+// ListAllSamples gets the keys for all the samples without loading them.
+func ListAllSamples(t *testing.T) []SampleKey {
+	matchEverything := regexp.MustCompile(".*")
+	return ListMatchingSamples(t, matchEverything)
+}
+
+// LoadSample loads one sample
+func LoadSample(t *testing.T, sampleKey SampleKey, project testgcp.GCPProject) Sample {
+	return loadSampleOntoUnstructs(t, sampleKey, project)
+}
+
+// SampleKey contains the metadata for a sample.
+// This lets us defer variable substitution.
+type SampleKey struct {
+	Name  string
+	files []string
+}
+
+func loadSampleOntoUnstructs(t *testing.T, sampleKey SampleKey, project testgcp.GCPProject) Sample {
 	t.Helper()
 
-	samples := make([]Sample, 0)
-	sampleNamesToFiles := mapSampleNamesToFilePaths(t, regex)
 	subVars := newSubstitutionVariables(t, project)
-	for sample, files := range sampleNamesToFiles {
-		resources := make([]*unstructured.Unstructured, 0)
-		for _, f := range files {
-			unstructs := readFileToUnstructs(t, f, subVars)
-			resources = append(resources, unstructs...)
-		}
-		s := Sample{
-			Name:      sample,
-			Resources: resources,
-		}
-		samples = append(samples, s)
+	resources := make([]*unstructured.Unstructured, 0)
+	for _, f := range sampleKey.files {
+		unstructs := readFileToUnstructs(t, f, subVars)
+		resources = append(resources, unstructs...)
 	}
-	return samples
+	s := Sample{
+		Name:      sampleKey.Name,
+		Resources: resources,
+	}
+	return s
 }
 
-func mapSampleNamesToFilePaths(t *testing.T, regex *regexp.Regexp) map[string][]string {
+// ListMatchingSamples gets the keys for all samples matching the regex, without loading them.
+func ListMatchingSamples(t *testing.T, regex *regexp.Regexp) []SampleKey {
 	t.Helper()
-	samples := make(map[string][]string)
-	q := queue.New(1)
-	q.Put(repo.GetResourcesSamplesPath())
-	for !q.Empty() {
-		items, err := q.Get(1)
+	samples := make(map[string]SampleKey)
+	baseDir := repo.GetResourcesSamplesPath()
+	if err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			t.Fatalf("error retrieving an item from queue: %v", err)
+			return err
 		}
-		dir := items[0].(string)
-		fileInfos, err := ioutil.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("error reading directory '%v': %v", dir, err)
+		if strings.HasSuffix(d.Name(), ".yaml") {
+			sampleName := filepath.Base(filepath.Dir(path))
+			if regex.MatchString(sampleName) {
+				sampleKey := samples[sampleName]
+				sampleKey.Name = sampleName
+				sampleKey.files = append(sampleKey.files, path)
+				samples[sampleName] = sampleKey
+			}
 		}
-		for _, fi := range fileInfos {
-			if fi.IsDir() {
-				q.Put(path.Join(dir, fi.Name()))
-				continue
-			}
-			if !strings.HasSuffix(fi.Name(), ".yaml") {
-				continue
-			}
-			sampleName := path.Base(dir)
-			if !regex.MatchString(sampleName) {
-				continue
-			}
-			filePath := path.Join(dir, fi.Name())
-			samples[sampleName] = append(samples[sampleName], filePath)
-		}
+		return nil
+	}); err != nil {
+		t.Fatalf("error walking samples directory %q: %v", baseDir, err)
 	}
-	return samples
+
+	var list []SampleKey
+	for _, sampleKey := range samples {
+		list = append(list, sampleKey)
+	}
+	return list
 }
 
 func newSubstitutionVariables(t *testing.T, project testgcp.GCPProject) map[string]string {

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -230,7 +230,7 @@ func TestAll(t *testing.T) {
 	project := testgcp.GetDefaultProject(t)
 
 	setup()
-	samples := loadSamplesOntoUnstructs(t, regexp.MustCompile(runTestsRegex), project)
+	samples := LoadMatchingSamples(t, regexp.MustCompile(runTestsRegex), project)
 	// Sort the samples in descending order by number of resources. This is an attempt to start the samples that use
 	// a network and have many dependencies sooner since they will likely be the longest running.
 	sortSamplesInDescendingOrderByNumberOfResources(samples)

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -85,7 +85,7 @@ func TestAllInSeries(t *testing.T) {
 	}
 
 	t.Run("samples", func(t *testing.T) {
-		samples := create.LoadSamples(t, project)
+		samples := create.LoadAllSamples(t, project)
 
 		for _, s := range samples {
 			s := s


### PR DESCRIPTION
This lets us load the samples before creating a test project, which in
turn lets us run samples in isolated projects, particularly in mocks.
