### PR TITLE
tests: Fix shutdown ordering (again)

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -31,7 +31,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 func TestAllInSeries(t *testing.T) {
@@ -39,7 +38,7 @@ func TestAllInSeries(t *testing.T) {
 		t.Skip("RUN_E2E not set; skipping")
 	}
 
-	ctx := signals.SetupSignalHandler()
+	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(func() {
 		cancel()


### PR DESCRIPTION
We need to pass the manager context to the mgr.Start method, not just
the mgr.New method.

Also there may have been some variable shadowing going on, and
possibly some unnecessary waiting on a channel.

Hopefully this will now address timeouts - I started hitting it
locally and this cleaned it up immediately, even with
--test.count=10

Also remove the signal handler in the test; it's not standard and it
breaks immediately with --test.count=10
