### PR TITLE
run tests isolated

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -16,8 +16,8 @@ package create
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path"
+	"io/fs"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,7 +36,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang-collections/go-datastructures/queue"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -238,62 +237,76 @@ func waitForDeleteToComplete(t *Harness, wg *sync.WaitGroup, u *unstructured.Uns
 
 // LoadSamples loads all the samples
 func LoadSamples(t *testing.T, project testgcp.GCPProject) []Sample {
-	matchEverything := regexp.MustCompile(".*")
-	return loadSamplesOntoUnstructs(t, matchEverything, project)
-}
-
-func loadSamplesOntoUnstructs(t *testing.T, regex *regexp.Regexp, project testgcp.GCPProject) []Sample {
-	t.Helper()
-
-	samples := make([]Sample, 0)
-	sampleNamesToFiles := mapSampleNamesToFilePaths(t, regex)
-	subVars := newSubstitutionVariables(t, project)
-	for sample, files := range sampleNamesToFiles {
-		resources := make([]*unstructured.Unstructured, 0)
-		for _, f := range files {
-			unstructs := readFileToUnstructs(t, f, subVars)
-			resources = append(resources, unstructs...)
-		}
-		s := Sample{
-			Name:      sample,
-			Resources: resources,
-		}
-		samples = append(samples, s)
+	sampleKeys := ListSamples(t)
+	var samples []Sample
+	for _, sampleKey := range sampleKeys {
+		sample := loadSampleOntoUnstructs(t, sampleKey, project)
+		samples = append(samples, sample)
 	}
 	return samples
 }
 
-func mapSampleNamesToFilePaths(t *testing.T, regex *regexp.Regexp) map[string][]string {
-	t.Helper()
-	samples := make(map[string][]string)
-	q := queue.New(1)
-	q.Put(repo.GetResourcesSamplesPath())
-	for !q.Empty() {
-		items, err := q.Get(1)
-		if err != nil {
-			t.Fatalf("error retrieving an item from queue: %v", err)
-		}
-		dir := items[0].(string)
-		fileInfos, err := ioutil.ReadDir(dir)
-		if err != nil {
-			t.Fatalf("error reading directory '%v': %v", dir, err)
-		}
-		for _, fi := range fileInfos {
-			if fi.IsDir() {
-				q.Put(path.Join(dir, fi.Name()))
-				continue
-			}
-			if !strings.HasSuffix(fi.Name(), ".yaml") {
-				continue
-			}
-			sampleName := path.Base(dir)
-			if !regex.MatchString(sampleName) {
-				continue
-			}
-			filePath := path.Join(dir, fi.Name())
-			samples[sampleName] = append(samples[sampleName], filePath)
-		}
+// ListSamples loads all the samples
+func ListSamples(t *testing.T) []SampleKey {
+	matchEverything := regexp.MustCompile(".*")
+	sampleKeys := listSamples(t, matchEverything)
+	var list []SampleKey
+	for _, sampleKey := range sampleKeys {
+		list = append(list, sampleKey)
 	}
+	return list
+}
+
+// LoadSample loads one sample
+func LoadSample(t *testing.T, sampleKey SampleKey, project testgcp.GCPProject) Sample {
+	return loadSampleOntoUnstructs(t, sampleKey, project)
+}
+
+// SampleKey contains the metadata for a sample.
+// This lets us defer variable substitution.
+type SampleKey struct {
+	Name  string
+	files []string
+}
+
+func loadSampleOntoUnstructs(t *testing.T, sampleKey SampleKey, project testgcp.GCPProject) Sample {
+	t.Helper()
+
+	subVars := newSubstitutionVariables(t, project)
+	resources := make([]*unstructured.Unstructured, 0)
+	for _, f := range sampleKey.files {
+		unstructs := readFileToUnstructs(t, f, subVars)
+		resources = append(resources, unstructs...)
+	}
+	s := Sample{
+		Name:      sampleKey.Name,
+		Resources: resources,
+	}
+	return s
+}
+
+func listSamples(t *testing.T, regex *regexp.Regexp) map[string]SampleKey {
+	t.Helper()
+	samples := make(map[string]SampleKey)
+	baseDir := repo.GetResourcesSamplesPath()
+	if err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(d.Name(), ".yaml") {
+			sampleName := filepath.Base(filepath.Dir(path))
+			if regex.MatchString(sampleName) {
+				sampleKey := samples[sampleName]
+				sampleKey.Name = sampleName
+				sampleKey.files = append(sampleKey.files, path)
+				samples[sampleName] = sampleKey
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("error walking samples directory %q: %v", baseDir, err)
+	}
+
 	return samples
 }
 

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -257,7 +257,7 @@ func TestAll(t *testing.T) {
 			ctx := context.TODO()
 
 			h := NewHarnessWithManager(t, ctx, mgr)
-			SetupNamespacesAndApplyDefaults(h, []Sample{s}, project)
+			SetupNamespacesAndApplyDefaults(h, s, project)
 
 			networkCount := int64(networksInSampleCount(s))
 			if networkCount > 0 {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
-	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/google/go-cmp v0.5.9
 	github.com/gosimple/slug v1.9.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 h1:ZHJ7+IGpuOXtVf6Zk/a3WuHQgkC+vXwaqfUBDFwahtI=
-github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=

--- a/pkg/test/resourcefixture/resourcefixture.go
+++ b/pkg/test/resourcefixture/resourcefixture.go
@@ -16,7 +16,8 @@ package resourcefixture
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -26,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang-collections/go-datastructures/queue"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -78,23 +78,25 @@ type HeavyFilter func(fixture ResourceFixture) bool
 func LoadWithFilter(t *testing.T, lightFilterFunc LightFilter, heavyFilterFunc HeavyFilter) []ResourceFixture {
 	t.Helper()
 	allCases := make([]ResourceFixture, 0)
-	q := queue.New(1)
-	rootDir := getTestDataPath(t)
-	q.Put(rootDir)
-	for !q.Empty() {
-		items, err := q.Get(1)
+	baseDir := getTestDataPath(t)
+	if err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			t.Fatalf("error retreiving an item from queue: %v", err)
+			return err
 		}
-		dir := items[0].(string)
-		fileInfos, err := ioutil.ReadDir(dir)
+
+		if !d.IsDir() {
+			return nil
+		}
+
+		// This is a slightly inefficient, but we want to reuse the existing code
+		fileInfos, err := os.ReadDir(path)
 		if err != nil {
-			t.Fatalf("error reading directory '%v': %v", dir, err)
+			return fmt.Errorf("error reading directory '%v': %w", path, err)
 		}
+
 		testToFileName := make(map[string]string)
 		for _, fi := range fileInfos {
 			if fi.IsDir() {
-				q.Put(path.Join(dir, fi.Name()))
 				continue
 			}
 			if !strings.HasSuffix(fi.Name(), ".yaml") {
@@ -102,26 +104,32 @@ func LoadWithFilter(t *testing.T, lightFilterFunc LightFilter, heavyFilterFunc H
 			}
 			fileNameNoExt := strings.TrimSuffix(fi.Name(), ".yaml")
 			if value, ok := testToFileName[fileNameNoExt]; ok {
-				t.Fatalf("error, conflicting files for test '%v' in '%v': {%v, %v}", fileNameNoExt, dir, value, fi.Name())
+				t.Fatalf("error, conflicting files for test '%v' in '%v': {%v, %v}", fileNameNoExt, path, value, fi.Name())
 			}
 			testToFileName[fileNameNoExt] = fi.Name()
 		}
+
 		// TODO: something about tags here
 		if createFile, ok := testToFileName["create"]; ok {
 			updateFile := testToFileName["update"]
 			depFile := testToFileName["dependencies"]
-			name := path.Base(dir)
-			testType := parseTestTypeFromPath(t, dir)
+			name := filepath.Base(path)
+			testType := parseTestTypeFromPath(t, path)
 			if lightFilterFunc != nil && !lightFilterFunc(name, testType) {
-				continue
+				return nil
 			}
-			rf := loadResourceFixture(t, name, testType, dir, createFile, updateFile, depFile)
+			rf := loadResourceFixture(t, name, testType, path, createFile, updateFile, depFile)
 			if heavyFilterFunc != nil && !heavyFilterFunc(rf) {
-				continue
+				return nil
 			}
 			allCases = append(allCases, rf)
 		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("error walking directory %q: %v", baseDir, err)
 	}
+
 	return allCases
 }
 

--- a/scripts/generate-google3-docs/resource-reference/main.go
+++ b/scripts/generate-google3-docs/resource-reference/main.go
@@ -46,9 +46,9 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/fileutil"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
-	"github.com/golang-collections/go-datastructures/set"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // convenience struct for converting to the desired human readable output on the docs page from the fielddesc.FieldDescription struct
@@ -298,9 +298,9 @@ func constructResourceForGVK(gvk schema.GroupVersionKind, smLoader *servicemappi
 }
 
 func handleAnnotationsAndIAMSettingsForDCLBasedResource(r *resource, gvk schema.GroupVersionKind) error {
-	annotationSet := set.New()
+	annotationSet := sets.NewString()
 	if k8s.ResourceSupportsStateAbsentInSpec(gvk.Kind) {
-		annotationSet.Add(k8s.StateIntoSpecAnnotation)
+		annotationSet.Insert(k8s.StateIntoSpecAnnotation)
 	}
 	resourceMetadata, found := serviceMetadataLoader.GetResourceWithGVK(gvk)
 	if !found {
@@ -314,7 +314,7 @@ func handleAnnotationsAndIAMSettingsForDCLBasedResource(r *resource, gvk schema.
 	// hierarchical references.
 	if !resourceMetadata.SupportsHierarchicalReferences {
 		for _, c := range containers {
-			annotationSet.Add(k8s.GetAnnotationForContainerType(c.Type))
+			annotationSet.Insert(k8s.GetAnnotationForContainerType(c.Type))
 		}
 	}
 	setAnnotations(r, annotationSet)
@@ -338,9 +338,9 @@ func handleAnnotationsAndIAMSettingsForDCLBasedResource(r *resource, gvk schema.
 }
 
 func handleAnnotationsAndIAMSettingsForTFBasedResource(r *resource, gvk schema.GroupVersionKind, smLoader *servicemappingloader.ServiceMappingLoader) error {
-	annotationSet := set.New()
+	annotationSet := sets.NewString()
 	if k8s.ResourceSupportsStateAbsentInSpec(gvk.Kind) {
-		annotationSet.Add(k8s.StateIntoSpecAnnotation)
+		annotationSet.Insert(k8s.StateIntoSpecAnnotation)
 	}
 	rcs, err := smLoader.GetResourceConfigs(gvk)
 	if err != nil {
@@ -349,14 +349,14 @@ func handleAnnotationsAndIAMSettingsForTFBasedResource(r *resource, gvk schema.G
 	for _, rc := range rcs {
 		if rc.Directives != nil {
 			for _, d := range rc.Directives {
-				annotationSet.Add(k8s.FormatAnnotation(text.SnakeCaseToKebabCase(d)))
+				annotationSet.Insert(k8s.FormatAnnotation(text.SnakeCaseToKebabCase(d)))
 			}
 		}
 		if !krmtotf.SupportsHierarchicalReferences(rc) {
 			// TODO(b/193177782): Delete this if-block once all resources
 			// support hierarchical references.
 			for _, c := range rc.Containers {
-				annotationSet.Add(k8s.GetAnnotationForContainerType(c.Type))
+				annotationSet.Insert(k8s.GetAnnotationForContainerType(c.Type))
 			}
 		}
 	}
@@ -378,16 +378,11 @@ func handleAnnotationsAndIAMSettingsForTFBasedResource(r *resource, gvk schema.G
 	return nil
 }
 
-func setAnnotations(r *resource, annotationSet *set.Set) {
+func setAnnotations(r *resource, annotationSet sets.String) {
 	if annotationSet.Len() > 0 {
-		// arrange annotations alphabetically
-		i := annotationSet.Flatten()
-		strArr := make([]string, len(i))
-		for k, v := range i {
-			strArr[k] = v.(string)
-		}
-		sort.Strings(strArr)
-		r.Annotations = strArr
+		annotations := annotationSet.List()
+		sort.Strings(annotations) // Should already be sorted, but for clarity
+		r.Annotations = annotations
 	}
 }
 

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -46,57 +46,63 @@ func TestAllInSeries(t *testing.T) {
 		cancel()
 	})
 
-	testHarness := create.NewHarness(t, ctx)
+	createProject := func(testHarness *create.Harness) testgcp.GCPProject {
+		if os.Getenv("E2E_GCP_TARGET") == "mock" {
+			// Some fixed-value fake org-ids for testing.
+			// We used fixed values so that the output is predictable (for golden testing)
+			testgcp.TestFolderID.Set("123451001")
+			testgcp.TestFolder2ID.Set("123451002")
+			testgcp.TestOrgID.Set("123450001")
+			testgcp.TestBillingAccountID.Set("123456-777777-000001")
+			testgcp.IAMIntegrationTestsOrganizationID.Set("123450002")
+			testgcp.IAMIntegrationTestsBillingAccountID.Set("123456-777777-000002")
+			testgcp.TestAttachedClusterName.Set("xks-cluster")
 
-	var project testgcp.GCPProject
-	if os.Getenv("E2E_GCP_TARGET") == "mock" {
-		// Some fixed-value fake org-ids for testing.
-		// We used fixed values so that the output is predictable (for golden testing)
-		testgcp.TestFolderID.Set("123451001")
-		testgcp.TestFolder2ID.Set("123451002")
-		testgcp.TestOrgID.Set("123450001")
-		testgcp.TestBillingAccountID.Set("123456-777777-000001")
-		testgcp.IAMIntegrationTestsOrganizationID.Set("123450002")
-		testgcp.IAMIntegrationTestsBillingAccountID.Set("123456-777777-000002")
-		testgcp.TestAttachedClusterName.Set("xks-cluster")
-
-		crm := testHarness.GetCloudResourceManagerClient()
-		req := &cloudresourcemanager.Project{
-			ProjectId: "mock-project",
+			crm := testHarness.GetCloudResourceManagerClient()
+			req := &cloudresourcemanager.Project{
+				ProjectId: "mock-project",
+			}
+			op, err := crm.Projects.Create(req).Context(testHarness.Ctx).Do()
+			if err != nil {
+				testHarness.Fatalf("error creating project: %v", err)
+			}
+			if !op.Done {
+				testHarness.Fatalf("expected mock create project operation to be done immediately")
+			}
+			found, err := crm.Projects.Get(req.ProjectId).Context(testHarness.Ctx).Do()
+			if err != nil {
+				testHarness.Fatalf("error reading created project: %v", err)
+			}
+			project := testgcp.GCPProject{
+				ProjectID:     found.ProjectId,
+				ProjectNumber: found.ProjectNumber,
+			}
+			testgcp.TestKCCAttachedClusterProject.Set("mock-project")
+			return project
+		} else {
+			return testgcp.GetDefaultProject(t)
 		}
-		op, err := crm.Projects.Create(req).Context(testHarness.Ctx).Do()
-		if err != nil {
-			testHarness.Fatalf("error creating project: %v", err)
-		}
-		if !op.Done {
-			testHarness.Fatalf("expected mock create project operation to be done immediately")
-		}
-		found, err := crm.Projects.Get(req.ProjectId).Context(testHarness.Ctx).Do()
-		if err != nil {
-			testHarness.Fatalf("error reading created project: %v", err)
-		}
-		project = testgcp.GCPProject{
-			ProjectID:     found.ProjectId,
-			ProjectNumber: found.ProjectNumber,
-		}
-		testgcp.TestKCCAttachedClusterProject.Set("mock-project")
-	} else {
-		project = testgcp.GetDefaultProject(t)
 	}
 
 	t.Run("samples", func(t *testing.T) {
-		samples := create.LoadSamples(t, project)
+		samples := create.ListSamples(t)
 
-		for _, s := range samples {
-			s := s
+		for _, sampleKey := range samples {
+			sampleKey := sampleKey
 			// TODO(b/259496928): Randomize the resource names for parallel execution when/if needed.
 
-			t.Run(s.Name, func(t *testing.T) {
-				create.MaybeSkip(t, s.Name, s.Resources)
+			t.Run(sampleKey.Name, func(t *testing.T) {
+				// Quickly load the sample with a dummy project, just to see if we should skip it
+				{
+					dummySample := create.LoadSample(t, sampleKey, testgcp.GCPProject{ProjectID: "test-skip", ProjectNumber: 123456789})
+					create.MaybeSkip(t, sampleKey.Name, dummySample.Resources)
+				}
 
-				h := testHarness.ForSubtest(t)
+				h := create.NewHarness(t, ctx)
+				project := createProject(h)
+				s := create.LoadSample(t, sampleKey, project)
 
-				create.SetupNamespacesAndApplyDefaults(h, []create.Sample{s}, project)
+				create.SetupNamespacesAndApplyDefaults(h, s.Resources, project)
 
 				// Hack: set project-id because mockkubeapiserver does not support webhooks
 				for _, u := range s.Resources {
@@ -119,37 +125,44 @@ func TestAllInSeries(t *testing.T) {
 			fixture := fixture
 			// TODO(b/259496928): Randomize the resource names for parallel execution when/if needed.
 
-			testID := testvariable.NewUniqueId()
+			t.Run(fixture.Name, func(t *testing.T) {
+				testID := testvariable.NewUniqueId()
 
-			s := create.Sample{
-				Name: fixture.Name,
-			}
+				loadFixture := func(project testgcp.GCPProject) (*unstructured.Unstructured, create.CreateDeleteTestOptions) {
+					primaryResource := bytesToUnstructured(t, fixture.Create, testID, project)
 
-			createResource := bytesToUnstructured(t, fixture.Create, testID, project)
-			s.Resources = append(s.Resources, createResource)
+					opt := create.CreateDeleteTestOptions{CleanupResources: true}
+					opt.Create = append(opt.Create, primaryResource)
 
-			exportResources := []*unstructured.Unstructured{createResource}
+					if fixture.Dependencies != nil {
+						dependencyYamls := testyaml.SplitYAML(t, fixture.Dependencies)
+						for _, dependBytes := range dependencyYamls {
+							depUnstruct := bytesToUnstructured(t, dependBytes, testID, project)
+							opt.Create = append(opt.Create, depUnstruct)
+						}
+					}
 
-			if fixture.Dependencies != nil {
-				dependencyYamls := testyaml.SplitYAML(t, fixture.Dependencies)
-				for _, dependBytes := range dependencyYamls {
-					depUnstruct := bytesToUnstructured(t, dependBytes, testID, project)
-					s.Resources = append(s.Resources, depUnstruct)
+					if fixture.Update != nil {
+						u := bytesToUnstructured(t, fixture.Update, testID, project)
+						opt.Updates = append(opt.Updates, u)
+					}
+					return primaryResource, opt
 				}
-			}
 
-			opt := create.CreateDeleteTestOptions{Create: s.Resources, CleanupResources: true}
-			if fixture.Update != nil {
-				u := bytesToUnstructured(t, fixture.Update, testID, project)
-				opt.Updates = append(opt.Updates, u)
-			}
+				// Quickly load the fixture with a dummy project, just to see if we should skip it
+				{
+					_, opt := loadFixture(testgcp.GCPProject{ProjectID: "test-skip", ProjectNumber: 123456789})
+					create.MaybeSkip(t, fixture.Name, opt.Create)
+				}
 
-			t.Run(s.Name, func(t *testing.T) {
-				create.MaybeSkip(t, s.Name, s.Resources)
+				h := create.NewHarness(t, ctx)
+				project := createProject(h)
 
-				h := testHarness.ForSubtest(t)
+				primaryResource, opt := loadFixture(project)
 
-				create.SetupNamespacesAndApplyDefaults(h, []create.Sample{s}, project)
+				exportResources := []*unstructured.Unstructured{primaryResource}
+
+				create.SetupNamespacesAndApplyDefaults(h, opt.Create, project)
 
 				opt.CleanupResources = false // We delete explicitly below
 				create.RunCreateDeleteTest(h, opt)
@@ -186,7 +199,7 @@ func TestAllInSeries(t *testing.T) {
 					h.CompareGoldenFile(expectedPath, string(output), h.IgnoreComments, h.ReplaceString(project.ProjectID, "example-project-id"))
 				}
 
-				create.DeleteResources(h, s.Resources)
+				create.DeleteResources(h, opt.Create)
 			})
 		}
 	})


### PR DESCRIPTION
- tests: refactor sample loading to defer substitution
- Remove last uses of go-datastructures library
- tests: support mockkubeapiserver as E2E_KUBE_TARGET
- tests: run each mock test in a different project
