### PR TITLE
Fix generate-third-party-licenses script

### DIFF
--- a/scripts/generate-third-party-licenses/main.go
+++ b/scripts/generate-third-party-licenses/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	for _, file := range files {
-		licensePath := strings.TrimLeft(file, "temp-vendor/")
+		licensePath := strings.TrimPrefix(file, "temp-vendor/")
 		repo, licenseFilename := splitLicensePath(licensePath)
 		licenseURL := repoToLicenseURL(repo, licenseFilename)
 		fmt.Println(licenseURL)
@@ -198,6 +198,7 @@ var manualLicenseURLMapping = map[string]string{
 	"bitbucket.org/creachadair/stringset":                     "https://bitbucket.org/creachadair/stringset/src/master/LICENSE",
 	"cloud.google.com/go":                                     "https://github.com/googleapis/google-cloud-go/blob/master/LICENSE",
 	"contrib.go.opencensus.io/exporter/prometheus":            "https://github.com/census-ecosystem/opencensus-go-exporter-prometheus/blob/master/LICENSE",
+	"dario.cat/mergo":                                         "https://github.com/darccio/mergo/blob/master/LICENSE",
 	"go.starlark.net":                                         "https://github.com/google/starlark-go/blob/master/LICENSE",
 	"gomodules.xyz/jsonpatch/v2":                              "https://https://github.com/gomodules/jsonpatch/blob/master/LICENSE",
 	"google.golang.org/api":                                   "https://github.com/googleapis/google-api-go-client/blob/master/LICENSE",


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes part of b/317999419.

In order to verify whether the operator still works without kubectl in the Dockerfile, we need to build the image and [generate the licenses for the third party libraries](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/958f7fdac577b11afbda5644ab68ba0cd70e827f/operator/Dockerfile#L41). With the current code, it errored out with the following error message:

```
panic: unhandled domain for repo ario.cat/mergo

goroutine 1 [running]:
main.repoToLicenseURL({0xc00022f6b0, 0xe}, {0xc0001112ac, 0x7})
	/go/src/github.com/GoogleCloudPlatform/k8s-config-connector/scripts/generate-third-party-licenses/main.go:178 +0x8a8
main.main()
	/go/src/github.com/GoogleCloudPlatform/k8s-config-connector/scripts/generate-third-party-licenses/main.go:58 +0x197
exit status 2
```

This was because

1. With [`strings.TrimLeft()`](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/958f7fdac577b11afbda5644ab68ba0cd70e827f/scripts/generate-third-party-licenses/main.go#L56), it trimmed any char contained in string "temp-vendor/" in the left part of the repo string until it hit a char not contained in the given string, so for `temp-vendor/dario.cat/mergo`, the `d` after `temp-vendor/` was also trimmed.
2. There was not a matching license option for `dario.cat/mergo`.

Fixed the first issue with `strings.TrimPrefix()` (as it trims the entire string instead of individual chars), and fixed the second issue with a new entry in the license map.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.

Ran `make -C operator docker-build` and it finished successfully.
