### PR TITLE
Move the state-into-spec defaulter from webhook to controllers

### DIFF
--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -197,6 +197,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %w", req.NamespacedName.String(), err)
 	}
+	if err := r.handleDefault(resource); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
+	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
 	}
@@ -414,6 +417,15 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 	return nil
 }
 
+func (r *Reconciler) handleDefault(resource *dcl.Resource) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, resource.Resource.GroupVersionKind(), k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+	}
+	return nil
+}
+
 func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, resource *dcl.Resource) error {
 	// Ensure the resource has a hierarchical reference. This is done to be
 	// backwards compatible with resources created before the webhook for
@@ -429,13 +441,6 @@ func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, 
 	}
 	if err := k8s.EnsureHierarchicalReference(ctx, &resource.Resource, hierarchicalRefs, containers, r.Client); err != nil {
 		return fmt.Errorf("error ensuring resource '%v' has a hierarchical reference: %v", k8s.GetNamespacedName(resource), err)
-	}
-
-	// Ensure the resource has a state-into-spec annotation.
-	// This is done to be backwards compatible with resources
-	// created before the webhook for defaulting the annotation was added.
-	if err := k8s.EnsureSpecIntoSateAnnotation(&resource.Resource); err != nil {
-		return fmt.Errorf("error ensuring resource '%v' has a '%v' annotation: %v", k8s.GetNamespacedName(resource), k8s.StateIntoSpecAnnotation, err)
 	}
 	return nil
 }

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -80,6 +80,9 @@ const (
 	StateMergeIntoSpec = "merge"
 	StateAbsentInSpec  = "absent"
 
+	// Default state into spec indicator value
+	DefaultStateIntoSpecIndicator = "true"
+
 	// Core kubernetes constants
 	LastAppliedConfigurationAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 	ManagedFieldsTypeFieldsV1          = "FieldsV1"
@@ -137,6 +140,11 @@ var (
 		StateMergeIntoSpec,
 		StateAbsentInSpec,
 	}
+	DefaultStateIntoSpecIndicatorAnnotation = FormatAnnotation("default-state-into-spec")
+	DefaultStateIntoSpecIndicatorValues     = []string{
+		DefaultStateIntoSpecIndicator,
+	}
+
 	// TODO(kcc-eng): Adjust the timeout back down after b/237398742 is fixed.
 	WebhookTimeoutSeconds = int32(10)
 

--- a/pkg/webhook/generic_defaulter.go
+++ b/pkg/webhook/generic_defaulter.go
@@ -52,8 +52,8 @@ func (a *genericDefaulter) Handle(ctx context.Context, req admission.Request) ad
 			fmt.Errorf("error decoding object: %v", err))
 	}
 	newObj := obj.DeepCopy()
-	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(newObj); err != nil {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error validating or defaulting '%v' annotation: %v", k8s.StateIntoSpecAnnotation, err))
+	if err := k8s.ValidateOrSetIndicatorForStateIntoSpecAnnotation(newObj); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error validating or setting indicator for '%v' annotation: %v", k8s.StateIntoSpecAnnotation, err))
 	}
 	return constructPatchResponse(obj, newObj)
 }


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes part of b/320784855

* Moved the defaulter for the `state-into-spec` annotation from the webhook to the controllers.
  * The webhook is at the cluster level and the controllers are at the namespace level. In order to support the default value overrides for the `state-into-spec` annotation at the namespace level, we decided that the defaulter should be moved to the controllers.
  * To distinguish between the following cases, a `default-state-into-spec` annotation is added:
    * New resource creation without defaulting: Validation is done for the `state-into-spec` annotation.
    * New resource creation with defaulting: Defaulting is done with the default value the controller chooses. 
    * Resource upgrade: Resources is ensured to have `state-into-spec: merge` for backwards compatibility purpose.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Ran integration tests locally to verify the DCL-based resources, TF-based resources, and IAMPolicy resources are still working.
