### PR TITLE
guard and pin kustomize ver for operator script

### DIFF
--- a/operator/scripts/utils/cmd.go
+++ b/operator/scripts/utils/cmd.go
@@ -18,6 +18,12 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"strings"
+)
+
+const (
+	// this should be the same as KUSTOMIZE_VERSION from scripts/shared-vars-public.sh.
+	requiredKustomizeVersion = "v3.5.4"
 )
 
 func DownloadAndExtractTarballAt(gcsPath, outputDir string) error {
@@ -42,7 +48,36 @@ func ExtractTarball(tarballPath, outputDir string) error {
 	return Execute(cmd)
 }
 
+// getKustomizeVersion returns the version of kustomize or an empty string and an error
+// if there is an issue running the kustomize version command or parsing the command output.
+func getKustomizeVersion() (string, error) {
+	cmd := exec.Command("kustomize", "version", "--short")
+	output, err := ExecuteAndCaptureOutput(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	return parseKustomizeVersion(output)
+}
+
+// A parseable input should look like {kustomize/v3.5.4  2020-01-11T03:12:59Z  }.
+func parseKustomizeVersion(input string) (string, error) {
+	versionComponents := strings.Fields(input) // should split as [{kustomize/v3.5.4, 2020-01-11T03:12:59Z, }]
+	if len(versionComponents) != 3 {
+		return "", fmt.Errorf("unexpected output from kustomize version --short: %s", input)
+	}
+
+	return strings.Trim(versionComponents[0], "{kustomize/"), nil
+}
+
 func KustomizeBuild(path, output string) error {
+	kustomizeVersion, err := getKustomizeVersion()
+	if err != nil {
+		return err
+	}
+	if requiredKustomizeVersion != kustomizeVersion {
+		return fmt.Errorf("kustomize version mismatch; want: %s, got: %s", requiredKustomizeVersion, kustomizeVersion)
+	}
 	cmd := exec.Command("kustomize", "build", path, "--output", output)
 	return Execute(cmd)
 }

--- a/operator/scripts/utils/cmd_test.go
+++ b/operator/scripts/utils/cmd_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "testing"
+
+func Test_parseKustomizeVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "valid version",
+			input:       "{kustomize/v3.5.4  2020-01-11T03:12:59Z  }",
+			wantVersion: "v3.5.4",
+		},
+		{
+			name:    "invalid version",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:        "newer valid version",
+			input:       "{v5.3.0  2023-12-07T10:45:14Z   }", // notice the lack of "kustomize/"
+			wantVersion: "v5.3.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := parseKustomizeVersion(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected nil error got %v", err)
+			}
+			if version != tt.wantVersion {
+				t.Fatalf("failed parsing want: %s, got: %s", tt.wantVersion, version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Very partially (and hacky-ily) proposes a way to address one of the issues in #1145 . 