### PR TITLE
Move the state-into-spec defaulter from webhook to controllers

### DIFF
--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -197,7 +197,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %w", req.NamespacedName.String(), err)
 	}
-	if err := r.handleDefault(resource); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
@@ -417,7 +417,7 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 	return nil
 }
 
-func (r *Reconciler) handleDefault(resource *dcl.Resource) error {
+func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *dcl.Resource) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -197,6 +197,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %w", req.NamespacedName.String(), err)
 	}
+	if err := r.handleDefault(resource); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
+	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
 	}
@@ -414,6 +417,15 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 	return nil
 }
 
+func (r *Reconciler) handleDefault(resource *dcl.Resource) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+	}
+	return nil
+}
+
 func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, resource *dcl.Resource) error {
 	// Ensure the resource has a hierarchical reference. This is done to be
 	// backwards compatible with resources created before the webhook for
@@ -429,13 +441,6 @@ func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, 
 	}
 	if err := k8s.EnsureHierarchicalReference(ctx, &resource.Resource, hierarchicalRefs, containers, r.Client); err != nil {
 		return fmt.Errorf("error ensuring resource '%v' has a hierarchical reference: %v", k8s.GetNamespacedName(resource), err)
-	}
-
-	// Ensure the resource has a state-into-spec annotation.
-	// This is done to be backwards compatible with resources
-	// created before the webhook for defaulting the annotation was added.
-	if err := k8s.EnsureSpecIntoSateAnnotation(&resource.Resource); err != nil {
-		return fmt.Errorf("error ensuring resource '%v' has a '%v' annotation: %v", k8s.GetNamespacedName(resource), k8s.StateIntoSpecAnnotation, err)
 	}
 	return nil
 }

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -198,7 +198,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %w", req.NamespacedName.String(), err)
 	}
 	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %w", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
@@ -421,7 +421,7 @@ func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *dcl.Resource) err
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -139,7 +139,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
-	if err := r.handleDefault(&auditConfig); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(&auditConfig); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(&auditConfig), err)
 	}
 	reconcileContext := &reconcileContext{
@@ -162,7 +162,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
 }
 
