### PR TITLE
tests: Add more logging in e2e tests

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -418,6 +418,7 @@ func testDriftCorrection(ctx context.Context, t *testing.T, testContext testrunn
 	// of this test that the right events are recorded.
 	testcontroller.DeleteAllEventsForUnstruct(t, kubeClient, testUnstruct)
 
+	t.Logf("testDriftCorrection: deleting kube object %v", testUnstruct)
 	if err := resourceContext.Delete(ctx, t, testUnstruct, systemContext.TFProvider, systemContext.Manager.GetClient(), systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter); err != nil {
 		t.Fatalf("error deleting: %v", err)
 	}

--- a/pkg/test/controller/reconcile.go
+++ b/pkg/test/controller/reconcile.go
@@ -193,15 +193,19 @@ func isTransientError(t *testing.T, err error) bool {
 }
 
 // RunReconcilerAssertResults asserts the expected state of the reconciler run.
-func RunReconcilerAssertResults(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler, objectMeta v1.ObjectMeta,
+func RunReconcilerAssertResults(ctx context.Context, t *testing.T, reconciler reconcile.Reconciler,
+	kind string, objectMeta v1.ObjectMeta,
 	expectedResult reconcile.Result, expectedErrorRegex *regexp.Regexp) {
 	attempt := 0
 tryAgain:
 	attempt++
 	t.Helper()
+	startTime := time.Now()
+	t.Logf("starting reconcile for %v:%v/%v", kind, objectMeta.Namespace, objectMeta.Name)
 	reconcileRequest := reconcile.Request{NamespacedName: k8s.GetNamespacedName(objectMeta.GetObjectMeta())}
 	result, err := reconciler.Reconcile(ctx, reconcileRequest)
-
+	t.Logf("reconcile for %v:%v/%v took %v, result was (%v, %v)",
+		kind, objectMeta.Namespace, objectMeta.Name, time.Since(startTime), result, err)
 	// Retry if we see a "transient" error (up to our retry limit)
 	if err != nil {
 		if isTransientError(t, err) {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -122,7 +122,7 @@ func (r *TestReconciler) Reconcile(ctx context.Context, unstruct *unstructured.U
 func (r *TestReconciler) ReconcileObjectMeta(ctx context.Context, om metav1.ObjectMeta, kind string, expectedResult reconcile.Result, expectedErrorRegex *regexp.Regexp) {
 	r.t.Helper()
 	reconciler := r.NewReconcilerForKind(kind)
-	testcontroller.RunReconcilerAssertResults(ctx, r.t, reconciler, om, expectedResult, expectedErrorRegex)
+	testcontroller.RunReconcilerAssertResults(ctx, r.t, reconciler, kind, om, expectedResult, expectedErrorRegex)
 }
 
 // Creates and reconciles all unstructureds in the unstruct list. Returns a cleanup function that should be defered immediately after calling this function.


### PR DESCRIPTION
In particular, we want to know if a reconcile operation is taking a
long time.
