### PR TITLE
Skip subtree commit validation if it is not pull_request event

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -41,6 +41,7 @@ jobs:
         env:
           # This is introduced to make sure 'go generate' works properly
           GOPATH: /home/runner/work/k8s-config-connector/k8s-config-connector
+          EVENT_NAME: ${{ github.event_name }}
           COMMIT_HEAD: ${{ github.event.pull_request.head.sha }}
           COMMIT_CNT: ${{ github.event.pull_request.commits }}
   unit-tests:

--- a/scripts/github-actions/ga-validation.sh
+++ b/scripts/github-actions/ga-validation.sh
@@ -24,19 +24,22 @@ source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
 
 echo "Running validations..."
 
-# Check if any commit contains changes both within and outside the TF Git Subtree
-SUBTREE_DIR="third_party/github.com/hashicorp/terraform-provider-google-beta/"
-COMMIT_HASHES=($(git rev-list --topo-order -n $COMMIT_CNT $COMMIT_HEAD))
+# If EVENT_NAME is "pull_request", then check if any commit contains changes both within and outside the TF Git Subtree
+if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+  # Check if any commit contains changes both within and outside the TF Git Subtree
+  SUBTREE_DIR="third_party/github.com/hashicorp/terraform-provider-google-beta/"
+  COMMIT_HASHES=($(git rev-list --topo-order -n $COMMIT_CNT $COMMIT_HEAD))
 
-for COMMIT in "${COMMIT_HASHES[@]}"; do
-  PARENT_COMMIT=$(git rev-parse $COMMIT^)
+  for COMMIT in "${COMMIT_HASHES[@]}"; do
+    PARENT_COMMIT=$(git rev-parse $COMMIT^)
 
-  if git diff --name-only $PARENT_COMMIT..$COMMIT | grep "^$SUBTREE_DIR" > /dev/null && git diff --name-only $PARENT_COMMIT..$COMMIT | grep -v "^$SUBTREE_DIR" > /dev/null
-  then
-    echo -e "Error: Your commit \"$COMMIT\" includes changes both within and outside the\n\"$SUBTREE_DIR\" directory.\nPlease ensure that changes made within this directory are grouped and\nsubmitted as a separate, dedicated commit.\n"
-    exit 1
+    if git diff --name-only $PARENT_COMMIT..$COMMIT | grep "^$SUBTREE_DIR" > /dev/null && git diff --name-only $PARENT_COMMIT..$COMMIT | grep -v "^$SUBTREE_DIR" > /dev/null
+    then
+      echo -e "Error: Your commit \"$COMMIT\" includes changes both within and outside the\n\"$SUBTREE_DIR\" directory.\nPlease ensure that changes made within this directory are grouped and\nsubmitted as a separate, dedicated commit.\n"
+      exit 1
+    fi
+  done
 fi
-done
 
 # Regular validations on fmt, generated doc, generated code, etc.
 ${REPO_ROOT}/scripts/validate-prereqs.sh


### PR DESCRIPTION
### Change description

The current GitHub action is triggered on both pull_request and push events. We don't need the commit validation check on push events. Also the validation will fail for push event since we don't have the required environment var from pull requests.

https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/7048083106/job/19183424021

Fixes b/313935741

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
