### PR TITLE
Remove kubectl from operator image

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -41,11 +41,6 @@ RUN go mod vendor -o temp-vendor # So we can load license files
 RUN go run scripts/generate-third-party-licenses/main.go
 RUN rm -rf temp-vendor
 
-# Build a specific version of kubectl to be used by the
-# kubebuilder-declarative-pattern library.
-RUN curl -fsSL https://dl.k8s.io/v1.27.4/bin/linux/amd64/kubectl > kubectl
-RUN chmod a+rx kubectl
-
 # Prepare a directory containing the binaries and other artifacts, and
 # configure any required permissions
 FROM alpine:latest AS packager
@@ -54,7 +49,6 @@ COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/gke_addon_poststart .
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/operator/channels/ channels/
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/operator/autopilot-channels/ autopilot-channels/
-COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/kubectl kubectl
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/THIRD_PARTY_NOTICES/ THIRD_PARTY_NOTICES/
 COPY --from=builder /go/src/github.com/GoogleCloudPlatform/k8s-config-connector/MIRRORED_LIBRARY_SOURCE/ MIRRORED_LIBRARY_SOURCE/
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/317999419

With kubebuilder-declarative-pattern library upgraded to v0.15.0-beta.2, kubectl is no longer a required dependency, so it can be removed from the operator Dockerfile.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.

Installed the operator locally onto a cluster following the steps below:

1. `make -C operator docker-build docker-push deploy`
2. `kubectl apply -f configconnector.yaml` (example yaml [here](https://cloud.google.com/config-connector/docs/how-to/install-manually#addon-configuring))
3. `kubectl apply -f configconnectorcontext.yaml` (example yaml [here](https://cloud.google.com/config-connector/docs/how-to/install-namespaced#creating_a_configconnectorcontext))
4. `kubectl apply -f pubsubtopic.yaml` (example yaml [here](https://cloud.google.com/config-connector/docs/reference/resource-docs/pubsub/pubsubtopic#typical_use_case))

Verified that the resources created in step 2-4 were all reconciled successfully.