### PR TITLE
Try moving EnsureFinalizers() up in the TF controller

### DIFF
--- a/pkg/controller/lifecyclehandler/handler.go
+++ b/pkg/controller/lifecyclehandler/handler.go
@@ -195,6 +195,19 @@ func reasonForUnresolvableDeps(err error) (string, error) {
 	}
 }
 
+func (r *LifecycleHandler) EnsureFinalizersInUnstructured(ctx context.Context, resource *unstructured.Unstructured, finalizers ...string) error {
+	if !k8s.EnsureFinalizers(resource, finalizers...) {
+		copy, err := k8s.NewResource(resource)
+		if err != nil {
+			return err
+		}
+		if err := r.updateAPIServer(ctx, copy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *LifecycleHandler) EnsureFinalizers(ctx context.Context, original, resource *k8s.Resource, finalizers ...string) error {
 	if !k8s.EnsureFinalizers(resource, finalizers...) {
 		u, err := original.MarshalAsUnstructured()

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -154,6 +154,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 		}
 		return reconcile.Result{}, err
 	}
+	if u.GetDeletionTimestamp().IsZero() {
+		if err := r.EnsureFinalizersInUnstructured(ctx, u, k8s.ControllerFinalizerName, k8s.DeletionDefenderFinalizerName); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
 	skip, err := resourceactuation.ShouldSkip(u)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -302,9 +307,6 @@ func (r *Reconciler) sync(ctx context.Context, krmResource *krmtotf.Resource) (r
 	if !liveState.Empty() && diff.RequiresNew() {
 		return false, r.HandleUpdateFailed(ctx, &krmResource.Resource,
 			k8s.NewImmutableFieldsMutationError(tfresource.ImmutableFieldsFromDiff(diff)))
-	}
-	if err := r.EnsureFinalizers(ctx, krmResource.Original, &krmResource.Resource, k8s.ControllerFinalizerName, k8s.DeletionDefenderFinalizerName); err != nil {
-		return false, err
 	}
 	if diff.Empty() {
 		r.logger.Info("underlying resource already up to date", "resource", k8s.GetNamespacedName(krmResource))


### PR DESCRIPTION
Commit [6869e87](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1179/commits/6869e875d689ec1fddc310ef714261014adb7f11) simply moved the `EnsureFinalizers()` up to the beginning of the reconciler and used the unstructured to do the update. And this resulted in the following error in the dynamic integration test:

```
reconcile.go:191: error was not considered transient; chain is [[*errors.errorString: couldn't update the API server due to 
conflict. Re-enqueue the request for another reconciliation attempt: Operation cannot be fulfilled on 
pubsubschemas.pubsub.cnrm.cloud.google.com "pubsubschema-m3d3aukju4za5uklrxtq": the object has been modified; 
please apply your changes to the latest version and try again]]

testreconciler.go:104: reconcile returned unexpected error: couldn't update the API server due to conflict. Re-enqueue the 
request for another reconciliation attempt: Operation cannot be fulfilled on pubsubschemas.pubsub.cnrm.cloud.google.com 
"pubsubschema-m3d3aukju4za5uklrxtq": the object has been modified; please apply your changes to the latest version and 
try again
```

Looks like the root cause was that unstructured contains generated fields that shouldn't be updated/maintained by the user.

Commit [b53356d](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1179/commits/b53356dd1226d1943031d1781d907c37413802f6) used the parsed Resource instead and it worked.
