### PR TITLE
build: set an email for github actions bot

### DIFF
--- a/.github/workflows/upgrade-operator.yaml
+++ b/.github/workflows/upgrade-operator.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: "Check current state"
         run: |
           git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config user.email "noreply@github.com"
           echo "Checking the current state..."
           echo "Release version: ${{ env.RELEASE_VERSION }}"
           echo "Location: $(pwd)"


### PR DESCRIPTION
The customary email is noreply@github.com.

Without setting an email, we can't pass the CLA.

Issue #1144
