### PR TITLE
tests: Add apikeys to set of supported services

### DIFF
--- a/scripts/shared-vars-public.sh
+++ b/scripts/shared-vars-public.sh
@@ -36,6 +36,7 @@ SUPPORTED_SERVICES=(
   anthosaudit.googleapis.com
   anthosgke.googleapis.com
   apigee.googleapis.com
+  apikeys.googleapis.com
   appengine.googleapis.com
   artifactregistry.googleapis.com
   bigquery.googleapis.com


### PR DESCRIPTION
Otherwise we don't activate in our e2e tests.
