### PR TITLE
Recover disabled integration test-Leaser,IAMPolicy,IAMPartialPolicy

### DIFF
--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
@@ -248,7 +248,7 @@ var resourceLevelIAMPartialPolicyTestFunc = func(ctx context.Context, t *testing
 func TestReconcileIAMPartialPolicyResourceLevelCreateNoChangesUpdateDelete(t *testing.T) {
 	ctx := context.TODO()
 
-	testiam.RunResourceLevelTest(ctx, t, mgr, resourceLevelIAMPartialPolicyTestFunc, testiam.ShouldRunWithNoProjectKind)
+	testiam.RunResourceLevelTest(ctx, t, mgr, resourceLevelIAMPartialPolicyTestFunc, nil)
 }
 
 func TestReconcileIAMPartialPolicyResourceLevelCreateNoChangesUpdateDeleteWithExternalRef(t *testing.T) {

--- a/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
+++ b/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
@@ -93,7 +93,7 @@ var resourceLevelIAMPolicyTestFunc = func(ctx context.Context, t *testing.T, _ s
 func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDelete(t *testing.T) {
 	ctx := context.TODO()
 
-	testiam.RunResourceLevelTest(ctx, t, mgr, resourceLevelIAMPolicyTestFunc, testiam.ShouldRunWithNoProjectKind)
+	testiam.RunResourceLevelTest(ctx, t, mgr, resourceLevelIAMPolicyTestFunc, nil)
 }
 
 func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithExternalRef(t *testing.T) {

--- a/pkg/lease/leaser/leaser_integration_test.go
+++ b/pkg/lease/leaser/leaser_integration_test.go
@@ -78,7 +78,7 @@ func TestAll(t *testing.T) {
 
 	shouldRun := func(fixture resourcefixture.ResourceFixture, mgr manager.Manager) bool {
 		switch fixture.GVK.Kind {
-		case "PubSubTopic":
+		case "Project", "PubSubTopic":
 			return true
 		default:
 			return false

--- a/pkg/test/iam/shouldrun.go
+++ b/pkg/test/iam/shouldrun.go
@@ -16,16 +16,6 @@ package testiam
 
 import "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture"
 
-func ShouldRunWithNoProjectKind(fixture resourcefixture.ResourceFixture) bool {
-	// A temporary should run function to skip testing kind project as it requires dynamically associating Billing Account
-	switch fixture.GVK.Kind {
-	case "Project":
-		return false
-	default:
-		return true
-	}
-}
-
 func ShouldRunWithExternalRef(fixture resourcefixture.ResourceFixture) bool {
 	// We only need to test the case of "IAMPolicy (or IAMPolicyMember) having
 	// an external reference" for a few resources. We could test both cases
@@ -37,7 +27,8 @@ func ShouldRunWithExternalRef(fixture resourcefixture.ResourceFixture) bool {
 	// NewExternalRef() cannot generate external references to resources with
 	// server-generated IDs (e.g. Folder).
 	switch fixture.GVK.Kind {
-	case "PubSubTopic", // Basic resource with no dependencies
+	case "Project", // Commonly referenced resource for IAMPolicy/IAMPolicyMember
+		"PubSubTopic",     // Basic resource with no dependencies
 		"SpannerDatabase": // Resource whose IAMPolicy/IAMPolicyMember spec must contain info about a dependency (name of the SpannerInstance)
 		return true
 	default:
@@ -51,7 +42,8 @@ func ShouldRunWithIAMConditions(fixture resourcefixture.ResourceFixture) bool {
 	// resourcs that support conditions, but this is very expensive and not
 	// really necessary.
 	switch fixture.GVK.Kind {
-	case "KMSKeyRing": // Basic resource that supports IAM conditions
+	case "Project", // Commonly referenced resource for IAMPolicy/IAMPolicyMember
+		"KMSKeyRing": // Basic resource that supports IAM conditions
 		return true
 	default:
 		return false
@@ -61,7 +53,7 @@ func ShouldRunWithIAMConditions(fixture resourcefixture.ResourceFixture) bool {
 func ShouldRunWithAuditConfigs(fixture resourcefixture.ResourceFixture) bool {
 	// Only the following resources support IAM audit configs in KCC currently
 	switch fixture.GVK.Kind {
-	case "Folder":
+	case "Project", "Folder":
 		return true
 	default:
 		return false
@@ -80,7 +72,7 @@ func ShouldRunAcquire(fixture resourcefixture.ResourceFixture) bool {
 
 func ShouldRunWithTFResourcesOnly(fixture resourcefixture.ResourceFixture) bool {
 	switch fixture.GVK.Kind {
-	case "BigtableInstance", "KMSKeyRing", "Folder",
+	case "BigtableInstance", "KMSKeyRing", "Project", "Folder",
 		"PubSubTopic", "PubSubSubscription", "SpannerInstance", "StorageBucket", "IAMServiceAccount":
 		return true
 	default:


### PR DESCRIPTION
### Change description

Fixes b/323007209

Recover Leaser integration test, IAMPolicy integration test and IAMPartialPolicy integration test

### Tests you have done
Ran tests locally with updated test data in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1170

Leaser integration test:
https://screenshot.googleplex.com/8BbER3TJf2TZtnQ.png

IAMPolicy integration test:
https://screenshot.googleplex.com/BWqiRAMwjBXi9SJ.png
https://screenshot.googleplex.com/5VTvDB7BNWPmxjV.png
https://screenshot.googleplex.com/8NKhFMuMDfNhXX4.png

IAMPartialPolicy integration test:
https://screenshot.googleplex.com/48HcsCwVfasRgYt.png


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
