### PR TITLE
gitignore: .tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # Temporary Build Files
 tmp/_output
 tmp/_test
+.tmp
 
 # build output
 bin/


### PR DESCRIPTION
Ignore `.tmp` folder for git. Ran into this while using `golangci-lint`.