### PR TITLE
Enable the configuration of state-into-spec default value for DCL controller

### DIFF
--- a/cmd/deletiondefender/main.go
+++ b/cmd/deletiondefender/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController); err != nil {
+	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
 		log.Fatal(err, "error adding registration controller")
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	controllermetrics "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/metrics"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp/profiler"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/krmtotf"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/metrics"
@@ -143,6 +144,8 @@ func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace strin
 
 	controllersCfg.UserProjectOverride = userProjectOverride
 	controllersCfg.BillingProject = billingProject
+	// TODO(b/320784855): StateIntoSpecDefaultValue and StateIntoSpecUserOverride values should come from the flags.
+	controllersCfg.StateIntoSpecDefaultValue = k8s.StateIntoSpecDefaultValueV1Beta1
 	mgr, err := kccmanager.New(ctx, restCfg, controllersCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating manager: %w", err)

--- a/cmd/unmanageddetector/main.go
+++ b/cmd/unmanageddetector/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create
 	// controllers for all our resources.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterUnmanagedDetectorController); err != nil {
+	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterUnmanagedDetectorController, nil); err != nil {
 		logging.Fatal(err, "error adding registration controller")
 	}
 

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/crdloader"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
 	testenvironment "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/environment"
@@ -114,6 +115,7 @@ func NewHarness(t *testing.T, ctx context.Context) *Harness {
 	kccConfig.ManagerOptions.HealthProbeBindAddress = "0"
 	// supply a concrete client to disable the default behavior of caching
 	kccConfig.ManagerOptions.NewClient = nocache.NoCacheClientFunc
+	kccConfig.StateIntoSpecDefaultValue = k8s.StateIntoSpecDefaultValueV1Beta1
 
 	var webhooks []cnrmwebhook.WebhookConfig
 
@@ -357,7 +359,7 @@ func NewHarness(t *testing.T, ctx context.Context) *Harness {
 	}
 
 	// Register the deletion defender controller.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController); err != nil {
+	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
 		t.Fatalf("error adding registration controller for deletion defender controllers: %v", err)
 	}
 	// Start the manager, Start(...) is a blocking operation so it needs to be done asynchronously.

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
 	testmain "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/main"
@@ -277,12 +278,12 @@ func setup() {
 	ctx := context.TODO()
 	flag.Parse()
 	var err error
-	mgr, err = kccmanager.New(ctx, unusedManager.GetConfig(), kccmanager.Config{})
+	mgr, err = kccmanager.New(ctx, unusedManager.GetConfig(), kccmanager.Config{StateIntoSpecDefaultValue: k8s.StateIntoSpecDefaultValueV1Beta1})
 	if err != nil {
 		logging.Fatal(err, "error creating new manager")
 	}
 	// Register the deletion defender controller
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController); err != nil {
+	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
 		logging.Fatal(err, "error adding registration controller for deletion defender controllers")
 	}
 	// start the manager, Start(...) is a blocking operation so it needs to be done asynchronously

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -78,6 +78,7 @@ type Reconciler struct {
 	lifecyclehandler.LifecycleHandler
 	metrics.ReconcilerMetrics
 	resourceLeaser *leaser.ResourceLeaser
+	defaulters     []k8s.Defaulter
 	mgr            manager.Manager
 	schemaRef      *k8s.SchemaReference
 	schemaRefMu    sync.RWMutex
@@ -94,13 +95,13 @@ type Reconciler struct {
 }
 
 func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter,
-	dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader) (k8s.SchemaReferenceUpdater, error) {
+	dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, defaulters []k8s.Defaulter) (k8s.SchemaReferenceUpdater, error) {
 	kind := crd.Spec.Names.Kind
 	apiVersion := k8s.GetAPIVersionFromCRD(crd)
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(kind))
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	r, err := NewReconciler(mgr, crd, converter, dclConfig, serviceMappingLoader, immediateReconcileRequests, resourceWatcherRoutines)
+	r, err := NewReconciler(mgr, crd, converter, dclConfig, serviceMappingLoader, immediateReconcileRequests, resourceWatcherRoutines, defaulters)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +125,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, conve
 	return r, nil
 }
 
