### PR TITLE
Resolve the observed state for TF-based resources

### DIFF
--- a/config/tests/servicemapping/servicemapping_test.go
+++ b/config/tests/servicemapping/servicemapping_test.go
@@ -1278,11 +1278,13 @@ func TestStorageVersionIsSetAndValidIFFV1alpha1ToV1beta1IsSet(t *testing.T) {
 func TestObservedFields(t *testing.T) {
 	t.Parallel()
 	serviceMappings := testservicemappingloader.New(t).GetServiceMappings()
+	provider := tfprovider.NewOrLogFatal(tfprovider.UnitTestConfig())
 	for _, sm := range serviceMappings {
 		sm := sm
 		t.Run(sm.Name, func(t *testing.T) {
 			t.Parallel()
 			for _, rc := range sm.Spec.Resources {
+				tfResource := provider.ResourcesMap[rc.Name]
 				rc := rc
 				t.Run(rc.Kind, func(t *testing.T) {
 					t.Parallel()
@@ -1291,6 +1293,14 @@ func TestObservedFields(t *testing.T) {
 					}
 					assertObservedFieldsSliceNotEmpty(t, rc)
 					assertNoDuplicatesInObservedFieldsSlice(t, rc)
+					// TODO(b/314840974): Remove after reference fields are supported as observed fields.
+					assertObservedFieldsNotReferences(t, rc)
+					// TODO(b/314841141): Remove after label fields are supported as observed fields.
+					assertObservedFieldsNotLabels(t, rc)
+					// TODO(b/314842047): Remove after name fields are supported as observed fields.
+					assertObservedFieldsNotName(t, rc)
+					// TODO(b/314841744): Remove after sensitive fields are supported as observed fields.
+					assertObservedFieldsNotSensitive(t, rc, tfResource)
 				})
 			}
 		})
@@ -1321,4 +1331,54 @@ func assertNoDuplicatesInObservedFieldsSlice(t *testing.T, rc v1alpha1.ResourceC
 		observedFieldMap[field] = true
 	}
 	return
+}
+
+func assertObservedFieldsNotReferences(t *testing.T, rc v1alpha1.ResourceConfig) {
+	t.Helper()
+	referenceFields := make(map[string]bool)
+	for _, refConfig := range rc.ResourceReferences {
+		referenceFields[refConfig.TFField] = true
+	}
+	for _, field := range *rc.ObservedFields {
+		if _, ok := referenceFields[field]; ok {
+			t.Errorf("kind %v contains observed field %v: reference "+
+				"fields are not supported as observed fields", rc.Kind, field)
+		}
+	}
+}
+
+func assertObservedFieldsNotLabels(t *testing.T, rc v1alpha1.ResourceConfig) {
+	t.Helper()
+	for _, field := range *rc.ObservedFields {
+		if field != "" && field == rc.MetadataMapping.Labels {
+			t.Errorf("kind %v contains observed field %v: labels "+
+				"field is not supported as ab observed field", rc.Kind, field)
+		}
+	}
+}
+
+func assertObservedFieldsNotName(t *testing.T, rc v1alpha1.ResourceConfig) {
+	for _, field := range *rc.ObservedFields {
+		if field != "" && (field == rc.MetadataMapping.Name ||
+			field == rc.ServerGeneratedIDField) {
+			t.Errorf("kind %v contains observed field %v: name "+
+				"field is not supported as an observed field", rc.Kind, field)
+		}
+	}
+}
+
+func assertObservedFieldsNotSensitive(t *testing.T, rc v1alpha1.ResourceConfig, tfResource *schema.Resource) {
+	t.Helper()
+	for _, field := range *rc.ObservedFields {
+		tfSchema, err := tfresource.GetTFSchemaForField(tfResource, field)
+		if err != nil {
+			t.Errorf("error getting Terraform schema for observed "+
+				"field %v in kind %v: %v", field, rc.Kind, err)
+		}
+		if tfresource.IsSensitiveField(tfSchema) {
+			t.Errorf("kind %v contains observed field %v: sensitive "+
+				"fields are not supported as observed fields", rc.Kind, field)
+		}
+	}
+
 }

--- a/pkg/krmtotf/resource.go
+++ b/pkg/krmtotf/resource.go
@@ -348,3 +348,15 @@ func GVKForResource(sm *corekccv1alpha1.ServiceMapping, rc *corekccv1alpha1.Reso
 func ServerGeneratedIdToTemplate(rc *corekccv1alpha1.ResourceConfig) string {
 	return fmt.Sprintf("{{%v}}", rc.ServerGeneratedIDField)
 }
+
+func isMetadataMappingLabelsField(field string, rc *corekccv1alpha1.ResourceConfig) bool {
+	return rc.MetadataMapping.Labels != "" && field == rc.MetadataMapping.Labels
+}
+
+func isMetadataMappingNameField(field string, rc *corekccv1alpha1.ResourceConfig) bool {
+	return rc.MetadataMapping.Name != "" && field == rc.MetadataMapping.Name
+}
+
+func isServerGeneratedIDField(field string, rc *corekccv1alpha1.ResourceConfig) bool {
+	return rc.ServerGeneratedIDField != "" && field == rc.ServerGeneratedIDField
+}

--- a/pkg/krmtotf/tftokrm_test.go
+++ b/pkg/krmtotf/tftokrm_test.go
@@ -2058,3 +2058,365 @@ func assertGetSpecAndStatusFromStateWithResourceIDPanic(t *testing.T, resource *
 	}()
 	ResolveSpecAndStatusWithResourceID(resource, state)
 }
+
+func TestResolveSpecAndStatusContainingObservedState(t *testing.T) {
+	tests := []struct {
+		name           string
+		rc             *corekccv1alpha1.ResourceConfig
+		metadataName   string
+		prevSpec       map[string]interface{}
+		prevStatus     map[string]interface{}
+		tfResource     *tfschema.Resource
+		tfAttributes   map[string]string
+		expectedSpec   map[string]interface{}
+		expectedStatus map[string]interface{}
+		shouldPanic    bool
+	}{
+		{
+			name: "with string observed fields",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"nested_object_key.nested_float_key",
+					"string_key",
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"string_key": {
+						Type:     tfschema.TypeString,
+						Optional: true,
+					},
+					"nested_object_key": {
+						Type:     tfschema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &tfschema.Resource{
+							Schema: map[string]*tfschema.Schema{
+								"nested_float_key": {
+									Type:     tfschema.TypeFloat,
+									Optional: true,
+								},
+								"nested_string_key": {
+									Type:     tfschema.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field":                            "desired-value",
+				"nested_object_key.#":                   "1",
+				"nested_object_key.0.nested_float_key":  "123",
+				"nested_object_key.0.nested_string_key": "not-in-observed-state",
+				"string_key":                            "test-observed-field",
+			},
+			expectedSpec: map[string]interface{}{
+				"testField": "desired-value",
+				"nestedObjectKey": map[string]interface{}{
+					"nestedFloatKey":  float64(123),
+					"nestedStringKey": "not-in-observed-state",
+				},
+				"stringKey": "test-observed-field",
+			},
+			expectedStatus: map[string]interface{}{
+				"observedState": map[string]interface{}{
+					"nestedObjectKey": map[string]interface{}{
+						"nestedFloatKey": float64(123),
+					},
+					"stringKey": "test-observed-field",
+				},
+			},
+		},
+		{
+			name: "with partial string observed fields in observed state",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"nested_object_key.nested_float_key",
+					"string_key",
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"string_key": {
+						Type:     tfschema.TypeString,
+						Optional: true,
+					},
+					"nested_object_key": {
+						Type:     tfschema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &tfschema.Resource{
+							Schema: map[string]*tfschema.Schema{
+								"nested_float_key": {
+									Type:     tfschema.TypeFloat,
+									Optional: true,
+								},
+								"nested_string_key": {
+									Type:     tfschema.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field": "desired-value",
+				"string_key": "test-observed-field",
+			},
+			expectedSpec: map[string]interface{}{
+				"testField": "desired-value",
+				"stringKey": "test-observed-field",
+			},
+			expectedStatus: map[string]interface{}{
+				"observedState": map[string]interface{}{
+					"stringKey": "test-observed-field",
+				},
+			},
+		},
+		{
+			name: "panic with observed reference fields",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"reference_key",
+				},
+				ResourceReferences: []corekccv1alpha1.ReferenceConfig{
+					{
+						TFField: "reference_key",
+						TypeConfig: corekccv1alpha1.TypeConfig{
+							Key: "referenceRef",
+							GVK: k8sschema.GroupVersionKind{
+								Group:   "test1.cnrm.cloud.google.com",
+								Version: "v1alpha1",
+								Kind:    "Test1Bar",
+							},
+						},
+					},
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"reference_key": {
+						Type:     tfschema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field":    "desired-value",
+				"reference_key": "invalid-observed-field",
+			},
+			expectedSpec:   nil,
+			expectedStatus: nil,
+			shouldPanic:    true,
+		},
+		{
+			name: "panic with observed labels fields",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"string_key",
+				},
+				MetadataMapping: corekccv1alpha1.MetadataMapping{
+					Labels: "string_key",
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"string_key": {
+						Type:     tfschema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field": "desired-value",
+				"string_key": "invalid-observed-field",
+			},
+			expectedSpec:   nil,
+			expectedStatus: nil,
+			shouldPanic:    true,
+		},
+		{
+			name: "panic with observed user-specified name fields",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"user_specified_name_key",
+				},
+				MetadataMapping: corekccv1alpha1.MetadataMapping{
+					Name: "user_specified_name_key",
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"user_specified_name_key": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field":              "desired-value",
+				"user_specified_name_key": "invalid-observed-field",
+			},
+			expectedSpec:   nil,
+			expectedStatus: nil,
+			shouldPanic:    true,
+		},
+		{
+			name: "panic with observed server-generated name fields",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"server_generated_name_key",
+				},
+				ServerGeneratedIDField: "server_generated_name_key",
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"server_generated_name_key": {
+						Type:     tfschema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field":                "desired-value",
+				"server_generated_name_key": "invalid-observed-field",
+			},
+			expectedSpec:   nil,
+			expectedStatus: nil,
+			shouldPanic:    true,
+		},
+		{
+			name: "panic with observed fields under array",
+			rc: &corekccv1alpha1.ResourceConfig{
+				ObservedFields: &[]string{
+					"list_of_objects_key.nested_int_key",
+				},
+			},
+			prevSpec: map[string]interface{}{
+				"testField": "desired-value",
+			},
+			prevStatus: map[string]interface{}{},
+			tfResource: &tfschema.Resource{
+				Schema: map[string]*tfschema.Schema{
+					"test_field": {
+						Type:     tfschema.TypeString,
+						Required: true,
+					},
+					"list_of_objects_key": {
+						Type:     tfschema.TypeList,
+						Optional: true,
+						Elem: &tfschema.Resource{
+							Schema: map[string]*tfschema.Schema{
+								"nested_int_key": {
+									Type:     tfschema.TypeInt,
+									Optional: true,
+								},
+								"sensitive_field_nested_in_list_of_objects_key": {
+									Type:      tfschema.TypeString,
+									Optional:  true,
+									Sensitive: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			tfAttributes: map[string]string{
+				"test_field":                           "desired-value",
+				"list_of_objects_key.#":                "2",
+				"list_of_objects_key.0.nested_int_key": "invalid-observed-field-1",
+				"list_of_objects_key.1.nested_int_key": "invalid-observed-field-2",
+			},
+			expectedSpec:   nil,
+			expectedStatus: nil,
+			shouldPanic:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+			r := resourceSkeleton()
+			if tc.metadataName != "" {
+				r.SetName(tc.metadataName)
+			}
+			r.Spec = tc.prevSpec
+			r.Status = tc.prevStatus
+			r.TFResource = tc.tfResource
+			if tc.rc != nil {
+				r.ResourceConfig = *tc.rc
+			}
+			state := terraform.InstanceState{
+				Attributes: tc.tfAttributes,
+			}
+			if tc.shouldPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("The code did not panic but it should")
+					}
+				}()
+				ResolveSpecAndStatusWithResourceID(r, &state)
+				return
+			}
+			spec, status := ResolveSpecAndStatusWithResourceID(r, &state)
+			if got, want := spec, tc.expectedSpec; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got: %v, want: %v", got, want)
+			}
+			if got, want := status, tc.expectedStatus; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/tf/resource/helpers.go
+++ b/pkg/tf/resource/helpers.go
@@ -131,3 +131,7 @@ func ImmutableFieldsFromDiff(diff *terraform.InstanceDiff) []string {
 	}
 	return fields
 }
+
+func IsSensitiveField(tfSchema *tfschema.Schema) bool {
+	return tfSchema.Sensitive
+}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/309651934

* Supported the logic to resolve the observed state for TF-based resources during a successful reconciliation.
  * Reference fields, labels field, name field, sensitive fields, and fields under an array are currently not supported in the observed state.
  * Added unit tests.
* Added more unit tests for service mappings to ensure the same limitations are enforced.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Added the following configurations in the resource config for StorageBucket and generated the CRD.

```
observedFields:
  - versioning.enabled
  - location
```

Ran the integration test with the following YAML:

```
apiVersion: storage.cnrm.cloud.google.com/v1beta1
kind: StorageBucket
metadata:
  name: storagebucket-sample-${uniqueId}
spec:
  versioning:
    enabled: true
  location: US-WEST1
  lifecycleRule:
    - action:
        type: Delete
      condition:
        age: 7
```

The created StorageBucket contains the observed state in `status`:

```
         "observedState": {
            "location": "US-WEST1",
            "versioning": {
                "enabled": true
            }
        },
```