### PR TITLE
Enforce separate commit for changes in TF Git Subtree

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           # This is introduced to make sure 'go generate' works properly
           path: "src/k8s-config-connector"
+          # This is to get all the commits in order to validate them
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21.4"
@@ -39,6 +41,8 @@ jobs:
         env:
           # This is introduced to make sure 'go generate' works properly
           GOPATH: /home/runner/work/k8s-config-connector/k8s-config-connector
+          COMMIT_HEAD: ${{ github.event.pull_request.head.sha }}
+          COMMIT_CNT: ${{ github.event.pull_request.commits }}
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/scripts/github-actions/ga-validation.sh
+++ b/scripts/github-actions/ga-validation.sh
@@ -23,4 +23,20 @@ source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
 	setup_envs
 
 echo "Running validations..."
-${REPO_ROOT}/scripts/validate-prereqs.sh
+
+# Check if any commit contains changes both within and outside the TF Git Subtree
+SUBTREE_DIR="third_party/github.com/hashicorp/terraform-provider-google-beta/"
+COMMIT_HASHES=($(git rev-list --topo-order -n $COMMIT_CNT $COMMIT_HEAD))
+
+for COMMIT in "${COMMIT_HASHES[@]}"; do
+  PARENT_COMMIT=$(git rev-parse $COMMIT^)
+
+  if git diff --name-only $PARENT_COMMIT..$COMMIT | grep "^$SUBTREE_DIR" > /dev/null && git diff --name-only $PARENT_COMMIT..$COMMIT | grep -v "^$SUBTREE_DIR" > /dev/null
+  then
+    echo -e "Error: Your commit \"$COMMIT\" includes changes both within and outside the\n\"$SUBTREE_DIR\" directory.\nPlease ensure that changes made within this directory are grouped and\nsubmitted as a separate, dedicated commit.\n"
+    exit 1
+fi
+done
+
+# Regular validations on fmt, generated doc, generated code, etc.
+#${REPO_ROOT}/scripts/validate-prereqs.sh

--- a/scripts/github-actions/ga-validation.sh
+++ b/scripts/github-actions/ga-validation.sh
@@ -39,4 +39,4 @@ fi
 done
 
 # Regular validations on fmt, generated doc, generated code, etc.
-#${REPO_ROOT}/scripts/validate-prereqs.sh
+${REPO_ROOT}/scripts/validate-prereqs.sh


### PR DESCRIPTION
### Change description

We have recently changed the Terraform Google Provider library as a Git Subtree in this Git repository:

third_party/github.com/hashicorp/terraform-provider-google-beta

As a result, we want to make sure all the custom changes to the Git Subtree are organized as separate commits, instead of having a commit with mixed subtree and parent project changes. 

Otherwise it will be tricky in future, if we want to update the Git Subtree and pick up changes from upstream, or we want to contribute any changes upstream.

An example of how the validation works, with an error message:

https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/7040435304/job/19161354482?pr=1045

Fixes: b/313935741

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
