### PR TITLE
change ComputeForwardingRule subnetworkRef to use self_link

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
@@ -465,7 +465,7 @@ spec:
                   - external
                 properties:
                   external:
-                    description: 'Allowed value: The `name` field of a `ComputeSubnetwork`
+                    description: 'Allowed value: The `selfLink` field of a `ComputeSubnetwork`
                       resource.'
                     type: string
                   name:

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeaddress.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeaddress.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  addressType: INTERNAL
+  location: us-central1
+  ipVersion: IPV4
+  purpose: SHARED_LOADBALANCER_VIP
+  subnetworkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computebackendservice.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computebackendservice.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  healthChecks:
+  - healthCheckRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  loadBalancingScheme: INTERNAL_MANAGED
+  location: global
+  protocol: HTTP
+  backend:
+  - balancingMode: UTILIZATION
+    group:
+      instanceGroupRef:
+        name: computeforwardingrule-dep-global-internal-http-proxy

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeforwardingrule.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeforwardingrule.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeForwardingRule
+metadata:
+  name: computeforwardingrule-sample-global-internal-http-proxy
+spec:
+  target:
+    targetHTTPProxyRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  ipAddress:
+    addressRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  ipProtocol: "TCP"
+  loadBalancingScheme: INTERNAL_MANAGED
+  location: global
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  subnetworkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  portRange: '80-80'
+  allowGlobalAccess: true

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computehealthcheck.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computehealthcheck.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeHealthCheck
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  httpHealthCheck:
+    port: 80
+  location: global

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeinstancegroup.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeinstancegroup.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeInstanceGroup
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  zone: us-central1-a
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computenetwork.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computenetwork.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  routingMode: REGIONAL
+  autoCreateSubnetworks: false

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computesubnetwork.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computesubnetwork.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  ipCidrRange: 10.2.0.0/28
+  region: us-central1
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computesubnetwork_proxy.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computesubnetwork_proxy.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy-proxy
+spec:
+  ipCidrRange: 10.3.0.0/26
+  region: us-central1
+  purpose: GLOBAL_MANAGED_PROXY
+  role: ACTIVE
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computetargethttpproxy.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computetargethttpproxy.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetHTTPProxy
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  urlMapRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  location: global

--- a/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeurlmap.yaml
+++ b/config/samples/resources/computeforwardingrule/global-internal-forwarding-rule-with-target-http-proxy/compute_v1beta1_computeurlmap.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeURLMap
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  defaultService:
+    backendServiceRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  location: global

--- a/config/servicemappings/compute.yaml
+++ b/config/servicemappings/compute.yaml
@@ -524,6 +524,7 @@ spec:
             kind: ComputeSubnetwork
             version: v1beta1
             group: compute.cnrm.cloud.google.com
+          targetField: self_link
         - key: backendServiceRef
           tfField: backend_service
           description: |-
@@ -672,6 +673,7 @@ spec:
             kind: ComputeSubnetwork
             version: v1beta1
             group: compute.cnrm.cloud.google.com
+          targetField: self_link
       containers:
         - type: project
           tfField: project

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
@@ -782,7 +782,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Allowed value: The `name` field of a `ComputeSubnetwork` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}Allowed value: The `selfLink` field of a `ComputeSubnetwork` resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1536,6 +1536,140 @@ spec:
   defaultService:
     backendServiceRef:
       name: computeforwardingrule-dep-global-with-grpc-proxy
+```
+
+### Global Internal Forwarding Rule With Target Http Proxy
+```yaml
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeForwardingRule
+metadata:
+  name: computeforwardingrule-sample-global-internal-http-proxy
+spec:
+  target:
+    targetHTTPProxyRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  ipAddress:
+    addressRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  ipProtocol: "TCP"
+  loadBalancingScheme: INTERNAL_MANAGED
+  location: global
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  subnetworkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  portRange: '80-80'
+  allowGlobalAccess: true
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  addressType: INTERNAL
+  location: us-central1
+  ipVersion: IPV4
+  purpose: SHARED_LOADBALANCER_VIP
+  subnetworkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  healthChecks:
+  - healthCheckRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  loadBalancingScheme: INTERNAL_MANAGED
+  location: global
+  protocol: HTTP
+  backend:
+  - balancingMode: UTILIZATION
+    group:
+      instanceGroupRef:
+        name: computeforwardingrule-dep-global-internal-http-proxy
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeHealthCheck
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  httpHealthCheck:
+    port: 80
+  location: global
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeInstanceGroup
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  zone: us-central1-a
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  routingMode: REGIONAL
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  ipCidrRange: 10.2.0.0/28
+  region: us-central1
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy-proxy
+spec:
+  ipCidrRange: 10.3.0.0/26
+  region: us-central1
+  purpose: GLOBAL_MANAGED_PROXY
+  role: ACTIVE
+  networkRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeTargetHTTPProxy
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  urlMapRef:
+    name: computeforwardingrule-dep-global-internal-http-proxy
+  location: global
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeURLMap
+metadata:
+  name: computeforwardingrule-dep-global-internal-http-proxy
+spec:
+  defaultService:
+    backendServiceRef:
+      name: computeforwardingrule-dep-global-internal-http-proxy
+  location: global
 ```
 
 ### Regional Forwarding Rule


### PR DESCRIPTION
### Change description

The sample added in this PR will fail when run with the current controller version with the following error:

```
Invalid value for subnetwork: Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.
```

This is because KCC currently passes the subnetwork `name` to Terraform, with no region information. This is not a problem for regional forwarding rules, since Terraform can use the forwarding rule’s region to infer the subnetwork’s region. However, since global forwarding rules don’t have a region, there is no backup value so we encounter this error.

The fix is to pass the subnetwork’s `self_link` instead, since that additionally includes the subnetwork’s region. This change should be invisible to current users since, for regional forwarding rules, Terraform will still pass the same subnetwork value in its API calls (it will just get the region info in a different way).

### Tests you have done

```
go test -v -timeout 600s -tags=integration ./config/tests/samples/create/ \
  -run-tests global-internal-forwarding-rule-with-target-http-proxy
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
