### PR TITLE
mockgcp: Refactor errors from storage.Get

### DIFF
--- a/mockgcp/common/operations/operations.go
+++ b/mockgcp/common/operations/operations.go
@@ -23,10 +23,8 @@ import (
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
 
@@ -122,11 +120,7 @@ func (s *Operations) GetOperation(ctx context.Context, req *pb.GetOperationReque
 
 	op := &pb.Operation{}
 	if err := s.storage.Get(ctx, fqn, op); err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.Infof("LRO not found for %v", prototext.Format(req))
-			return nil, status.Errorf(codes.NotFound, "LRO %q not found", req.Name)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading LRO: %v", err)
+		return nil, err
 	}
 
 	return op, nil

--- a/mockgcp/mockapikeys/key.go
+++ b/mockgcp/mockapikeys/key.go
@@ -44,11 +44,7 @@ func (s *APIKeysV2) GetKey(ctx context.Context, req *pb.GetKeyRequest) (*pb.Key,
 
 	obj := &pb.Key{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "key %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading key: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -64,11 +60,7 @@ func (s *APIKeysV2) GetKeyString(ctx context.Context, req *pb.GetKeyStringReques
 
 	obj := &pb.Key{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "key %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading key: %v", err)
-		}
+		return nil, err
 	}
 
 	keyString := "dummy-encrypted-value"
@@ -112,11 +104,7 @@ func (s *APIKeysV2) UpdateKey(ctx context.Context, req *pb.UpdateKeyRequest) (*l
 
 	obj := &pb.Key{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "key %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading key: %v", err)
-		}
+		return nil, err
 	}
 
 	// From the proto:

