### PR TITLE
chore: add a license-lint gh action

### DIFF
--- a/.github/license-lint-config.yml
+++ b/.github/license-lint-config.yml
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+unrestricted_licenses:
+  - Apache-2.0
+  - MIT
+  - BSD-3-Clause
+  - BSD-2-Clause
+  - 0BSD
+
+reciprocal_licenses:
+  - MPL-2.0
+  - MPL-2.0-no-copyleft-exception
+
+allowlisted_modules:
+  # MIT: https://github.com/ghodss/yaml/blob/master/LICENSE
+  - github.com/ghodss/yaml
+  # BSD: https://github.com/gogo/protobuf/blob/master/LICENSE
+  - github.com/gogo/protobuf
+  # Apache 2.0
+  - github.com/spf13/cobra
+  # MIT: https://github.com/kubernetes-sigs/yaml/blob/master/LICENSE
+  - sigs.k8s.io/yaml
+  - github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp
+  # MIT: https://github.com/go-errors/errors/blob/master/LICENSE.MIT
+  - github.com/go-errors/errors
+  # Apache 2.0 for repo and third_party is BSD-3-Clause
+  - github.com/google/pprof

--- a/.github/license-lint-config.yml
+++ b/.github/license-lint-config.yml
@@ -37,3 +37,5 @@ allowlisted_modules:
   - github.com/go-errors/errors
   # Apache 2.0 for repo and third_party is BSD-3-Clause
   - github.com/google/pprof
+  # Apache 2.0: https://github.com/apparentlymart/go-textseg/blob/5b41aa275ccaac4ccaa91729a8ee92e7eac9c728/LICENSE
+  - github.com/apparentlymart/go-textseg/v13

--- a/.github/workflows/license-lint.yaml
+++ b/.github/workflows/license-lint.yaml
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: license-lint
+on:
+  push:
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "vendor/**" # if we ever use vendor we can target the paths too
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "vendor/**" # if we ever use vendor we can target the paths too
+jobs:
+  license-lint:
+    name: "license-lint"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: license-lint
+        run: |
+          export GOPATH="$HOME/go"
+          PATH="$GOPATH/bin:$PATH"
+
+          go install istio.io/tools/cmd/license-lint@1.16.0
+
+          license-lint --config ./.github/license-lint-config.yml 2>&1


### PR DESCRIPTION
Add a cheap license linter. Currently the linter is https://github.com/istio/tools/tree/master/cmd/license-lint but we can swap it down the road if needed.

This doesn't replace any license gathering tooling we already have. Just a check to make sure we don't use restrictive licenses.

note for reviewers:

* [act](https://github.com/nektos/act) can be used to test a gh action e2e. Here it is in a _made-up_ scenario where the tool fails:

```
#  *made-up* scenario where the tool fails:
$ act -j license-lint
Found licenses: 23 reciprocal, 187 unrestricted, 0 restricted, 1 unrecognized, and 0 unlicensed. 6 are allowlisted.
ERROR: Some modules have unrecognized licenses:
  github.com/google/pprof: path '<MY_PATH>/github.com/google/pprof@v0.0.0-20210804190019-f964ff605595/third_party/svgpan/LICENSE'
```