### PR TITLE
Add the GitHub action to upgrade the operator when a new version tag is created

### DIFF
--- a/.github/workflows/upgrade-operator.yaml
+++ b/.github/workflows/upgrade-operator.yaml
@@ -53,14 +53,16 @@ jobs:
           echo "Running 'make upgrade-kcc'..."
           make -C operator upgrade-kcc
           echo "Ensuring there is diff and committing the change..."
-          git diff
+          if [[ -z `git status --porcelain` ]]; then
+            echo "Exiting the workflow as there is no change to generate a PR."
+            exit 1
+          fi
           git add .
           git commit -m "Upgrade KCC operator to version ${{ env.RELEASE_VERSION }}"
       - name: "Create PR"
         run: |
           echo "Adding a remote pointing to GoogleCloudPlatform/k8s-config-connector..."
           git remote add target https://github.com/GoogleCloudPlatform/k8s-config-connector.git
-          git remote -vv
           export BRANCH=operator-upgrade-$(date +"%Y%m%d%H%M%S")
           echo "Setting up branch '${BRANCH}'..."
           git checkout -b ${BRANCH}

--- a/.github/workflows/upgrade-operator.yaml
+++ b/.github/workflows/upgrade-operator.yaml
@@ -1,0 +1,72 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Upgrade Operator
+
+on:
+  push:
+    # The action is only triggered when a new tag following the current
+    # convention is created.
+    tags: [ "v1.[0-9]+.[0-9]+" ]
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # This is to get all the commits.
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.5"
+      - name: "Set env"
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      # ${{ env.RELEASE_VERSION }} is not accessible in the same step when it is
+      # set.
+      - name: "Check current state"
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          echo "Checking the current state..."
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+          echo "Location: $(pwd)"
+          echo "Commit history:"
+          git log --oneline -10
+          echo "Current branch:"
+          git branch
+      - name: "Upgrade KCC operator"
+        run: |
+          echo "Running 'make upgrade-kcc'..."
+          make -C operator upgrade-kcc
+          echo "Ensuring there is diff and committing the change..."
+          git diff
+          git add .
+          git commit -m "Upgrade KCC operator to version ${{ env.RELEASE_VERSION }}"
+      - name: "Create PR"
+        run: |
+          echo "Adding a remote pointing to GoogleCloudPlatform/k8s-config-connector..."
+          git remote add target https://github.com/GoogleCloudPlatform/k8s-config-connector.git
+          git remote -vv
+          export BRANCH=operator-upgrade-$(date +"%Y%m%d%H%M%S")
+          echo "Setting up branch '${BRANCH}'..."
+          git checkout -b ${BRANCH}
+          echo "Creating the PR against master branch of GoogleCloudPlatform/k8s-config-connector..."
+          git push -u target ${BRANCH}
+          gh repo set-default GoogleCloudPlatform/k8s-config-connector
+          gh pr create --head ${BRANCH} --title 'Upgrade KCC operator to version ${{ env.RELEASE_VERSION }}' --body 'Upgrade KCC operator to version ${{ env.RELEASE_VERSION }}.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upgrade-operator.yaml
+++ b/.github/workflows/upgrade-operator.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "Checking the current state..."
           echo "Release version: ${{ env.RELEASE_VERSION }}"
           echo "Location: $(pwd)"
-          echo "Commit history:"
+          echo "Last 10 commits:"
           git log --oneline -10
           echo "Current branch:"
           git branch
@@ -57,7 +57,7 @@ jobs:
             echo "Exiting the workflow as there is no change to generate a PR."
             exit 1
           fi
-          git add .
+          git add -A .
           git commit -m "Upgrade KCC operator to version ${{ env.RELEASE_VERSION }}"
       - name: "Create PR"
         run: |


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/315219970

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.

Tested the GitHub action against my fork repo with the following commands (to create a new test tag):

```
git tag -a "v1.200.9" [LAST_COMMIT_SHA_IN_HISTORY] -m "test"
git push origin v1.200.9
```

The action was triggered here: https://github.com/maqiuyujoyce/k8s-config-connector/actions/runs/7332214200/job/19966023037

And it created a PR containing all the changes in my branch: https://github.com/maqiuyujoyce/k8s-config-connector/pull/13

(This PR contains the changes in one commit so it doesn't have the same commit history as the PR.)

We should verify it works fine against the product repo in the next release.
