### PR TITLE
Fix MockService for mockapikeys

### DIFF
--- a/mockgcp/mockapikeys/service.go
+++ b/mockgcp/mockapikeys/service.go
@@ -16,6 +16,7 @@ package mockapikeys
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
@@ -59,7 +60,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterApiKeysServer(grpcServer, s.v2)
 }
 
-func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (*runtime.ServeMux, error) {
+func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux := runtime.NewServeMux()
 
 	if err := pb.RegisterApiKeysHandler(ctx, mux, conn); err != nil {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes the following error in the unit test:

```
Error: mockgcp/mock_http_roundtrip.go:90:30: cannot use mockapikeys.New(env, storage) (value of type *mockapikeys.MockService) as MockService value in argument to append: *mockapikeys.MockService does not implement MockService (wrong type for method NewHTTPMux)
		have NewHTTPMux(context.Context, *grpc.ClientConn) (*"github.com/grpc-ecosystem/grpc-gateway/v2/runtime".ServeMux, error)
		want NewHTTPMux(context.Context, *grpc.ClientConn) (http.Handler, error)
```

This was introduced in #1168.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.

Ran `make test` locally and there was no errors.
