### PR TITLE
Make sure that totalMaxNodeCount and totalMinNodeCount are considered when scaling the nodepool up or down

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_node_pool.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_node_pool.go
@@ -1278,7 +1278,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			maxNodeCount := autoscaling["max_node_count"].(int)
 			totalMaxNodeCount := autoscaling["total_max_node_count"].(int)
 			totalMinNodeCount := autoscaling["total_min_node_count"].(int)
-			if (minNodeCount == 0) && (maxNodeCount == 0) || (totalMaxNodeCount == 0) && (totalMinNodeCount == 0) {
+			if ((minNodeCount == 0) && (maxNodeCount == 0)) && ((totalMaxNodeCount == 0) && (totalMinNodeCount == 0)) {
 				update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
 					Enabled: false,
 				}

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_node_pool.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_node_pool.go
@@ -1276,7 +1276,9 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			// disable autoscaling if both min/max node counts are set to 0
 			minNodeCount := autoscaling["min_node_count"].(int)
 			maxNodeCount := autoscaling["max_node_count"].(int)
-			if (minNodeCount == 0) && (maxNodeCount == 0) {
+			totalMaxNodeCount := autoscaling["total_max_node_count"].(int)
+			totalMinNodeCount := autoscaling["total_min_node_count"].(int)
+			if (minNodeCount == 0) && (maxNodeCount == 0) || (totalMaxNodeCount == 0) && (totalMinNodeCount == 0) {
 				update.DesiredNodePoolAutoscaling = &container.NodePoolAutoscaling{
 					Enabled: false,
 				}
@@ -1285,8 +1287,8 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					Enabled:           true,
 					MinNodeCount:      int64(minNodeCount),
 					MaxNodeCount:      int64(maxNodeCount),
-					TotalMinNodeCount: int64(autoscaling["total_min_node_count"].(int)),
-					TotalMaxNodeCount: int64(autoscaling["total_max_node_count"].(int)),
+					TotalMinNodeCount: int64(totalMinNodeCount),
+					TotalMaxNodeCount: int64(totalMaxNodeCount),
 					LocationPolicy:    autoscaling["location_policy"].(string),
 					ForceSendFields:   []string{"MinNodeCount", "TotalMinNodeCount"},
 				}


### PR DESCRIPTION

### Change description
Fixes #833 where autoscaling would be outright removed when specifying the total totalMaxNodeCount instead of the per zone MaxNodeCount.

### Tests you have done

I have run `make ready-pr`.

I have deployed it to our dev test cluster and made sure that it works as intended:
My original YAML spec:
```
spec:
  autoscaling:
    totalMaxNodeCount: 4
    locationPolicy: ANY
```
resulted in this container node pool being deployed:
```
Spec:
  Autoscaling:
    Location Policy:       ANY
    Total Max Node Count:  4
```
Changing the spec to:
```
spec:
  autoscaling:
    totalMaxNodeCount: 1
    locationPolicy: ANY
```
Results in this being updated to:
```
Spec:
  Autoscaling:
    Location Policy:       ANY
    Total Max Node Count:  1
```

It seems to work properly.


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
