### PR TITLE
tests: Don't try to delete APIKeysKey

### DIFF
--- a/pkg/test/gcp/gcp.go
+++ b/pkg/test/gcp/gcp.go
@@ -277,6 +277,10 @@ func NewIAMClient(t *testing.T) *iam.Service {
 
 func ResourceSupportsDeletion(resourceKind string) bool {
 	switch resourceKind {
+	case "APIKeysKey":
+		// APIKeysKey has a delete method, but the key is only marked for deletion.
+		return false
+
 	case "BigQueryJob",
 		"BinaryAuthorizationPolicy",
 		"ComputeProjectMetadata",


### PR DESCRIPTION
Deletion of a key is not standard; the key is still returned by the
API, though with deleteTime set.  Actual removal takes 30 days.
