### PR TITLE
mockgcp: services should return http.Handler

### DIFF
--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,7 +52,7 @@ type mockRoundTripper struct {
 	grpcConnection *grpc.ClientConn
 	grpcListener   net.Listener
 
-	hosts map[string]*runtime.ServeMux
+	hosts map[string]http.Handler
 
 	iamPolicies *mockIAMPolicies
 }
@@ -64,7 +63,7 @@ type MockService interface {
 	Register(grpcServer *grpc.Server)
 
 	// NewHTTPMux creates an HTTP mux for serving http traffic
-	NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error)
+	NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error)
 
 	// ExpectedHost is the hostname we serve on e.g. foo.googleapis.com
 	ExpectedHost() string
@@ -82,7 +81,7 @@ func NewMockRoundTripper(t *testing.T, k8sClient client.Client, storage storage.
 	var serverOpts []grpc.ServerOption
 	server := grpc.NewServer(serverOpts...)
 
-	rt.hosts = make(map[string]*runtime.ServeMux)
+	rt.hosts = make(map[string]http.Handler)
 
 	var services []MockService
 

--- a/mockgcp/mockbilling/service.go
+++ b/mockgcp/mockbilling/service.go
@@ -16,6 +16,7 @@ package mockbilling
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterCloudBillingServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterCloudBillingHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockcertificatemanager/service.go
+++ b/mockgcp/mockcertificatemanager/service.go
@@ -16,6 +16,7 @@ package mockcertificatemanager
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterCertificateManagerServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterCertificateManagerHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockcloudfunctions/service.go
+++ b/mockgcp/mockcloudfunctions/service.go
@@ -16,6 +16,7 @@ package mockcloudfunctions
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterCloudFunctionsServiceServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterCloudFunctionsServiceHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -64,7 +64,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterSubnetworksServer(grpcServer, s.subnetsv1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	// Terraform uses the /beta/ endpoints, but we have protos only for v1.

--- a/mockgcp/mockedgecontainer/service.go
+++ b/mockgcp/mockedgecontainer/service.go
@@ -16,6 +16,7 @@ package mockedgecontainer
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -64,7 +65,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterEdgeContainerServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterEdgeContainerHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockedgenetwork/service.go
+++ b/mockgcp/mockedgenetwork/service.go
@@ -16,6 +16,7 @@ package mockedgenetwork
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -64,7 +65,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterEdgeNetworkServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterEdgeNetworkHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockgkemulticloud/service.go
+++ b/mockgcp/mockgkemulticloud/service.go
@@ -16,6 +16,7 @@ package mockgkemulticloud
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterAttachedClustersServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterAttachedClustersHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockiam/service.go
+++ b/mockgcp/mockiam/service.go
@@ -16,8 +16,8 @@ package mockiam
 
 import (
 	"context"
+	"net/http"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/iam/admin/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 )
 
 // MockService represents a mocked IAM service.
@@ -61,7 +62,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterIAMServer(grpcServer, s.serverV1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 	if err := pb.RegisterIAMHandler(ctx, mux, conn); err != nil {
 		return nil, err

--- a/mockgcp/mocknetworkservices/service.go
+++ b/mockgcp/mocknetworkservices/service.go
@@ -16,6 +16,7 @@ package mocknetworkservices
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterNetworkServicesServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterNetworkServicesHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockprivateca/service.go
+++ b/mockgcp/mockprivateca/service.go
@@ -16,6 +16,7 @@ package mockprivateca
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterCertificateAuthorityServiceServer(grpcServer, s.v1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterCertificateAuthorityServiceHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mockresourcemanager/service.go
+++ b/mockgcp/mockresourcemanager/service.go
@@ -71,7 +71,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb_v3.RegisterProjectsServer(grpcServer, s.projectsV3)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux(runtime.WithErrorHandler(customErrorHandler))
 
 	if err := pb_v1.RegisterProjectsHandler(ctx, mux, conn); err != nil {

--- a/mockgcp/mocksecretmanager/service.go
+++ b/mockgcp/mocksecretmanager/service.go
@@ -16,6 +16,7 @@ package mocksecretmanager
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -57,7 +58,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	// longrunning.RegisterOperationsServer(grpcServer, s)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 	if err := pb.RegisterSecretManagerServiceHandler(ctx, mux, conn); err != nil {
 		return nil, err

--- a/mockgcp/mockserviceusage/service.go
+++ b/mockgcp/mockserviceusage/service.go
@@ -16,6 +16,7 @@ package mockserviceusage
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -63,7 +64,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb_v1beta1.RegisterServiceUsageServer(grpcServer, s.serviceusagev1beta1)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb_v1.RegisterServiceUsageHandler(ctx, mux, conn); err != nil {


### PR DESCRIPTION
This avoids requiring grpc-gateway, and means we can more cleanly
inject advanced behaviours.
