### PR TITLE
mockgcp support for ComputeNodeGroup and ComputeNodeTemplate

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -411,6 +411,8 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "containerattached.cnrm.cloud.google.com", Kind: "ContainerAttachedCluster"}:
 
 			case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeNetwork"}:
+			case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeNodeGroup"}:
+			case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeNodeTemplate"}:
 			case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeSubnetwork"}:
 				// ok
 

--- a/mockgcp/mockcompute/nodegroupsv1.go
+++ b/mockgcp/mockcompute/nodegroupsv1.go
@@ -1,0 +1,170 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockcompute
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+)
+
+type NodeGroupsV1 struct {
+	*MockService
+	pb.UnimplementedNodeGroupsServer
+}
+
+func (s *NodeGroupsV1) Get(ctx context.Context, req *pb.GetNodeGroupRequest) (*pb.NodeGroup, error) {
+	name, err := s.newNodeGroupName(req.GetProject(), req.GetZone(), req.GetNodeGroup())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.NodeGroup{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *NodeGroupsV1) Insert(ctx context.Context, req *pb.InsertNodeGroupRequest) (*pb.Operation, error) {
+	name, err := s.newNodeGroupName(req.GetProject(), req.GetZone(), req.GetNodeGroupResource().GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	id := s.generateID()
+
+	obj := proto.Clone(req.GetNodeGroupResource()).(*pb.NodeGroup)
+	obj.SelfLink = PtrTo("https://compute.googleapis.com/compute/v1/" + name.String())
+	obj.CreationTimestamp = PtrTo(s.nowString())
+	obj.Id = &id
+	obj.Kind = PtrTo("compute#nodegroup")
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error creating node group: %v", err)
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+func (s *NodeGroupsV1) Patch(ctx context.Context, req *pb.PatchNodeGroupRequest) (*pb.Operation, error) {
+	name, err := s.newNodeGroupName(req.GetProject(), req.GetZone(), req.GetNodeGroup())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	obj := &pb.NodeGroup{}
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error updating node group: %v", err)
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+func (s *NodeGroupsV1) Delete(ctx context.Context, req *pb.DeleteNodeGroupRequest) (*pb.Operation, error) {
+	name, err := s.newNodeGroupName(req.GetProject(), req.GetZone(), req.GetNodeGroup())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.NodeGroup{}
+	if err := s.storage.Delete(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+func (s *NodeGroupsV1) SetNodeTemplate(ctx context.Context, req *pb.SetNodeTemplateNodeGroupRequest) (*pb.Operation, error) {
+	name, err := s.newNodeTemplateNodeGroupName(req.GetProject(), req.GetZone(), req.GetNodeGroup(), req.GetNodeGroupsSetNodeTemplateRequestResource().GetNodeTemplate())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.NodeGroup{}
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error set node template for node group: %v", err)
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+type nodeGroupName struct {
+	Project *projects.ProjectData
+	Zone    string
+	Name    string
+}
+
+type nodeTemplateNodeGroupName struct {
+	Project          *projects.ProjectData
+	Zone             string
+	NodeGroupName    string
+	NodeTemplateName string
+}
+
+func (n *nodeGroupName) String() string {
+	return "projects/" + n.Project.ID + "/zones/" + n.Zone + "/nodeGroups/" + n.Name
+}
+
+func (n *nodeTemplateNodeGroupName) String() string {
+	return "projects/" + n.Project.ID + "/zones/" + n.Zone + "/nodeGroups/" + n.NodeGroupName + "/setNodeTemplate/" + n.NodeTemplateName
+}
+
+// newNodeGroupName builds a normalized nodeGroupName from the constituent parts.
+// The expected form is `projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}`.
+func (s *MockService) newNodeGroupName(project string, zone string, name string) (*nodeGroupName, error) {
+	projectObj, err := s.projects.GetProjectByID(project)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodeGroupName{
+		Project: projectObj,
+		Zone:    zone,
+		Name:    name,
+	}, nil
+}
+
+// newNodeGroupName builds a normalized nodeGroupName from the constituent parts.
+// The expected form is `projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}/setNodeTemplate/{nodeTemplate}`.
+func (s *MockService) newNodeTemplateNodeGroupName(project string, zone string, nodeGroupName string, nodeTemplateName string) (*nodeTemplateNodeGroupName, error) {
+	projectObj, err := s.projects.GetProjectByID(project)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodeTemplateNodeGroupName{
+		Project:          projectObj,
+		Zone:             zone,
+		NodeGroupName:    nodeGroupName,
+		NodeTemplateName: nodeTemplateName,
+	}, nil
+}

--- a/mockgcp/mockcompute/nodetemplatesv1.go
+++ b/mockgcp/mockcompute/nodetemplatesv1.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockcompute
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type NodeTemplatesV1 struct {
+	*MockService
+	pb.UnimplementedNodeTemplatesServer
+}
+
+func (s *NodeTemplatesV1) Get(ctx context.Context, req *pb.GetNodeTemplateRequest) (*pb.NodeTemplate, error) {
+	name, err := s.newNodeTemplateName(req.GetProject(), req.GetRegion(), req.GetNodeTemplate())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.NodeTemplate{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *NodeTemplatesV1) Insert(ctx context.Context, req *pb.InsertNodeTemplateRequest) (*pb.Operation, error) {
+	name, err := s.newNodeTemplateName(req.GetProject(), req.GetRegion(), req.GetNodeTemplateResource().GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	id := s.generateID()
+
+	obj := proto.Clone(req.GetNodeTemplateResource()).(*pb.NodeTemplate)
+	obj.SelfLink = PtrTo("https://compute.googleapis.com/compute/v1/" + name.String())
+	obj.CreationTimestamp = PtrTo(s.nowString())
+	obj.Id = &id
+	obj.Kind = PtrTo("compute#nodetemplate")
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error creating node template: %v", err)
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+func (s *NodeTemplatesV1) Delete(ctx context.Context, req *pb.DeleteNodeTemplateRequest) (*pb.Operation, error) {
+	name, err := s.newNodeTemplateName(req.GetProject(), req.GetRegion(), req.GetNodeTemplate())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.NodeTemplate{}
+	if err := s.storage.Delete(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
+type nodeTemplateName struct {
+	Project *projects.ProjectData
+	Region  string
+	Name    string
+}
+
+func (n *nodeTemplateName) String() string {
+	return "projects/" + n.Project.ID + "/regions/" + n.Region + "/nodeTemplates/" + n.Name
+}
+
+// newNodeTemplateName builds a normalized nodeTemplateName from the constituent parts.
+// The expected form is `projects/{project}/regions/{region}/nodeTemplates/{nodeTemplate}`.
+func (s *MockService) newNodeTemplateName(project string, region string, name string) (*nodeTemplateName, error) {
+	projectObj, err := s.projects.GetProjectByID(project)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodeTemplateName{
+		Project: projectObj,
+		Region:  region,
+		Name:    name,
+	}, nil
+}

--- a/mockgcp/mockcompute/nodetemplatesv1.go
+++ b/mockgcp/mockcompute/nodetemplatesv1.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -62,7 +60,7 @@ func (s *NodeTemplatesV1) Insert(ctx context.Context, req *pb.InsertNodeTemplate
 	obj.Kind = PtrTo("compute#nodetemplate")
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating node template: %v", err)
+		return nil, err
 	}
 
 	return s.newLRO(ctx, name.Project.ID)

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -38,8 +38,10 @@ type MockService struct {
 	projects   projects.ProjectStore
 	operations *operations.Operations
 
-	networksv1 *NetworksV1
-	subnetsv1  *SubnetsV1
+	networksv1      *NetworksV1
+	nodegroupsv1    *NodeGroupsV1
+	nodetemplatesv1 *NodeTemplatesV1
+	subnetsv1       *SubnetsV1
 }
 
 // New creates a MockService.
@@ -51,6 +53,8 @@ func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 		operations: operations.NewOperationsService(storage),
 	}
 	s.networksv1 = &NetworksV1{MockService: s}
+	s.nodegroupsv1 = &NodeGroupsV1{MockService: s}
+	s.nodetemplatesv1 = &NodeTemplatesV1{MockService: s}
 	s.subnetsv1 = &SubnetsV1{MockService: s}
 	return s
 }
@@ -61,6 +65,8 @@ func (s *MockService) ExpectedHost() string {
 
 func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterNetworksServer(grpcServer, s.networksv1)
+	pb.RegisterNodeGroupsServer(grpcServer, s.nodegroupsv1)
+	pb.RegisterNodeTemplatesServer(grpcServer, s.nodetemplatesv1)
 	pb.RegisterSubnetworksServer(grpcServer, s.subnetsv1)
 }
 
@@ -94,6 +100,12 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 	}
 
 	if err := pb.RegisterNetworksHandler(ctx, mux, conn); err != nil {
+		return nil, err
+	}
+	if err := pb.RegisterNodeGroupsHandler(ctx, mux, conn); err != nil {
+		return nil, err
+	}
+	if err := pb.RegisterNodeTemplatesHandler(ctx, mux, conn); err != nil {
 		return nil, err
 	}
 	if err := pb.RegisterSubnetworksHandler(ctx, mux, conn); err != nil {

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodegroup/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodegroup/_http.log
@@ -21,8 +21,8 @@ Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "name": "operation-1707517787800-99b5547e-4961-44de-8ad6-76dbd62840d2",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517787800-99b5547e-4961-44de-8ad6-76dbd62840d2",
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
   "status": "DONE",
   "warnings": []
 }
@@ -40,9 +40,9 @@ Grpc-Metadata-Content-Type: application/grpc
 {
   "accelerators": [],
   "cpuOvercommitType": "NONE",
-  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "disks": [],
-  "id": "1707517787800358353",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {
@@ -54,7 +54,7 @@ Grpc-Metadata-Content-Type: application/grpc
     "memory": "any"
   },
   "region": "projects/${projectId}/global/regions/us-central1",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
 }
 
 ---
@@ -70,9 +70,9 @@ Grpc-Metadata-Content-Type: application/grpc
 {
   "accelerators": [],
   "cpuOvercommitType": "NONE",
-  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "disks": [],
-  "id": "1707517787800358353",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {
@@ -84,7 +84,7 @@ Grpc-Metadata-Content-Type: application/grpc
     "memory": "any"
   },
   "region": "projects/${projectId}/global/regions/us-central1",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
 }
 
 ---
@@ -107,8 +107,8 @@ Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "name": "operation-1707517790516-8ef521f9-8418-4b12-8d5e-08641d5e023b",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517790516-8ef521f9-8418-4b12-8d5e-08641d5e023b",
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
   "status": "DONE",
   "warnings": []
 }
@@ -124,9 +124,9 @@ Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A single sole-tenant node in the us-central1-b zone.",
-  "id": "1707517790516025747",
+  "id": "000000000000000000000",
   "kind": "compute#nodegroup",
   "maintenancePolicy": "DEFAULT",
   "name": "computenodegroup-${uniqueId}",
@@ -147,9 +147,9 @@ Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A single sole-tenant node in the us-central1-b zone.",
-  "id": "1707517790516025747",
+  "id": "000000000000000000000",
   "kind": "compute#nodegroup",
   "maintenancePolicy": "DEFAULT",
   "name": "computenodegroup-${uniqueId}",
@@ -161,69 +161,42 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
-POST https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}/setNodeTemplate?alt=json
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-{
-  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
-}
 
 200 OK
 Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "name": "operation-1707517790546-9fdf5874-7556-4113-8e3d-4294beada097",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517790546-9fdf5874-7556-4113-8e3d-4294beada097",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "id": "000000000000000000000",
+  "kind": "compute#nodegroup",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
   "status": "DONE",
   "warnings": []
-}
-
----
-
-GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Content-Type: application/json
-Grpc-Metadata-Content-Type: application/grpc
-
-{
-  "creationTimestamp": "2024-02-09T22:29:50.516Z",
-  "description": "A single sole-tenant node in the us-central1-b zone.",
-  "id": "1707517790516025747",
-  "kind": "compute#nodegroup",
-  "maintenancePolicy": "DEFAULT",
-  "name": "computenodegroup-${uniqueId}",
-  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
-  "size": 1,
-  "zone": "projects/${projectId}/global/zones/us-central1-b"
-}
-
----
-
-GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Content-Type: application/json
-Grpc-Metadata-Content-Type: application/grpc
-
-{
-  "creationTimestamp": "2024-02-09T22:29:50.516Z",
-  "description": "A single sole-tenant node in the us-central1-b zone.",
-  "id": "1707517790516025747",
-  "kind": "compute#nodegroup",
-  "maintenancePolicy": "DEFAULT",
-  "name": "computenodegroup-${uniqueId}",
-  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
-  "size": 1,
-  "zone": "projects/${projectId}/global/zones/us-central1-b"
 }
 
 ---
@@ -239,9 +212,9 @@ Grpc-Metadata-Content-Type: application/grpc
 {
   "accelerators": [],
   "cpuOvercommitType": "NONE",
-  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "disks": [],
-  "id": "1707517787800358353",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {
@@ -253,24 +226,7 @@ Grpc-Metadata-Content-Type: application/grpc
     "memory": "any"
   },
   "region": "projects/${projectId}/global/regions/us-central1",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Content-Type: application/json
-Grpc-Metadata-Content-Type: application/grpc
-
-{
-  "name": "operation-1707517791061-a4404c06-c824-496a-a553-34c86e5bf5f9",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517791061-a4404c06-c824-496a-a553-34c86e5bf5f9",
-  "status": "DONE",
-  "warnings": []
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
 }
 
 ---
@@ -284,8 +240,8 @@ Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 
 {
-  "name": "operation-1707517791062-9560dc85-77fc-4782-95bc-ba3d24b95a53",
-  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517791062-9560dc85-77fc-4782-95bc-ba3d24b95a53",
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
   "status": "DONE",
   "warnings": []
 }

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodegroup/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodegroup/_http.log
@@ -1,0 +1,291 @@
+POST https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "cpuOvercommitType": "NONE",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "any",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1"
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "operation-1707517787800-99b5547e-4961-44de-8ad6-76dbd62840d2",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517787800-99b5547e-4961-44de-8ad6-76dbd62840d2",
+  "status": "DONE",
+  "warnings": []
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "disks": [],
+  "id": "1707517787800358353",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "any",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "disks": [],
+  "id": "1707517787800358353",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "any",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups?alt=json&initialNodeCount=1
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "operation-1707517790516-8ef521f9-8418-4b12-8d5e-08641d5e023b",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517790516-8ef521f9-8418-4b12-8d5e-08641d5e023b",
+  "status": "DONE",
+  "warnings": []
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "id": "1707517790516025747",
+  "kind": "compute#nodegroup",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "id": "1707517790516025747",
+  "kind": "compute#nodegroup",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}/setNodeTemplate?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "operation-1707517790546-9fdf5874-7556-4113-8e3d-4294beada097",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517790546-9fdf5874-7556-4113-8e3d-4294beada097",
+  "status": "DONE",
+  "warnings": []
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "id": "1707517790516025747",
+  "kind": "compute#nodegroup",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "creationTimestamp": "2024-02-09T22:29:50.516Z",
+  "description": "A single sole-tenant node in the us-central1-b zone.",
+  "id": "1707517790516025747",
+  "kind": "compute#nodegroup",
+  "maintenancePolicy": "DEFAULT",
+  "name": "computenodegroup-${uniqueId}",
+  "nodeTemplate": "projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}",
+  "size": 1,
+  "zone": "projects/${projectId}/global/zones/us-central1-b"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-02-09T22:29:47.8Z",
+  "disks": [],
+  "id": "1707517787800358353",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "any",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-b/nodeGroups/computenodegroup-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "operation-1707517791061-a4404c06-c824-496a-a553-34c86e5bf5f9",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517791061-a4404c06-c824-496a-a553-34c86e5bf5f9",
+  "status": "DONE",
+  "warnings": []
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "operation-1707517791062-9560dc85-77fc-4782-95bc-ba3d24b95a53",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/operation-1707517791062-9560dc85-77fc-4782-95bc-ba3d24b95a53",
+  "status": "DONE",
+  "warnings": []
+}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodetemplate/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodetemplate/_http.log
@@ -1,0 +1,143 @@
+POST https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "cpuOvercommitType": "NONE",
+  "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true",
+    "memory_guarantee": "false"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "96",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1"
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
+  "status": "DONE",
+  "warnings": []
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
+  "disks": [],
+  "id": "1707779855744494373",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true",
+    "memory_guarantee": "false"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "96",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
+  "disks": [],
+  "id": "1707779855744494373",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true",
+    "memory_guarantee": "false"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "96",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "accelerators": [],
+  "cpuOvercommitType": "NONE",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
+  "disks": [],
+  "id": "1707779855744494373",
+  "kind": "compute#nodetemplate",
+  "name": "computenodetemplate-${uniqueId}",
+  "nodeAffinityLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true",
+    "memory_guarantee": "false"
+  },
+  "nodeTypeFlexibility": {
+    "cpus": "96",
+    "memory": "any"
+  },
+  "region": "projects/${projectId}/global/regions/us-central1",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/nodeTemplates/computenodetemplate-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "name": "${operationId}",
+  "selfLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationId}",
+  "status": "DONE",
+  "warnings": []
+}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodetemplate/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenodetemplate/_http.log
@@ -45,7 +45,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
   "disks": [],
-  "id": "1707779855744494373",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {
@@ -77,7 +77,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
   "disks": [],
-  "id": "1707779855744494373",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {
@@ -109,7 +109,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
   "disks": [],
-  "id": "1707779855744494373",
+  "id": "000000000000000000000",
   "kind": "compute#nodetemplate",
   "name": "computenodetemplate-${uniqueId}",
   "nodeAffinityLabels": {

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -173,8 +173,12 @@ func TestAllInSeries(t *testing.T) {
 						body := event.Response.ParseBody()
 						val, ok := body["name"]
 						if ok {
-							if strings.Contains(val.(string), "operations/") {
+							// operation name format: operations/operation-{operationId}
+							if strings.HasPrefix(val.(string), "operations/") {
 								id = strings.TrimPrefix(val.(string), "operations/")
+								// operation name format: operation-{operationId}
+							} else if strings.HasPrefix(val.(string), "operation") {
+								id = val.(string)
 							}
 						}
 						if id != "" {
@@ -257,6 +261,7 @@ func TestAllInSeries(t *testing.T) {
 
 					addReplacement("createTime", "2024-04-01T12:34:56.123456Z")
 					addReplacement("response.createTime", "2024-04-01T12:34:56.123456Z")
+					addReplacement("creationTimestamp", "2024-04-01T12:34:56.123456Z")
 					addReplacement("updateTime", "2024-04-01T12:34:56.123456Z")
 					addReplacement("response.updateTime", "2024-04-01T12:34:56.123456Z")
 
@@ -277,7 +282,7 @@ func TestAllInSeries(t *testing.T) {
 						normalizers = append(normalizers, h.ReplaceString(k, v))
 					}
 					for k := range operationIDs {
-						normalizers = append(normalizers, h.ReplaceString("operations/"+k, "operations/${operationId}"))
+						normalizers = append(normalizers, h.ReplaceString(k, "${operationId}"))
 					}
 					h.CompareGoldenFile(expectedPath, got, normalizers...)
 				}

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -252,6 +252,7 @@ func TestAllInSeries(t *testing.T) {
 						})
 					}
 
+					addReplacement("id", "000000000000000000000")
 					addReplacement("uniqueId", "111111111111111111111")
 					addReplacement("oauth2ClientId", "888888888888888888888")
 


### PR DESCRIPTION
### Change description

Fixes b/323011402

### Tests you have done
E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock GOLDEN_REQUEST_CHECKS=1 WRITE_GOLDEN_OUTPUT=1 go test -test.count=1 -timeout 300s -v ./tests/e2e -run TestAllInSeries/fixtures/computenodetemplate

E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock GOLDEN_REQUEST_CHECKS=1 WRITE_GOLDEN_OUTPUT=1 go test -test.count=1 -timeout 300s -v ./tests/e2e -run TestAllInSeries/fixtures/computenodegroup


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
