### PR TITLE
Client type generation: don't depend on controller-runtime

### DIFF
--- a/scripts/generate-go-crd-clients/general_types.go
+++ b/scripts/generate-go-crd-clients/general_types.go
@@ -121,10 +121,6 @@ func (g *GeneralTypes) Generate() {
 	g.Print("   metav1.ListMeta `json:\"metadata,omitempty\"`")
 	g.Print("   Items []%s `json:\"items\"`", g.Name)
 	g.Print(" }")
-
-	g.Print(" func init() {")
-	g.Print("   SchemeBuilder.Register(&%s{}, &%sList{})", g.Name, g.Name)
-	g.Print(" }")
 }
 
 func (g *GeneralTypes) structField(f *fieldProperties) {

--- a/scripts/generate-go-crd-clients/register.go.tmpl
+++ b/scripts/generate-go-crd-clients/register.go.tmpl
@@ -37,10 +37,9 @@
 package {{.Version}}
 
 import (
-	"reflect"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -48,18 +47,31 @@ var (
 	SchemeGroupVersion = schema.GroupVersion{Group: "{{.Service}}.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme is a global function that registers this API group & version to a scheme
-	AddToScheme = SchemeBuilder.AddToScheme
+	localSchemeBuilder = &SchemeBuilder
+	AddToScheme = localSchemeBuilder.AddToScheme
 
 	{{ range $k := $.Kinds }}
-  	{{$k}}GVK = schema.GroupVersionKind{
-  		Group:   SchemeGroupVersion.Group,
-  		Version: SchemeGroupVersion.Version,
-  		Kind:    reflect.TypeOf({{$k}}{}).Name(),
+	{{$k}}GVK = schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    "{{$k}}",
   	}
-  {{ end }}
+    {{ end }}
 
   	{{.Service}}APIVersion = SchemeGroupVersion.String()
 )
+
+// Adds the list of known types to the given scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		{{- range $k := $.Kinds }}
+		&{{$k}}{},
+		&{{$k}}List{},
+		{{- end }}
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}


### PR DESCRIPTION
We don't need to depend on controller-runtime (the types remain
compatible with controller-runtime), and this reduces the dependency
tree for clients.
