### PR TITLE
chore: updated smd, fix: use typed scalar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	sigs.k8s.io/controller-tools v0.6.2
 	sigs.k8s.io/kubebuilder-declarative-pattern v0.15.0-beta.2
 	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20230303024857-d1f76c15e05b
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1586,8 +1586,8 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:w
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
+sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/k8s/managedfields.go
+++ b/pkg/k8s/managedfields.go
@@ -393,7 +393,7 @@ func jsonSchemaToAtom(jsonSchema *apiextensions.JSONSchemaProps) schema.Atom {
 		// has no schema available for map elements. We must include some
 		// sort of schema value, as map validation fails otherwise. Merges
 		// on custom scalar types are supported by the SMD library.
-		scalarUnknown = schema.Scalar("unknown")
+		scalarUnknown = schema.Untyped
 	)
 	switch jsonSchema.Type {
 	case "object":


### PR DESCRIPTION
~testing out proposed fix from~ context: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1122#issuecomment-1915758071

In lieu of https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1122