### PR TITLE
fix tests introduced in #1097

### DIFF
--- a/config/samples/resources/dnsrecordset/dns-routing-policy-geo/dns_v1beta1_dnsmanagedzone.yaml
+++ b/config/samples/resources/dnsrecordset/dns-routing-policy-geo/dns_v1beta1_dnsmanagedzone.yaml
@@ -15,6 +15,6 @@
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
-  name: dnsrecordset-dep-rp
+  name: dnsrecordset-dep-rp-geo
 spec:
-  dnsName: "example.com."
+  dnsName: "kcc-sample-dnsrecordset-rp-geo.com."

--- a/config/samples/resources/dnsrecordset/dns-routing-policy-geo/dns_v1beta1_dnsrecordset.yaml
+++ b/config/samples/resources/dnsrecordset/dns-routing-policy-geo/dns_v1beta1_dnsrecordset.yaml
@@ -17,11 +17,11 @@ kind: DNSRecordSet
 metadata:
   name: dnsrecordset-sample-rp-geo
 spec:
-  name: "www.example.com."
+  name: "www.kcc-sample-dnsrecordset-rp-geo.com."
   type: "A"
   ttl: 300
   managedZoneRef:
-    name: dnsrecordset-dep-rp
+    name: dnsrecordset-dep-rp-geo
   routingPolicy:
     geo:
       - location: us-central1

--- a/config/samples/resources/dnsrecordset/dns-routing-policy-wrr/dns_v1beta1_dnsmanagedzone.yaml
+++ b/config/samples/resources/dnsrecordset/dns-routing-policy-wrr/dns_v1beta1_dnsmanagedzone.yaml
@@ -15,6 +15,6 @@
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
-  name: dnsrecordset-dep-rp
+  name: dnsrecordset-dep-rp-wrr
 spec:
-  dnsName: "example.com."
+  dnsName: "kcc-sample-dnsrecordset-rp-wrr.com."

--- a/config/samples/resources/dnsrecordset/dns-routing-policy-wrr/dns_v1beta1_dnsrecordset.yaml
+++ b/config/samples/resources/dnsrecordset/dns-routing-policy-wrr/dns_v1beta1_dnsrecordset.yaml
@@ -17,11 +17,11 @@ kind: DNSRecordSet
 metadata:
   name: dnsrecordset-sample-rp-wrr
 spec:
-  name: "www.example.com."
+  name: "www.kcc-sample-dnsrecordset-rp-wrr.com."
   type: "A"
   ttl: 300
   managedZoneRef:
-    name: dnsrecordset-dep-rp
+    name: dnsrecordset-dep-rp-wrr
   routingPolicy:
     wrr:
       - weight: 0.5

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnsrecordset.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dns/dnsrecordset.md
@@ -829,11 +829,11 @@ kind: DNSRecordSet
 metadata:
   name: dnsrecordset-sample-rp-geo
 spec:
-  name: "www.example.com."
+  name: "www.kcc-sample-dnsrecordset-rp-geo.com."
   type: "A"
   ttl: 300
   managedZoneRef:
-    name: dnsrecordset-dep-rp
+    name: dnsrecordset-dep-rp-geo
   routingPolicy:
     geo:
       - location: us-central1
@@ -848,9 +848,9 @@ spec:
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
-  name: dnsrecordset-dep-rp
+  name: dnsrecordset-dep-rp-geo
 spec:
-  dnsName: "example.com."
+  dnsName: "kcc-sample-dnsrecordset-rp-geo.com."
 ```
 
 ### DNS Routing Policy Geo With Compute Address Reference
@@ -960,11 +960,11 @@ kind: DNSRecordSet
 metadata:
   name: dnsrecordset-sample-rp-wrr
 spec:
-  name: "www.example.com."
+  name: "www.kcc-sample-dnsrecordset-rp-wrr.com."
   type: "A"
   ttl: 300
   managedZoneRef:
-    name: dnsrecordset-dep-rp
+    name: dnsrecordset-dep-rp-wrr
   routingPolicy:
     wrr:
       - weight: 0.5
@@ -979,9 +979,9 @@ spec:
 apiVersion: dns.cnrm.cloud.google.com/v1beta1
 kind: DNSManagedZone
 metadata:
-  name: dnsrecordset-dep-rp
+  name: dnsrecordset-dep-rp-wrr
 spec:
-  dnsName: "example.com."
+  dnsName: "kcc-sample-dnsrecordset-rp-wrr.com."
 ```
 
 ### DNS Srv Record Set


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1097 added support for static routing policies. the new tests created public zones, and it seems like they ran into nameserver limitations (too many `example.com.` domains). changing the dnsname fixed the error in local runs.

I'm not sure why this wasn't an issue earlier, though.

### Tests you have done

```
go test -v -timeout 180s -tags=integration ./config/tests/samples/create/ -run-tests dns-routing-policy-geo

go test -v -timeout 180s -tags=integration ./config/tests/samples/create/ -run-tests dns-routing-policy-wrr
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
