### PR TITLE
tests: when creating a folder, inject a wait afterwards

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -591,6 +591,11 @@ func testReconcileAcquire(ctx context.Context, t *testing.T, testContext testrun
 		if gcpUnstruct, err = resourceContext.Create(ctx, t, unstructToCreate, systemContext.TFProvider, kubeClient, systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter); err != nil {
 			t.Fatalf("unexpected error when creating GCP resource '%v': %v", unstructToCreate.GetName(), err)
 		}
+		if unstructToCreate.GroupVersionKind().Kind == "Folder" {
+			// We should not be using the search method, it is only eventually consistent.
+			t.Logf("created GCP Folder; waiting 60 seconds for eventual consistency to catch up")
+			time.Sleep(time.Minute)
+		}
 	}
 
 	// Acquire the resource using the original unstruct.


### PR DESCRIPTION
When we create a folder, we then try to reacquire it immediately
afterwards using the eventually-consistent search method.  Eventual
consistency is not good enough, and we regularly see flakes here.

This is a workaround to (hopefully) verify the root cause of these
flakes; we can then move to a strongly-consistent approach in a future
change.

Issue #1199