-func (r *Reconciler) handleDefault(auditConfig *iamv1beta1.IAMAuditConfig) error {
+func (r *Reconciler) handleDefaultStateIntoSpecValue(auditConfig *iamv1beta1.IAMAuditConfig) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(auditConfig, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -139,6 +139,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
+	if err := r.handleDefault(&auditConfig); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(&auditConfig), err)
+	}
 	reconcileContext := &reconcileContext{
 		Reconciler:     r,
 		Ctx:            ctx,
@@ -157,6 +160,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	logger.Info("successfully finished reconcile", "resource", request.NamespacedName, "time to next reconciliation", jitteredPeriod)
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
+}
+
+func (r *Reconciler) handleDefault(auditConfig *iamv1beta1.IAMAuditConfig) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(auditConfig, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(auditConfig), err)
+	}
+	return nil
 }
 
 func (r *reconcileContext) doReconcile(auditConfig *iamv1beta1.IAMAuditConfig) (requeue bool, err error) {

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -140,7 +140,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 	if err := r.handleDefaultStateIntoSpecValue(&auditConfig); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(&auditConfig), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(&auditConfig), err)
 	}
 	reconcileContext := &reconcileContext{
 		Reconciler:     r,
@@ -166,7 +166,7 @@ func (r *Reconciler) handleDefaultStateIntoSpecValue(auditConfig *iamv1beta1.IAM
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(auditConfig, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(auditConfig), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(auditConfig), err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -152,7 +152,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{}, err
 	}
 	if err := r.handleDefaultStateIntoSpecValue(policy); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM parital policy '%v': %v", k8s.GetNamespacedName(policy), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM partial policy '%v': %w", k8s.GetNamespacedName(policy), err)
 	}
 	runCtx := &reconcileContext{
 		Reconciler:     r,
@@ -178,7 +178,7 @@ func (r *ReconcileIAMPartialPolicy) handleDefaultStateIntoSpecValue(pp *iamv1bet
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(pp, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(pp), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(pp), err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	if err := r.handleDefault(policy); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM parital policy '%v': %v", k8s.GetNamespacedName(policy), err)
 	}
 	runCtx := &reconcileContext{
@@ -174,7 +174,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
 }
 
-func (r *ReconcileIAMPartialPolicy) handleDefault(pp *iamv1beta1.IAMPartialPolicy) error {
+func (r *ReconcileIAMPartialPolicy) handleDefaultStateIntoSpecValue(pp *iamv1beta1.IAMPartialPolicy) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(pp, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -151,6 +151,9 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	if err := r.handleDefault(policy); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM parital policy '%v': %v", k8s.GetNamespacedName(policy), err)
+	}
 	runCtx := &reconcileContext{
 		Reconciler:     r,
 		Ctx:            ctx,
@@ -169,6 +172,15 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 	}
 	logger.Info("successfully finished reconcile", "resource", request.NamespacedName, "time to next reconciliation", jitteredPeriod)
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
+}
+
+func (r *ReconcileIAMPartialPolicy) handleDefault(pp *iamv1beta1.IAMPartialPolicy) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(pp, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(pp), err)
+	}
+	return nil
 }
 
 func (r *reconcileContext) doReconcile(pp *iamv1beta1.IAMPartialPolicy) (requeue bool, err error) {

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 	if err := r.handleDefaultStateIntoSpecValue(policy); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(policy), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(policy), err)
 	}
 	runCtx := &reconcileContext{
 		Reconciler:     r,
@@ -177,7 +177,7 @@ func (r *ReconcileIAMPolicy) handleDefaultStateIntoSpecValue(policy *iamv1beta1.
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policy, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policy), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policy), err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -150,6 +150,9 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	if err := r.handleDefault(policy); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(policy), err)
+	}
 	runCtx := &reconcileContext{
 		Reconciler:     r,
 		Ctx:            ctx,
@@ -168,6 +171,15 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 	}
 	logger.Info("successfully finished reconcile", "resource", request.NamespacedName, "time to next reconciliation", jitteredPeriod)
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
+}
+
+func (r *ReconcileIAMPolicy) handleDefault(policy *iamv1beta1.IAMPolicy) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policy, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policy), err)
+	}
+	return nil
 }
 
 func (r *reconcileContext) doReconcile(policy *iamv1beta1.IAMPolicy) (requeue bool, err error) {

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -150,7 +150,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	if err := r.handleDefault(policy); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %v", k8s.GetNamespacedName(policy), err)
 	}
 	runCtx := &reconcileContext{
@@ -173,7 +173,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 	return reconcile.Result{RequeueAfter: jitteredPeriod}, nil
 }
 
-func (r *ReconcileIAMPolicy) handleDefault(policy *iamv1beta1.IAMPolicy) error {
+func (r *ReconcileIAMPolicy) handleDefaultStateIntoSpecValue(policy *iamv1beta1.IAMPolicy) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policy, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -149,6 +149,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
+	if err := r.handleDefault(&memberPolicy); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %v", k8s.GetNamespacedName(&memberPolicy), err)
+	}
 	reconcileContext := &reconcileContext{
 		Reconciler:     r,
 		Ctx:            ctx,
@@ -170,6 +173,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	requeueAfter := jitteredPeriod + requeueDelay
 	logger.Info("successfully finished reconcile", "resource", request.NamespacedName, "time to next reconciliation", requeueAfter)
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *Reconciler) handleDefault(policyMember *iamv1beta1.IAMPolicyMember) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policyMember, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policyMember), err)
+	}
+	return nil
 }
 
 func (r *reconcileContext) doReconcile(policyMember *iamv1beta1.IAMPolicyMember) (requeue bool, err error) {

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -149,7 +149,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 		return reconcile.Result{}, err
 	}
-	if err := r.handleDefault(&memberPolicy); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(&memberPolicy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %v", k8s.GetNamespacedName(&memberPolicy), err)
 	}
 	reconcileContext := &reconcileContext{
@@ -175,7 +175,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
-func (r *Reconciler) handleDefault(policyMember *iamv1beta1.IAMPolicyMember) error {
+func (r *Reconciler) handleDefaultStateIntoSpecValue(policyMember *iamv1beta1.IAMPolicyMember) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policyMember, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -150,7 +150,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 	if err := r.handleDefaultStateIntoSpecValue(&memberPolicy); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %v", k8s.GetNamespacedName(&memberPolicy), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %w", k8s.GetNamespacedName(&memberPolicy), err)
 	}
 	reconcileContext := &reconcileContext{
 		Reconciler:     r,
@@ -179,7 +179,7 @@ func (r *Reconciler) handleDefaultStateIntoSpecValue(policyMember *iamv1beta1.IA
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(policyMember, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policyMember), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(policyMember), err)
 	}
 	return nil
 }

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -175,7 +175,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %v", req.NamespacedName.String(), err)
 	}
 	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