--- a/mockgcp/mockbilling/billingv1.go
+++ b/mockgcp/mockbilling/billingv1.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/billing/v1"
@@ -51,13 +50,13 @@ func (s *BillingV1) GetProjectBillingInfo(ctx context.Context, req *pb.GetProjec
 
 	obj := &pb.ProjectBillingInfo{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
+		if status.Code(err) == codes.NotFound {
 			// Expected if billing info has not yet been set
 			obj.Name = fqn
 			obj.BillingEnabled = false
 			obj.ProjectId = projectName.ProjectID
 		} else {
-			return nil, status.Errorf(codes.Internal, "error reading projectBillingInfo: %v", err)
+			return nil, err
 		}
 	}
 

--- a/mockgcp/mockcertificatemanager/v1.go
+++ b/mockgcp/mockcertificatemanager/v1.go
@@ -42,11 +42,7 @@ func (s *CertificateManagerV1) GetCertificate(ctx context.Context, req *pb.GetCe
 
 	obj := &pb.Certificate{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificate %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading certificate: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -82,10 +78,7 @@ func (s *CertificateManagerV1) UpdateCertificate(ctx context.Context, req *pb.Up
 	fqn := name.String()
 	obj := &pb.Certificate{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificate %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading certificate: %v", err)
+		return nil, err
 	}
 
 	// Required. The update mask applies to the resource.
@@ -143,11 +136,7 @@ func (s *CertificateManagerV1) GetCertificateMap(ctx context.Context, req *pb.Ge
 
 	obj := &pb.CertificateMap{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificateMap %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading certificateMap: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -183,10 +172,7 @@ func (s *CertificateManagerV1) UpdateCertificateMap(ctx context.Context, req *pb
 	fqn := name.String()
 	obj := &pb.CertificateMap{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificateMap %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading certificateMap: %v", err)
+		return nil, err
 	}
 
 	// Required. The update mask applies to the resource.
@@ -243,11 +229,7 @@ func (s *CertificateManagerV1) GetDnsAuthorization(ctx context.Context, req *pb.
 
 	obj := &pb.DnsAuthorization{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "dns authorization %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading dns authorization: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -283,10 +265,7 @@ func (s *CertificateManagerV1) UpdateDnsAuthorization(ctx context.Context, req *
 	fqn := name.String()
 	obj := &pb.DnsAuthorization{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "dnsAuthorization %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading dnsAuthorization: %v", err)
+		return nil, err
 	}
 
 	// Required. The update mask applies to the resource.
@@ -344,11 +323,7 @@ func (s *CertificateManagerV1) GetCertificateMapEntry(ctx context.Context, req *
 
 	obj := &pb.CertificateMapEntry{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificate map entry %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading certificate map entry: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -384,10 +359,7 @@ func (s *CertificateManagerV1) UpdateCertificateMapEntry(ctx context.Context, re
 	fqn := name.String()
 	obj := &pb.CertificateMapEntry{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "certificateMapEntry %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading certificateMapEntry: %v", err)
+		return nil, err
 	}
 
 	// Required. The update mask applies to the resource.

--- a/mockgcp/mockcloudfunctions/v1.go
+++ b/mockgcp/mockcloudfunctions/v1.go
@@ -42,11 +42,7 @@ func (s *CloudFunctionsV1) GetFunction(ctx context.Context, req *pb.GetFunctionR
 
 	obj := &pb.CloudFunction{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "function %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading function: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -81,10 +77,7 @@ func (s *CloudFunctionsV1) UpdateFunction(ctx context.Context, req *pb.UpdateFun
 	fqn := name.String()
 	obj := &pb.CloudFunction{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "cloudFunction %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading cloudFunction: %v", err)
+		return nil, err
 	}
 
 	// Required. The update mask applies to the resource.

--- a/mockgcp/mockcompute/networksv1.go
+++ b/mockgcp/mockcompute/networksv1.go
@@ -43,11 +43,7 @@ func (s *NetworksV1) Get(ctx context.Context, req *pb.GetNetworkRequest) (*pb.Ne
 
 	obj := &pb.Network{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "network %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading network: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -88,10 +84,7 @@ func (s *NetworksV1) Patch(ctx context.Context, req *pb.PatchNetworkRequest) (*p
 	fqn := name.String()
 	obj := &pb.Network{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "network %q not found", fqn)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading network: %v", err)
+		return nil, err
 	}
 
 	if req.GetNetworkResource().RoutingConfig != nil {

--- a/mockgcp/mockcompute/subnetsv1.go
+++ b/mockgcp/mockcompute/subnetsv1.go
@@ -42,11 +42,7 @@ func (s *SubnetsV1) Get(ctx context.Context, req *pb.GetSubnetworkRequest) (*pb.
 
 	obj := &pb.Subnetwork{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "subnet %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading subnet: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -104,10 +100,7 @@ func (s *SubnetsV1) SetPrivateIpGoogleAccess(ctx context.Context, req *pb.SetPri
 	fqn := name.String()
 	obj := &pb.Subnetwork{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "subnet %q not found", fqn)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading subnet: %v", err)
+		return nil, err
 	}
 
 	obj.PrivateIpGoogleAccess = PtrTo(req.GetSubnetworksSetPrivateIpGoogleAccessRequestResource().GetPrivateIpGoogleAccess())

--- a/mockgcp/mockedgecontainer/cluster.go
+++ b/mockgcp/mockedgecontainer/cluster.go
@@ -35,11 +35,7 @@ func (s *EdgeContainerV1) GetCluster(ctx context.Context, req *pb.GetClusterRequ
 	fqn := name.String()
 	obj := &pb.Cluster{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "cluster %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading cluster: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mockedgecontainer/nodepool.go
+++ b/mockgcp/mockedgecontainer/nodepool.go
@@ -35,11 +35,7 @@ func (s *EdgeContainerV1) GetNodePool(ctx context.Context, req *pb.GetNodePoolRe
 	fqn := name.String()
 	obj := &pb.NodePool{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "nodePool %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading nodePool: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mockedgenetwork/network.go
+++ b/mockgcp/mockedgenetwork/network.go
@@ -36,11 +36,7 @@ func (s *EdgenetworkV1) GetNetwork(ctx context.Context, req *pb.GetNetworkReques
 	fqn := name.String()
 	obj := &pb.Network{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "network %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading network: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mockedgenetwork/subnet.go
+++ b/mockgcp/mockedgenetwork/subnet.go
@@ -35,11 +35,7 @@ func (s *EdgenetworkV1) GetSubnet(ctx context.Context, req *pb.GetSubnetRequest)
 	fqn := name.String()
 	obj := &pb.Subnet{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "subnet %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading subnet: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mockgkemulticloud/attachedcluster.go
+++ b/mockgcp/mockgkemulticloud/attachedcluster.go
@@ -41,11 +41,7 @@ func (s *GKEMulticloudV1) GetAttachedCluster(ctx context.Context, req *pb.GetAtt
 
 	obj := &pb.AttachedCluster{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "attachedCluster %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading attachedCluster: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -79,10 +75,7 @@ func (s *GKEMulticloudV1) UpdateAttachedCluster(ctx context.Context, req *pb.Upd
 	fqn := name.String()
 	obj := &pb.AttachedCluster{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "attachedCluster %q not found", fqn)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading attachedCluster: %v", err)
+		return nil, err
 	}
 	// Mask of fields to update. At least one path must be supplied in
 	// this field. The elements of the repeated paths field can only include these

--- a/mockgcp/mockiam/serviceaccounts.go
+++ b/mockgcp/mockiam/serviceaccounts.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
@@ -70,10 +69,7 @@ func (s *ServerV1) GetServiceAccount(ctx context.Context, req *pb.GetServiceAcco
 	sa := &pb.ServiceAccount{}
 	fqn := name.String()
 	if err := s.storage.Get(ctx, fqn, sa); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "Service account %q not found", req.Name)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading serviceaccount: %v", err)
+		return nil, err
 	}
 
 	return sa, nil
@@ -159,10 +155,7 @@ func (s *ServerV1) PatchServiceAccount(ctx context.Context, req *pb.PatchService
 	fqn := name.String()
 	sa := &pb.ServiceAccount{}
 	if err := s.storage.Get(ctx, fqn, sa); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "serviceaccount %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading serviceaccount: %v", err)
+		return nil, err
 	}
 
 	// You can patch only the `display_name` and `description` fields.

--- a/mockgcp/mocknetworkservices/networkservices.go
+++ b/mockgcp/mocknetworkservices/networkservices.go
@@ -45,11 +45,7 @@ func (s *NetworkServicesServer) GetMesh(ctx context.Context, req *pb.GetMeshRequ
 
 	obj := &pb.Mesh{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "mesh %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading mesh: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -84,10 +80,7 @@ func (s *NetworkServicesServer) UpdateMesh(ctx context.Context, req *pb.UpdateMe
 	fqn := name.String()
 	obj := &pb.Mesh{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "mesh %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading mesh: %v", err)
+		return nil, err
 	}
 
 	// Field mask is used to specify the fields to be overwritten in the

--- a/mockgcp/mockprivateca/capool.go
+++ b/mockgcp/mockprivateca/capool.go
@@ -41,11 +41,7 @@ func (s *PrivateCAV1) GetCaPool(ctx context.Context, req *pb.GetCaPoolRequest) (
 
 	obj := &pb.CaPool{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "caPool %q not found", name)
-		} else {
-			return nil, status.Errorf(codes.Internal, "error reading caPool: %v", err)
-		}
+		return nil, err
 	}
 
 	return obj, nil
@@ -81,10 +77,7 @@ func (s *PrivateCAV1) UpdateCaPool(ctx context.Context, req *pb.UpdateCaPoolRequ
 	fqn := name.String()
 	obj := &pb.CaPool{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "caPool %q not found", reqName)
-		}
-		return nil, status.Errorf(codes.Internal, "error reading caPool: %v", err)
+		return nil, err
 	}
 
 	// Required. A list of fields to be updated in this request.

--- a/mockgcp/mockresourcemanager/projects_internal.go
+++ b/mockgcp/mockresourcemanager/projects_internal.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type ProjectsInternal struct {
@@ -109,10 +108,10 @@ func (s *ProjectsInternal) tryGetProjectByID(ctx context.Context, projectID stri
 
 	obj := &pb.Project{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
+		if status.Code(err) == codes.NotFound {
 			return nil, nil
 		} else {
-			return nil, status.Errorf(codes.Internal, "error reading project: %v", err)
+			return nil, err
 		}
 	}
 

--- a/mockgcp/mocksecretmanager/secrets.go
+++ b/mockgcp/mocksecretmanager/secrets.go
@@ -88,11 +88,7 @@ func (s *SecretsV1) GetSecret(ctx context.Context, req *pb.GetSecretRequest) (*p
 	var secret pb.Secret
 	fqn := name.String()
 	if err := s.storage.Get(ctx, fqn, &secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "secret %q not found", req.Name)
-
-		}
-		return nil, status.Errorf(codes.Internal, "error reading secret: %v", err)
+		return nil, err
 	}
 
 	return &secret, nil

--- a/mockgcp/mocksecretmanager/secretversions.go
+++ b/mockgcp/mocksecretmanager/secretversions.go
@@ -45,11 +45,7 @@ func (s *SecretsV1) AddSecretVersion(ctx context.Context, req *pb.AddSecretVersi
 	var secret pb.Secret
 
 	if err := s.storage.Get(ctx, secretName.String(), &secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "secret %q not found", req.Parent)
-
-		}
-		return nil, status.Errorf(codes.Internal, "error reading secret: %v", err)
+		return nil, err
 	}
 
 	secretVersionKind := (&pb.SecretVersion{}).ProtoReflect().Descriptor()
@@ -168,7 +164,7 @@ func (s *MockService) getSecretVersion(ctx context.Context, name *secretVersionN
 	if err := s.storage.Get(ctx, fqn, secretVersionObj); err != nil {
 		// TODO: Delete secret data?
 		// TODO: Owner ref?
-		return nil, status.Errorf(codes.Internal, "error creating secret version: %v", err)
+		return nil, err
 	}
 	return secretVersionObj, nil
 }

--- a/mockgcp/mockserviceusage/serviceusagev1.go
+++ b/mockgcp/mockserviceusage/serviceusagev1.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
@@ -54,10 +53,10 @@ func (s *ServiceUsageV1) EnableService(ctx context.Context, req *pb.EnableServic
 	create := false
 	service := &pb.Service{}
 	if err := s.storage.Get(ctx, fqn, service); err != nil {
-		if apierrors.IsNotFound(err) {
+		if status.Code(err) == codes.NotFound {
 			create = true
 		} else {
-			return nil, status.Errorf(codes.Internal, "error reading service: %v", err)
+			return nil, err
 		}
 	}
 
@@ -99,10 +98,10 @@ func (s *ServiceUsageV1) DisableService(ctx context.Context, req *pb.DisableServ
 	exists := true
 	service := &pb.Service{}
 	if err := s.storage.Get(ctx, fqn, service); err != nil {
-		if apierrors.IsNotFound(err) {
+		if status.Code(err) == codes.NotFound {
 			exists = false
 		} else {
-			return nil, status.Errorf(codes.Internal, "error reading service: %v", err)
+			return nil, err
 		}
 	}
 
@@ -128,14 +127,14 @@ func (s *ServiceUsageV1) GetService(ctx context.Context, req *pb.GetServiceReque
 
 	obj := &pb.Service{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if apierrors.IsNotFound(err) {
+		if status.Code(err) == codes.NotFound {
 			// Mock: everything is enabled
 			obj = &pb.Service{
 				Name:  serviceName.String(),
 				State: pb.State_DISABLED,
 			}
 		} else {
-			return nil, status.Errorf(codes.Internal, "error reading service: %v", err)
+			return nil, err
 		}
 	}
 

--- a/mockgcp/pkg/storage/interfaces.go
+++ b/mockgcp/pkg/storage/interfaces.go
@@ -26,8 +26,11 @@ type Storage interface {
 	Create(ctx context.Context, fqn string, create proto.Message) error
 	// Update stores a new version of an object, erroring if it does not already exist
 	Update(ctx context.Context, fqn string, update proto.Message) error
-	// Get returns an existing object
+
+	// Get returns an existing object.
+	// The error is "ready to return"; we return codes.NotFound if not found.
 	Get(ctx context.Context, fqn string, dest proto.Message) error
+
 	// List returns all matching objects
 	List(ctx context.Context, kind protoreflect.Descriptor, options ListOptions, callback func(obj proto.Message) error) error
 	// Deleting deletes the object, returning a not found error if it does not exist.


### PR DESCRIPTION
Going through one method at a time, but the code is much simplified by
having storage.Get return an object that follows the GRPC design
patterns, where codes.NotFound is returned when the object is not
found.
