### PR TITLE
mockgcp: Refactor to pass around environment

### DIFF
--- a/mockgcp/common/env.go
+++ b/mockgcp/common/env.go
@@ -21,21 +21,6 @@ import (
 )
 
 type MockEnvironment struct {
-	projects   projects.ProjectStore
-	kubeClient client.Client
-}
-
-func NewMockEnvironment(kubeClient client.Client, projects projects.ProjectStore) *MockEnvironment {
-	e := &MockEnvironment{}
-	e.kubeClient = kubeClient
-	e.projects = projects
-	return e
-}
-
-func (e *MockEnvironment) GetProjects() projects.ProjectStore {
-	return e.projects
-}
-
-func (e *MockEnvironment) GetKubeClient() client.Client {
-	return e.kubeClient
+	Projects   projects.ProjectStore
+	KubeClient client.Client
 }

--- a/mockgcp/mockaiplatform/service.go
+++ b/mockgcp/mockaiplatform/service.go
@@ -21,30 +21,27 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/aiplatform/v1beta1"
 )
 
 // MockService represents a mocked aiplatform service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
+
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 }
 
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	return s
 }

--- a/mockgcp/mockaiplatform/tensorboard.go
+++ b/mockgcp/mockaiplatform/tensorboard.go
@@ -187,7 +187,7 @@ func (s *MockService) parseTensorboardName(name string) (*TensorboardName, error
 		if err != nil {
 			return nil, err
 		}
-		project, err := s.projects.GetProject(projectName)
+		project, err := s.Projects.GetProject(projectName)
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockapikeys/names.go
+++ b/mockgcp/mockapikeys/names.go
@@ -38,7 +38,7 @@ func (s *MockService) parseAPIKeyName(name string) (*apiKeyName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "keys" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockapikeys/service.go
+++ b/mockgcp/mockapikeys/service.go
@@ -21,20 +21,17 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/api/apikeys/v2"
 )
 
 // MockService represents a mocked apikeys service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v2 *APIKeysV2
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v2 = &APIKeysV2{MockService: s}
 	return s

--- a/mockgcp/mockbilling/service.go
+++ b/mockgcp/mockbilling/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/billing/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked certificatemanager service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *BillingV1
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &BillingV1{MockService: s}
 	return s

--- a/mockgcp/mockcertificatemanager/names.go
+++ b/mockgcp/mockcertificatemanager/names.go
@@ -39,7 +39,7 @@ func (s *MockService) parseCertificateName(name string) (*certificateName, error
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "certificates" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (s *MockService) parseCertificateMapName(name string) (*certificateMapName,
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "certificateMaps" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ func (s *MockService) parseDNSAuthorizationName(name string) (*dnsAuthorizationN
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "dnsAuthorizations" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func (s *MockService) parseCertificateMapEntryName(name string) (*certificateMap
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "certificateMaps" && tokens[6] == "certificateMapEntries" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcertificatemanager/service.go
+++ b/mockgcp/mockcertificatemanager/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/certificatemanager/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked certificatemanager service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *CertificateManagerV1
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &CertificateManagerV1{MockService: s}
 	return s

--- a/mockgcp/mockcloudfunctions/names.go
+++ b/mockgcp/mockcloudfunctions/names.go
@@ -38,7 +38,7 @@ func (s *MockService) parseFunctionName(name string) (*functionName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "functions" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcloudfunctions/service.go
+++ b/mockgcp/mockcloudfunctions/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/functions/v1"
 )
 
 // MockService represents a mocked cloudfunctions service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *CloudFunctionsV1
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &CloudFunctionsV1{MockService: s}
 	return s

--- a/mockgcp/mockcompute/disksv1.go
+++ b/mockgcp/mockcompute/disksv1.go
@@ -139,7 +139,7 @@ func (s *MockService) parseZonalDiskName(name string) (*zonalDiskName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "zones" && tokens[4] == "disks" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcompute/globaladdress.go
+++ b/mockgcp/mockcompute/globaladdress.go
@@ -128,7 +128,7 @@ func (s *MockService) parseGlobalAddressName(name string) (*globalAddressName, e
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 5 && tokens[0] == "projects" && tokens[2] == "global" && tokens[3] == "addresses" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcompute/networksv1.go
+++ b/mockgcp/mockcompute/networksv1.go
@@ -160,7 +160,7 @@ func (s *MockService) parseNetworkName(name string) (*networkName, error) {
 
 // newNetworkName builds a normalized networkName from the constituent parts.
 func (s *MockService) newNetworkName(project string, name string) (*networkName, error) {
-	projectObj, err := s.projects.GetProjectByID(project)
+	projectObj, err := s.Projects.GetProjectByID(project)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockcompute/nodegroupsv1.go
+++ b/mockgcp/mockcompute/nodegroupsv1.go
@@ -112,7 +112,7 @@ func (n *nodeGroupName) String() string {
 // newNodeGroupName builds a normalized nodeGroupName from the constituent parts.
 // The expected form is `projects/{project}/zones/{zone}/nodeGroups/{nodeGroup}`.
 func (s *MockService) newNodeGroupName(project string, zone string, name string) (*nodeGroupName, error) {
-	projectObj, err := s.projects.GetProjectByID(project)
+	projectObj, err := s.Projects.GetProjectByID(project)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockcompute/nodetemplatesv1.go
+++ b/mockgcp/mockcompute/nodetemplatesv1.go
@@ -95,7 +95,7 @@ func (n *nodeTemplateName) String() string {
 // newNodeTemplateName builds a normalized nodeTemplateName from the constituent parts.
 // The expected form is `projects/{project}/regions/{region}/nodeTemplates/{nodeTemplate}`.
 func (s *MockService) newNodeTemplateName(project string, region string, name string) (*nodeTemplateName, error) {
-	projectObj, err := s.projects.GetProjectByID(project)
+	projectObj, err := s.Projects.GetProjectByID(project)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockcompute/regionaladdress.go
+++ b/mockgcp/mockcompute/regionaladdress.go
@@ -127,7 +127,7 @@ func (s *MockService) parseRegionalAddressName(name string) (*regionalAddressNam
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "addresses" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcompute/regiondisksv1.go
+++ b/mockgcp/mockcompute/regiondisksv1.go
@@ -139,7 +139,7 @@ func (s *MockService) parseZonalRegionDiskName(name string) (*regionalDiskName, 
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "disks" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -20,21 +20,17 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
 )
 
 // MockService represents a mocked compute service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
-
-	projects projects.ProjectStore
 
 	*computeOperations
 
@@ -47,9 +43,8 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:              env.GetKubeClient(),
+		MockEnvironment:   env,
 		storage:           storage,
-		projects:          env.GetProjects(),
 		computeOperations: newComputeOperationsService(storage),
 	}
 	return s

--- a/mockgcp/mockcompute/subnetsv1.go
+++ b/mockgcp/mockcompute/subnetsv1.go
@@ -131,7 +131,7 @@ func (s *MockService) parseSubnetName(name string) (*subnetName, error) {
 
 // newSubnetName builds a normalized subnetName from the constituent parts.
 func (s *MockService) newSubnetName(project string, region string, name string) (*subnetName, error) {
-	projectObj, err := s.projects.GetProjectByID(project)
+	projectObj, err := s.Projects.GetProjectByID(project)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockedgecontainer/names.go
+++ b/mockgcp/mockedgecontainer/names.go
@@ -39,7 +39,7 @@ func (s *MockService) parseClusterName(name string) (*clusterName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "clusters" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (s *MockService) parseNodePoolName(name string) (*nodePoolName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "clusters" && tokens[6] == "nodePools" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockedgecontainer/service.go
+++ b/mockgcp/mockedgecontainer/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/edgecontainer/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked edgecontainer service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *EdgeContainerV1
@@ -48,10 +45,9 @@ type EdgeContainerV1 struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &EdgeContainerV1{MockService: s}
 	return s

--- a/mockgcp/mockedgenetwork/names.go
+++ b/mockgcp/mockedgenetwork/names.go
@@ -40,7 +40,7 @@ func (s *MockService) parseNetworkName(name string) (*networkName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "zones" && tokens[6] == "networks" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}
@@ -75,7 +75,7 @@ func (s *MockService) parseSubnetName(name string) (*subnetName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "zones" && tokens[6] == "subnets" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockedgenetwork/service.go
+++ b/mockgcp/mockedgenetwork/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/edgenetwork/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked edgenetwork service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *EdgenetworkV1
@@ -48,10 +45,9 @@ type EdgenetworkV1 struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &EdgenetworkV1{MockService: s}
 	return s

--- a/mockgcp/mockgkemulticloud/names.go
+++ b/mockgcp/mockgkemulticloud/names.go
@@ -39,7 +39,7 @@ func (s *MockService) parseAttachedClustersName(name string) (*attachedClustersN
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "attachedClusters" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockgkemulticloud/service.go
+++ b/mockgcp/mockgkemulticloud/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/gkemulticloud/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked containerattachedcluster service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *GKEMulticloudV1
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &GKEMulticloudV1{MockService: s}
 	return s

--- a/mockgcp/mockiam/names.go
+++ b/mockgcp/mockiam/names.go
@@ -55,7 +55,7 @@ func (s *MockService) parseServiceAccountName(ctx context.Context, name string) 
 				}
 
 				projectNumber := uniqueID >> 32
-				project, err := s.projects.GetProjectByNumber(strconv.FormatInt(projectNumber, 10))
+				project, err := s.Projects.GetProjectByNumber(strconv.FormatInt(projectNumber, 10))
 				if err != nil {
 					return nil, err
 				}
@@ -67,7 +67,7 @@ func (s *MockService) parseServiceAccountName(ctx context.Context, name string) 
 			}
 		}
 
-		project, err := s.projects.GetProjectByID(projectID)
+		project, err := s.Projects.GetProjectByID(projectID)
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockiam/service.go
+++ b/mockgcp/mockiam/service.go
@@ -19,21 +19,17 @@ import (
 	"net/http"
 
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/iam/admin/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked IAM service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
-
-	projects projects.ProjectStore
 
 	serverV1 *ServerV1
 }
@@ -46,9 +42,8 @@ type ServerV1 struct {
 // New creates a MockService
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:     env.GetKubeClient(),
-		storage:  storage,
-		projects: env.GetProjects(),
+		MockEnvironment: env,
+		storage:         storage,
 	}
 	s.serverV1 = &ServerV1{MockService: s}
 	return s

--- a/mockgcp/mockiam/serviceaccounts.go
+++ b/mockgcp/mockiam/serviceaccounts.go
@@ -93,7 +93,7 @@ func (s *ServerV1) CreateServiceAccount(ctx context.Context, req *pb.CreateServi
 	if err != nil {
 		return nil, err
 	}
-	project, err := s.projects.GetProject(projectName)
+	project, err := s.Projects.GetProject(projectName)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mocknetworkservices/names.go
+++ b/mockgcp/mocknetworkservices/names.go
@@ -39,7 +39,7 @@ func (s *MockService) parseMeshName(name string) (*meshName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[3] == "global" && tokens[4] == "meshes" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mocknetworkservices/service.go
+++ b/mockgcp/mocknetworkservices/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/networkservices/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked networkservices service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *NetworkServicesServer
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &NetworkServicesServer{MockService: s}
 	return s

--- a/mockgcp/mockprivateca/names.go
+++ b/mockgcp/mockprivateca/names.go
@@ -39,7 +39,7 @@ func (s *MockService) parseCAPoolName(name string) (*caPoolName, error) {
 	tokens := strings.Split(name, "/")
 
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "caPools" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockprivateca/service.go
+++ b/mockgcp/mockprivateca/service.go
@@ -20,21 +20,18 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/security/privateca/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked privateca service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	v1 *PrivateCAV1
@@ -43,10 +40,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &PrivateCAV1{MockService: s}
 	return s

--- a/mockgcp/mockresourcemanager/projectsv3.go
+++ b/mockgcp/mockresourcemanager/projectsv3.go
@@ -92,6 +92,7 @@ func (s *ProjectsV3) CreateProject(ctx context.Context, req *pb.CreateProjectReq
 	if err != nil {
 		return nil, err
 	}
+
 	response := &longrunningpb.Operation_Response{}
 	response.Response = any
 

--- a/mockgcp/mockresourcemanager/service.go
+++ b/mockgcp/mockresourcemanager/service.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
@@ -31,22 +31,22 @@ import (
 
 // MockService represents a mocked privateca service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projectsInternal *ProjectsInternal
-	operations       *operations.Operations
+	operations *operations.Operations
 
-	projectsV1 *ProjectsV1
-	projectsV3 *ProjectsV3
+	projectsInternal *ProjectsInternal
+	projectsV1       *ProjectsV1
+	projectsV3       *ProjectsV3
 }
 
 // New creates a MockService.
-func New(kubeClient client.Client, storage storage.Storage) *MockService {
+func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       kubeClient,
-		storage:    storage,
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.projectsInternal = &ProjectsInternal{MockService: s}
 	s.projectsV1 = &ProjectsV1{MockService: s}
@@ -54,7 +54,7 @@ func New(kubeClient client.Client, storage storage.Storage) *MockService {
 	return s
 }
 
-func (s *MockService) GetInternalService() projects.ProjectStore {
+func (s *MockService) GetProjectStore() projects.ProjectStore {
 	return s.projectsInternal
 }
 

--- a/mockgcp/mocksecretmanager/secrets.go
+++ b/mockgcp/mocksecretmanager/secrets.go
@@ -47,7 +47,7 @@ func (s *SecretsV1) CreateSecret(ctx context.Context, req *pb.CreateSecretReques
 		return nil, err
 	}
 
-	project, err := s.projects.GetProject(parent)
+	project, err := s.Projects.GetProject(parent)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *MockService) parseSecretName(name string) (*secretName, error) {
 			return nil, err
 		}
 
-		project, err := s.projects.GetProject(projectName)
+		project, err := s.Projects.GetProject(projectName)
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mocksecretmanager/secretversions.go
+++ b/mockgcp/mocksecretmanager/secretversions.go
@@ -110,7 +110,7 @@ func (s *SecretsV1) AddSecretVersion(ctx context.Context, req *pb.AddSecretVersi
 	{
 		ns := &corev1.Namespace{}
 		ns.SetName(secretKey.Namespace)
-		if err := s.kube.Create(ctx, ns); err != nil {
+		if err := s.KubeClient.Create(ctx, ns); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				// somewhat expected
 			} else {
@@ -119,7 +119,7 @@ func (s *SecretsV1) AddSecretVersion(ctx context.Context, req *pb.AddSecretVersi
 		}
 	}
 
-	if err := s.kube.Create(ctx, secretObj); err != nil {
+	if err := s.KubeClient.Create(ctx, secretObj); err != nil {
 		return nil, status.Errorf(codes.Internal, "error creating secret data: %v", err)
 	}
 	klog.Infof("created Secret %v", secretObj.GetNamespace()+"/"+secretObj.GetName())
@@ -178,7 +178,7 @@ func (s *MockService) accessSecret(ctx context.Context, secretVersion *pb.Secret
 	key := name.kubernetesSecretID()
 	secretObj := &corev1.Secret{}
 
-	if err := s.kube.Get(ctx, key, secretObj); err != nil {
+	if err := s.KubeClient.Get(ctx, key, secretObj); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("did not find secret with id %v", key)
 			return nil, status.Errorf(codes.NotFound, "secret version %q not found", name)
@@ -315,7 +315,7 @@ func (n *secretVersionName) String() string {
 func (s *MockService) parseSecretVersionName(name string) (*secretVersionName, error) {
 	tokens := strings.Split(name, "/")
 	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "secrets" && tokens[4] == "versions" {
-		project, err := s.projects.GetProjectByNumber(tokens[1])
+		project, err := s.Projects.GetProjectByNumber(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mocksecretmanager/service.go
+++ b/mockgcp/mocksecretmanager/service.go
@@ -20,30 +20,25 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/secretmanager/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked secret manager service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
-
-	projects projects.ProjectStore
 
 	v1 *SecretsV1
 }
 
 // New creates a mockSecretManager
-func New(mockenv *common.MockEnvironment, storage storage.Storage) *MockService {
+func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:     mockenv.GetKubeClient(),
-		storage:  storage,
-		projects: mockenv.GetProjects(),
+		MockEnvironment: env,
+		storage:         storage,
 	}
 	s.v1 = &SecretsV1{MockService: s}
 	return s

--- a/mockgcp/mockserviceusage/names.go
+++ b/mockgcp/mockserviceusage/names.go
@@ -38,7 +38,7 @@ func (n *serviceName) String() string {
 func (s *MockService) parseServiceName(name string) (*serviceName, error) {
 	tokens := strings.Split(name, "/")
 	if len(tokens) == 4 && tokens[0] == "projects" && tokens[2] == "services" {
-		project, err := s.projects.GetProjectByID(tokens[1])
+		project, err := s.Projects.GetProjectByID(tokens[1])
 		if err != nil {
 			return nil, err
 		}

--- a/mockgcp/mockserviceusage/service.go
+++ b/mockgcp/mockserviceusage/service.go
@@ -20,11 +20,9 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb_v1 "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/api/serviceusage/v1"
 	pb_v1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/api/serviceusage/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
@@ -32,10 +30,9 @@ import (
 
 // MockService represents a mocked serviceusage service.
 type MockService struct {
-	kube    client.Client
+	*common.MockEnvironment
 	storage storage.Storage
 
-	projects   projects.ProjectStore
 	operations *operations.Operations
 
 	serviceusagev1      *ServiceUsageV1
@@ -45,10 +42,9 @@ type MockService struct {
 // New creates a MockService
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.serviceusagev1 = &ServiceUsageV1{MockService: s}
 	s.serviceusagev1beta1 = &ServiceUsageV1Beta1{MockService: s}

--- a/mockgcp/mockserviceusage/serviceusagev1.go
+++ b/mockgcp/mockserviceusage/serviceusagev1.go
@@ -160,7 +160,7 @@ func (s *ServiceUsageV1) ListServices(ctx context.Context, req *pb.ListServicesR
 		return nil, err
 	}
 
-	project, err := s.projects.GetProject(parent)
+	project, err := s.Projects.GetProject(parent)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockstorage/service.go
+++ b/mockgcp/mockstorage/service.go
@@ -20,21 +20,17 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/storage/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 )
 
 // MockService represents a mocked storage service.
 type MockService struct {
-	kube    client.Client
-	storage storage.Storage
-
-	projects   projects.ProjectStore
+	*common.MockEnvironment
+	storage    storage.Storage
 	operations *operations.Operations
 
 	v1 *StorageV1
@@ -43,10 +39,9 @@ type MockService struct {
 // New creates a MockService.
 func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
 	s := &MockService{
-		kube:       env.GetKubeClient(),
-		storage:    storage,
-		projects:   env.GetProjects(),
-		operations: operations.NewOperationsService(storage),
+		MockEnvironment: env,
+		storage:         storage,
+		operations:      operations.NewOperationsService(storage),
 	}
 	s.v1 = &StorageV1{MockService: s}
 	return s


### PR DESCRIPTION
This will (in future) enable "loopback" calls, like creating a default network when the project is created.