+		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %w", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
@@ -405,7 +405,7 @@ func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *krmtotf.Resource)
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
 	}
 	return nil
 }

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -174,6 +174,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %v", req.NamespacedName.String(), err)
 	}
+	if err := r.handleDefault(resource); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
+	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
 	}
@@ -398,6 +401,15 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 	r.immediateReconcileRequests <- genEvent
 }
 
+func (r *Reconciler) handleDefault(resource *krmtotf.Resource) error {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {
+		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %v", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+	}
+	return nil
+}
+
 func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, resource *krmtotf.Resource) error {
 	rc := resource.ResourceConfig
 
@@ -413,13 +425,6 @@ func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, 
 	// defaulting hierarchical references was added.
 	if err := k8s.EnsureHierarchicalReference(ctx, &resource.Resource, rc.HierarchicalReferences, rc.Containers, r.Client); err != nil {
 		return fmt.Errorf("error ensuring resource '%v' has a hierarchical reference: %v", k8s.GetNamespacedName(resource), err)
-	}
-
-	// Ensure the resource has a state-into-spec annotation.
-	// This is done to be backwards compatible with resources
-	// created before the webhook for defaulting the annotation was added.
-	if err := k8s.EnsureSpecIntoSateAnnotation(&resource.Resource); err != nil {
-		return fmt.Errorf("error ensuring resource '%v' has a '%v' annotation: %v", k8s.GetNamespacedName(resource), k8s.StateIntoSpecAnnotation, err)
 	}
 	return nil
 }

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -174,7 +174,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %v", req.NamespacedName.String(), err)
 	}
-	if err := r.handleDefault(resource); err != nil {
+	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %v", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
@@ -401,7 +401,7 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 	r.immediateReconcileRequests <- genEvent
 }
 
-func (r *Reconciler) handleDefault(resource *krmtotf.Resource) error {
+func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *krmtotf.Resource) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
 	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {

--- a/pkg/k8s/state_into_spec_annotation.go
+++ b/pkg/k8s/state_into_spec_annotation.go
@@ -26,16 +26,11 @@ import (
 // passed in defaultValue if it is unset.
 func ValidateOrDefaultStateIntoSpecAnnotation(obj metav1.Object, defaultValue string) error {
 	_, found := GetAnnotation(StateIntoSpecAnnotation, obj)
-	if found {
-		return validateStateIntoSpecAnnotation(obj)
+	if !found {
+		// TODO(b/322836859): Ensure ComputeAddress doesn't need special handling.
+		SetAnnotation(StateIntoSpecAnnotation, defaultValue, obj)
 	}
-	defaultStateIntoSpecAnnotation(obj, defaultValue)
-	return nil
-}
-
-func defaultStateIntoSpecAnnotation(obj metav1.Object, defaultValue string) {
-	SetAnnotation(StateIntoSpecAnnotation, defaultValue, obj)
-	return
+	return validateStateIntoSpecAnnotation(obj)
 }
 
 func validateStateIntoSpecAnnotation(obj metav1.Object) error {

--- a/pkg/k8s/state_into_spec_annotation_test.go
+++ b/pkg/k8s/state_into_spec_annotation_test.go
@@ -22,13 +22,14 @@ import (
 
 func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 	tests := []struct {
-		name        string
-		obj         *unstructured.Unstructured
-		hasError    bool
-		expectedVal string
+		name         string
+		obj          *unstructured.Unstructured
+		defaultValue string
+		hasError     bool
+		expectedVal  string
 	}{
 		{
-			name: "user specifies an accepted value",
+			name: "valid 'state-into-spec' value",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
@@ -40,10 +41,11 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expectedVal: "merge",
+			defaultValue: "merge",
+			expectedVal:  "merge",
 		},
 		{
-			name: "user specifies an unacceptable value",
+			name: "invalid 'state-into-spec' value",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
@@ -55,10 +57,11 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 					},
 				},
 			},
-			hasError: true,
+			defaultValue: "merge",
+			hasError:     true,
 		},
 		{
-			name: "user specifies an empty string",
+			name: "'state-into-spec' value is an empty string",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
@@ -70,20 +73,22 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 					},
 				},
 			},
-			hasError: true,
+			defaultValue: "merge",
+			hasError:     true,
 		},
 		{
-			name: "defaulting if absent",
+			name: "'state-into-spec' annotation defaulted to defaultValue if unset",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
 					"kind":       "Test1Bar",
 				},
 			},