-func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter, dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted) (*Reconciler, error) {
+func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter, dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter) (*Reconciler, error) {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(crd.Spec.Names.Kind))
 	gvk := schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
@@ -151,6 +152,7 @@ func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinit
 			GVK:        gvk,
 		},
 		resourceLeaser:             leaser.NewResourceLeaser(nil, nil, mgr.GetClient()),
+		defaulters:                 defaulters,
 		schema:                     dclSchema,
 		logger:                     logger.WithName(controllerName),
 		dclConfig:                  dclclientconfig.CopyAndModifyForKind(dclConfig, gvk.Kind),
@@ -197,7 +199,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %w", req.NamespacedName.String(), err)
 	}
-	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
+	if err := r.handleDefaults(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %w", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
@@ -417,11 +419,11 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 	return nil
 }
 
-func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *dcl.Resource) error {
-	// Validate or set the default value (cluster-level or namespace-level) for
-	// the 'state-into-spec' annotation.
-	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, k8s.StateMergeIntoSpec); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+func (r *Reconciler) handleDefaults(ctx context.Context, resource *dcl.Resource) error {
+	for _, defaulter := range r.defaulters {
+		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -187,7 +187,11 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	var immediateReconcileRequests chan event.GenericEvent = nil
 	var resourceWatcherRoutines *semaphore.Weighted = nil
 
-	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, nil)
+	stateIntoSpecDefaulter, err := k8s.NewStateIntoSpecDefaulter(k8s.StateIntoSpecDefaultValueV1Beta1, nil)
+	if err != nil {
+		t.Fatalf("error constructing new state into spec value: %v", err)
+	}
+	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)
 	}

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -187,7 +187,7 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	var immediateReconcileRequests chan event.GenericEvent = nil
 	var resourceWatcherRoutines *semaphore.Weighted = nil
 
-	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines)
+	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, nil)
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)
 	}

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -191,7 +191,7 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	if err != nil {
 		t.Fatalf("error constructing new state into spec value: %v", err)
 	}
-	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
+	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)
 	}

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -126,13 +126,13 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 		return nil, fmt.Errorf("error creating a DCL client config: %w", err)
 	}
 
