### PR TITLE
Add description and link to GCP services supported by ServiceIdentity

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/serviceusage/serviceidentity.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/serviceusage/serviceidentity.md
@@ -6,6 +6,10 @@
 {% block body %}
 
 
+
+<code>ServiceIdentity</code> generates service identity for <a href="/iam/docs/service-agents">supported {{gcp_name_short}} services</a>.
+You can find the emails of the Google-managed service accounts in the status of a <code>ServiceIdentity</code> resource.
+
 <table>
 <thead>
 <tr>

--- a/scripts/generate-google3-docs/resource-reference/templates/serviceusage_serviceidentity.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/serviceusage_serviceidentity.tmpl
@@ -5,6 +5,10 @@
 {% block page_title %}{{ .Kind}}{% endblock %}
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
+
+<code>{{.Kind}}</code> generates service identity for <a href="/iam/docs/service-agents">supported {{"{{gcp_name_short}}"}} services</a>.
+You can find the emails of the Google-managed service accounts in the status of a <code>{{.Kind}}</code> resource.
+
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
### Change description

This was causing confusions previously when users try to use the ServiceIdentity CRD. As a result we want to provide a link to the list of GCP services supported by this resource.

Fixes b/319135394

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