-			expectedVal: "merge",
+			defaultValue: "absent",
+			expectedVal:  "absent",
 		},
 		{
-			name: "BigQueryDataset kind can use 'absent' value",
+			name: "BigQueryDataset kind can use 'absent' as the 'state-into-spec' value",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "bigquery.cnrm.cloud.google.com/v1beta1",
@@ -95,10 +100,11 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expectedVal: "absent",
+			defaultValue: "absent",
+			expectedVal:  "absent",
 		},
 		{
-			name: "BigQueryDataset kind can use 'merge' value",
+			name: "BigQueryDataset kind can use 'merge' as the 'state-into-spec' value",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "bigquery.cnrm.cloud.google.com/v1beta1",
@@ -110,14 +116,27 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expectedVal: "merge",
+			defaultValue: "merge",
+			expectedVal:  "merge",
+		},
+		{
+			name: "ComputeAddress has 'state-into-spec' annotation defaulted " +
+				"to 'merge' even if defaultValue is 'absent'",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
+					"kind":       "ComputeAddress",
+				},
+			},
+			defaultValue: "absent",
+			expectedVal:  "merge",
 		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateOrDefaultStateIntoSpecAnnotation(tc.obj)
+			err := ValidateOrDefaultStateIntoSpecAnnotation(tc.obj, tc.defaultValue)
 			if tc.hasError {
 				if err == nil {
 					t.Fatalf("got nil, but expect an error")

--- a/pkg/k8s/state_into_spec_annotation_test.go
+++ b/pkg/k8s/state_into_spec_annotation_test.go
@@ -120,16 +120,15 @@ func TestValidateOrDefaultStateIntoSpecAnnotation(t *testing.T) {
 			expectedVal:  "merge",
 		},
 		{
-			name: "ComputeAddress has 'state-into-spec' annotation defaulted " +
-				"to 'merge' even if defaultValue is 'absent'",
+			name: "error out if defaultValue is invalid",
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "test1.cnrm.cloud.google.com/v1alpha1",
-					"kind":       "ComputeAddress",
+					"kind":       "Test1Bar",
 				},
 			},
-			defaultValue: "absent",
-			expectedVal:  "merge",
+			defaultValue: "invalid",
+			hasError:     true,
 		},
 	}
 

--- a/pkg/webhook/generic_defaulter.go
+++ b/pkg/webhook/generic_defaulter.go
@@ -16,13 +16,7 @@ package webhook
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -44,16 +38,5 @@ func NewGenericDefaulter() HandlerFunc {
 }
 
 func (a *genericDefaulter) Handle(ctx context.Context, req admission.Request) admission.Response {
-	deserializer := codecs.UniversalDeserializer()
-	obj := &unstructured.Unstructured{}
-	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
-		klog.Error(err)
-		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding object: %v", err))
-	}
-	newObj := obj.DeepCopy()
-	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(newObj); err != nil {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error validating or defaulting '%v' annotation: %v", k8s.StateIntoSpecAnnotation, err))
-	}
-	return constructPatchResponse(obj, newObj)
+	return admission.ValidationResponse(true, "no-op: this webhook is deprecated")
 }


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/323999277

* Moved the defaulter for the `state-into-spec` annotation from the webhook to the controllers.
  * The webhook is at the cluster level and the controllers are at the namespace level. In order to support the default value overrides for the `state-into-spec` annotation at the namespace level, we decided that the defaulter should be moved to the controllers.
  * We assume that backwards compatibility is not a concern because users will first upgrade Config Connector to the new version, and after the upgrade is completed (all the existing CRs have been reconciled and all the unset `state-into-spec` annotations have been defaulted to `merge`), they will leverage the new feature to override the namespace-level `state-into-spec` annotation.
* Fixed the EnsureFinalizers function as it would wipe out the defaulted annotations including the `state-into-spec` annotation.

This is a improved and simplified solution compared with #1140 .

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Ran integration tests locally to verify the DCL-based resources, TF-based resources, and IAMPolicy resources are still working.