-	stateIntoSpecValue, err := k8s.NewStateIntoSpecValue(config.StateIntoSpecDefaultValue, config.StateIntoSpecUserOverride)
+	stateIntoSpecDefaulter, err := k8s.NewStateIntoSpecDefaulter(config.StateIntoSpecDefaultValue, config.StateIntoSpecUserOverride)
 	if err != nil {
 		return nil, fmt.Errorf("error constructing new state into spec value: %v", err)
 	}
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, provider, smLoader, dclConfig, dclConverter, registration.RegisterDefaultController, stateIntoSpecValue); err != nil {
+	if err := registration.Add(mgr, provider, smLoader, dclConfig, dclConverter, registration.RegisterDefaultController, stateIntoSpecDefaulter); err != nil {
 		return nil, fmt.Errorf("error adding registration controller: %w", err)
 	}
 	return mgr, nil

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -132,7 +132,7 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	}
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, provider, smLoader, dclConfig, dclConverter, registration.RegisterDefaultController, stateIntoSpecDefaulter); err != nil {
+	if err := registration.Add(mgr, provider, smLoader, dclConfig, dclConverter, registration.RegisterDefaultController, []k8s.Defaulter{stateIntoSpecDefaulter}); err != nil {
 		return nil, fmt.Errorf("error adding registration controller: %w", err)
 	}
 	return mgr, nil

--- a/pkg/controller/kccmanager/kccmanager_test.go
+++ b/pkg/controller/kccmanager/kccmanager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
 	testcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/controller"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
@@ -76,7 +77,7 @@ func TestSchemeIsUniqueAcrossManagers(t *testing.T) {
 
 func TestClusterModeManager(t *testing.T) {
 	ctx := context.TODO()
-	mgr, err := kccmanager.New(ctx, clusterModeManager.GetConfig(), kccmanager.Config{})
+	mgr, err := kccmanager.New(ctx, clusterModeManager.GetConfig(), kccmanager.Config{StateIntoSpecDefaultValue: k8s.StateIntoSpecDefaultValueV1Beta1})
 	if err != nil {
 		t.Fatalf("error creating manager: %v", err)
 	}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -56,17 +56,17 @@ var logger = klog.Log.WithName(controllerName)
 
 // Add creates a new registration Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, dclConfig *dcl.Config, dclConverter *conversion.Converter, regFunc registrationFunc, stateIntoSpecDefaulter k8s.Defaulter) error {
+func Add(mgr manager.Manager, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, dclConfig *dcl.Config, dclConverter *conversion.Converter, regFunc registrationFunc, defaulters []k8s.Defaulter) error {
 	r := &ReconcileRegistration{
-		Client:                 mgr.GetClient(),
-		provider:               p,
-		smLoader:               smLoader,
-		dclConfig:              dclConfig,
-		dclConverter:           dclConverter,
-		mgr:                    mgr,
-		controllers:            make(map[string]map[string]controllerContext),
-		registrationFunc:       regFunc,
-		stateIntoSpecDefaulter: stateIntoSpecDefaulter,
+		Client:           mgr.GetClient(),
+		provider:         p,
+		smLoader:         smLoader,
+		dclConfig:        dclConfig,
+		dclConverter:     dclConverter,
+		mgr:              mgr,
+		controllers:      make(map[string]map[string]controllerContext),
+		registrationFunc: regFunc,
+		defaulters:       defaulters,
 	}
 	c, err := controller.New(controllerName, mgr,
 		controller.Options{
@@ -84,15 +84,15 @@ var _ reconcile.Reconciler = &ReconcileRegistration{}
 // ReconcileRegistration reconciles a CRD owned by KCC
 type ReconcileRegistration struct {
 	client.Client
-	provider               *tfschema.Provider
-	smLoader               *servicemappingloader.ServiceMappingLoader
-	dclConfig              *dcl.Config
-	dclConverter           *conversion.Converter
-	mgr                    manager.Manager
-	controllers            map[string]map[string]controllerContext
-	registrationFunc       registrationFunc
-	stateIntoSpecDefaulter k8s.Defaulter
-	mu                     sync.Mutex
+	provider         *tfschema.Provider
+	smLoader         *servicemappingloader.ServiceMappingLoader
+	dclConfig        *dcl.Config
+	dclConverter     *conversion.Converter
+	mgr              manager.Manager
+	controllers      map[string]map[string]controllerContext
+	registrationFunc registrationFunc
+	defaulters       []k8s.Defaulter
+	mu               sync.Mutex
 }
 
 type controllerContext struct {
@@ -195,7 +195,7 @@ func RegisterDefaultController(r *ReconcileRegistration, crd *apiextensions.Cust
 			logger.Info("unrecognized CRD; skipping controller registration", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 			return nil, nil
 		}
-		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.stateIntoSpecDefaulter)
+		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.defaulters)
 		if err != nil {
 			return nil, fmt.Errorf("error adding terraform controller for %v to a manager: %v", crd.Spec.Names.Kind, err)
 		}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -56,17 +56,17 @@ var logger = klog.Log.WithName(controllerName)
 
 // Add creates a new registration Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, dclConfig *dcl.Config, dclConverter *conversion.Converter, regFunc registrationFunc, stateIntoSpecValue *k8s.StateIntoSpecValue) error {
+func Add(mgr manager.Manager, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, dclConfig *dcl.Config, dclConverter *conversion.Converter, regFunc registrationFunc, stateIntoSpecDefaulter k8s.Defaulter) error {
 	r := &ReconcileRegistration{
-		Client:             mgr.GetClient(),
-		provider:           p,
-		smLoader:           smLoader,
-		dclConfig:          dclConfig,
-		dclConverter:       dclConverter,
-		mgr:                mgr,
-		controllers:        make(map[string]map[string]controllerContext),
-		registrationFunc:   regFunc,
-		stateIntoSpecValue: stateIntoSpecValue,
+		Client:                 mgr.GetClient(),
+		provider:               p,
+		smLoader:               smLoader,
+		dclConfig:              dclConfig,
+		dclConverter:           dclConverter,
+		mgr:                    mgr,
+		controllers:            make(map[string]map[string]controllerContext),
+		registrationFunc:       regFunc,
+		stateIntoSpecDefaulter: stateIntoSpecDefaulter,
 	}
 	c, err := controller.New(controllerName, mgr,
 		controller.Options{
@@ -84,15 +84,15 @@ var _ reconcile.Reconciler = &ReconcileRegistration{}
 // ReconcileRegistration reconciles a CRD owned by KCC
 type ReconcileRegistration struct {
 	client.Client
-	provider           *tfschema.Provider
-	smLoader           *servicemappingloader.ServiceMappingLoader
-	dclConfig          *dcl.Config
-	dclConverter       *conversion.Converter
-	mgr                manager.Manager
-	controllers        map[string]map[string]controllerContext
-	registrationFunc   registrationFunc
-	stateIntoSpecValue *k8s.StateIntoSpecValue
-	mu                 sync.Mutex
+	provider               *tfschema.Provider
+	smLoader               *servicemappingloader.ServiceMappingLoader
+	dclConfig              *dcl.Config
+	dclConverter           *conversion.Converter
+	mgr                    manager.Manager
+	controllers            map[string]map[string]controllerContext
+	registrationFunc       registrationFunc
+	stateIntoSpecDefaulter k8s.Defaulter
+	mu                     sync.Mutex
 }
 
 type controllerContext struct {
@@ -195,7 +195,7 @@ func RegisterDefaultController(r *ReconcileRegistration, crd *apiextensions.Cust
 			logger.Info("unrecognized CRD; skipping controller registration", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 			return nil, nil
 		}
-		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.stateIntoSpecValue)
+		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.stateIntoSpecDefaulter)
 		if err != nil {
 			return nil, fmt.Errorf("error adding terraform controller for %v to a manager: %v", crd.Spec.Names.Kind, err)
 		}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -184,7 +184,7 @@ func RegisterDefaultController(r *ReconcileRegistration, crd *apiextensions.Cust
 	default:
 		// register controllers for dcl-based CRDs
 		if val, ok := crd.Labels[k8s.DCL2CRDLabel]; ok && val == "true" {
-			su, err := dclcontroller.Add(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader)
+			su, err := dclcontroller.Add(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, r.defaulters)
 			if err != nil {
 				return nil, fmt.Errorf("error adding dcl controller for %v to a manager: %v", crd.Spec.Names.Kind, err)
 			}

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -64,26 +64,26 @@ var logger = klog.Log
 type Reconciler struct {
 	lifecyclehandler.LifecycleHandler
 	metrics.ReconcilerMetrics
-	resourceLeaser         *leaser.ResourceLeaser
-	stateIntoSpecDefaulter k8s.Defaulter
-	mgr                    manager.Manager
-	schemaRef              *k8s.SchemaReference
-	schemaRefMu            sync.RWMutex
-	provider               *tfschema.Provider
-	smLoader               *servicemappingloader.ServiceMappingLoader
-	logger                 logr.Logger
+	resourceLeaser *leaser.ResourceLeaser
+	defaulters     []k8s.Defaulter
+	mgr            manager.Manager
+	schemaRef      *k8s.SchemaReference
+	schemaRefMu    sync.RWMutex
+	provider       *tfschema.Provider
+	smLoader       *servicemappingloader.ServiceMappingLoader
+	logger         logr.Logger
 	// Fields used for triggering reconciliations when dependencies are ready
 	immediateReconcileRequests chan event.GenericEvent
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
 }
 
-func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, stateIntoSpecDefaulter k8s.Defaulter) (k8s.SchemaReferenceUpdater, error) {
+func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, defaulters []k8s.Defaulter) (k8s.SchemaReferenceUpdater, error) {
 	kind := crd.Spec.Names.Kind
 	apiVersion := k8s.GetAPIVersionFromCRD(crd)
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(kind))
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	r, err := NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
+	r, err := NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, defaulters)
 	if err != nil {
 		return nil, err
 	}
@@ -107,16 +107,16 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provi
 	return r, nil
 }
 
-func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, stateIntoSpecDefaulter k8s.Defaulter) (*Reconciler, error) {
+func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter) (*Reconciler, error) {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(crd.Spec.Names.Kind))
 	return &Reconciler{
 		LifecycleHandler: lifecyclehandler.NewLifecycleHandler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor(controllerName),
 		),
-		resourceLeaser:         leaser.NewResourceLeaser(p, smLoader, mgr.GetClient()),
-		stateIntoSpecDefaulter: stateIntoSpecDefaulter,
-		mgr:                    mgr,
+		resourceLeaser: leaser.NewResourceLeaser(p, smLoader, mgr.GetClient()),
+		defaulters:     defaulters,
+		mgr:            mgr,
 		schemaRef: &k8s.SchemaReference{
 			CRD:        crd,
 			JsonSchema: k8s.GetOpenAPIV3SchemaFromCRD(crd),
@@ -176,7 +176,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not parse resource %s: %v", req.NamespacedName.String(), err)
 	}
-	if err := r.handleDefaultStateIntoSpecValue(resource); err != nil {
+	if err := r.handleDefaults(ctx, resource); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %w", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
@@ -403,11 +403,11 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 	r.immediateReconcileRequests <- genEvent
 }
 
-func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *krmtotf.Resource) error {
-	// Validate or set the default value (cluster-level or namespace-level) for
-	// the 'state-into-spec' annotation.
-	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, r.stateIntoSpecDefaulter.GetValue()); err != nil {
-		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
+func (r *Reconciler) handleDefaults(ctx context.Context, resource *krmtotf.Resource) error {
+	for _, defaulter := range r.defaulters {
+		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -64,26 +64,26 @@ var logger = klog.Log
 type Reconciler struct {
 	lifecyclehandler.LifecycleHandler
 	metrics.ReconcilerMetrics
-	resourceLeaser     *leaser.ResourceLeaser
-	stateIntoSpecValue *k8s.StateIntoSpecValue
-	mgr                manager.Manager
-	schemaRef          *k8s.SchemaReference
-	schemaRefMu        sync.RWMutex
-	provider           *tfschema.Provider
-	smLoader           *servicemappingloader.ServiceMappingLoader
-	logger             logr.Logger
+	resourceLeaser         *leaser.ResourceLeaser
+	stateIntoSpecDefaulter k8s.Defaulter
+	mgr                    manager.Manager
+	schemaRef              *k8s.SchemaReference
+	schemaRefMu            sync.RWMutex
+	provider               *tfschema.Provider
+	smLoader               *servicemappingloader.ServiceMappingLoader
+	logger                 logr.Logger
 	// Fields used for triggering reconciliations when dependencies are ready
 	immediateReconcileRequests chan event.GenericEvent
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
 }
 
-func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, stateIntoSpecValue *k8s.StateIntoSpecValue) (k8s.SchemaReferenceUpdater, error) {
+func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, stateIntoSpecDefaulter k8s.Defaulter) (k8s.SchemaReferenceUpdater, error) {
 	kind := crd.Spec.Names.Kind
 	apiVersion := k8s.GetAPIVersionFromCRD(crd)
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(kind))
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	r, err := NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecValue)
+	r, err := NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
 	if err != nil {
 		return nil, err
 	}
@@ -107,16 +107,16 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provi
 	return r, nil
 }
 
-func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, stateIntoSpecValue *k8s.StateIntoSpecValue) (*Reconciler, error) {
+func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, stateIntoSpecDefaulter k8s.Defaulter) (*Reconciler, error) {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(crd.Spec.Names.Kind))
 	return &Reconciler{
 		LifecycleHandler: lifecyclehandler.NewLifecycleHandler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor(controllerName),
 		),
-		resourceLeaser:     leaser.NewResourceLeaser(p, smLoader, mgr.GetClient()),
-		stateIntoSpecValue: stateIntoSpecValue,
-		mgr:                mgr,
+		resourceLeaser:         leaser.NewResourceLeaser(p, smLoader, mgr.GetClient()),
+		stateIntoSpecDefaulter: stateIntoSpecDefaulter,
+		mgr:                    mgr,
 		schemaRef: &k8s.SchemaReference{
 			CRD:        crd,
 			JsonSchema: k8s.GetOpenAPIV3SchemaFromCRD(crd),
@@ -406,7 +406,7 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 func (r *Reconciler) handleDefaultStateIntoSpecValue(resource *krmtotf.Resource) error {
 	// Validate or set the default value (cluster-level or namespace-level) for
 	// the 'state-into-spec' annotation.
-	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, r.stateIntoSpecValue.GetValue()); err != nil {
+	if err := k8s.ValidateOrDefaultStateIntoSpecAnnotation(&resource.Resource, r.stateIntoSpecDefaulter.GetValue()); err != nil {
 		return fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", k8s.StateIntoSpecAnnotation, k8s.GetNamespacedName(resource), err)
 	}
 	return nil

--- a/pkg/dcl/resource.go
+++ b/pkg/dcl/resource.go
@@ -17,6 +17,8 @@ package dcl
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	dclextension "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/extension"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 
@@ -57,6 +59,11 @@ func NewResource(u *unstructured.Unstructured, schema *openapi.Schema) (*Resourc
 		return nil, err
 	}
 	return resource, nil
+}
+
+// DeepCopyObject is needed to implement the interface of client.Object.
+func (r *Resource) DeepCopyObject() runtime.Object {
+	panic("unexpected call to resource.DeepCopyObject(...)")
 }
 
 func (r *Resource) ValidateResourceIDIfSupported() error {

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -77,8 +77,9 @@ const (
 	ManagementConflictPreventionPolicyResource = "resource"
 
 	// State into spec annotation values
-	StateMergeIntoSpec = "merge"
-	StateAbsentInSpec  = "absent"
+	StateMergeIntoSpec               = "merge"
+	StateAbsentInSpec                = "absent"
+	StateIntoSpecDefaultValueV1Beta1 = StateMergeIntoSpec
 
 	// Core kubernetes constants
 	LastAppliedConfigurationAnnotation = "kubectl.kubernetes.io/last-applied-configuration"

--- a/pkg/k8s/defaulter.go
+++ b/pkg/k8s/defaulter.go
@@ -14,8 +14,16 @@
 
 package k8s
 
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 type Defaulter interface {
-	GetValue() string
+	ApplyDefaults(ctx context.Context, obj client.Object) (changed bool, err error)
 }
 
 // StateIntoSpecDefaulter contains the required 'defaultValue' field and the
@@ -25,7 +33,29 @@ type StateIntoSpecDefaulter struct {
 	userOverride *string
 }
 
-func (v *StateIntoSpecDefaulter) GetValue() string {
+func NewStateIntoSpecDefaulter(defaultValue string, userOverride *string) (Defaulter, error) {
+	if !isAcceptedValue(defaultValue, StateIntoSpecAnnotationValues) {
+		return nil, fmt.Errorf("invalid default value '%v' for '%v' annotation, need to be one of {%v}", defaultValue, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
+	}
+	if userOverride != nil && !isAcceptedValue(*userOverride, StateIntoSpecAnnotationValues) {
+		return nil, fmt.Errorf("invalid user override value '%v' for '%v' annotation, need to be one of {%v}", userOverride, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
+	}
+	return &StateIntoSpecDefaulter{
+		defaultValue: defaultValue,
+		userOverride: userOverride,
+	}, nil
+}
+
+func (v *StateIntoSpecDefaulter) ApplyDefaults(_ context.Context, resource client.Object) (changed bool, err error) {
+	// Validate or set the default value (cluster-level or namespace-level) for
+	// the 'state-into-spec' annotation.
+	if err := ValidateOrDefaultStateIntoSpecAnnotation(resource, v.getValue()); err != nil {
+		return false, fmt.Errorf("error validating or defaulting the '%v' annotation for resource '%v': %w", StateIntoSpecAnnotation, GetNamespacedName(resource), err)
+	}
+	return true, nil
+}
+
+func (v *StateIntoSpecDefaulter) getValue() string {
 	if v.userOverride == nil {
 		return v.defaultValue
 	}

--- a/pkg/k8s/defaulter.go
+++ b/pkg/k8s/defaulter.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+type Defaulter interface {
+	GetValue() string
+}
+
+// StateIntoSpecDefaulter contains the required 'defaultValue' field and the
+// optional 'userOverride' field.
+type StateIntoSpecDefaulter struct {
+	defaultValue string
+	userOverride *string
+}
+
+func (v *StateIntoSpecDefaulter) GetValue() string {
+	if v.userOverride == nil {
+		return v.defaultValue
+	}
+	return *v.userOverride
+}

--- a/pkg/k8s/state_into_spec_annotation.go
+++ b/pkg/k8s/state_into_spec_annotation.go
@@ -21,19 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewStateIntoSpecDefaulter(defaultValue string, userOverride *string) (Defaulter, error) {
-	if !isAcceptedValue(defaultValue, StateIntoSpecAnnotationValues) {
-		return nil, fmt.Errorf("invalid default value '%v' for '%v' annotation, need to be one of {%v}", defaultValue, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
-	}
-	if userOverride != nil && !isAcceptedValue(*userOverride, StateIntoSpecAnnotationValues) {
-		return nil, fmt.Errorf("invalid user override value '%v' for '%v' annotation, need to be one of {%v}", userOverride, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
-	}
-	return &StateIntoSpecDefaulter{
-		defaultValue: defaultValue,
-		userOverride: userOverride,
-	}, nil
-}
-
 // ValidateOrDefaultStateIntoSpecAnnotation validates the value of the
 // 'state-into-spec' annotation if it is set and defaults the annotation to the
 // passed in defaultValue if it is unset.

--- a/pkg/k8s/state_into_spec_annotation.go
+++ b/pkg/k8s/state_into_spec_annotation.go
@@ -21,31 +21,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// StateIntoSpecValue contains the required 'defaultValue' field and the
-// optional 'userOverride' field.
-type StateIntoSpecValue struct {
-	defaultValue string
-	userOverride *string
-}
-
-func NewStateIntoSpecValue(defaultValue string, userOverride *string) (*StateIntoSpecValue, error) {
+func NewStateIntoSpecDefaulter(defaultValue string, userOverride *string) (Defaulter, error) {
 	if !isAcceptedValue(defaultValue, StateIntoSpecAnnotationValues) {
 		return nil, fmt.Errorf("invalid default value '%v' for '%v' annotation, need to be one of {%v}", defaultValue, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
 	}
 	if userOverride != nil && !isAcceptedValue(*userOverride, StateIntoSpecAnnotationValues) {
 		return nil, fmt.Errorf("invalid user override value '%v' for '%v' annotation, need to be one of {%v}", userOverride, StateIntoSpecAnnotation, strings.Join(StateIntoSpecAnnotationValues, ", "))
 	}
-	return &StateIntoSpecValue{
+	return &StateIntoSpecDefaulter{
 		defaultValue: defaultValue,
 		userOverride: userOverride,
 	}, nil
-}
-
-func (v *StateIntoSpecValue) GetValue() string {
-	if v.userOverride == nil {
-		return v.defaultValue
-	}
-	return *v.userOverride
 }
 
 // ValidateOrDefaultStateIntoSpecAnnotation validates the value of the

--- a/pkg/krmtotf/resource.go
+++ b/pkg/krmtotf/resource.go
@@ -99,6 +99,7 @@ func getServerGeneratedIDFromStatus(rc *corekccv1alpha1.ResourceConfig, status m
 	return unstructured.NestedString(status, splitPath...)
 }
 
+// DeepCopyObject is needed to implement the interface of client.Object.
 func (r *Resource) DeepCopyObject() runtime.Object {
 	panic("unexpected call to resource.DeepCopyObject(...)")
 }

--- a/pkg/krmtotf/resource.go
+++ b/pkg/krmtotf/resource.go
@@ -27,6 +27,7 @@ import (
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -96,6 +97,10 @@ func getServerGeneratedIDFromStatus(rc *corekccv1alpha1.ResourceConfig, status m
 		strings.Split(rc.ServerGeneratedIDField, "."))
 
 	return unstructured.NestedString(status, splitPath...)
+}
+
+func (r *Resource) DeepCopyObject() runtime.Object {
+	panic("unexpected call to resource.DeepCopyObject(...)")
 }
 
 func (r *Resource) ValidateResourceIDIfSupported() error {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -215,9 +215,13 @@ func (r *TestReconciler) newReconcilerForCRD(crd *apiextensions.CustomResourceDe
 		// nature.
 		var immediateReconcileRequests chan event.GenericEvent = nil
 		var resourceWatcherRoutines *semaphore.Weighted = nil
+		stateIntoSpecValue, err := k8s.NewStateIntoSpecValue(k8s.StateIntoSpecDefaultValueV1Beta1, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error constructing new state into spec value: %v", err)
+		}
 
 		if crd.GetLabels()[crdgeneration.TF2CRDLabel] == "true" {
-			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines)
+			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecValue)
 		}
 		if crd.GetLabels()[k8s.DCL2CRDLabel] == "true" {
 			return dclcontroller.NewReconciler(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines)

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -224,7 +224,7 @@ func (r *TestReconciler) newReconcilerForCRD(crd *apiextensions.CustomResourceDe
 			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
 		}
 		if crd.GetLabels()[k8s.DCL2CRDLabel] == "true" {
-			return dclcontroller.NewReconciler(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines)
+			return dclcontroller.NewReconciler(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
 		}
 	}
 	return nil, fmt.Errorf("CRD format not recognized")

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -215,13 +215,13 @@ func (r *TestReconciler) newReconcilerForCRD(crd *apiextensions.CustomResourceDe
 		// nature.
 		var immediateReconcileRequests chan event.GenericEvent = nil
 		var resourceWatcherRoutines *semaphore.Weighted = nil
-		stateIntoSpecValue, err := k8s.NewStateIntoSpecValue(k8s.StateIntoSpecDefaultValueV1Beta1, nil)
+		stateIntoSpecDefaulter, err := k8s.NewStateIntoSpecDefaulter(k8s.StateIntoSpecDefaultValueV1Beta1, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error constructing new state into spec value: %v", err)
 		}
 
 		if crd.GetLabels()[crdgeneration.TF2CRDLabel] == "true" {
-			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecValue)
+			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
 		}
 		if crd.GetLabels()[k8s.DCL2CRDLabel] == "true" {
 			return dclcontroller.NewReconciler(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines)

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -221,7 +221,7 @@ func (r *TestReconciler) newReconcilerForCRD(crd *apiextensions.CustomResourceDe
 		}
 
 		if crd.GetLabels()[crdgeneration.TF2CRDLabel] == "true" {
-			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, stateIntoSpecDefaulter)
+			return tf.NewReconciler(r.mgr, crd, r.provider, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
 		}
 		if crd.GetLabels()[k8s.DCL2CRDLabel] == "true" {
 			return dclcontroller.NewReconciler(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, immediateReconcileRequests, resourceWatcherRoutines)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes part of b/320784855

Should diff based on https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1151.

* Used the configuration passed from the kccmanager to determine the default value of the `state-into-spec` annotation in the DCL controller.


### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Ran `go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests containeranalysisnote -timeout 900s` and the created ContainerAnalysisNote has `state-into-spec: merge`.