### PR TITLE
ci: add errorlint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
-    # - errorlint
+    - errorlint
     # - exportloopref
     # - forcetypeassert
     # - gci

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -163,7 +163,7 @@ func forEach(c client.Client, gvk schema.GroupVersionKind, listOptions *client.L
 		list.SetGroupVersionKind(gvk)
 		err := c.List(context.Background(), &list, listOptions)
 		if err != nil {
-			return fmt.Errorf("error listing objects:%v", err)
+			return fmt.Errorf("error listing objects: %w", err)
 		}
 		for _, item := range list.Items {
 			if err := fn(item); err != nil {

--- a/operator/cmd/gke_addon_poststart/main.go
+++ b/operator/cmd/gke_addon_poststart/main.go
@@ -66,7 +66,7 @@ func createDefaultConfigConnector(ctx context.Context, dynamicClient dynamic.Int
 	u := &unstructured.Unstructured{}
 	b := []byte(defaultConfigConnector)
 	if err := yaml.Unmarshal(b, u); err != nil {
-		return fmt.Errorf("error unmarshalling bytes to unstruct: %v", err)
+		return fmt.Errorf("error unmarshalling bytes to unstruct: %w", err)
 	}
 
 	// Create the ConfigConnector object. Retry on error just in case the

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -141,7 +141,7 @@ func (r *ConfigConnectorContextReconciler) Reconcile(ctx context.Context, req re
 	_, reconciliationErr := r.reconciler.Reconcile(ctx, req)
 	if reconciliationErr != nil {
 		if err := r.handleReconcileFailed(ctx, req.NamespacedName, reconciliationErr); err != nil {
-			return reconcile.Result{}, fmt.Errorf("error handling reconciled failed: %v, original reconciliation error: %w", err, reconciliationErr)
+			return reconcile.Result{}, fmt.Errorf("error handling reconciled failed: %w, original reconciliation error: %w", err, reconciliationErr)
 		}
 		return reconcile.Result{}, reconciliationErr
 	}
@@ -298,11 +298,11 @@ func (r *ConfigConnectorContextReconciler) finalizeCCContextDeletion(ctx context
 func (r *ConfigConnectorContextReconciler) finalizeNamespacedComponentsDeletion(ctx context.Context, ccc *corev1beta1.ConfigConnectorContext, m *manifest.Objects) error {
 	r.log.Info("finalizing namespaced components deletion...", "namespace", ccc.Namespace)
 	if err := removeNamespacedComponents(ctx, r.client, m.Items); err != nil {
-		return fmt.Errorf("error finalizing ConfigConnectorContext %v/%v deletion: %v", ccc.Namespace, ccc.Name, err)
+		return fmt.Errorf("error finalizing ConfigConnectorContext %v/%v deletion: %w", ccc.Namespace, ccc.Name, err)
 	}
 	if controllers.RemoveOperatorFinalizer(ccc) {
 		if err := r.client.Update(ctx, ccc); err != nil {
-			return fmt.Errorf("error removing %v finalizer in ConfigConnectorContext object %v/%v: %v", k8s.OperatorFinalizer, ccc.Namespace, ccc.GetName(), err)
+			return fmt.Errorf("error removing %v finalizer in ConfigConnectorContext object %v/%v: %w", k8s.OperatorFinalizer, ccc.Namespace, ccc.GetName(), err)
 		}
 	}
 	return nil
@@ -331,7 +331,7 @@ func (r *ConfigConnectorContextReconciler) handleCCContextLifecycleForNamespaced
 
 	if !controllers.EnsureOperatorFinalizer(ccc) {
 		if err := r.client.Update(ctx, ccc); err != nil {
-			return fmt.Errorf("error adding %v finalizer in ConfigConnectorContext object %v: %v", k8s.OperatorFinalizer, client.ObjectKeyFromObject(ccc), err)
+			return fmt.Errorf("error adding %v finalizer in ConfigConnectorContext object %v: %w", k8s.OperatorFinalizer, client.ObjectKeyFromObject(ccc), err)
 		}
 	}
 	return nil

--- a/operator/pkg/controllers/configconnectorcontext/namespaced.go
+++ b/operator/pkg/controllers/configconnectorcontext/namespaced.go
@@ -81,11 +81,11 @@ func handleControllerManagerService(ctx context.Context, c client.Client, ccc *c
 	u := obj.UnstructuredObject().DeepCopy()
 	nsId, err := cluster.GetNamespaceID(k8s.OperatorNamespaceIDConfigMapNN, c, ctx, ccc.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error getting namespace id for namespace %v: %v", ccc.Namespace, err)
+		return nil, fmt.Errorf("error getting namespace id for namespace %v: %w", ccc.Namespace, err)
 	}
 	u.SetName(strings.ReplaceAll(u.GetName(), "${NAMESPACE?}", nsId))
 	if err := removeStaleControllerManagerService(ctx, c, ccc.Namespace, u.GetName()); err != nil {
-		return nil, fmt.Errorf("error deleting stale Services for watched namespace %v: %v", ccc.Namespace, err)
+		return nil, fmt.Errorf("error deleting stale Services for watched namespace %v: %w", ccc.Namespace, err)
 	}
 	return manifest.NewObject(u)
 }
@@ -96,7 +96,7 @@ func removeStaleControllerManagerService(ctx context.Context, c client.Client, n
 	svcList := &corev1.ServiceList{}
 	if err := c.List(ctx, svcList, client.InNamespace(k8s.CNRMSystemNamespace),
 		client.MatchingLabels{k8s.NamespacedComponentLabel: ns}); err != nil {
-		return fmt.Errorf("error listing existing %v Services for watched namespace %v: %v", k8s.KCCControllerManagerComponent, ns, err)
+		return fmt.Errorf("error listing existing %v Services for watched namespace %v: %w", k8s.KCCControllerManagerComponent, ns, err)
 	}
 	for _, svc := range svcList.Items {
 		if strings.HasPrefix(svc.Name, k8s.NamespacedManagerServicePrefix) && svc.Name != validSts {
@@ -113,14 +113,14 @@ func handleControllerManagerStatefulSet(ctx context.Context, c client.Client, cc
 
 	nsId, err := cluster.GetNamespaceID(k8s.OperatorNamespaceIDConfigMapNN, c, ctx, ccc.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error getting namespace id for namespace %v: %v", ccc.Namespace, err)
+		return nil, fmt.Errorf("error getting namespace id for namespace %v: %w", ccc.Namespace, err)
 	}
 
 	u.SetName(strings.ReplaceAll(u.GetName(), "${NAMESPACE?}", nsId))
 
 	serviceName, found, err := unstructured.NestedString(u.Object, "spec", "serviceName")
 	if err != nil || !found {
-		return nil, fmt.Errorf("couldn't resolve serviceName in StatefulSet %v for watched namespace %v: %v", u.GetName(), ccc.Namespace, err)
+		return nil, fmt.Errorf("couldn't resolve serviceName in StatefulSet %v for watched namespace %v: %w", u.GetName(), ccc.Namespace, err)
 	}
 	if err := unstructured.SetNestedField(u.Object, strings.ReplaceAll(serviceName, "${NAMESPACE?}", nsId), "spec", "serviceName"); err != nil {
 		return nil, err
@@ -128,21 +128,21 @@ func handleControllerManagerStatefulSet(ctx context.Context, c client.Client, cc
 
 	if ccc.GetRequestProjectPolicy() == k8s.ResourceProjectPolicy {
 		if err := enableUserProjectOverride(u); err != nil {
-			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %v", k8s.UserProjectOverrideFlag, u.GetName(), ccc.Namespace, err)
+			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %w", k8s.UserProjectOverrideFlag, u.GetName(), ccc.Namespace, err)
 		}
 	}
 
 	if ccc.GetRequestProjectPolicy() == k8s.BillingProjectPolicy {
 		if err := enableUserProjectOverride(u); err != nil {
-			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %v", k8s.UserProjectOverrideFlag, u.GetName(), ccc.Namespace, err)
+			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %w", k8s.UserProjectOverrideFlag, u.GetName(), ccc.Namespace, err)
 		}
 		if err := enableBillingProject(u, ccc.Spec.BillingProject); err != nil {
-			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %v", k8s.BillingProjectFlag, u.GetName(), ccc.Namespace, err)
+			return nil, fmt.Errorf("error enabling %v in StatefulSet %v for watched namespace %v: %w", k8s.BillingProjectFlag, u.GetName(), ccc.Namespace, err)
 		}
 	}
 
 	if err := removeStaleControllerManagerStatefulSet(ctx, c, ccc.Namespace, u.GetName()); err != nil {
-		return nil, fmt.Errorf("error deleting stale StatefulSet for watched namespace %v: %v", ccc.Namespace, err)
+		return nil, fmt.Errorf("error deleting stale StatefulSet for watched namespace %v: %w", ccc.Namespace, err)
 	}
 
 	return manifest.NewObject(u)
@@ -164,7 +164,7 @@ func findManagerContainer(containers []interface{}) (managerContainer map[string
 		}
 		name, found, err := unstructured.NestedString(containerAsMap, "name")
 		if err != nil || !found {
-			return nil, 0, fmt.Errorf("couldn't resolve name of container configuration %v: %v", container, err)
+			return nil, 0, fmt.Errorf("couldn't resolve name of container configuration %v: %w", container, err)
 		}
 		if name == k8s.CNRMManagerContainerName {
 			return containerAsMap, i, nil
@@ -183,7 +183,7 @@ func setFlagForManagerContainer(u *unstructured.Unstructured, flag string, flagV
 
 	managerContainer, index, err := findManagerContainer(containers)
 	if err != nil {
-		return fmt.Errorf("error finding manager container: %v", err)
+		return fmt.Errorf("error finding manager container: %w", err)
 	}
 	args, found, err := unstructured.NestedStringSlice(managerContainer, "args")
 	if err != nil {
@@ -195,12 +195,12 @@ func setFlagForManagerContainer(u *unstructured.Unstructured, flag string, flagV
 	newArgs := removeFlagFromArgs(args, flag)
 	newArgs = append(newArgs, flag+"="+flagValue)
 	if err := unstructured.SetNestedStringSlice(managerContainer, newArgs, "args"); err != nil {
-		return fmt.Errorf("error setting args in manager container: %v", err)
+		return fmt.Errorf("error setting args in manager container: %w", err)
 	}
 
 	containers[index] = managerContainer
 	if err := unstructured.SetNestedSlice(u.Object, containers, containersPath...); err != nil {
-		return fmt.Errorf("error setting containers: %v", err)
+		return fmt.Errorf("error setting containers: %w", err)
 	}
 	return nil
 }
@@ -221,7 +221,7 @@ func removeStaleControllerManagerStatefulSet(ctx context.Context, c client.Clien
 	stsList := &appsv1.StatefulSetList{}
 	if err := c.List(ctx, stsList, client.InNamespace(k8s.CNRMSystemNamespace),
 		client.MatchingLabels{k8s.KCCSystemComponentLabel: k8s.KCCControllerManagerComponent, k8s.NamespacedComponentLabel: ns}); err != nil {
-		return fmt.Errorf("error listing existing %v StatefulSets for watched namespace %v: %v", k8s.KCCControllerManagerComponent, ns, err)
+		return fmt.Errorf("error listing existing %v StatefulSets for watched namespace %v: %w", k8s.KCCControllerManagerComponent, ns, err)
 	}
 
 	hasStale := false

--- a/operator/pkg/k8s/crds.go
+++ b/operator/pkg/k8s/crds.go
@@ -34,7 +34,7 @@ func ListCRDs(ctx context.Context, kubeClient client.Client, pageToken string) (
 	list := v1.CustomResourceDefinitionList{}
 	labelSelector, err := labels.Parse(KCCSystemLabelSelectorRaw)
 	if err != nil {
-		return nil, "", fmt.Errorf("error parsing '%v' as a label selector: %v", KCCSystemLabelSelectorRaw, err)
+		return nil, "", fmt.Errorf("error parsing '%v' as a label selector: %w", KCCSystemLabelSelectorRaw, err)
 	}
 	opts := &client.ListOptions{
 		Limit:         100,

--- a/operator/pkg/manifest/manifest_loader.go
+++ b/operator/pkg/manifest/manifest_loader.go
@@ -61,7 +61,7 @@ func (c *ManifestLoader) ResolveManifest(ctx context.Context, o runtime.Object) 
 	channelName := k8s.StableChannel
 	version, err := ResolveVersion(ctx, c.repo, componentName, channelName)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving the version for %v in %v channel: %v", componentName, channelName, err)
+		return nil, fmt.Errorf("error resolving the version for %v in %v channel: %w", componentName, channelName, err)
 	}
 	mlog.Info("resolved version from channel", "channel", channelName, "version", version)
 	return c.repo.LoadManifest(ctx, componentName, version, cc)

--- a/operator/pkg/manifest/per_namespace_manifest_loader.go
+++ b/operator/pkg/manifest/per_namespace_manifest_loader.go
@@ -48,7 +48,7 @@ func (p *PerNamespaceManifestLoader) ResolveManifest(ctx context.Context, o runt
 	channelName := k8s.StableChannel
 	v, err := ResolveVersion(ctx, p.repo, componentName, channelName)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving the version for %v in %v channel: %v", componentName, channelName, err)
+		return nil, fmt.Errorf("error resolving the version for %v in %v channel: %w", componentName, channelName, err)
 	}
 
 	return p.repo.LoadNamespacedComponents(ctx, componentName, v)

--- a/operator/pkg/manifest/repo.go
+++ b/operator/pkg/manifest/repo.go
@@ -55,12 +55,12 @@ func (r *LocalRepository) LoadChannel(ctx context.Context, name string) (*loader
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
 		rlog.Error(err, "error reading channel", "path", p)
-		return nil, fmt.Errorf("error reading channel %s: %v", p, err)
+		return nil, fmt.Errorf("error reading channel %s: %w", p, err)
 	}
 
 	channel := &loaders.Channel{}
 	if err := yaml.Unmarshal(b, channel); err != nil {
-		return nil, fmt.Errorf("error parsing channel %s: %v", p, err)
+		return nil, fmt.Errorf("error parsing channel %s: %w", p, err)
 	}
 
 	return channel, nil
@@ -76,7 +76,7 @@ func (r *LocalRepository) LoadManifest(ctx context.Context, componentName string
 	p := filepath.Join(r.basedir, "packages", componentName, version, crdFileName)
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %s: %v", p, err)
+		return nil, fmt.Errorf("error reading file %s: %w", p, err)
 	}
 	var sb strings.Builder
 	sb.Write(b)
@@ -92,7 +92,7 @@ func (r *LocalRepository) LoadManifest(ctx context.Context, componentName string
 		p := filepath.Join(r.basedir, "packages", componentName, version, mode, authIdentity, cnrmSystemFileName)
 		b, err := ioutil.ReadFile(p)
 		if err != nil {
-			return nil, fmt.Errorf("error reading file %s: %v", p, err)
+			return nil, fmt.Errorf("error reading file %s: %w", p, err)
 		}
 		sb.Write(b)
 		path := strings.Join([]string{r.basedir, "packages", componentName, version, mode, authIdentity}, "/")
@@ -102,7 +102,7 @@ func (r *LocalRepository) LoadManifest(ctx context.Context, componentName string
 		p := filepath.Join(r.basedir, "packages", componentName, version, "namespaced", cnrmSystemFileName)
 		b, err := ioutil.ReadFile(p)
 		if err != nil {
-			return nil, fmt.Errorf("error reading file %s: %v", p, err)
+			return nil, fmt.Errorf("error reading file %s: %w", p, err)
 		}
 		sb.Write(b)
 		path := strings.Join([]string{r.basedir, "packages", componentName, version, mode}, "/")
@@ -114,7 +114,7 @@ func (r *LocalRepository) LoadNamespacedComponents(ctx context.Context, componen
 	p := filepath.Join(r.basedir, "packages", componentName, version, "namespaced", perNamespaceComponentsFileName)
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file %s: %v", p, err)
+		return nil, fmt.Errorf("error reading file %s: %w", p, err)
 	}
 	return map[string]string{p: string(b)}, nil
 }

--- a/operator/pkg/preflight/upgrade.go
+++ b/operator/pkg/preflight/upgrade.go
@@ -68,11 +68,11 @@ func (u *UpgradeChecker) Preflight(ctx context.Context, o declarative.Declarativ
 
 	channel, err := u.repo.LoadChannel(ctx, k8s.StableChannel)
 	if err != nil {
-		return fmt.Errorf("preflight check failed loading the channel %v: %v", k8s.StableChannel, err)
+		return fmt.Errorf("preflight check failed loading the channel %v: %w", k8s.StableChannel, err)
 	}
 	version, err := channel.Latest(ctx, k8s.ConfigConnectorComponentName)
 	if err != nil {
-		return fmt.Errorf("preflight check failed resolving the version to deploy: %v", err)
+		return fmt.Errorf("preflight check failed resolving the version to deploy: %w", err)
 	}
 	if version == nil {
 		return fmt.Errorf("could not find the latest version in channel %v", k8s.StableChannel)
@@ -80,12 +80,12 @@ func (u *UpgradeChecker) Preflight(ctx context.Context, o declarative.Declarativ
 	versionToDeployRaw := version.Version
 	currentVersion, err := semver.ParseTolerant(currentVersionRaw)
 	if err != nil {
-		return fmt.Errorf("current version %v is not a valid semantic version: %v", currentVersionRaw, err)
+		return fmt.Errorf("current version %v is not a valid semantic version: %w", currentVersionRaw, err)
 	}
 	ulog.Info("Checking version", "current version", currentVersion)
 	versionToDeploy, err := semver.ParseTolerant(versionToDeployRaw)
 	if err != nil {
-		return fmt.Errorf("the version to deploy %v is not a valid semantic version: %v", versionToDeployRaw, err)
+		return fmt.Errorf("the version to deploy %v is not a valid semantic version: %w", versionToDeployRaw, err)
 	}
 	ulog.Info("Checking version", "version to deploy", versionToDeploy)
 	if compareMajorOnly(currentVersion, versionToDeploy) != 0 {

--- a/operator/pkg/test/main/testmain.go
+++ b/operator/pkg/test/main/testmain.go
@@ -93,7 +93,7 @@ func StartTestManager(cfg *rest.Config) (manager.Manager, func(), error) {
 		Scheme:                 scheme,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating manager: %v", err)
+		return nil, nil, fmt.Errorf("error creating manager: %w", err)
 	}
 	stopFunc := startMgr(mgr, log.Fatalf)
 	return mgr, stopFunc, nil
@@ -108,7 +108,7 @@ func startMgr(mgr manager.Manager, mgrStartErrHandler func(string, ...interface{
 	go func() {
 		defer wg.Done()
 		if err := mgr.Start(ctx); err != nil {
-			mgrStartErrHandler("unable to start manager: %v", err)
+			mgrStartErrHandler("unable to start manager: %w", err)
 		}
 	}()
 	stop := func() {

--- a/operator/scripts/utils/cmd.go
+++ b/operator/scripts/utils/cmd.go
@@ -28,12 +28,12 @@ const (
 
 func DownloadAndExtractTarballAt(gcsPath, outputDir string) error {
 	if err := DownloadObjectFromGCS(gcsPath, outputDir); err != nil {
-		return fmt.Errorf("error downloading tarball at '%v': %v", gcsPath, err)
+		return fmt.Errorf("error downloading tarball at '%v': %w", gcsPath, err)
 	}
 	tarballName := path.Base(gcsPath)
 	tarballPath := path.Join(outputDir, tarballName)
 	if err := ExtractTarball(tarballPath, outputDir); err != nil {
-		return fmt.Errorf("error extracting tarball: %v", err)
+		return fmt.Errorf("error extracting tarball: %w", err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func Execute(cmd *exec.Cmd) error {
 func ExecuteAndCaptureOutput(cmd *exec.Cmd) (stdout string, err error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%v: %v", err, string(out))
+		return "", fmt.Errorf("%w: %v", err, string(out))
 	}
 	return string(out), nil
 }

--- a/operator/scripts/utils/yaml.go
+++ b/operator/scripts/utils/yaml.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -36,7 +37,7 @@ func UnstructToYaml(u *unstructured.Unstructured) ([]byte, error) {
 func BytesToUnstruct(bytes []byte) (*unstructured.Unstructured, error) {
 	u := unstructured.Unstructured{}
 	if err := yaml.Unmarshal(bytes, &u); err != nil {
-		return nil, fmt.Errorf("error unmarshalling bytes to unstruct: %v", err)
+		return nil, fmt.Errorf("error unmarshalling bytes to unstruct: %w", err)
 	}
 	return &u, nil
 }
@@ -66,13 +67,13 @@ func SplitYAML(yamlBytes []byte) ([][]byte, error) {
 	dec := goyaml.NewDecoder(r)
 	results := make([][]byte, 0)
 	var value map[string]interface{}
-	for eof := dec.Decode(&value); eof != io.EOF; eof = dec.Decode(&value) {
+	for eof := dec.Decode(&value); errors.Is(eof, io.EOF); eof = dec.Decode(&value) {
 		if eof != nil {
 			return nil, eof
 		}
 		bytes, err := goyaml.Marshal(value)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling '%v' to YAML: %v", value, err)
+			return nil, fmt.Errorf("error marshalling '%v' to YAML: %w", value, err)
 		}
 		results = append(results, bytes)
 	}

--- a/pkg/cli/asset/asset.go
+++ b/pkg/cli/asset/asset.go
@@ -33,7 +33,7 @@ func GetServiceMappingAndResourceConfig(smLoader *servicemappingloader.ServiceMa
 	serviceHostName := pieces[0]
 	sm, err := smLoader.GetServiceMappingForServiceHostName(serviceHostName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting service mapping: %v", err)
+		return nil, nil, fmt.Errorf("error getting service mapping: %w", err)
 	}
 	assetKind := pieces[1]
 	resourceConfigs, err := getResourceConfigs(sm, assetKind)
@@ -96,7 +96,7 @@ func matchAssetNameToRC(assetName string, resourceConfigs []v1alpha1.ResourceCon
 		regexIDTemplate := idTemplateToRegex(rc.IDTemplate)
 		regex, err := regexp.Compile(regexIDTemplate)
 		if err != nil {
-			return nil, fmt.Errorf("error compiling '%v' to regex: %v", regexIDTemplate, err)
+			return nil, fmt.Errorf("error compiling '%v' to regex: %w", regexIDTemplate, err)
 		}
 		if regex.MatchString(assetName) {
 			return &rc, nil

--- a/pkg/cli/asset/asset_test.go
+++ b/pkg/cli/asset/asset_test.go
@@ -15,6 +15,7 @@
 package asset_test
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestGetServiceMappingAndResourceConfig(t *testing.T) {
 	stream := newStreamFromFile(t, "testdata/cai-export.json")
 	defer closeStream(t, stream)
 	smLoader := testservicemappingloader.New(t)
-	for a, err := stream.Next(); err != io.EOF; a, err = stream.Next() {
+	for a, err := stream.Next(); !errors.Is(err, io.EOF); a, err = stream.Next() {
 		if err != nil {
 			t.Fatalf("unexpected error reading asset: %v", err)
 		}

--- a/pkg/cli/asset/export/export.go
+++ b/pkg/cli/asset/export/export.go
@@ -46,21 +46,21 @@ func ForParentToStorageObject(ctx context.Context, httpClient *http.Client, pare
 	}
 	assetClient, err := newAssetInventoryClient(ctx, httpClient)
 	if err != nil {
-		return fmt.Errorf("error creating asset client: %v", err)
+		return fmt.Errorf("error creating asset client: %w", err)
 	}
 	projectNum, err := getDefaultProjectNumber(ctx, httpClient)
 	if err != nil {
-		return fmt.Errorf("error getting project number: %v", err)
+		return fmt.Errorf("error getting project number: %w", err)
 	}
 	projectNumString := fmt.Sprint(projectNum)
 	request := assetClient.V1.ExportAssets(parent, &exportAssetsRequest)
 	request.Header().Add("X-Goog-User-Project", projectNumString)
 	op, err := request.Do()
 	if err != nil {
-		return fmt.Errorf("error response from exportassets request: %v", err)
+		return fmt.Errorf("error response from exportassets request: %w", err)
 	}
 	if _, err := gcp.WaitForAssetInventoryOperationDefaultTimeout(assetClient, op, projectNumString, nil); err != nil {
-		return fmt.Errorf("error waiting for operation: %v", err)
+		return fmt.Errorf("error waiting for operation: %w", err)
 	}
 	return nil
 }
@@ -68,11 +68,11 @@ func ForParentToStorageObject(ctx context.Context, httpClient *http.Client, pare
 func NewTemporaryBucketAndObjectName(ctx context.Context, httpClient *http.Client) (string, string, error) {
 	storageClient, err := newStorageClient(ctx, httpClient)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating storage client: %v", err)
+		return "", "", fmt.Errorf("error creating storage client: %w", err)
 	}
 	projectId, err := gcp.GetDefaultProjectID()
 	if err != nil {
-		return "", "", fmt.Errorf("error getting project id: %v", err)
+		return "", "", fmt.Errorf("error getting project id: %w", err)
 	}
 	bucketName := fmt.Sprintf("export-%v", randomid.New().String())
 	bucket := &storage.Bucket{
@@ -80,7 +80,7 @@ func NewTemporaryBucketAndObjectName(ctx context.Context, httpClient *http.Clien
 	}
 	_, err = storageClient.Buckets.Insert(projectId, bucket).Do()
 	if err != nil {
-		return "", "", fmt.Errorf("error creating bucket '%v': %v", bucketName, err)
+		return "", "", fmt.Errorf("error creating bucket '%v': %w", bucketName, err)
 	}
 	objectName := NewObjectName()
 	return bucketName, objectName, nil
@@ -93,10 +93,10 @@ func NewObjectName() string {
 func DeleteExport(ctx context.Context, httpClient *http.Client, bucketName, objectName string) error {
 	storageClient, err := newStorageClient(ctx, httpClient)
 	if err != nil {
-		return fmt.Errorf("error creating storage client: %v", err)
+		return fmt.Errorf("error creating storage client: %w", err)
 	}
 	if err := storageClient.Objects.Delete(bucketName, objectName).Do(); err != nil {
-		return fmt.Errorf("error deleting storage object gs://%v/%v: %v", bucketName, objectName, err)
+		return fmt.Errorf("error deleting storage object gs://%v/%v: %w", bucketName, objectName, err)
 	}
 	return err
 }
@@ -104,10 +104,10 @@ func DeleteExport(ctx context.Context, httpClient *http.Client, bucketName, obje
 func DeleteTemporaryBucket(ctx context.Context, httpClient *http.Client, bucketName string) error {
 	storageClient, err := newStorageClient(ctx, httpClient)
 	if err != nil {
-		return fmt.Errorf("error creating storage client: %v", err)
+		return fmt.Errorf("error creating storage client: %w", err)
 	}
 	if err := storageClient.Buckets.Delete(bucketName).Do(); err != nil {
-		return fmt.Errorf("error deleting temporary bucket '%v': %v", bucketName, err)
+		return fmt.Errorf("error deleting temporary bucket '%v': %w", bucketName, err)
 	}
 	return nil
 }
@@ -115,7 +115,7 @@ func DeleteTemporaryBucket(ctx context.Context, httpClient *http.Client, bucketN
 func newAssetInventoryClient(ctx context.Context, httpClient *http.Client) (*cloudasset.Service, error) {
 	client, err := cloudasset.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
-		return nil, fmt.Errorf("error creating asset inventory client: %v", err)
+		return nil, fmt.Errorf("error creating asset inventory client: %w", err)
 	}
 	return client, nil
 }
@@ -123,7 +123,7 @@ func newAssetInventoryClient(ctx context.Context, httpClient *http.Client) (*clo
 func newStorageClient(ctx context.Context, httpClient *http.Client) (*storage.Service, error) {
 	client, err := storage.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {
-		return nil, fmt.Errorf("error creating storage client: %v", err)
+		return nil, fmt.Errorf("error creating storage client: %w", err)
 	}
 	return client, nil
 }

--- a/pkg/cli/asset/stream.go
+++ b/pkg/cli/asset/stream.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,9 +43,10 @@ func (a *Stream) Next() (*Asset, error) {
 	var asset Asset
 	err := a.decoder.Decode(&asset)
 	if err != nil {
-		if err != io.EOF {
-			err = fmt.Errorf("error decoding asset from reader: %v", err)
+		if !errors.Is(err, io.EOF) {
+			err = fmt.Errorf("error decoding asset from reader: %w", err)
 		}
+
 		return nil, err
 	}
 	return &asset, nil
@@ -78,7 +80,7 @@ func NewStream(r io.Reader) *Stream {
 func NewStreamFromFile(filePath string) (*Stream, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening file '%v': %v", filePath, err)
+		return nil, fmt.Errorf("error opening file '%v': %w", filePath, err)
 	}
 	return NewStream(file), nil
 }

--- a/pkg/cli/asset/stream_test.go
+++ b/pkg/cli/asset/stream_test.go
@@ -16,6 +16,7 @@ package asset_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -57,7 +58,7 @@ func testFileStream(t *testing.T, filePath string, expectedCount int) {
 
 func testStream(t *testing.T, stream *asset.Stream, expectedCount int) {
 	count := 0
-	for asset, err := stream.Next(); err != io.EOF; asset, err = stream.Next() {
+	for asset, err := stream.Next(); !errors.Is(err, io.EOF); asset, err = stream.Next() {
 		if err != nil {
 			t.Fatalf("unexpected error reading asset: %v", err)
 		}

--- a/pkg/cli/cmd/apply/execute.go
+++ b/pkg/cli/cmd/apply/execute.go
@@ -33,17 +33,17 @@ func Execute(ctx context.Context, params *parameters.Parameters, output io.Write
 	}
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
-		return fmt.Errorf("error loading service mappings: %v", err)
+		return fmt.Errorf("error loading service mappings: %w", err)
 	}
 
 	usFromFile, err := yamlresource.UnstructuredFromYamlFile(params.Input)
 	if err != nil {
-		return fmt.Errorf("error loading resource from file: %v", err)
+		return fmt.Errorf("error loading resource from file: %w", err)
 	}
 	client := gcpclient.New(tfProvider, smLoader)
 	appliedResource, err := client.Apply(usFromFile)
 	if err != nil {
-		return fmt.Errorf("error applying resource from file: %v", err)
+		return fmt.Errorf("error applying resource from file: %w", err)
 	}
 
 	return yamlresource.RenderJSON(appliedResource, output)

--- a/pkg/cli/cmd/apply/yamlresource/yaml_to_unstructured_resource.go
+++ b/pkg/cli/cmd/apply/yamlresource/yaml_to_unstructured_resource.go
@@ -50,7 +50,7 @@ func RenderJSON(res *unstructured.Unstructured, output io.Writer) error {
 func RenderYAML(res *unstructured.Unstructured, output io.Writer) error {
 	bytes, err := yaml.Marshal(res)
 	if err != nil {
-		return fmt.Errorf("error marshalling unstructured to yaml: %v", err)
+		return fmt.Errorf("error marshalling unstructured to yaml: %w", err)
 	}
 	_, err = output.Write(bytes)
 	return err

--- a/pkg/cli/cmd/bulkexport/execute.go
+++ b/pkg/cli/cmd/bulkexport/execute.go
@@ -16,6 +16,7 @@ package bulkexport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -56,9 +57,9 @@ func Execute(ctx context.Context, params *parameters.Parameters) error {
 		return err
 	}
 	defer outputSink.Close()
-	for bytes, unstructured, err := recoverableStream.Next(ctx); err != io.EOF; bytes, unstructured, err = recoverableStream.Next(ctx) {
+	for bytes, unstructured, err := recoverableStream.Next(ctx); !errors.Is(err, io.EOF); bytes, unstructured, err = recoverableStream.Next(ctx) {
 		if err != nil {
-			if err := errorHandler.Handle(fmt.Errorf("error getting next YAML: %v", err)); err != nil {
+			if err := errorHandler.Handle(fmt.Errorf("error getting next YAML: %w", err)); err != nil {
 				return err
 			}
 			continue

--- a/pkg/cli/cmd/bulkexport/filteredinputstream/filteredinputstream.go
+++ b/pkg/cli/cmd/bulkexport/filteredinputstream/filteredinputstream.go
@@ -60,7 +60,7 @@ func isDefaultNetworkingAsset(smLoader *servicemappingloader.ServiceMappingLoade
 func NewFilteredAssetStream(assetStream *asset.Stream, tfProvider *schema.Provider) (stream.AssetStream, error) {
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
-		return nil, fmt.Errorf("error loading service mappings: %v", err)
+		return nil, fmt.Errorf("error loading service mappings: %w", err)
 	}
 	filter := func(a *asset.Asset) bool {
 		if !isAssetSupported(smLoader, tfProvider, a) {

--- a/pkg/cli/cmd/bulkexport/inputstream/inputstream.go
+++ b/pkg/cli/cmd/bulkexport/inputstream/inputstream.go
@@ -37,7 +37,7 @@ var (
 func NewAssetStream(params *parameters.Parameters, stdin *os.File) (*asset.Stream, error) {
 	piped, err := parameters.IsInputPiped(stdin)
 	if err != nil {
-		return nil, fmt.Errorf("error checking if stdin has piped input: %v", err)
+		return nil, fmt.Errorf("error checking if stdin has piped input: %w", err)
 	}
 	if piped {
 		return asset.NewStream(stdin), nil
@@ -53,7 +53,7 @@ func newStorageObjectStream(params *parameters.Parameters) (*asset.Stream, error
 	var bucketName, objectName string
 	httpClient, err := serviceclient.NewHTTPClient(context.TODO(), params.OAuth2Token)
 	if err != nil {
-		return nil, fmt.Errorf("error creating http client: %v", err)
+		return nil, fmt.Errorf("error creating http client: %w", err)
 	}
 	if params.StorageKey == "" {
 		log.Verbose("Creating temporary bucket for export...")
@@ -61,13 +61,13 @@ func newStorageObjectStream(params *parameters.Parameters) (*asset.Stream, error
 		defer cancel()
 		bucketName, objectName, err = export.NewTemporaryBucketAndObjectName(ctx, httpClient)
 		if err != nil {
-			return nil, fmt.Errorf("error creating temporary bucket and prefix: %v", err)
+			return nil, fmt.Errorf("error creating temporary bucket and prefix: %w", err)
 		}
 		defer deleteTemporaryBucket(httpClient, bucketName)
 	} else {
 		bucketName, objectName, err = storage.GetBucketAndPrefix(params.StorageKey)
 		if err != nil {
-			return nil, fmt.Errorf("error extracting bucket and prefix from parameter '%v': %v", parameters.StorageKeyParam, err)
+			return nil, fmt.Errorf("error extracting bucket and prefix from parameter '%v': %w", parameters.StorageKeyParam, err)
 		}
 		if objectName == "" {
 			objectName = export.NewObjectName()
@@ -83,7 +83,7 @@ func newStorageObjectStream(params *parameters.Parameters) (*asset.Stream, error
 	defer cancel()
 	log.Verbose("Creating asset inventory export at %v", storage.GetFullURI(bucketName, objectName))
 	if err := export.ForParentToStorageObject(exportCtx, httpClient, parent, bucketName, objectName); err != nil {
-		return nil, fmt.Errorf("error exporting asset inventory: %v", err)
+		return nil, fmt.Errorf("error exporting asset inventory: %w", err)
 	}
 	defer deleteExport(httpClient, bucketName, objectName)
 	return newStreamFromStorageObject(httpClient, bucketName, objectName)

--- a/pkg/cli/cmd/bulkexport/outputstream/outputstream.go
+++ b/pkg/cli/cmd/bulkexport/outputstream/outputstream.go
@@ -33,7 +33,7 @@ import (
 func NewResourceByteStream(tfProvider *schema.Provider, params *parameters.Parameters, assetStream stream.AssetStream) (stream.ByteStream, error) {
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
-		return nil, fmt.Errorf("error creating service mapping loader: %v", err)
+		return nil, fmt.Errorf("error creating service mapping loader: %w", err)
 	}
 	unstructuredStream, err := NewUnstructuredStream(params, assetStream, tfProvider, smLoader)
 	if err != nil {
@@ -45,13 +45,13 @@ func NewResourceByteStream(tfProvider *schema.Provider, params *parameters.Param
 func NewUnstructuredStream(params *parameters.Parameters, assetStream stream.AssetStream, provider *schema.Provider, smLoader *servicemappingloader.ServiceMappingLoader) (stream.UnstructuredStream, error) {
 	httpClient, err := serviceclient.NewHTTPClient(context.TODO(), params.OAuth2Token)
 	if err != nil {
-		return nil, fmt.Errorf("error creating http client: %v", err)
+		return nil, fmt.Errorf("error creating http client: %w", err)
 	}
 	serviceClient := serviceclient.NewServiceClient(httpClient)
 	gcpClient := gcpclient.New(provider, smLoader)
 	unstructuredResourceStream, err := stream.NewUnstructuredResourceStreamFromAssetStream(assetStream, gcpClient, provider, &serviceClient)
 	if err != nil {
-		return nil, fmt.Errorf("error creating unstructured resource stream: %v", err)
+		return nil, fmt.Errorf("error creating unstructured resource stream: %w", err)
 	}
 	fixupStream := stream.NewUnstructuredResourceFixupStream(unstructuredResourceStream)
 	if params.IAMFormat == commonparams.NoneIAMFormatOption {

--- a/pkg/cli/cmd/bulkexport/parameters/parameters.go
+++ b/pkg/cli/cmd/bulkexport/parameters/parameters.go
@@ -108,7 +108,7 @@ func Validate(p *Parameters, stdin *os.File) error {
 func IsInputPiped(stdin *os.File) (bool, error) {
 	fi, err := stdin.Stat()
 	if err != nil {
-		return false, fmt.Errorf("error stating stdin: %v", err)
+		return false, fmt.Errorf("error stating stdin: %w", err)
 	}
 	return (fi.Mode() & os.ModeCharDevice) == 0, nil
 }

--- a/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
+++ b/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
@@ -49,7 +49,7 @@ func New(tfProvider *schema.Provider, smloader *servicemappingloader.ServiceMapp
 func (i *iamClient) SupportsIAM(unstructured *unstructured.Unstructured) (bool, error) {
 	rc, err := i.smLoader.GetResourceConfig(unstructured)
 	if err != nil {
-		return false, fmt.Errorf("error getting resource config for %v with name '%v': %v",
+		return false, fmt.Errorf("error getting resource config for %v with name '%v': %w",
 			unstructured.GetKind(), unstructured.GetName(), err)
 	}
 	return krmtotf.SupportsIAM(rc), nil
@@ -63,7 +63,7 @@ func (i *iamClient) GetPolicy(ctx context.Context, resource *unstructured.Unstru
 	iamClient := kcciamclient.New(i.tfProvider, i.smLoader, kubeClient, nil, nil).TFIAMClient
 	iamPolicySkeleton, err := i.newIAMPolicySkeleton(resource, kubeClient)
 	if err != nil {
-		return nil, fmt.Errorf("error creating new iam policy skeleton: %v", err)
+		return nil, fmt.Errorf("error creating new iam policy skeleton: %w", err)
 	}
 	return iamClient.GetPolicy(ctx, iamPolicySkeleton)
 }
@@ -71,15 +71,15 @@ func (i *iamClient) GetPolicy(ctx context.Context, resource *unstructured.Unstru
 func (i *iamClient) newIAMPolicySkeleton(u *unstructured.Unstructured, kubeClient client.Client) (*v1beta1.IAMPolicy, error) {
 	sm, err := i.smLoader.GetServiceMapping(u.GroupVersionKind().Group)
 	if err != nil {
-		return nil, fmt.Errorf("error getting service mapping for '%v': %v", u.GroupVersionKind().Group, err)
+		return nil, fmt.Errorf("error getting service mapping for '%v': %w", u.GroupVersionKind().Group, err)
 	}
 	resource, err := krmtotf.NewResource(u, sm, i.tfProvider)
 	if err != nil {
-		return nil, fmt.Errorf("error converting '%v' with name '%v' to krmtotf resource: %v", u.GroupVersionKind(), u.GetName(), err)
+		return nil, fmt.Errorf("error converting '%v' with name '%v' to krmtotf resource: %w", u.GroupVersionKind(), u.GetName(), err)
 	}
 	importId, err := resource.GetImportID(kubeClient, i.smLoader)
 	if err != nil {
-		return nil, fmt.Errorf("error getting import id for '%v' with name '%v': %v",
+		return nil, fmt.Errorf("error getting import id for '%v' with name '%v': %w",
 			resource.GroupVersionKind(),
 			resource.GetName(),
 			err)

--- a/pkg/cli/cmd/export/execute.go
+++ b/pkg/cli/cmd/export/execute.go
@@ -16,6 +16,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/cmd/export/outputstream"
@@ -42,7 +43,7 @@ func Execute(ctx context.Context, params *parameters.Parameters) error {
 		return err
 	}
 	defer outputSink.Close()
-	for bytes, unstructured, err := recoverableStream.Next(ctx); err != io.EOF; bytes, unstructured, err = recoverableStream.Next(ctx) {
+	for bytes, unstructured, err := recoverableStream.Next(ctx); !errors.Is(err, io.EOF); bytes, unstructured, err = recoverableStream.Next(ctx) {
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/export/outputstream/outputstream.go
+++ b/pkg/cli/cmd/export/outputstream/outputstream.go
@@ -31,7 +31,7 @@ import (
 func NewResourceByteStream(tfProvider *schema.Provider, params *parameters.Parameters) (stream.ByteStream, error) {
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
-		return nil, fmt.Errorf("error creating service mapping loader: %v", err)
+		return nil, fmt.Errorf("error creating service mapping loader: %w", err)
 	}
 	unstructuredStream, err := NewUnstructuredStream(params, tfProvider, smLoader)
 	if err != nil {

--- a/pkg/cli/gcpclient/client.go
+++ b/pkg/cli/gcpclient/client.go
@@ -70,11 +70,11 @@ func (c *gcpClient) Get(ctx context.Context, u *unstructured.Unstructured) (*uns
 	}
 	resource, err := krmtotf.NewResource(u, sm, c.tfProvider)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse resource %s: %v", u.GetName(), err)
+		return nil, fmt.Errorf("could not parse resource %s: %w", u.GetName(), err)
 	}
 	state, err := krmtotf.FetchLiveState(ctx, resource, c.tfProvider, c.erroringK8sClient, c.smLoader)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching live state: %v", err)
+		return nil, fmt.Errorf("error fetching live state: %w", err)
 	}
 	if state == nil {
 		return nil, NotFoundError
@@ -90,15 +90,15 @@ func (c *gcpClient) Apply(u *unstructured.Unstructured) (*unstructured.Unstructu
 	}
 	krmResource, err := krmtotf.NewResource(u, sm, c.tfProvider)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse resource %s: %v", u.GetName(), err)
+		return nil, fmt.Errorf("could not parse resource %s: %w", u.GetName(), err)
 	}
 	liveState, err := krmtotf.FetchLiveState(ctx, krmResource, c.tfProvider, c.erroringK8sClient, c.smLoader)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching live state: %v", err)
+		return nil, fmt.Errorf("error fetching live state: %w", err)
 	}
 	config, _, err := krmtotf.KRMResourceToTFResourceConfig(krmResource, c.erroringK8sClient, c.smLoader)
 	if err != nil {
-		return nil, fmt.Errorf("error expanding resource configuration: %v", err)
+		return nil, fmt.Errorf("error expanding resource configuration: %w", err)
 	}
 	diff, err := krmResource.TFResource.Diff(ctx, liveState, config, c.tfProvider.Meta())
 	if err != nil {
@@ -129,18 +129,18 @@ func (c *gcpClient) Delete(u *unstructured.Unstructured) error {
 	}
 	krmResource, err := krmtotf.NewResource(u, sm, c.tfProvider)
 	if err != nil {
-		return fmt.Errorf("could not parse resource %s: %v", u.GetName(), err)
+		return fmt.Errorf("could not parse resource %s: %w", u.GetName(), err)
 	}
 	liveState, err := krmtotf.FetchLiveState(ctx, krmResource, c.tfProvider, c.erroringK8sClient, c.smLoader)
 	if err != nil {
-		return fmt.Errorf("error fetching live state: %v", err)
+		return fmt.Errorf("error fetching live state: %w", err)
 	}
 	if liveState.Empty() {
 		return nil
 	}
 	_, diagnostics := krmResource.TFResource.Apply(ctx, liveState, &terraform.InstanceDiff{Destroy: true}, c.tfProvider.Meta())
 	if err := krmtotf.NewErrorFromDiagnostics(diagnostics); err != nil {
-		return fmt.Errorf("error deleting resource: %v", err)
+		return fmt.Errorf("error deleting resource: %w", err)
 	}
 	return nil
 }

--- a/pkg/cli/gcpclient/resolve_apiserver_dependencies_test.go
+++ b/pkg/cli/gcpclient/resolve_apiserver_dependencies_test.go
@@ -131,7 +131,7 @@ func convertSensitiveFieldsToValue(t *testing.T, resources []*unstructured.Unstr
 func getSecretValue(secretResource *unstructured.Unstructured, key string) (string, error) {
 	var secret v1.Secret
 	if err := util.Marshal(secretResource, &secret); err != nil {
-		return "", fmt.Errorf("error marshalling '%v' to a Secret: %v", secretResource, err)
+		return "", fmt.Errorf("error marshalling '%v' to a Secret: %w", secretResource, err)
 	}
 	if secret.Data != nil {
 		value, ok := secret.Data[key]

--- a/pkg/cli/krmtohcl/krmtohcl.go
+++ b/pkg/cli/krmtohcl/krmtohcl.go
@@ -38,11 +38,11 @@ func UnstructuredToHCL(ctx context.Context, u *unstructured.Unstructured, smLoad
 	}
 	krmResource, err := krmtotf.NewResource(u, sm, tfProvider)
 	if err != nil {
-		return "", fmt.Errorf("could not parse resource %s: %v", u.GetName(), err)
+		return "", fmt.Errorf("could not parse resource %s: %w", u.GetName(), err)
 	}
 	config, _, err := krmtotf.KRMResourceToTFResourceConfigFull(krmResource, k8s.NewErroringClient(), smLoader, nil, nil, true, map[string]string{})
 	if err != nil {
-		return "", fmt.Errorf("error expanding resource configuration: %v", err)
+		return "", fmt.Errorf("error expanding resource configuration: %w", err)
 	}
 	configAsMap := krmtotf.ResourceConfigToMap(config)
 	tfResource := krmResource.TFResource

--- a/pkg/cli/outputsink/filename/filename.go
+++ b/pkg/cli/outputsink/filename/filename.go
@@ -45,7 +45,7 @@ func Get(ctx context.Context, u *unstructured.Unstructured, smLoader *servicemap
 	}
 	location, err := getLocation(u)
 	if err != nil {
-		return "", fmt.Errorf("error getting location field for %v '%v': %v", u.GetKind(), u.GetName(), err)
+		return "", fmt.Errorf("error getting location field for %v '%v': %w", u.GetKind(), u.GetName(), err)
 	}
 	return path.Join(parentPrefix, u.GetKind(), location, u.GetName()), nil
 }
@@ -266,7 +266,7 @@ func getHierarchalParentPathFromSpec(u *unstructured.Unstructured) (string, bool
 func getHierarchalParentPathFromSpecField(u *unstructured.Unstructured, refFieldName string) (string, bool, error) {
 	val, ok, err := unstructured.NestedMap(u.Object, "spec", refFieldName)
 	if err != nil {
-		return "", false, fmt.Errorf("error retrieving 'spec.%v' from unstructured with kind '%v': '%v'", refFieldName, u.GetKind(), err)
+		return "", false, fmt.Errorf("error retrieving 'spec.%v' from unstructured with kind '%v': '%w'", refFieldName, u.GetKind(), err)
 	}
 	if !ok {
 		return "", false, nil
@@ -282,11 +282,11 @@ func getHierarchalParentPathFromSpecField(u *unstructured.Unstructured, refField
 func toGeneralResourceReference(value map[string]interface{}) (v1alpha1.ResourceReference, error) {
 	bytes, err := yaml.Marshal(value)
 	if err != nil {
-		return v1alpha1.ResourceReference{}, fmt.Errorf("error marshalling '%v' to YAML: %v", value, err)
+		return v1alpha1.ResourceReference{}, fmt.Errorf("error marshalling '%v' to YAML: %w", value, err)
 	}
 	var resourceReference v1alpha1.ResourceReference
 	if err := yaml.Unmarshal(bytes, &resourceReference); err != nil {
-		return v1alpha1.ResourceReference{}, fmt.Errorf("error unmarshalling to resource reference; %v", err)
+		return v1alpha1.ResourceReference{}, fmt.Errorf("error unmarshalling to resource reference; %w", err)
 	}
 	return resourceReference, nil
 }
@@ -294,11 +294,11 @@ func toGeneralResourceReference(value map[string]interface{}) (v1alpha1.Resource
 func toIAMResourceReference(value map[string]interface{}) (iamapi.ResourceReference, error) {
 	bytes, err := yaml.Marshal(value)
 	if err != nil {
-		return iamapi.ResourceReference{}, fmt.Errorf("error marshalling '%v' to YAML: %v", value, err)
+		return iamapi.ResourceReference{}, fmt.Errorf("error marshalling '%v' to YAML: %w", value, err)
 	}
 	var resourceReference iamapi.ResourceReference
 	if err := yaml.Unmarshal(bytes, &resourceReference); err != nil {
-		return iamapi.ResourceReference{}, fmt.Errorf("error unmarshalling to resource reference; %v", err)
+		return iamapi.ResourceReference{}, fmt.Errorf("error unmarshalling to resource reference; %w", err)
 	}
 	return resourceReference, nil
 }
@@ -320,7 +320,7 @@ func getLocation(u *unstructured.Unstructured) (string, error) {
 func getStringField(u *unstructured.Unstructured, path string) (string, bool, error) {
 	val, ok, err := unstructured.NestedString(u.Object, strings.Split(path, ".")...)
 	if err != nil {
-		return "", false, fmt.Errorf("error retrieving '%v' from %v: %v", path, u.GetKind(), err)
+		return "", false, fmt.Errorf("error retrieving '%v' from %v: %w", path, u.GetKind(), err)
 	}
 	if ok {
 		return val, true, nil

--- a/pkg/cli/outputsink/sink.go
+++ b/pkg/cli/outputsink/sink.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +64,7 @@ func NewWriter(w io.Writer) *WriterSink {
 
 func (ws *WriterSink) Receive(ctx context.Context, bytes []byte, _ *unstructured.Unstructured) error {
 	if _, err := ws.w.Write(bytes); err != nil {
-		return fmt.Errorf("error writing bytes: %v", err)
+		return fmt.Errorf("error writing bytes: %w", err)
 	}
 	return nil
 }
@@ -83,7 +82,7 @@ type FileSink struct {
 func NewFile(filePath string) (*FileSink, error) {
 	file, err := os.Create(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening file '%v': %v", filePath, err)
+		return nil, fmt.Errorf("error opening file '%v': %w", filePath, err)
 	}
 	sink := FileSink{
 		file:   file,
@@ -96,7 +95,7 @@ func (fs *FileSink) Receive(ctx context.Context, bytes []byte, _ *unstructured.U
 	// bufio.Writer either writes all the bytes or returns an error so we can ignore the first 'nn' return value
 	_, err := fs.writer.Write(bytes)
 	if err != nil {
-		return fmt.Errorf("error writing to '%v': %v", fs.file.Name(), err)
+		return fmt.Errorf("error writing to '%v': %w", fs.file.Name(), err)
 	}
 	return nil
 }
@@ -106,10 +105,10 @@ func (fs *FileSink) Close() error {
 		return nil
 	}
 	if err := fs.writer.Flush(); err != nil {
-		return fmt.Errorf("error flushing buffered writes for '%v': %v", fs.file.Name(), err)
+		return fmt.Errorf("error flushing buffered writes for '%v': %w", fs.file.Name(), err)
 	}
 	if err := fs.file.Close(); err != nil {
-		return fmt.Errorf("error closing '%v': %v", fs.file.Name(), err)
+		return fmt.Errorf("error closing '%v': %w", fs.file.Name(), err)
 	}
 	fs.file = nil
 	fs.writer = nil
@@ -141,8 +140,8 @@ func (ds *DirectorySink) receive(ctx context.Context, bytes []byte, unstructured
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("error ensuring parent path '%v' exists: %w", dir, err)
 	}
-	if err := ioutil.WriteFile(filePath, bytes, 0644); err != nil {
-		return fmt.Errorf("error writing bytes to '%v': %v", filePath, err)
+	if err := os.WriteFile(filePath, bytes, 0644); err != nil {
+		return fmt.Errorf("error writing bytes to '%v': %w", filePath, err)
 	}
 	return nil
 }
@@ -245,7 +244,7 @@ func newSink(tfProvider *schema.Provider, outputParam string, newDirectoryFunc f
 	// if the output path ends with a '/' then the user intends for a directory to be created
 	if strings.HasSuffix(outputParam, string(os.PathSeparator)) {
 		if err := os.MkdirAll(outputParam, os.ModePerm); err != nil {
-			return nil, fmt.Errorf("error creating directory '%v': %v", outputParam, err)
+			return nil, fmt.Errorf("error creating directory '%v': %w", outputParam, err)
 		}
 		return newDirectoryFunc(tfProvider, outputParam), nil
 	}
@@ -261,7 +260,7 @@ func newSink(tfProvider *schema.Provider, outputParam string, newDirectoryFunc f
 		return nil, fmt.Errorf("cannot use output parameter '%v': parent path '%v' exists, but is not a directory", outputParam, dir)
 	}
 	if err := os.MkdirAll(outputParam, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("error creating directory '%v': %v", outputParam, err)
+		return nil, fmt.Errorf("error creating directory '%v': %w", outputParam, err)
 	}
 	return newDirectoryFunc(tfProvider, outputParam), nil
 }

--- a/pkg/cli/serviceclient/serviceclient.go
+++ b/pkg/cli/serviceclient/serviceclient.go
@@ -45,7 +45,7 @@ func NewServiceClient(httpClient *http.Client) serviceClient {
 func (s *serviceClient) GetProjectFromProjectIDOrNumber(projectIDOrNumber string) (*resourcemanager.Project, error) {
 	resourceManagerClient, err := NewResourceManagerClient(context.Background(), s.httpClient)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create resource manager client: %v", err)
+		return nil, fmt.Errorf("unable to create resource manager client: %w", err)
 	}
 	// Technically this API is supposed to only supports the project ID, but
 	// have verified that the project number also work.
@@ -54,7 +54,7 @@ func (s *serviceClient) GetProjectFromProjectIDOrNumber(projectIDOrNumber string
 	// project information by project number.
 	project, err := resourceManagerClient.Projects.Get(projectIDOrNumber).Do()
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve project with project id or number %v : %v", projectIDOrNumber, err)
+		return nil, fmt.Errorf("unable to retrieve project with project id or number %v : %w", projectIDOrNumber, err)
 	}
 	return project, nil
 }

--- a/pkg/cli/storage/storage.go
+++ b/pkg/cli/storage/storage.go
@@ -23,7 +23,7 @@ import (
 func GetBucketAndPrefix(storageKey string) (string, string, error) {
 	u, err := url.Parse(storageKey)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing url '%v': %v", storageKey, err)
+		return "", "", fmt.Errorf("error parsing url '%v': %w", storageKey, err)
 	}
 	expectedScheme := "gs"
 	if u.Scheme != expectedScheme {

--- a/pkg/cli/stream/asset_to_unstructured_resource_stream_test.go
+++ b/pkg/cli/stream/asset_to_unstructured_resource_stream_test.go
@@ -16,6 +16,7 @@ package stream_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -55,7 +56,7 @@ func unstructuredStreamToSlice(t *testing.T, stream stream.UnstructuredStream) [
 	ctx := context.TODO()
 
 	results := make([]*unstructured.Unstructured, 0)
-	for u, err := stream.Next(ctx); err != io.EOF; u, err = stream.Next(ctx) {
+	for u, err := stream.Next(ctx); !errors.Is(err, io.EOF); u, err = stream.Next(ctx) {
 		if err != nil {
 			t.Fatalf("error reading asset: %v", err)
 		}

--- a/pkg/cli/stream/filteredassetstream.go
+++ b/pkg/cli/stream/filteredassetstream.go
@@ -15,6 +15,7 @@
 package stream
 
 import (
+	"errors"
 	"io"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/asset"
@@ -48,7 +49,7 @@ func (f *FilteredAssetStream) Next() (*asset.Asset, error) {
 	if f.shouldInclude == nil {
 		return f.assetStream.Next()
 	}
-	for asset, err := f.assetStream.Next(); err != io.EOF; asset, err = f.assetStream.Next() {
+	for asset, err := f.assetStream.Next(); !errors.Is(err, io.EOF); asset, err = f.assetStream.Next() {
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cli/stream/filteredassetstream_test.go
+++ b/pkg/cli/stream/filteredassetstream_test.go
@@ -15,6 +15,7 @@
 package stream_test
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestFilteredAssetStream(t *testing.T) {
 
 func assetStreamToSlice(t *testing.T, stream stream.AssetStream) []asset.Asset {
 	results := make([]asset.Asset, 0)
-	for asset, err := stream.Next(); err != io.EOF; asset, err = stream.Next() {
+	for asset, err := stream.Next(); !errors.Is(err, io.EOF); asset, err = stream.Next() {
 		if err != nil {
 			t.Fatalf("error reading asset: %v", err)
 		}

--- a/pkg/cli/stream/hclstream.go
+++ b/pkg/cli/stream/hclstream.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -44,7 +45,7 @@ func NewHCLStream(unstructuredStream UnstructuredStream, smLoader *servicemappin
 func (h *HCLStream) Next(ctx context.Context) ([]byte, *unstructured.Unstructured, error) {
 	unstructured, err := h.unstructuredStream.Next(ctx)
 	if err != nil {
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			err = fmt.Errorf("error getting next asset: %w", err)
 		}
 		return nil, unstructured, err

--- a/pkg/cli/stream/hclstream_test.go
+++ b/pkg/cli/stream/hclstream_test.go
@@ -16,6 +16,7 @@ package stream_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"reflect"
@@ -43,7 +44,7 @@ func hclStreamToBytes(t *testing.T, stream *stream.HCLStream) []byte {
 	ctx := context.TODO()
 
 	results := make([]byte, 0)
-	for bytes, _, err := stream.Next(ctx); err != io.EOF; bytes, _, err = stream.Next(ctx) {
+	for bytes, _, err := stream.Next(ctx); !errors.Is(err, io.EOF); bytes, _, err = stream.Next(ctx) {
 		if err != nil {
 			t.Fatalf("error reading next terraform file: %v", err)
 		}

--- a/pkg/cli/stream/unstructuredresource_iampolicystream.go
+++ b/pkg/cli/stream/unstructuredresource_iampolicystream.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -71,8 +72,8 @@ func (s *UnstructuredResourceAndIAMPolicyStream) Next(ctx context.Context) (*uns
 	}
 	resourceUnstruct, err := s.unstructStream.Next(ctx)
 	if err != nil {
-		if err != io.EOF {
-			err = fmt.Errorf("error getting next unstruct: %v", err)
+		if !errors.Is(err, io.EOF) {
+			err = fmt.Errorf("error getting next unstruct: %w", err)
 		}
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func (s *UnstructuredResourceAndIAMPolicyStream) Next(ctx context.Context) (*uns
 func (s *UnstructuredResourceAndIAMPolicyStream) fillNextIAMPolicyIfSupportedAndIfNonEmpty(u *unstructured.Unstructured) error {
 	hasIAMSupport, err := s.iamClient.SupportsIAM(u)
 	if err != nil {
-		return fmt.Errorf("error determining if resource supports iam: %v", err)
+		return fmt.Errorf("error determining if resource supports iam: %w", err)
 	}
 	if !hasIAMSupport {
 		return nil
@@ -103,7 +104,7 @@ func (s *UnstructuredResourceAndIAMPolicyStream) fillNextIAMPolicyIfNonEmpty(u *
 	defer cancel()
 	iamPolicy, err := s.iamClient.GetPolicy(ctx, u)
 	if err != nil {
-		return fmt.Errorf("error getting iam policy for '%v' with name '%v': %v",
+		return fmt.Errorf("error getting iam policy for '%v' with name '%v': %w",
 			u.GetKind(), u.GetName(), err)
 	}
 	if s.filterDeletedIAMMembers {

--- a/pkg/cli/stream/url_to_unstructured_resource_stream.go
+++ b/pkg/cli/stream/url_to_unstructured_resource_stream.go
@@ -51,11 +51,11 @@ func (s *URLToUnstructuredResourceStream) Next(ctx context.Context) (*unstructur
 	}
 	skel, err := resourceskeleton.NewFromURI(s.url, s.smLoader, s.tfProvider)
 	if err != nil {
-		return nil, fmt.Errorf("error converting url '%v' to skeleton: %v", s.url, err)
+		return nil, fmt.Errorf("error converting url '%v' to skeleton: %w", s.url, err)
 	}
 	u, err := s.gcpClient.Get(ctx, skel)
 	if err != nil {
-		return nil, fmt.Errorf("error getting '%v': %v", s.url, err)
+		return nil, fmt.Errorf("error getting '%v': %w", s.url, err)
 	}
 	s.done = true
 	return u, nil

--- a/pkg/cli/stream/yamlstream.go
+++ b/pkg/cli/stream/yamlstream.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -62,7 +63,7 @@ func (y *YAMLStream) Next(ctx context.Context) ([]byte, *unstructured.Unstructur
 	bytes, unstructured, err := y.nextBytes, y.nextUnstructured, y.nextErr
 	if err != nil {
 		// if the error is EOF and we have not yet returned the YAML terminator, '...', then return it
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if !y.returnedTransmissionTerminator {
 				if y.returnedAtLeastOneNonErrorResult {
 					y.returnedTransmissionTerminator = true
@@ -88,8 +89,8 @@ func (y *YAMLStream) fillNext(ctx context.Context) {
 func (y *YAMLStream) getNext(ctx context.Context) ([]byte, *unstructured.Unstructured, error) {
 	unstructured, err := y.unstructuredStream.Next(ctx)
 	if err != nil {
-		if err != io.EOF {
-			err = fmt.Errorf("error getting unstructured: %v", err)
+		if !errors.Is(err, io.EOF) {
+			err = fmt.Errorf("error getting unstructured: %w", err)
 		}
 		return nil, unstructured, err
 	}
@@ -97,7 +98,7 @@ func (y *YAMLStream) getNext(ctx context.Context) ([]byte, *unstructured.Unstruc
 	delete(unstructured.Object, "status")
 	bytes, err := yaml.Marshal(unstructured.Object)
 	if err != nil {
-		return nil, unstructured, fmt.Errorf("error marshalling unstructured to YAML: %v", err)
+		return nil, unstructured, fmt.Errorf("error marshalling unstructured to YAML: %w", err)
 	}
 	return bytes, unstructured, nil
 }

--- a/pkg/cli/stream/yamlstream_test.go
+++ b/pkg/cli/stream/yamlstream_test.go
@@ -16,6 +16,7 @@ package stream_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"reflect"
@@ -176,7 +177,7 @@ func yamlStreamToBytes(t *testing.T, stream *stream.YAMLStream) []byte {
 	ctx := context.TODO()
 
 	results := make([]byte, 0)
-	for bytes, _, err := stream.Next(ctx); err != io.EOF; bytes, _, err = stream.Next(ctx) {
+	for bytes, _, err := stream.Next(ctx); !errors.Is(err, io.EOF); bytes, _, err = stream.Next(ctx) {
 		if err != nil {
 			t.Fatalf("error reading next yaml: %v", err)
 		}
@@ -189,7 +190,7 @@ func yamlStreamToBytesIgnoreErrors(t *testing.T, stream *stream.YAMLStream) []by
 	ctx := context.TODO()
 
 	results := make([]byte, 0)
-	for bytes, _, err := stream.Next(ctx); err != io.EOF; bytes, _, err = stream.Next(ctx) {
+	for bytes, _, err := stream.Next(ctx); !errors.Is(err, io.EOF); bytes, _, err = stream.Next(ctx) {
 		if err != nil {
 			continue
 		}

--- a/pkg/cli/tf/tf.go
+++ b/pkg/cli/tf/tf.go
@@ -28,7 +28,7 @@ func NewProvider(ctx context.Context, gcpAccessToken string) (*schema.Provider, 
 	}
 	p, err := tfprovider.New(ctx, config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating tf provider: %v", err)
+		return nil, fmt.Errorf("error creating tf provider: %w", err)
 	}
 	return p, nil
 }

--- a/pkg/cluster/installation_identifier.go
+++ b/pkg/cluster/installation_identifier.go
@@ -94,7 +94,7 @@ func getOrSetNamespaceId(namespaceIDConfigMapNN types.NamespacedName, kubeClient
 		if err == nil || errors.IsConflict(err) {
 			return err
 		}
-		return backoff.Permanent(fmt.Errorf("error updating config map '%v': %v", namespaceIDConfigMapNN, err))
+		return backoff.Permanent(fmt.Errorf("error updating config map '%v': %w", namespaceIDConfigMapNN, err))
 	}
 	if err := backoff.Retry(getOrUpdateConfigMapFunc, backoff.NewExponentialBackOff()); err != nil {
 		return "", err
@@ -107,10 +107,10 @@ func createOrGetNamespaceIDConfigMap(namespaceIDConfigMapNN types.NamespacedName
 	if err := kubeClient.Create(ctx, &configMap); err == nil {
 		return &configMap, nil
 	} else if !errors.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("error creating configmap '%v': %v", namespaceIDConfigMapNN, err)
+		return nil, fmt.Errorf("error creating configmap '%v': %w", namespaceIDConfigMapNN, err)
 	}
 	if err := kubeClient.Get(ctx, namespaceIDConfigMapNN, &configMap); err != nil {
-		return nil, fmt.Errorf("error getting configmap '%v': %v", namespaceIDConfigMapNN, err)
+		return nil, fmt.Errorf("error getting configmap '%v': %w", namespaceIDConfigMapNN, err)
 	}
 	return &configMap, nil
 }

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -119,7 +119,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, conve
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)
 	if err != nil {
-		return nil, fmt.Errorf("error creating new controller: %v", err)
+		return nil, fmt.Errorf("error creating new controller: %w", err)
 	}
 	logger.V(2).Info("Registered dcl controller", "kind", kind, "apiVersion", apiVersion)
 	return r, nil
@@ -203,7 +203,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 		return reconcile.Result{}, fmt.Errorf("error handling default values for resource '%v': %w", k8s.GetNamespacedName(resource), err)
 	}
 	if err := r.applyChangesForBackwardsCompatibility(ctx, resource); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %v", k8s.GetNamespacedName(resource), err)
+		return reconcile.Result{}, fmt.Errorf("error applying changes to resource '%v' for backwards compatibility: %w", k8s.GetNamespacedName(resource), err)
 	}
 	// Apply pre-actuation transformation.
 	if err := resourceoverrides.Handler.PreActuationTransform(&resource.Resource); err != nil {
@@ -435,14 +435,14 @@ func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, 
 	gvk := resource.GroupVersionKind()
 	containers, err := dclcontainer.GetContainersForGVK(gvk, r.converter.MetadataLoader, r.converter.SchemaLoader)
 	if err != nil {
-		return fmt.Errorf("error getting containers supported by GroupVersionKind %v: %v", gvk, err)
+		return fmt.Errorf("error getting containers supported by GroupVersionKind %v: %w", gvk, err)
 	}
 	hierarchicalRefs, err := dcl.GetHierarchicalReferencesForGVK(gvk, r.converter.MetadataLoader, r.converter.SchemaLoader)
 	if err != nil {
-		return fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %v", gvk, err)
+		return fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %w", gvk, err)
 	}
 	if err := k8s.EnsureHierarchicalReference(ctx, &resource.Resource, hierarchicalRefs, containers, r.Client); err != nil {
-		return fmt.Errorf("error ensuring resource '%v' has a hierarchical reference: %v", k8s.GetNamespacedName(resource), err)
+		return fmt.Errorf("error ensuring resource '%v' has a hierarchical reference: %w", k8s.GetNamespacedName(resource), err)
 	}
 	return nil
 }
@@ -485,7 +485,7 @@ func (r *Reconciler) constructDesiredStateWithManagedFields(original *dcl.Resour
 	gvk := original.GroupVersionKind()
 	hierarchicalRefs, err := dcl.GetHierarchicalReferencesForGVK(gvk, r.converter.MetadataLoader, r.converter.SchemaLoader)
 	if err != nil {
-		return nil, fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %v", gvk, err)
+		return nil, fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %w", gvk, err)
 	}
 	trimmed, err := k8s.ConstructTrimmedSpecWithManagedFields(&original.Resource, r.schemaRef.JsonSchema, hierarchicalRefs)
 	if err != nil {

--- a/pkg/controller/deletiondefender/controller.go
+++ b/pkg/controller/deletiondefender/controller.go
@@ -70,7 +70,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition) error
 		For(obj, builder.OnlyMetadata).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	logger.Info("Registered controller", "kind", kind, "apiVersion", apiVersion)
 	return nil
@@ -80,7 +80,7 @@ func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinit
 	controllerName := fmt.Sprintf("%v-deletion-defender-controller", strings.ToLower(crd.Spec.Names.Kind))
 	clientSet, err := clientset.NewForConfig(mgr.GetConfig())
 	if err != nil {
-		return nil, fmt.Errorf("error creating new clientset: %v", err)
+		return nil, fmt.Errorf("error creating new clientset: %w", err)
 	}
 	return &Reconciler{
 		Client:    mgr.GetClient(),
@@ -131,9 +131,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	}
 	if err := r.Update(ctx, u); err != nil {
 		if errors.IsConflict(err) {
-			return reconcile.Result{}, fmt.Errorf("couldn't update the api server due to conflict. Re-enqueue the request for another reconciliation attempt: %v", err)
+			return reconcile.Result{}, fmt.Errorf("couldn't update the api server due to conflict. Re-enqueue the request for another reconciliation attempt: %w", err)
 		}
-		return reconcile.Result{}, fmt.Errorf("error with update call to API server: %v", err)
+		return reconcile.Result{}, fmt.Errorf("error with update call to API server: %w", err)
 	}
 
 	r.logger.Info("successfully finalized deletion defense", "resource", req.NamespacedName)

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -98,7 +98,7 @@ func add(mgr manager.Manager, r *Reconciler) error {
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -107,7 +107,7 @@ func add(mgr manager.Manager, r *ReconcileIAMPartialPolicy) error {
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -105,7 +105,7 @@ func add(mgr manager.Manager, r *ReconcileIAMPolicy) error {
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -105,7 +105,7 @@ func add(mgr manager.Manager, r *Reconciler) error {
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -128,7 +128,7 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 
 	stateIntoSpecDefaulter, err := k8s.NewStateIntoSpecDefaulter(config.StateIntoSpecDefaultValue, config.StateIntoSpecUserOverride)
 	if err != nil {
-		return nil, fmt.Errorf("error constructing new state into spec value: %v", err)
+		return nil, fmt.Errorf("error constructing new state into spec value: %w", err)
 	}
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.

--- a/pkg/controller/lifecyclehandler/handler.go
+++ b/pkg/controller/lifecyclehandler/handler.go
@@ -16,6 +16,7 @@ package lifecyclehandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
@@ -63,9 +64,9 @@ func (r *LifecycleHandler) updateStatus(ctx context.Context, resource *k8s.Resou
 	}
 	if err := r.Client.Status().Update(ctx, u, client.FieldOwner(r.fieldOwner)); err != nil {
 		if apierrors.IsConflict(err) {
-			return fmt.Errorf("couldn't update the API server due to conflict. Re-enqueue the request for another reconciliation attempt: %v", err)
+			return fmt.Errorf("couldn't update the API server due to conflict. Re-enqueue the request for another reconciliation attempt: %w", err)
 		}
-		return fmt.Errorf("error with status update call to API server: %v", err)
+		return fmt.Errorf("error with status update call to API server: %w", err)
 	}
 	// rejections by some validating webhooks won't be returned as an error; instead, they will be
 	// objects of kind "Status" with a "Failure" status.
@@ -95,9 +96,9 @@ func (r *LifecycleHandler) updateAPIServer(ctx context.Context, resource *k8s.Re
 	removeSystemLabels(u)
 	if err := r.Client.Update(ctx, u, client.FieldOwner(r.fieldOwner)); err != nil {
 		if apierrors.IsConflict(err) {
-			return fmt.Errorf("couldn't update the API server due to conflict. Re-enqueue the request for another reconciliation attempt: %v", err)
+			return fmt.Errorf("couldn't update the API server due to conflict. Re-enqueue the request for another reconciliation attempt: %w", err)
 		}
-		return fmt.Errorf("error with update call to API server: %v", err)
+		return fmt.Errorf("error with update call to API server: %w", err)
 	}
 	// rejections by validating webhooks won't be returned as an error; instead, they will be
 	// objects of kind "Status" with a "Failure" status.
@@ -183,15 +184,15 @@ func CausedByUnresolvableDeps(err error) (unwrappedErr error, ok bool) {
 }
 
 func reasonForUnresolvableDeps(err error) (string, error) {
-	switch err.(type) {
-	case *k8s.ReferenceNotReadyError, *k8s.TransitiveDependencyNotReadyError:
+	switch {
+	case errors.Is(err, &k8s.ReferenceNotReadyError{}) || errors.Is(err, &k8s.TransitiveDependencyNotReadyError{}):
 		return k8s.DependencyNotReady, nil
-	case *k8s.ReferenceNotFoundError, *k8s.SecretNotFoundError, *k8s.TransitiveDependencyNotFoundError:
+	case errors.Is(err, &k8s.ReferenceNotFoundError{}) ||  errors.Is(err, &k8s.SecretNotFoundError{}) || errors.Is(err, &k8s.TransitiveDependencyNotFoundError{}):
 		return k8s.DependencyNotFound, nil
-	case *k8s.KeyInSecretNotFoundError:
+	case  errors.Is(err, &k8s.KeyInSecretNotFoundError{}):
 		return k8s.DependencyInvalid, nil
 	default:
-		return "", fmt.Errorf("unrecognized error caused by unresolvable dependencies: %v", err)
+		return "", fmt.Errorf("unrecognized error caused by unresolvable dependencies: %w", err)
 	}
 }
 
@@ -304,7 +305,7 @@ func (r *LifecycleHandler) HandleUpdating(ctx context.Context, resource *k8s.Res
 }
 
 func (r *LifecycleHandler) HandleUpdateFailed(ctx context.Context, resource *k8s.Resource, err error) error {
-	msg := fmt.Sprintf("Update call failed: %v", err)
+	msg := fmt.Sprintf("Update call failed: %w", err)
 	setCondition(resource, corev1.ConditionFalse, k8s.UpdateFailed, msg)
 	setObservedGeneration(resource, resource.GetGeneration())
 	if err := r.updateStatus(ctx, resource); err != nil {
@@ -419,7 +420,7 @@ func IsOrphaned(resource *k8s.Resource, parentReferenceConfigs []corekccv1alpha1
 			if k8s.IsReferenceNotFoundError(err) {
 				return true, nil, nil
 			}
-			return false, nil, fmt.Errorf("error getting parent reference 'spec.%v': %v", refConfig.Key, err)
+			return false, nil, fmt.Errorf("error getting parent reference 'spec.%v': %w", refConfig.Key, err)
 		}
 		return false, parent, nil
 	}

--- a/pkg/controller/lifecyclehandler/handler.go
+++ b/pkg/controller/lifecyclehandler/handler.go
@@ -305,7 +305,7 @@ func (r *LifecycleHandler) HandleUpdating(ctx context.Context, resource *k8s.Res
 }
 
 func (r *LifecycleHandler) HandleUpdateFailed(ctx context.Context, resource *k8s.Resource, err error) error {
-	msg := fmt.Sprintf("Update call failed: %w", err)
+	msg := fmt.Errorf("Update call failed: %w", err).Error()
 	setCondition(resource, corev1.ConditionFalse, k8s.UpdateFailed, msg)
 	setObservedGeneration(resource, resource.GetGeneration())
 	if err := r.updateStatus(ctx, resource); err != nil {

--- a/pkg/controller/lifecyclehandler/handler.go
+++ b/pkg/controller/lifecyclehandler/handler.go
@@ -187,9 +187,9 @@ func reasonForUnresolvableDeps(err error) (string, error) {
 	switch {
 	case errors.Is(err, &k8s.ReferenceNotReadyError{}) || errors.Is(err, &k8s.TransitiveDependencyNotReadyError{}):
 		return k8s.DependencyNotReady, nil
-	case errors.Is(err, &k8s.ReferenceNotFoundError{}) ||  errors.Is(err, &k8s.SecretNotFoundError{}) || errors.Is(err, &k8s.TransitiveDependencyNotFoundError{}):
+	case errors.Is(err, &k8s.ReferenceNotFoundError{}) || errors.Is(err, &k8s.SecretNotFoundError{}) || errors.Is(err, &k8s.TransitiveDependencyNotFoundError{}):
 		return k8s.DependencyNotFound, nil
-	case  errors.Is(err, &k8s.KeyInSecretNotFoundError{}):
+	case errors.Is(err, &k8s.KeyInSecretNotFoundError{}):
 		return k8s.DependencyInvalid, nil
 	default:
 		return "", fmt.Errorf("unrecognized error caused by unresolvable dependencies: %w", err)

--- a/pkg/controller/mocktests/harness.go
+++ b/pkg/controller/mocktests/harness.go
@@ -17,6 +17,7 @@ package mocktests
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -89,7 +90,7 @@ func (h *Harness) ParseObjects(y string) []*unstructured.Unstructured {
 	for {
 		var rawObj runtime.RawExtension
 		if err := decoder.Decode(&rawObj); err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				t.Fatalf("error decoding yaml: %v", err)
 			}
 			break

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -186,7 +186,7 @@ func RegisterDefaultController(r *ReconcileRegistration, crd *apiextensions.Cust
 		if val, ok := crd.Labels[k8s.DCL2CRDLabel]; ok && val == "true" {
 			su, err := dclcontroller.Add(r.mgr, crd, r.dclConverter, r.dclConfig, r.smLoader, r.defaulters)
 			if err != nil {
-				return nil, fmt.Errorf("error adding dcl controller for %v to a manager: %v", crd.Spec.Names.Kind, err)
+				return nil, fmt.Errorf("error adding dcl controller for %v to a manager: %w", crd.Spec.Names.Kind, err)
 			}
 			return su, nil
 		}
@@ -197,14 +197,14 @@ func RegisterDefaultController(r *ReconcileRegistration, crd *apiextensions.Cust
 		}
 		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.defaulters)
 		if err != nil {
-			return nil, fmt.Errorf("error adding terraform controller for %v to a manager: %v", crd.Spec.Names.Kind, err)
+			return nil, fmt.Errorf("error adding terraform controller for %v to a manager: %w", crd.Spec.Names.Kind, err)
 		}
 		schemaUpdater = su
 		// register the controller to automatically create secrets for GSA keys
 		if isServiceAccountKeyCRD(crd) {
 			logger.Info("registering the GSA-Key-to-Secret generation controller")
 			if err := gsakeysecretgenerator.Add(r.mgr, crd); err != nil {
-				return nil, fmt.Errorf("error adding the gsa-to-secret generator for %v to a manager: %v", crd.Spec.Names.Kind, err)
+				return nil, fmt.Errorf("error adding the gsa-to-secret generator for %v to a manager: %w", crd.Spec.Names.Kind, err)
 			}
 		}
 	}

--- a/pkg/controller/resourceactuation/resourceactuation.go
+++ b/pkg/controller/resourceactuation/resourceactuation.go
@@ -28,14 +28,14 @@ import (
 func ShouldSkip(u *unstructured.Unstructured) (bool, error) {
 	generation, found, err := unstructured.NestedInt64(u.Object, "metadata", "generation")
 	if err != nil {
-		return false, fmt.Errorf("error getting the value for 'metadata.generation' %v", err)
+		return false, fmt.Errorf("error getting the value for 'metadata.generation' %w", err)
 	}
 	if !found {
 		return false, nil
 	}
 	observedGeneration, found, err := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
 	if err != nil {
-		return false, fmt.Errorf("error getting the value for 'status.observedGeneration': %v", err)
+		return false, fmt.Errorf("error getting the value for 'status.observedGeneration': %w", err)
 	}
 	if !found {
 		return false, nil
@@ -52,7 +52,7 @@ func ShouldSkip(u *unstructured.Unstructured) (bool, error) {
 		if reconcileInterval == 0 {
 			conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
 			if err != nil {
-				return false, fmt.Errorf("error getting object conditions: %v", err)
+				return false, fmt.Errorf("error getting object conditions: %w", err)
 			}
 			if !found {
 				return false, nil

--- a/pkg/controller/unmanageddetector/controller.go
+++ b/pkg/controller/unmanageddetector/controller.go
@@ -68,7 +68,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition) error
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(UnmanagedDetectorPredicate{})).
 		Build(r)
 	if err != nil {
-		return fmt.Errorf("error creating new controller: %v", err)
+		return fmt.Errorf("error creating new controller: %w", err)
 	}
 	logger.Info("Registered unmanaged detector controller", "kind", kind, "apiVersion", apiVersion)
 	return nil
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 
 	yes, err := controllerExistsForNamespace(ctx, u.GetNamespace(), r)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error determining if controller exists for namespace %v: %v", u.GetNamespace(), err)
+		return reconcile.Result{}, fmt.Errorf("error determining if controller exists for namespace %v: %w", u.GetNamespace(), err)
 	}
 	if yes {
 		// Don't requeue resource for reconciliation; this controller has
@@ -120,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 
 	resource, err := k8s.NewResource(u)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not parse resource %v: %v", k8s.GetNamespacedName(u), err)
+		return reconcile.Result{}, fmt.Errorf("could not parse resource %v: %w", k8s.GetNamespacedName(u), err)
 	}
 
 	// Don't requeue resource for reconciliation (unless there's an error
@@ -136,7 +136,7 @@ func controllerExistsForNamespace(ctx context.Context, namespace string, c clien
 	)
 	stsLabelSelector, err := labels.Parse(stsLabelSelectorRaw)
 	if err != nil {
-		return false, fmt.Errorf("error parsing '%v' as a label selector: %v", stsLabelSelectorRaw, err)
+		return false, fmt.Errorf("error parsing '%v' as a label selector: %w", stsLabelSelectorRaw, err)
 	}
 	stsList := &v1.StatefulSetList{}
 	stsOpts := &client.ListOptions{

--- a/pkg/controller/unmanageddetector/controller_test.go
+++ b/pkg/controller/unmanageddetector/controller_test.go
@@ -62,11 +62,11 @@ func TestReconcile_UnmanagedResource(t *testing.T) {
 
 	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD)
 	if err != nil {
-		t.Fatalf("error creating reconciler: %v", err)
+		t.Fatal(fmt.Errorf("error creating reconciler: %w", err))
 	}
 	res, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: resourceNN})
 	if err != nil {
-		t.Fatalf("unexpected error during reconciliation: %v", err)
+		t.Fatal(fmt.Errorf("unexpected error during reconciliation: %w", err))
 	}
 	emptyResult := reconcile.Result{}
 	if got, want := res, emptyResult; !reflect.DeepEqual(got, want) {
@@ -75,7 +75,7 @@ func TestReconcile_UnmanagedResource(t *testing.T) {
 
 	condition, found, err := getCurrentCondition(context.TODO(), client, resource)
 	if err != nil {
-		t.Fatalf("error getting resource's condition: %v", err)
+		t.Fatal(fmt.Errorf("error getting resource's condition: %w", err))
 	}
 	if !found {
 		t.Fatalf("got nil condition for resource, want non-nil condition with reason '%v'", k8s.Unmanaged)
@@ -107,11 +107,11 @@ func TestReconcile_ManagedResource(t *testing.T) {
 
 	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD)
 	if err != nil {
-		t.Fatalf("error creating reconciler: %v", err)
+		t.Fatal(fmt.Errorf("error creating reconciler: %w", err))
 	}
 	res, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: resourceNN})
 	if err != nil {
-		t.Fatalf("unexpected error during reconciliation: %v", err)
+		t.Fatal(fmt.Errorf("unexpected error during reconciliation: %w", err))
 	}
 	emptyResult := reconcile.Result{}
 	if got, want := res, emptyResult; !reflect.DeepEqual(got, want) {
@@ -120,7 +120,7 @@ func TestReconcile_ManagedResource(t *testing.T) {
 
 	condition, found, err := getCurrentCondition(context.TODO(), client, resource)
 	if err != nil {
-		t.Fatalf("error getting resource's condition: %v", err)
+		t.Fatal(fmt.Errorf("error getting resource's condition: %w", err))
 	}
 	if found {
 		t.Fatalf("got non-nil condition '%v' for resource, want nil condition", condition)
@@ -195,11 +195,11 @@ func getCurrentCondition(ctx context.Context, c client.Client, u *unstructured.U
 	unstruct := &unstructured.Unstructured{}
 	unstruct.SetGroupVersionKind(u.GroupVersionKind())
 	if err := c.Get(ctx, nn, unstruct); err != nil {
-		return v1alpha1.Condition{}, false, fmt.Errorf("error getting resource from API server: %v", err)
+		return v1alpha1.Condition{}, false, fmt.Errorf("error getting resource from API server: %w", err)
 	}
 	resource, err := k8s.NewResource(unstruct)
 	if err != nil {
-		return v1alpha1.Condition{}, false, fmt.Errorf("error marhsalling unstruct to k8s resource: %v", err)
+		return v1alpha1.Condition{}, false, fmt.Errorf("error marhsalling unstruct to k8s resource: %w", err)
 	}
 	condition, found = k8s.GetReadyCondition(resource)
 	return condition, found, nil

--- a/pkg/crd/crdgeneration/dcl2crdgeneration.go
+++ b/pkg/crd/crdgeneration/dcl2crdgeneration.go
@@ -68,7 +68,7 @@ func (a *DCL2CRDGenerator) GenerateCRDFromOpenAPISchema(schema *openapi.Schema, 
 	}
 	openAPIV3Schema, err := a.generateOpenAPIV3Schema(schema, r)
 	if err != nil {
-		return nil, fmt.Errorf("error generating CRD schema for %v: %v", gvk.Kind, err)
+		return nil, fmt.Errorf("error generating CRD schema for %v: %w", gvk.Kind, err)
 	}
 	crd := GetCustomResourceDefinition(gvk.Kind, gvk.Group, []string{gvk.Version}, "", openAPIV3Schema, Dcl2CRDLabel)
 	if r.DCLVersion == "alpha" {
@@ -99,7 +99,7 @@ func (a *DCL2CRDGenerator) generateOpenAPIV3Schema(schema *openapi.Schema, resou
 	if statusJSONSchema != nil {
 		statusJSONSchema, err = k8s.RenameStatusFieldsWithReservedNames(statusJSONSchema)
 		if err != nil {
-			return nil, fmt.Errorf("error renaming status fields with reserved names: %v", err)
+			return nil, fmt.Errorf("error renaming status fields with reserved names: %w", err)
 		}
 		for k, v := range statusJSONSchema.Properties {
 			crdSchema.Properties["status"].Properties[k] = v
@@ -120,7 +120,7 @@ func (a *DCL2CRDGenerator) generateSpecJSONSchema(schema *openapi.Schema, resour
 	required := make([]string, 0)
 	dclLabelsField, _, dclLabelsFieldFound, err := extension.GetLabelsFieldSchema(schema)
 	if err != nil {
-		return nil, fmt.Errorf("error extracting DCL labels field schema: %v", err)
+		return nil, fmt.Errorf("error extracting DCL labels field schema: %w", err)
 	}
 	for k, v := range schema.Properties {
 		if !v.ReadOnly {
@@ -156,7 +156,7 @@ func (a *DCL2CRDGenerator) generateSpecJSONSchema(schema *openapi.Schema, resour
 				for fieldName, s := range refs {
 					s, err := prependImmutableToDescriptionIfImmutable(s, v)
 					if err != nil {
-						return nil, fmt.Errorf("error prepending Immutable to description of hierarchical reference field %v if field is immutable: %v", fieldName, err)
+						return nil, fmt.Errorf("error prepending Immutable to description of hierarchical reference field %v if field is immutable: %w", fieldName, err)
 					}
 					jsonSchema.Properties[fieldName] = *s
 				}
@@ -261,7 +261,7 @@ func (a *DCL2CRDGenerator) dclSchemaToSpecJSONSchema(path []string, schema *open
 		}
 		refSchema, err = prependImmutableToDescriptionIfImmutable(refSchema, schema)
 		if err != nil {
-			return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %v", field, err)
+			return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %w", field, err)
 		}
 		return refFieldName, refSchema, nil
 	}
@@ -274,7 +274,7 @@ func (a *DCL2CRDGenerator) dclSchemaToSpecJSONSchema(path []string, schema *open
 		s.Description = schema.Description
 		jsonSchema, err := prependImmutableToDescriptionIfImmutable(&s, schema)
 		if err != nil {
-			return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %v", field, err)
+			return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %w", field, err)
 		}
 		return field, jsonSchema, nil
 	}
@@ -285,7 +285,7 @@ func (a *DCL2CRDGenerator) dclSchemaToSpecJSONSchema(path []string, schema *open
 
 	jsonSchema, err = prependImmutableToDescriptionIfImmutable(jsonSchema, schema)
 	if err != nil {
-		return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %v", field, err)
+		return "", nil, fmt.Errorf("error prepending Immutable to description of field %v if field is immutable: %w", field, err)
 	}
 
 	fieldName := field
@@ -589,7 +589,7 @@ func prependImmutableToDescriptionIfImmutable(jsonSchema *apiextensions.JSONSche
 	jsonSchemaCopy := jsonSchema.DeepCopy()
 	ok, err := dclextension.IsImmutableField(schema)
 	if err != nil {
-		return nil, fmt.Errorf("error determining if field is immutable: %v", err)
+		return nil, fmt.Errorf("error determining if field is immutable: %w", err)
 	}
 	if ok {
 		jsonSchemaCopy.Description = strings.TrimSpace("Immutable. " + jsonSchemaCopy.Description)

--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -69,7 +69,7 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 
 	statusJSONSchema, err := k8s.RenameStatusFieldsWithReservedNamesIfResourceNotExcluded(resource, statusJSONSchema)
 	if err != nil {
-		return nil, fmt.Errorf("error renaming status fields with reserved names for %#v: %v", statusJSONSchema, err)
+		return nil, fmt.Errorf("error renaming status fields with reserved names for %#v: %w", statusJSONSchema, err)
 	}
 	populateObservedState(resourceConfig, specJSONSchema, statusJSONSchema)
 	for k, v := range statusJSONSchema.Properties {

--- a/pkg/crd/crdgeneration/tf2crdgeneration_test.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration_test.go
@@ -142,7 +142,7 @@ func TestTFSchemaToJSONSchema(t *testing.T) {
 			json: apiextensions.JSONSchemaProps{
 				Type: "object",
 				Properties: map[string]apiextensions.JSONSchemaProps{
-					"sensitiveField": apiextensions.JSONSchemaProps{
+					"sensitiveField": {
 						Type: "string",
 					},
 				},

--- a/pkg/crd/crdloader/crdloader.go
+++ b/pkg/crd/crdloader/crdloader.go
@@ -72,7 +72,7 @@ func (l *CrdLoader) getCRDViaList(group, version, kind string) (*apiextensions.C
 	for ok := true; ok; ok = listOptions.Raw.Continue != "" {
 		var list apiextensions.CustomResourceDefinitionList
 		if err := l.kubeClient.List(context.TODO(), &list, &listOptions); err != nil {
-			return nil, fmt.Errorf("error listing CRDs for GVK %v: %v", formatGVK(group, version, kind), err)
+			return nil, fmt.Errorf("error listing CRDs for GVK %v: %w", formatGVK(group, version, kind), err)
 		}
 		crds = append(crds, list.Items...)
 		listOptions.Raw.Continue = list.Continue
@@ -85,7 +85,7 @@ func (l *CrdLoader) getCRDViaGet(group, version, kind string) (*apiextensions.Cu
 	var crd apiextensions.CustomResourceDefinition
 	nn := types.NamespacedName{Name: fmt.Sprintf("%v.%v", lowercasePluralKind, group)}
 	if err := l.kubeClient.Get(context.TODO(), nn, &crd); err != nil {
-		return nil, fmt.Errorf("error getting CRD for GVK %v: %v", formatGVK(group, version, kind), err)
+		return nil, fmt.Errorf("error getting CRD for GVK %v: %w", formatGVK(group, version, kind), err)
 	}
 	return &crd, nil
 }
@@ -104,7 +104,7 @@ func GetCRDForGVK(gvk schema.GroupVersionKind) (*apiextensions.CustomResourceDef
 func GetCRD(group, version, kind string) (*apiextensions.CustomResourceDefinition, error) {
 	crds, err := LoadCRDs()
 	if err != nil {
-		return nil, fmt.Errorf("error loading CRDs: %v", err)
+		return nil, fmt.Errorf("error loading CRDs: %w", err)
 	}
 	return getMatchingCRD(group, version, kind, crds)
 }
@@ -158,7 +158,7 @@ func LoadCRDs() ([]apiextensions.CustomResourceDefinition, error) {
 	crdsRoot := repo.GetCRDsPath()
 	files, err := ioutil.ReadDir(crdsRoot)
 	if err != nil {
-		return nil, fmt.Errorf("error listing directory '%v': %v", crdsRoot, err)
+		return nil, fmt.Errorf("error listing directory '%v': %w", crdsRoot, err)
 	}
 	results := make([]apiextensions.CustomResourceDefinition, 0)
 	for _, crdFile := range files {
@@ -174,12 +174,12 @@ func LoadCRDs() ([]apiextensions.CustomResourceDefinition, error) {
 func FileToCRD(fileName string) (*apiextensions.CustomResourceDefinition, error) {
 	bytes, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file '%v': %v", fileName, err)
+		return nil, fmt.Errorf("error reading file '%v': %w", fileName, err)
 	}
 	var crd apiextensions.CustomResourceDefinition
 	err = yaml.Unmarshal(bytes, &crd)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling '%v' to CRD: %v", fileName, err)
+		return nil, fmt.Errorf("error unmarshalling '%v' to CRD: %w", fileName, err)
 	}
 	return &crd, nil
 }

--- a/pkg/crd/template/template.go
+++ b/pkg/crd/template/template.go
@@ -48,7 +48,7 @@ func propsToYAML(props apiextensions.JSONSchemaProps) ([]byte, error) {
 	value := propsToValue(props)
 	bytes, err := yaml.Marshal(value)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling value yaml: %v", err)
+		return nil, fmt.Errorf("error marshalling value yaml: %w", err)
 	}
 	return bytes, nil
 }

--- a/pkg/dcl/conversion/converter.go
+++ b/pkg/dcl/conversion/converter.go
@@ -245,7 +245,7 @@ func convertToKRMSpec(val interface{}, path []string, schema *openapi.Schema, sm
 		for _, item := range items {
 			processedItem, err := convertToKRMSpec(item, path, schema.Items, smLoader, resourceMetadata, true)
 			if err != nil {
-				return nil, fmt.Errorf("error converting list item: %v", err)
+				return nil, fmt.Errorf("error converting list item: %w", err)
 			}
 			res = append(res, processedItem)
 		}
@@ -397,7 +397,7 @@ func convertToDCL(val interface{}, path []string, schema *openapi.Schema,
 		for _, item := range items {
 			processedItem, err := convertToDCL(item, path, schema.Items, smLoader, true)
 			if err != nil {
-				return nil, fmt.Errorf("error converting the item: %v", err)
+				return nil, fmt.Errorf("error converting the item: %w", err)
 			}
 			res = append(res, processedItem)
 		}
@@ -692,7 +692,7 @@ func getContainerFieldName(schema *openapi.Schema) (string, bool, error) {
 func liftDCLLabelsField(obj *unstructured.Unstructured, dclSchema *openapi.Schema) error {
 	labelsField, _, found, err := extension.GetLabelsFieldSchema(dclSchema)
 	if err != nil {
-		return fmt.Errorf("error getting DCL labels field : '%v'", err)
+		return fmt.Errorf("error getting DCL labels field : '%w'", err)
 	}
 	if !found {
 		return nil
@@ -787,7 +787,7 @@ func convertToDCLNameField(obj *unstructured.Unstructured, r *dclunstruct.Resour
 func convertToDCLLabelsField(obj *unstructured.Unstructured, r *dclunstruct.Resource, schema *openapi.Schema) error {
 	labelsField, _, _, err := extension.GetLabelsFieldSchema(schema)
 	if err != nil {
-		return fmt.Errorf("error getting DCL labels field: '%v'", err)
+		return fmt.Errorf("error getting DCL labels field: '%w'", err)
 	}
 	//TODO(b/164208968): handle edge cases where 'labels' field is not at the top level
 	if _, ok := schema.Properties[labelsField]; !ok {

--- a/pkg/dcl/errors.go
+++ b/pkg/dcl/errors.go
@@ -15,6 +15,8 @@
 package dcl
 
 import (
+	"errors"
+
 	dclunstruct "github.com/GoogleCloudPlatform/declarative-resource-client-library/unstructured"
 )
 
@@ -22,8 +24,6 @@ func IsNoSuchMethodError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err == dclunstruct.ErrNoSuchMethod {
-		return true
-	}
-	return false
+
+	return errors.Is(err, dclunstruct.ErrNoSuchMethod)
 }

--- a/pkg/dcl/livestate/fetchlivestate.go
+++ b/pkg/dcl/livestate/fetchlivestate.go
@@ -207,7 +207,7 @@ func SetMutableButUnreadableFields(kccLite *unstructured.Unstructured, mutableBu
 func resolveSensitiveValueForLiveState(value interface{}, secretVersions map[string]string, namespace string, kubeClient client.Client) (string, error) {
 	sensitiveField := corekccv1alpha1.SensitiveField{}
 	if err := util.Marshal(value, &sensitiveField); err != nil {
-		return "", fmt.Errorf("error parsing %v onto a SensitiveField struct: %v", value, err)
+		return "", fmt.Errorf("error parsing %v onto a SensitiveField struct: %w", value, err)
 	}
 
 	if sensitiveField.Value != nil {

--- a/pkg/dcl/references.go
+++ b/pkg/dcl/references.go
@@ -199,11 +199,11 @@ func getDCLReferenceExtensionElems(schema *openapi.Schema) ([]dclReferenceExtens
 func toDCLReferenceExtensionElem(rawElem map[interface{}]interface{}) (dclReferenceExtensionElem, error) {
 	m, err := convertToStringInterfaceMap(rawElem)
 	if err != nil {
-		return dclReferenceExtensionElem{}, fmt.Errorf("error converting 'x-dcl-references' element to map[string]interface{}: %v", err)
+		return dclReferenceExtensionElem{}, fmt.Errorf("error converting 'x-dcl-references' element to map[string]interface{}: %w", err)
 	}
 	e := dclReferenceExtensionElem{}
 	if err := util.Marshal(m, &e); err != nil {
-		return dclReferenceExtensionElem{}, fmt.Errorf("error marshalling 'x-dcl-references' element to struct: %v", err)
+		return dclReferenceExtensionElem{}, fmt.Errorf("error marshalling 'x-dcl-references' element to struct: %w", err)
 	}
 	return e, nil
 }

--- a/pkg/dcl/schema/dclschemaloader/dclschemaloader.go
+++ b/pkg/dcl/schema/dclschemaloader/dclschemaloader.go
@@ -94,11 +94,11 @@ func constructSchemaMap() (map[string]*openapi.Schema, error) {
 		queue = queue[1:]
 		curDir, err := embed.Assets.Open(dirPath)
 		if err != nil {
-			return nil, fmt.Errorf("error opening directory %v: %v", dirPath, err)
+			return nil, fmt.Errorf("error opening directory %v: %w", dirPath, err)
 		}
 		fileInfos, err := curDir.Readdir(0)
 		if err != nil {
-			return nil, fmt.Errorf("error reading files in directory %v: %v", curDir, err)
+			return nil, fmt.Errorf("error reading files in directory %v: %w", curDir, err)
 		}
 		for _, f := range fileInfos {
 			if f.IsDir() {
@@ -147,7 +147,7 @@ func parseOpenAPISchema(filePath string) (*openapi.Schema, error) {
 	defer file.Close()
 	b, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file: %v", err)
+		return nil, fmt.Errorf("error reading file: %w", err)
 	}
 	if err := yaml.Unmarshal(b, document); err != nil {
 		return nil, err

--- a/pkg/execution/builtin.go
+++ b/pkg/execution/builtin.go
@@ -15,26 +15,26 @@
 package execution
 
 import (
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/errors"
+	kccerrors "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/errors"
 )
 
 // RecoverWithGenericError is a general purpose function for recovering from panics. A useful error is written to 'err'. See
 // RecoverWithInternalError for recovering inside a controller Reconcile loop
 func RecoverWithGenericError(err *error) {
 	if rec := recover(); rec != nil {
-		handleRecovery(err, rec, goerrors.New)
+		handleRecovery(err, rec, errors.New)
 	}
 }
 
 // Recovers with the 'err' value being filled in with an InternalError, used by controllers to enable metric collection
 func RecoverWithInternalError(err *error) {
 	newError := func(message string) error {
-		return errors.NewInternalError("panic", message)
+		return kccerrors.NewInternalError("panic", message)
 	}
 	if rec := recover(); rec != nil {
 		handleRecovery(err, rec, newError)

--- a/pkg/gcp/errors.go
+++ b/pkg/gcp/errors.go
@@ -37,7 +37,7 @@ func isGoogleErrorWithCode(err error, code int) bool {
 		return false
 	}
 	ge := &googleapi.Error{}
-	if errors.Is(err, ge) {
+	if errors.As(err, &ge) {
 		return ge.Code == code
 	}
 

--- a/pkg/gcp/errors.go
+++ b/pkg/gcp/errors.go
@@ -15,6 +15,7 @@
 package gcp
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -35,9 +36,11 @@ func isGoogleErrorWithCode(err error, code int) bool {
 	if err == nil {
 		return false
 	}
-	if ge, ok := err.(*googleapi.Error); ok {
+	ge := &googleapi.Error{}
+	if errors.Is(err, ge) {
 		return ge.Code == code
 	}
+
 	return false
 }
 

--- a/pkg/gcp/profiler/profiler.go
+++ b/pkg/gcp/profiler/profiler.go
@@ -43,7 +43,7 @@ func start() error {
 	}
 	// Profiler initialization, best done as early as possible.
 	if err := profiler.Start(cfg); err != nil {
-		return fmt.Errorf("error starting profiler: %v", err)
+		return fmt.Errorf("error starting profiler: %w", err)
 	}
 	return nil
 }

--- a/pkg/gcp/project.go
+++ b/pkg/gcp/project.go
@@ -42,7 +42,7 @@ func getGCloudDefaultProjectID() (string, error) {
 	cmd := exec.Command("gcloud", "config", "get-value", "project")
 	bytes, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("error executing command '%v': %v'", cmd, err)
+		return "", fmt.Errorf("error executing command '%v': %w'", cmd, err)
 	}
 	value := string(bytes)
 	if value == "" {

--- a/pkg/gcp/wait.go
+++ b/pkg/gcp/wait.go
@@ -57,13 +57,13 @@ func WaitForAssetInventoryOperation(assetClient *cloudasset.Service, operation *
 		request.Header().Add("X-Goog-User-Project", projectNum)
 		newOp, err := request.Do()
 		if err != nil {
-			return false, fmt.Errorf("error getting operation %v: %v", operation.Name,
+			return false, fmt.Errorf("error getting operation %v: %w", operation.Name,
 				err)
 		}
 		operation = newOp
 		if callback != nil {
 			if err = callback(operation); err != nil {
-				return false, fmt.Errorf("error returned by wait callback: %v", err)
+				return false, fmt.Errorf("error returned by wait callback: %w", err)
 			}
 		}
 		return operation.Done, nil
@@ -81,13 +81,13 @@ func WaitForResourceManagerOperation(rmClient *resourcemanager.Service, operatio
 	err := wait.PollImmediate(interval, timeout, func() (done bool, err error) {
 		newOp, err := rmClient.Operations.Get(operation.Name).Do()
 		if err != nil {
-			return false, fmt.Errorf("error getting operation %v: %v", operation.Name,
+			return false, fmt.Errorf("error getting operation %v: %w", operation.Name,
 				err)
 		}
 		operation = newOp
 		if callback != nil {
 			if err = callback(operation); err != nil {
-				return false, fmt.Errorf("error returned by wait callback: %v", err)
+				return false, fmt.Errorf("error returned by wait callback: %w", err)
 			}
 		}
 		return operation.Done, nil
@@ -114,13 +114,13 @@ func WaitForComputeOperation(computeClient *compute.Service, operation *compute.
 			newOp, err = computeClient.GlobalOperations.Get(projectID, operation.Name).Do()
 		}
 		if err != nil {
-			return false, fmt.Errorf("error getting operation %v/%v: %v", projectID, operation.Name,
+			return false, fmt.Errorf("error getting operation %v/%v: %w", projectID, operation.Name,
 				err)
 		}
 		operation = newOp
 		if callback != nil {
 			if err = callback(operation); err != nil {
-				return false, fmt.Errorf("error returned by wait callback: %v", err)
+				return false, fmt.Errorf("error returned by wait callback: %w", err)
 			}
 		}
 		return operation.Status == "DONE", nil

--- a/pkg/k8s/condition.go
+++ b/pkg/k8s/condition.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
@@ -43,7 +44,8 @@ func NewReadyCondition() v1alpha1.Condition {
 
 func NewReadyConditionWithError(err error) v1alpha1.Condition {
 	var readyCondition v1alpha1.Condition
-	if errWithReason, ok := err.(ErrorWithReason); ok {
+	errWithReason := &ErrorWithReason{}
+	if errors.As(err, errWithReason) {
 		readyCondition = NewCustomReadyCondition(v1.ConditionFalse, errWithReason.Reason, errWithReason.Message)
 	} else {
 		readyCondition = NewReadyCondition()

--- a/pkg/k8s/managedfields.go
+++ b/pkg/k8s/managedfields.go
@@ -189,7 +189,7 @@ func OverlayManagedFieldsOntoState(spec, stateAsKRM map[string]interface{}, mana
 	if len(hierarchicalRefs) > 0 {
 		config, err = addHierarchicalReferenceToConfig(config, spec, hierarchicalRefs)
 		if err != nil {
-			return nil, fmt.Errorf("error adding hierarchical reference to config: %v", err)
+			return nil, fmt.Errorf("error adding hierarchical reference to config: %w", err)
 		}
 	}
 
@@ -441,17 +441,17 @@ func addHierarchicalReferenceToConfig(config, spec map[string]interface{}, hiera
 	modifiedConfig := deepcopy.MapStringInterface(config)
 	resourceRef, hierarchicalRef, err := GetHierarchicalReferenceFromSpec(spec, hierarchicalRefs)
 	if err != nil {
-		return nil, fmt.Errorf("error getting hierarchical reference: %v", err)
+		return nil, fmt.Errorf("error getting hierarchical reference: %w", err)
 	}
 	if resourceRef == nil {
 		return modifiedConfig, nil
 	}
 	var resourceRefRaw map[string]interface{}
 	if err := util.Marshal(resourceRef, &resourceRefRaw); err != nil {
-		return nil, fmt.Errorf("error marshalling hierarchical reference to map[string]interface{}: %v", err)
+		return nil, fmt.Errorf("error marshalling hierarchical reference to map[string]interface{}: %w", err)
 	}
 	if err := unstructured.SetNestedField(modifiedConfig, resourceRefRaw, hierarchicalRef.Key); err != nil {
-		return nil, fmt.Errorf("error setting hierarchical reference in config: %v", err)
+		return nil, fmt.Errorf("error setting hierarchical reference in config: %w", err)
 	}
 	return modifiedConfig, nil
 }

--- a/pkg/k8s/meta.go
+++ b/pkg/k8s/meta.go
@@ -93,7 +93,7 @@ func ToGVR(gvk schema.GroupVersionKind) schema.GroupVersionResource {
 func GetProjectIDForNamespace(c client.Client, ctx context.Context, namespaceName string) (string, error) {
 	var ns corev1.Namespace
 	if err := c.Get(ctx, types.NamespacedName{Name: namespaceName}, &ns); err != nil {
-		return "", fmt.Errorf("error getting namespace '%v': %v", namespaceName, err)
+		return "", fmt.Errorf("error getting namespace '%v': %w", namespaceName, err)
 	}
 	if val, ok := GetAnnotation(ProjectIDAnnotation, &ns); ok {
 		return val, nil
@@ -139,7 +139,7 @@ func GetManagementConflictPreventionAnnotationValue(obj metav1.Object) (Manageme
 func EnsureManagementConflictPreventionAnnotationForTFBasedResource(c client.Client, ctx context.Context, obj metav1.Object, rc *corekccv1alpha1.ResourceConfig, tfResourceMap map[string]*tfschema.Resource) error {
 	ns := corev1.Namespace{}
 	if err := c.Get(ctx, types.NamespacedName{Name: obj.GetNamespace()}, &ns); err != nil {
-		return fmt.Errorf("error getting namespace %v: %v", obj.GetNamespace(), err)
+		return fmt.Errorf("error getting namespace %v: %w", obj.GetNamespace(), err)
 	}
 	return ValidateOrDefaultManagementConflictPreventionAnnotationForTFBasedResource(obj, &ns, rc, tfResourceMap)
 }
@@ -184,7 +184,7 @@ func getDefaultManagementConflictPreventAnnotationForNamespace(ns *corev1.Namesp
 	if ok {
 		policy, err := valueToManagementConflictPreventionPolicy(value)
 		if err != nil {
-			return ManagementConflictPreventionPolicyNone, fmt.Errorf("unable to use default management conflict policy for namespace: %v", err)
+			return ManagementConflictPreventionPolicyNone, fmt.Errorf("unable to use default management conflict policy for namespace: %w", err)
 		}
 		if !isManagementConflictPolicyValidForResource(policy, supportLeasing) {
 			return ManagementConflictPreventionPolicyNone, nil
@@ -251,7 +251,7 @@ func SetDefaultContainerAnnotation(obj metav1.Object, ns *corev1.Namespace, cont
 	// If the resource already has a container annotation, no modification is required
 	val, _, err := GetContainerAnnotation(obj.GetAnnotations(), ContainerTypes(containers))
 	if err != nil {
-		return fmt.Errorf("error getting container annotation from object: %v", err)
+		return fmt.Errorf("error getting container annotation from object: %w", err)
 	}
 	if val != "" {
 		return nil
@@ -259,7 +259,7 @@ func SetDefaultContainerAnnotation(obj metav1.Object, ns *corev1.Namespace, cont
 	// if the Namespace has a container annotation, we'll use that as the default
 	val, containerType, err := GetContainerAnnotation(ns.GetAnnotations(), ContainerTypes(containers))
 	if err != nil {
-		return fmt.Errorf("error getting container annotation from object: %v", err)
+		return fmt.Errorf("error getting container annotation from object: %w", err)
 	}
 	if val != "" {
 		SetAnnotation(GetAnnotationForContainerType(containerType), val, obj)

--- a/pkg/k8s/mutableunreadable.go
+++ b/pkg/k8s/mutableunreadable.go
@@ -41,13 +41,13 @@ func GenerateMutableButUnreadableFieldsState(resource *Resource, mutableButUnrea
 		krmField := strings.Join(krmPath, ".")
 		val, found, err := unstructured.NestedFieldCopy(resource.Spec, krmPath[1:]...)
 		if err != nil {
-			return nil, fmt.Errorf("error reading %v: %v", krmField, err)
+			return nil, fmt.Errorf("error reading %v: %w", krmField, err)
 		}
 		if !found {
 			continue
 		}
 		if err := unstructured.SetNestedField(state, val, krmPath...); err != nil {
-			return nil, fmt.Errorf("error saving %v: %v", krmField, err)
+			return nil, fmt.Errorf("error saving %v: %w", krmField, err)
 		}
 	}
 	return state, nil

--- a/pkg/k8s/references.go
+++ b/pkg/k8s/references.go
@@ -88,7 +88,7 @@ func EnsureHierarchicalReference(ctx context.Context, resource *Resource, hierar
 
 	ns := corev1.Namespace{}
 	if err := c.Get(ctx, types.NamespacedName{Name: resource.GetNamespace()}, &ns); err != nil {
-		return fmt.Errorf("error getting namespace %v: %v", resource.GetNamespace(), err)
+		return fmt.Errorf("error getting namespace %v: %w", resource.GetNamespace(), err)
 	}
 
 	return SetDefaultHierarchicalReference(resource, &ns, hierarchicalRefs, containers)
@@ -110,7 +110,7 @@ func SetDefaultHierarchicalReference(resource *Resource, ns *corev1.Namespace, h
 	// required.
 	ref, _, err := GetHierarchicalReference(resource, hierarchicalRefs)
 	if err != nil {
-		return fmt.Errorf("error getting hierarchical reference from object: %v", err)
+		return fmt.Errorf("error getting hierarchical reference from object: %w", err)
 	}
 	if ref != nil {
 		return nil
@@ -123,7 +123,7 @@ func SetDefaultHierarchicalReference(resource *Resource, ns *corev1.Namespace, h
 		containerTypes := ContainerTypes(containers)
 		err := setHierarchicalReferenceUsingContainerAnnotation(resource, annotations, hierarchicalRefs, containerTypes)
 		if err != nil && !errors.Is(err, errContainerAnnotationNotFound) {
-			return fmt.Errorf("error setting hierarchical reference using resource-level container annotation: %v", err)
+			return fmt.Errorf("error setting hierarchical reference using resource-level container annotation: %w", err)
 		} else if err == nil {
 			return nil
 		}
@@ -138,7 +138,7 @@ func SetDefaultHierarchicalReference(resource *Resource, ns *corev1.Namespace, h
 	nsContainerTypes := ContainerTypesFor(hierarchicalRefs)
 	err = setHierarchicalReferenceUsingContainerAnnotation(resource, nsAnnotations, hierarchicalRefs, nsContainerTypes)
 	if err != nil && !errors.Is(err, errContainerAnnotationNotFound) {
-		return fmt.Errorf("error setting hierarchical reference using namespace-level container annotation: %v", err)
+		return fmt.Errorf("error setting hierarchical reference using namespace-level container annotation: %w", err)
 	} else if err == nil {
 		return nil
 	}
@@ -147,7 +147,7 @@ func SetDefaultHierarchicalReference(resource *Resource, ns *corev1.Namespace, h
 	h := HierarchicalReferenceWithType(hierarchicalRefs, corekccv1alpha1.HierarchicalReferenceTypeProject)
 	if h != nil {
 		if err := SetHierarchicalReference(resource, h, ns.GetName()); err != nil {
-			return fmt.Errorf("error setting hierarchical reference from using namespace name: %v", err)
+			return fmt.Errorf("error setting hierarchical reference from using namespace name: %w", err)
 		}
 		return nil
 	}
@@ -177,7 +177,7 @@ func GetHierarchicalReferenceFromSpec(spec map[string]interface{}, hierarchicalR
 		val, ok, err := unstructured.NestedMap(spec, h.Key)
 		if err != nil {
 			return nil, corekccv1alpha1.HierarchicalReference{},
-				fmt.Errorf("error reading spec.%v: %v", h.Key, err)
+				fmt.Errorf("error reading spec.%v: %w", h.Key, err)
 		}
 		if !ok {
 			continue
@@ -191,7 +191,7 @@ func GetHierarchicalReferenceFromSpec(spec map[string]interface{}, hierarchicalR
 		ref := &corekccv1alpha1.ResourceReference{}
 		if err = util.Marshal(val, ref); err != nil {
 			return nil, corekccv1alpha1.HierarchicalReference{},
-				fmt.Errorf("error marshalling spec.%v into a resource reference: %v", h.Key, err)
+				fmt.Errorf("error marshalling spec.%v into a resource reference: %w", h.Key, err)
 		}
 		resourceRef = ref
 		hierarchicalRef = h
@@ -204,7 +204,7 @@ func setHierarchicalReferenceUsingContainerAnnotation(resource *Resource, annota
 
 	containerVal, containerType, err := GetContainerAnnotation(annotations, containerTypes)
 	if err != nil {
-		return fmt.Errorf("error getting container annotation from annotations: %v", err)
+		return fmt.Errorf("error getting container annotation from annotations: %w", err)
 	}
 	if containerVal == "" {
 		return errContainerAnnotationNotFound
@@ -224,7 +224,7 @@ func SetHierarchicalReference(resource *Resource, hierarchicalRef *corekccv1alph
 	}
 	var valAsMap map[string]interface{}
 	if err := util.Marshal(val, &valAsMap); err != nil {
-		return fmt.Errorf("error marshalling resource reference to map: %v", err)
+		return fmt.Errorf("error marshalling resource reference to map: %w", err)
 	}
 	if resource.Spec == nil {
 		resource.Spec = make(map[string]interface{})

--- a/pkg/k8s/secrets.go
+++ b/pkg/k8s/secrets.go
@@ -37,7 +37,7 @@ func GetSecretVal(secretKeyRef *corekccv1alpha1.SecretKeyReference, secretNamesp
 		if errors.IsNotFound(err) {
 			return "", "", NewSecretNotFoundError(nn)
 		}
-		return "", "", fmt.Errorf("error getting Secret %v: %v", nn, err)
+		return "", "", fmt.Errorf("error getting Secret %v: %w", nn, err)
 	}
 	secretValBytes, ok := secret.Data[secretKeyRef.Key]
 	if !ok {
@@ -53,7 +53,7 @@ func GetSecretVersionsFromAnnotations(resource *Resource) (map[string]string, er
 	}
 	secretVersions := make(map[string]string)
 	if err := json.Unmarshal([]byte(annotationVal), &secretVersions); err != nil {
-		return nil, fmt.Errorf("error unmarshalling value of %v: %v", ObservedSecretVersionsAnnotation, err)
+		return nil, fmt.Errorf("error unmarshalling value of %v: %w", ObservedSecretVersionsAnnotation, err)
 	}
 	return secretVersions, nil
 }

--- a/pkg/krmtotf/conversion.go
+++ b/pkg/krmtotf/conversion.go
@@ -40,7 +40,7 @@ func InstanceStateToMap(r *schema.Resource, state *terraform.InstanceState) map[
 	ctyType := ctyTypeForResource(r)
 	stateVal, err := state.AttrsAsObjectValue(ctyType)
 	if err != nil {
-		panic(fmt.Errorf("error parsing instance state as cty.Value: %v", err))
+		panic(fmt.Errorf("error parsing instance state as cty.Value: %w", err))
 	}
 	return CtyValToMap(stateVal, ctyType)
 }
@@ -64,11 +64,11 @@ func MapToResourceConfig(r *schema.Resource, m map[string]interface{}) *terrafor
 func CtyValToMap(val cty.Value, t cty.Type) map[string]interface{} {
 	b, err := ctyjson.Marshal(val, t)
 	if err != nil {
-		panic(fmt.Errorf("error marshaling cty.Value as JSON: %v", err))
+		panic(fmt.Errorf("error marshaling cty.Value as JSON: %w", err))
 	}
 	var ret map[string]interface{}
 	if err := json.Unmarshal(b, &ret); err != nil {
-		panic(fmt.Errorf("error unmarshaling JSON as map[string]interface{}: %v", err))
+		panic(fmt.Errorf("error unmarshaling JSON as map[string]interface{}: %w", err))
 	}
 	return ret
 }
@@ -76,11 +76,11 @@ func CtyValToMap(val cty.Value, t cty.Type) map[string]interface{} {
 func MapToCtyVal(m map[string]interface{}, t cty.Type) cty.Value {
 	b, err := json.Marshal(&m)
 	if err != nil {
-		panic(fmt.Errorf("error marshaling map as JSON: %v", err))
+		panic(fmt.Errorf("error marshaling map as JSON: %w", err))
 	}
 	ret, err := ctyjson.Unmarshal(b, t)
 	if err != nil {
-		panic(fmt.Errorf("error unmarshaling JSON as cty.Value: %v", err))
+		panic(fmt.Errorf("error unmarshaling JSON as cty.Value: %w", err))
 	}
 	return ret
 }
@@ -88,11 +88,11 @@ func MapToCtyVal(m map[string]interface{}, t cty.Type) cty.Value {
 func MapToCtyValWithSchema(m map[string]interface{}, s map[string]*schema.Schema) cty.Value {
 	b, err := json.Marshal(&m)
 	if err != nil {
-		panic(fmt.Errorf("error marshaling map as JSON: %v", err))
+		panic(fmt.Errorf("error marshaling map as JSON: %w", err))
 	}
 	ret, err := ctyjson.Unmarshal(b, schema.InternalMap(s).CoreConfigSchema().ImpliedType())
 	if err != nil {
-		panic(fmt.Errorf("error unmarshaling JSON as cty.Value: %v", err))
+		panic(fmt.Errorf("error unmarshaling JSON as cty.Value: %w", err))
 	}
 	return ret
 }

--- a/pkg/krmtotf/krmtotf.go
+++ b/pkg/krmtotf/krmtotf.go
@@ -76,7 +76,7 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 		path := text.SnakeCaseToLowerCamelCase(r.ResourceConfig.MetadataMapping.Labels)
 		labels := label.NewGCPLabelsFromK8SLabels(r.GetLabels(), defaultLabels)
 		if err := setValue(config, path, labels); err != nil {
-			return nil, nil, fmt.Errorf("error mapping 'metadata.labels': %v", err)
+			return nil, nil, fmt.Errorf("error mapping 'metadata.labels': %w", err)
 		}
 	}
 	if r.ResourceConfig.Locationality != "" {
@@ -104,7 +104,7 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 	}
 	config, err = KRMObjectToTFObjectWithConfigurableFieldsOnly(config, r.TFResource)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error converting to config: %v", err)
+		return nil, nil, fmt.Errorf("error converting to config: %w", err)
 	}
 	for _, d := range r.ResourceConfig.Directives {
 		key := k8s.FormatAnnotation(text.SnakeCaseToKebabCase(d))
@@ -113,12 +113,12 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 				return nil, nil, fmt.Errorf("the value for directive '%v' must not be empty", key)
 			}
 			if err := setValue(config, d, val); err != nil {
-				return nil, nil, fmt.Errorf("error mapping directive '%v': %v", d, err)
+				return nil, nil, fmt.Errorf("error mapping directive '%v': %w", d, err)
 			}
 		}
 	}
 	if err := resolveContainerValue(config, r, c, smLoader); err != nil {
-		return nil, nil, fmt.Errorf("error resolving container value: %v", err)
+		return nil, nil, fmt.Errorf("error resolving container value: %w", err)
 	}
 	config, err = withCustomFlatteners(config, r.Kind)
 	if err != nil {
@@ -159,7 +159,7 @@ func krmObjectToTFObject(obj map[string]interface{}, resource *tfschema.Resource
 		}
 		ret[tfKey], err = convertToTF(v, schema, includeConfigurableFieldsOnly)
 		if err != nil {
-			return nil, fmt.Errorf("error converting '%v': %v", k, err)
+			return nil, fmt.Errorf("error converting '%v': %w", k, err)
 		}
 	}
 	return ret, nil
@@ -185,7 +185,7 @@ func convertToTF(obj interface{}, schema *tfschema.Schema, includeConfigurableFi
 			case *tfschema.Schema:
 				processedItem, err = convertToTF(item, elem, includeConfigurableFieldsOnly)
 				if err != nil {
-					return nil, fmt.Errorf("error converting list item: %v", err)
+					return nil, fmt.Errorf("error converting list item: %w", err)
 				}
 			case *tfschema.Resource:
 				itemAsMap, ok := item.(map[string]interface{})
@@ -194,7 +194,7 @@ func convertToTF(obj interface{}, schema *tfschema.Schema, includeConfigurableFi
 				}
 				processedItem, err = krmObjectToTFObject(itemAsMap, elem, includeConfigurableFieldsOnly)
 				if err != nil {
-					return nil, fmt.Errorf("error converting map list item: %v", err)
+					return nil, fmt.Errorf("error converting map list item: %w", err)
 				}
 			default:
 				return nil, fmt.Errorf("unknown elem type")
@@ -220,19 +220,19 @@ func handleUserSpecifiedID(config map[string]interface{}, r *Resource, smLoader 
 		path := text.SnakeCaseToLowerCamelCase(r.ResourceConfig.ResourceID.TargetField)
 		resourceID, err := resolveResourceID(r, c, smLoader)
 		if err != nil {
-			return fmt.Errorf("error resolving resource ID: %v", err)
+			return fmt.Errorf("error resolving resource ID: %w", err)
 		}
 		if err := setValue(config, path, resourceID); err != nil {
-			return fmt.Errorf("error mapping user-specified %v: %v", k8s.ResourceIDFieldPath, err)
+			return fmt.Errorf("error mapping user-specified %v: %w", k8s.ResourceIDFieldPath, err)
 		}
 	} else if r.ResourceConfig.MetadataMapping.Name != "" && r.GetName() != "" {
 		path := text.SnakeCaseToLowerCamelCase(r.ResourceConfig.MetadataMapping.Name)
 		name, err := resolveNameMetadataMapping(r, c, smLoader)
 		if err != nil {
-			return fmt.Errorf("error resolving metadata.name mapping: %v", err)
+			return fmt.Errorf("error resolving metadata.name mapping: %w", err)
 		}
 		if err := setValue(config, path, name); err != nil {
-			return fmt.Errorf("error mapping metadata.name: %v", err)
+			return fmt.Errorf("error mapping metadata.name: %w", err)
 		}
 	}
 	return nil
@@ -255,7 +255,7 @@ func resolveSensitiveFields(config map[string]interface{}, resource *tfschema.Re
 
 			field := corekccv1alpha1.SensitiveField{}
 			if err := util.Marshal(v, &field); err != nil {
-				return nil, nil, fmt.Errorf("error parsing %v onto a SensitiveField struct: %v", v, err)
+				return nil, nil, fmt.Errorf("error parsing %v onto a SensitiveField struct: %w", v, err)
 			}
 
 			if field.Value != nil {
@@ -379,10 +379,10 @@ func resolveContainerValue(config map[string]interface{}, r *Resource, c client.
 		}
 		val, err := ResolveValueTemplate(container.ValueTemplate, val, r, c, smLoader)
 		if err != nil {
-			return fmt.Errorf("error resolving templated value: %v", err)
+			return fmt.Errorf("error resolving templated value: %w", err)
 		}
 		if err := setValue(config, container.TFField, val); err != nil {
-			return fmt.Errorf("error setting container value: %v", err)
+			return fmt.Errorf("error setting container value: %w", err)
 		}
 		return nil
 	}

--- a/pkg/krmtotf/references.go
+++ b/pkg/krmtotf/references.go
@@ -187,7 +187,7 @@ func ResolveReferenceObject(resourceRefValRaw map[string]interface{},
 			}
 			return nil, err
 		}
-		return nil, fmt.Errorf("error getting referenced resource from API server: %v", err)
+		return nil, fmt.Errorf("error getting referenced resource from API server: %w", err)
 	}
 
 	if !deleting && !k8s.IsResourceReady(&refResource.Resource) {

--- a/pkg/krmtotf/resource.go
+++ b/pkg/krmtotf/resource.go
@@ -111,7 +111,7 @@ func (r *Resource) ValidateResourceIDIfSupported() error {
 
 	_, err := r.IsResourceIDConfigured()
 	if err != nil {
-		return fmt.Errorf("error validating '%s' field: %v", k8s.ResourceIDFieldPath, err)
+		return fmt.Errorf("error validating '%s' field: %w", k8s.ResourceIDFieldPath, err)
 	}
 	return nil
 }
@@ -246,7 +246,7 @@ func (r *Resource) GetServerGeneratedID() (string, error) {
 	// if the field is not specified, fallback to resolve it from status.
 	idInStatus, exists, err := getServerGeneratedIDFromStatus(&r.ResourceConfig, r.Status)
 	if err != nil {
-		return "", fmt.Errorf("error getting server-generated ID: %v", err)
+		return "", fmt.Errorf("error getting server-generated ID: %w", err)
 	}
 	if !exists {
 		return "", k8s.NewServerGeneratedIDNotFoundError(r.GroupVersionKind(),

--- a/pkg/krmtotf/templating.go
+++ b/pkg/krmtotf/templating.go
@@ -215,7 +215,7 @@ func getValueFromReference(refConfig *corekccv1alpha1.ReferenceConfig, r *Resour
 	pathToRef := getPathToReferenceKey(refConfig)
 	refObj, ok, err := unstructured.NestedMap(r.Spec, pathToRef...)
 	if err != nil {
-		return "", false, fmt.Errorf("error getting reference object '%v': %v", strings.Join(pathToRef, "."), err)
+		return "", false, fmt.Errorf("error getting reference object '%v': %w", strings.Join(pathToRef, "."), err)
 	}
 	if !ok {
 		return "", false, nil

--- a/pkg/krmtotf/tftokrm.go
+++ b/pkg/krmtotf/tftokrm.go
@@ -447,7 +447,7 @@ func ConvertTFObjToKCCObj(state map[string]interface{}, prevSpec map[string]inte
 	// Round-trip via JSON in order to ensure consistency with unstructured.Unstructured's Object type.
 	var ret map[string]interface{}
 	if err := util.Marshal(raw, &ret); err != nil {
-		panic(fmt.Errorf("error normalizing KRM-ified object: %v", err))
+		panic(fmt.Errorf("error normalizing KRM-ified object: %w", err))
 	}
 	return ret
 }
@@ -717,7 +717,7 @@ func convertTFSetToKCCSet(stateVal, prevSpecVal interface{}, schema *tfschema.Sc
 			// convert the KRM previous spec object to a TF object so that we can calculate the correct hash
 			prevElemAsTFObject, err := KRMObjectToTFObject(prevElem.(map[string]interface{}), schemaElem)
 			if err != nil {
-				panic(fmt.Errorf("error converting set object: %v", err))
+				panic(fmt.Errorf("error converting set object: %w", err))
 			}
 			prevHashable = asHashable(prevElemAsTFObject, schemaElem)
 		default:
@@ -775,7 +775,7 @@ func asHashable(o, schemaElem interface{}) interface{} {
 		}
 		val, err := reader.ReadField([]string{key})
 		if err != nil {
-			panic(fmt.Errorf("unable to convert field to hashable: %v", err))
+			panic(fmt.Errorf("unable to convert field to hashable: %w", err))
 		}
 		var ret interface{}
 		if val.Exists {
@@ -796,7 +796,7 @@ func asHashable(o, schemaElem interface{}) interface{} {
 		for k, s := range schemaElem.Schema {
 			val, err := reader.ReadField([]string{k})
 			if err != nil {
-				panic(fmt.Errorf("unable to read field %v: %v", k, err))
+				panic(fmt.Errorf("unable to read field %v: %w", k, err))
 			}
 			if val.Exists {
 				res[k] = val.Value

--- a/pkg/lease/leasable/leasable.go
+++ b/pkg/lease/leasable/leasable.go
@@ -42,7 +42,7 @@ func ResourceConfigSupportsLeasing(rc *v1alpha1.ResourceConfig, tfResourceMap ma
 	}
 	labelsFieldSchema, err := tfresource.GetTFSchemaForField(tfResource, labelsField)
 	if err != nil {
-		return false, fmt.Errorf("error getting schema for field '%v' of resource '%v': %v", labelsField, rc.Name, err)
+		return false, fmt.Errorf("error getting schema for field '%v' of resource '%v': %w", labelsField, rc.Name, err)
 	}
 	labelsFieldIsMutable := !labelsFieldSchema.ForceNew
 	return labelsFieldIsMutable, nil

--- a/pkg/lease/leaser/resource_leaser.go
+++ b/pkg/lease/leaser/resource_leaser.go
@@ -47,10 +47,10 @@ func NewResourceLeaser(tfProvider *schema.Provider, smLoader *servicemappingload
 func (l *ResourceLeaser) SoftObtain(ctx context.Context, resource *k8s.Resource, liveLabels map[string]string) error {
 	uniqueId, err := cluster.GetNamespaceID(k8s.NamespaceIDConfigMapNN, l.kubeClient, ctx, resource.GetNamespace())
 	if err != nil {
-		return fmt.Errorf("error getting unique id for namespace '%v': %v", resource.GetNamespace(), err)
+		return fmt.Errorf("error getting unique id for namespace '%v': %w", resource.GetNamespace(), err)
 	}
 	if err := l.leaser.SoftObtain(resource, liveLabels, uniqueId, k8s.TimeToLeaseExpiration, k8s.TimeToLeaseRenewal); err != nil {
-		return fmt.Errorf("error obtaining lease: %v", err)
+		return fmt.Errorf("error obtaining lease: %w", err)
 	}
 	return nil
 }
@@ -58,10 +58,10 @@ func (l *ResourceLeaser) SoftObtain(ctx context.Context, resource *k8s.Resource,
 func (l *ResourceLeaser) Release(ctx context.Context, u *unstructured.Unstructured) error {
 	uniqueId, err := cluster.GetNamespaceID(k8s.NamespaceIDConfigMapNN, l.kubeClient, ctx, u.GetNamespace())
 	if err != nil {
-		return fmt.Errorf("error getting unique id for namespace '%v': %v", u.GetNamespace(), err)
+		return fmt.Errorf("error getting unique id for namespace '%v': %w", u.GetNamespace(), err)
 	}
 	if err := l.leaser.Release(ctx, u, uniqueId); err != nil {
-		return fmt.Errorf("error releasing lease on %v with name '%v': %v", u.GroupVersionKind(), u.GetName(), err)
+		return fmt.Errorf("error releasing lease on %v with name '%v': %w", u.GroupVersionKind(), u.GetName(), err)
 	}
 	return nil
 }

--- a/pkg/metrics/register.go
+++ b/pkg/metrics/register.go
@@ -39,7 +39,7 @@ func RegisterPrometheusExporter(addr string) error {
 		Namespace: "configconnector",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create the Prometheus stats exporter: %v", err)
+		return fmt.Errorf("failed to create the Prometheus stats exporter: %w", err)
 	}
 
 	// Run the Prometheus exporter as a scrape endpoint.

--- a/pkg/resourceoverrides/utils.go
+++ b/pkg/resourceoverrides/utils.go
@@ -108,13 +108,13 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 	parentPathStr := strings.Join(parentPath, ".")
 	parent, err = getSchemaForPath(schema, parentPath)
 	if err != nil {
-		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 
 	// 2. Check if the reference field is required.
 	requiredFields, err := crdutil.GetRequiredRuleForObjectOrArray(parent)
 	if err != nil {
-		return fmt.Errorf("error getting the required rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+		return fmt.Errorf("error getting the required rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 	}
 	var required bool
 	for _, field := range requiredFields {
@@ -129,7 +129,7 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 	if required {
 		oneOfRule, err := crdutil.GetOneOfRuleForObjectOrArray(parent)
 		if err != nil {
-			return fmt.Errorf("error getting the oneOf rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+			return fmt.Errorf("error getting the oneOf rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 		}
 		// TODO(b/223688758): Handle multiple oneOf rules.
 		if oneOfRule != nil {
@@ -145,7 +145,7 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 			},
 		}
 		if err := crdutil.SetOneOfRuleForObjectOrArray(parent, oneOfRule); err != nil {
-			return fmt.Errorf("error setting the oneOf rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+			return fmt.Errorf("error setting the oneOf rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 		}
 
 		var updatedRequiredFields []string
@@ -155,12 +155,12 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 			}
 		}
 		if err := crdutil.SetRequiredRuleForObjectOrArray(parent, updatedRequiredFields); err != nil {
-			return fmt.Errorf("error setting the required rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+			return fmt.Errorf("error setting the required rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 		}
 	} else {
 		notRule, err := crdutil.GetNotRuleForObjectOrArray(parent)
 		if err != nil {
-			return fmt.Errorf("error getting the not rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+			return fmt.Errorf("error getting the not rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 		}
 		// TODO(b/223688758): Handle multiple not rules.
 		if notRule != nil {
@@ -171,14 +171,14 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 			Required: []string{nonReferenceFieldName, referenceFieldName},
 		}
 		if err := crdutil.SetNotRuleForObjectOrArray(parent, notRule); err != nil {
-			return fmt.Errorf("error setting the not rule under path %s for CRD %s: %v", parentPath, crd.Name, err)
+			return fmt.Errorf("error setting the not rule under path %s for CRD %s: %w", parentPath, crd.Name, err)
 		}
 	}
 
 	// 4. Add the non-reference field into the schema.
 	referenceFieldSchema, ok, err := crdutil.GetSchemaForFieldUnderObjectOrArray(referenceFieldName, parent)
 	if err != nil {
-		return fmt.Errorf("error getting schema for reference field %s under path %s for CRD %s: %v", referenceFieldName, parentPath, crd.Name, err)
+		return fmt.Errorf("error getting schema for reference field %s under path %s for CRD %s: %w", referenceFieldName, parentPath, crd.Name, err)
 	}
 	if !ok {
 		return fmt.Errorf("can't find reference field %s under path %s for CRD %s", referenceFieldName, parentPath, crd.Name)
@@ -213,16 +213,16 @@ func PreserveMutuallyExclusiveNonReferenceField(crd *apiextensions.CustomResourc
 	}
 
 	if err := crdutil.SetSchemaForFieldUnderObjectOrArray(nonReferenceFieldName, parent, nonReferenceFieldSchema); err != nil {
-		return fmt.Errorf("error setting schema for non-reference field %s under path %s for CRD %s: %v", nonReferenceFieldName, parentPath, crd.Name, err)
+		return fmt.Errorf("error setting schema for non-reference field %s under path %s for CRD %s: %w", nonReferenceFieldName, parentPath, crd.Name, err)
 	}
 
 	// 5. Set the updated schema.
 	updatedSchema, err := getSchemaForPath(schema, parentPath[:len(parentPath)-1])
 	if err != nil {
-		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 	if err := crdutil.SetSchemaForFieldUnderObjectOrArray(parentPath[len(parentPath)-1], updatedSchema, parent); err != nil {
-		return fmt.Errorf("error setting updated schema for parent path '%v' for CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("error setting updated schema for parent path '%v' for CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 
 	return nil
@@ -248,14 +248,14 @@ func EnsureReferenceFieldIsMultiKind(crd *apiextensions.CustomResourceDefinition
 	parentPathStr := strings.Join(parentPath, ".")
 	parent, err = getSchemaForPath(schema, parentPath)
 	if err != nil {
-		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 
 	// 2. Ensure the required `kind` subfield is supported in the reference
 	// field.
 	referenceFieldSchema, ok, err := crdutil.GetSchemaForFieldUnderObjectOrArray(referenceFieldName, parent)
 	if err != nil {
-		return fmt.Errorf("error getting schema for reference field %s under path %s for CRD %s: %v", referenceFieldName, parentPath, crd.Name, err)
+		return fmt.Errorf("error getting schema for reference field %s under path %s for CRD %s: %w", referenceFieldName, parentPath, crd.Name, err)
 	}
 	if !ok {
 		return fmt.Errorf("can't find reference field %s under path %s for CRD %s", referenceFieldName, parentPath, crd.Name)
@@ -288,17 +288,17 @@ func EnsureReferenceFieldIsMultiKind(crd *apiextensions.CustomResourceDefinition
 			referenceFieldSchema = referenceFieldSchemaWithKind
 		}
 		if err := crdutil.SetSchemaForFieldUnderObjectOrArray(referenceFieldName, parent, referenceFieldSchema); err != nil {
-			return fmt.Errorf("error setting schema for reference field %s under path %s for CRD %s: %v", referenceFieldName, parentPath, crd.Name, err)
+			return fmt.Errorf("error setting schema for reference field %s under path %s for CRD %s: %w", referenceFieldName, parentPath, crd.Name, err)
 		}
 	}
 
 	// 3. Set the updated schema.
 	updatedSchema, err := getSchemaForPath(schema, parentPath[:len(parentPath)-1])
 	if err != nil {
-		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("can't get schema for path '%v' in CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 	if err := crdutil.SetSchemaForFieldUnderObjectOrArray(parentPath[len(parentPath)-1], updatedSchema, parent); err != nil {
-		return fmt.Errorf("error setting updated schema for parent path '%v' for CRD %s: %v", parentPathStr, crd.Name, err)
+		return fmt.Errorf("error setting updated schema for parent path '%v' for CRD %s: %w", parentPathStr, crd.Name, err)
 	}
 
 	return nil
@@ -335,11 +335,11 @@ func PreserveUserSpecifiedLegacyField(original, reconciled *k8s.Resource, path .
 func PreserveUserSpecifiedLegacyFieldUnderSlice(original, reconciled *k8s.Resource, upToSlicePath []string, path []string) error {
 	originalSlice, foundOriginal, err := unstructured.NestedSlice(original.Spec, upToSlicePath...)
 	if err != nil {
-		return fmt.Errorf("error getting the nested slice under path %s for the original resource: %v", strings.Join(upToSlicePath, "."), err)
+		return fmt.Errorf("error getting the nested slice under path %s for the original resource: %w", strings.Join(upToSlicePath, "."), err)
 	}
 	reconciledSlice, foundReconciled, err := unstructured.NestedSlice(reconciled.Spec, upToSlicePath...)
 	if err != nil {
-		return fmt.Errorf("error getting the nested slice under path %s for the reconciled resource: %v", strings.Join(upToSlicePath, "."), err)
+		return fmt.Errorf("error getting the nested slice under path %s for the reconciled resource: %w", strings.Join(upToSlicePath, "."), err)
 	}
 	if !foundOriginal || !foundReconciled {
 		return nil
@@ -347,17 +347,17 @@ func PreserveUserSpecifiedLegacyFieldUnderSlice(original, reconciled *k8s.Resour
 	for i, v := range originalSlice {
 		pathFieldValue, foundPathField, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), path...)
 		if err != nil {
-			return fmt.Errorf("error getting the user-specified value from the path %s within the slice field: %v", strings.Join(path, "."), err)
+			return fmt.Errorf("error getting the user-specified value from the path %s within the slice field: %w", strings.Join(path, "."), err)
 		}
 		if !foundPathField {
 			continue
 		}
 		if err := unstructured.SetNestedField(reconciledSlice[i].(map[string]interface{}), pathFieldValue, path...); err != nil {
-			return fmt.Errorf("error setting original value to reconciled slice element: %v", err)
+			return fmt.Errorf("error setting original value to reconciled slice element: %w", err)
 		}
 	}
 	if err := unstructured.SetNestedSlice(reconciled.Spec, reconciledSlice, upToSlicePath...); err != nil {
-		return fmt.Errorf("error setting preserved values back into reconciled object: %v", err)
+		return fmt.Errorf("error setting preserved values back into reconciled object: %w", err)
 	}
 	return nil
 }
@@ -415,11 +415,11 @@ func PruneDefaultedAuthoritativeFieldIfOnlyLegacyFieldSpecified(original, reconc
 func PruneDefaultedAuthoritativeFieldIfOnlyLegacyFieldSpecifiedUnderSlice(original, reconciled *k8s.Resource, pathUpToSlice, nonReferenceFieldPath, referenceFieldPath []string) error {
 	originalSlice, foundOriginal, err := unstructured.NestedSlice(original.Spec, pathUpToSlice...)
 	if err != nil {
-		return fmt.Errorf("error getting the nested slice under path %s for the original resource: %v", strings.Join(pathUpToSlice, "."), err)
+		return fmt.Errorf("error getting the nested slice under path %s for the original resource: %w", strings.Join(pathUpToSlice, "."), err)
 	}
 	reconciledSlice, foundReconciled, err := unstructured.NestedSlice(reconciled.Spec, pathUpToSlice...)
 	if err != nil {
-		return fmt.Errorf("error getting the nested slice under path %s for the reconciled resource: %v", strings.Join(pathUpToSlice, "."), err)
+		return fmt.Errorf("error getting the nested slice under path %s for the reconciled resource: %w", strings.Join(pathUpToSlice, "."), err)
 	}
 	if !foundOriginal || !foundReconciled {
 		return nil
@@ -427,18 +427,18 @@ func PruneDefaultedAuthoritativeFieldIfOnlyLegacyFieldSpecifiedUnderSlice(origin
 	for i, v := range originalSlice {
 		_, foundReferenceField, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), referenceFieldPath...)
 		if err != nil {
-			return fmt.Errorf("error checking the existence of the nested reference field %s within the slice field of the original resource: %v", strings.Join(referenceFieldPath, "."), err)
+			return fmt.Errorf("error checking the existence of the nested reference field %s within the slice field of the original resource: %w", strings.Join(referenceFieldPath, "."), err)
 		}
 		_, foundNonReferenceField, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), nonReferenceFieldPath...)
 		if err != nil {
-			return fmt.Errorf("error checking the existence of the nested non-reference field %s within the slice field of the original resource: %v", strings.Join(nonReferenceFieldPath, "."), err)
+			return fmt.Errorf("error checking the existence of the nested non-reference field %s within the slice field of the original resource: %w", strings.Join(nonReferenceFieldPath, "."), err)
 		}
 		if !foundReferenceField && foundNonReferenceField {
 			unstructured.RemoveNestedField(reconciledSlice[i].(map[string]interface{}), referenceFieldPath...)
 		}
 	}
 	if err := unstructured.SetNestedSlice(reconciled.Spec, reconciledSlice, pathUpToSlice...); err != nil {
-		return fmt.Errorf("error setting the altered slice field %s back into the reconciled resource: %v", strings.Join(pathUpToSlice, "."), err)
+		return fmt.Errorf("error setting the altered slice field %s back into the reconciled resource: %w", strings.Join(pathUpToSlice, "."), err)
 	}
 	return nil
 }
@@ -539,7 +539,7 @@ func FavorReferenceFieldOverNonReferenceFieldUnderSlice(r *k8s.Resource, pathUpT
 	}
 	sliceVal, found, err := unstructured.NestedSlice(r.Spec, pathUpToSlice...)
 	if err != nil {
-		return fmt.Errorf("error getting nested slice field %s from resource: %v", strings.Join(pathUpToSlice, "."), err)
+		return fmt.Errorf("error getting nested slice field %s from resource: %w", strings.Join(pathUpToSlice, "."), err)
 	}
 	if !found {
 		return nil
@@ -547,18 +547,18 @@ func FavorReferenceFieldOverNonReferenceFieldUnderSlice(r *k8s.Resource, pathUpT
 	for i, v := range sliceVal {
 		nonReferenceVal, found, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), nonReferenceFieldPath...)
 		if err != nil {
-			return fmt.Errorf("error getting non-reference field %s from slice field: %v", strings.Join(nonReferenceFieldPath, "."), err)
+			return fmt.Errorf("error getting non-reference field %s from slice field: %w", strings.Join(nonReferenceFieldPath, "."), err)
 		}
 		if !found {
 			continue
 		}
 		if err := unstructured.SetNestedField(sliceVal[i].(map[string]interface{}), nonReferenceVal, append(referenceFieldPath, "external")...); err != nil {
-			return fmt.Errorf("error setting non-reference value to reference field path %s: %v", strings.Join(append(referenceFieldPath, "external"), "."), err)
+			return fmt.Errorf("error setting non-reference value to reference field path %s: %w", strings.Join(append(referenceFieldPath, "external"), "."), err)
 		}
 		unstructured.RemoveNestedField(sliceVal[i].(map[string]interface{}), nonReferenceFieldPath...)
 	}
 	if err := unstructured.SetNestedSlice(r.Spec, sliceVal, pathUpToSlice...); err != nil {
-		return fmt.Errorf("error setting altered slice %s back into resource: %v", strings.Join(pathUpToSlice, "."), err)
+		return fmt.Errorf("error setting altered slice %s back into resource: %w", strings.Join(pathUpToSlice, "."), err)
 	}
 	return nil
 }
@@ -589,7 +589,7 @@ func validateIfAuthoritativeFieldAndLegacyFieldTakeDifferentValues(r *k8s.Resour
 func validateAtMostOneFieldIsSetUnderSlice(r *k8s.Resource, fieldPathUpToSlice, fieldPath1, fieldPath2 []string) error {
 	sliceField, found, err := unstructured.NestedSlice(r.Spec, fieldPathUpToSlice...)
 	if err != nil {
-		return fmt.Errorf("error getting slice field %s from resource: %v", strings.Join(fieldPathUpToSlice, "."), err)
+		return fmt.Errorf("error getting slice field %s from resource: %w", strings.Join(fieldPathUpToSlice, "."), err)
 	}
 	if !found {
 		return nil
@@ -597,11 +597,11 @@ func validateAtMostOneFieldIsSetUnderSlice(r *k8s.Resource, fieldPathUpToSlice, 
 	for _, v := range sliceField {
 		_, found1, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), fieldPath1...)
 		if err != nil {
-			return fmt.Errorf("error checking existence of nested field %s within slice field: %v", strings.Join(fieldPath1, "."), err)
+			return fmt.Errorf("error checking existence of nested field %s within slice field: %w", strings.Join(fieldPath1, "."), err)
 		}
 		_, found2, err := unstructured.NestedFieldCopy(v.(map[string]interface{}), fieldPath2...)
 		if err != nil {
-			return fmt.Errorf("error checking existence of nested field %s within slice field: %v", strings.Join(fieldPath2, "."), err)
+			return fmt.Errorf("error checking existence of nested field %s within slice field: %w", strings.Join(fieldPath2, "."), err)
 		}
 		if !found1 || !found2 {
 			continue
@@ -636,11 +636,11 @@ func markFieldAsManaged(r *k8s.Resource, fieldPath ...string) error {
 func FavorReferenceArrayFieldOverNonReferenceArrayField(r *k8s.Resource, nonReferenceFieldPath, referenceFieldPath []string) error {
 	nonRefArray, foundNonRef, err := unstructured.NestedStringSlice(r.Spec, nonReferenceFieldPath...)
 	if err != nil {
-		return fmt.Errorf("error getting the non-reference field '%v': %v", strings.Join(nonReferenceFieldPath, "."), err)
+		return fmt.Errorf("error getting the non-reference field '%v': %w", strings.Join(nonReferenceFieldPath, "."), err)
 	}
 	_, foundRef, err := unstructured.NestedSlice(r.Spec, referenceFieldPath...)
 	if err != nil {
-		return fmt.Errorf("error getting the reference field '%v': %v", strings.Join(referenceFieldPath, "."), err)
+		return fmt.Errorf("error getting the reference field '%v': %w", strings.Join(referenceFieldPath, "."), err)
 	}
 
 	if foundNonRef && foundRef {
@@ -658,7 +658,7 @@ func FavorReferenceArrayFieldOverNonReferenceArrayField(r *k8s.Resource, nonRefe
 	for i, val := range nonRefArray {
 		refItem := make(map[string]interface{})
 		if err := unstructured.SetNestedField(refItem, val, "external"); err != nil {
-			return fmt.Errorf("error setting the 'external' field under the reference array '%v': %v", strings.Join(referenceFieldPath, "."), err)
+			return fmt.Errorf("error setting the 'external' field under the reference array '%v': %w", strings.Join(referenceFieldPath, "."), err)
 		}
 		refArray[i] = refItem
 	}

--- a/pkg/resourceskeleton/uri/uri.go
+++ b/pkg/resourceskeleton/uri/uri.go
@@ -25,7 +25,7 @@ import (
 func GetServiceMappingAndResourceConfig(smLoader *servicemappingloader.ServiceMappingLoader, urlHost, urlPath string) (*v1alpha1.ServiceMapping, *v1alpha1.ResourceConfig, error) {
 	sm, err := smLoader.GetServiceMappingForServiceHostName(urlHost)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting service mapping: %v", err)
+		return nil, nil, fmt.Errorf("error getting service mapping: %w", err)
 	}
 	rc, err := matchResourceNameToRC(urlPath, sm)
 	if err != nil {
@@ -54,7 +54,7 @@ func matchResourceNameToRCGeneral(uriPath string, sm *v1alpha1.ServiceMapping) (
 		regexIDTemplate := idTemplateToRegex(rc.IDTemplate)
 		regex, err := regexp.Compile(regexIDTemplate)
 		if err != nil {
-			return nil, fmt.Errorf("error compiling '%v' to regex: %v", regexIDTemplate, err)
+			return nil, fmt.Errorf("error compiling '%v' to regex: %w", regexIDTemplate, err)
 		}
 		if regex.MatchString(uriPath) {
 			return &rc, nil

--- a/pkg/servicemapping/servicemappingloader/servicemappingloader.go
+++ b/pkg/servicemapping/servicemappingloader/servicemappingloader.go
@@ -36,7 +36,7 @@ type ServiceMappingLoader struct {
 func New() (*ServiceMappingLoader, error) {
 	serviceMappings, err := GetServiceMappings()
 	if err != nil {
-		return nil, fmt.Errorf("error loading service mappings: %v", err)
+		return nil, fmt.Errorf("error loading service mappings: %w", err)
 	}
 	return NewFromServiceMappings(serviceMappings), nil
 }
@@ -82,7 +82,7 @@ func (s *ServiceMappingLoader) GetServiceMappings() []v1alpha1.ServiceMapping {
 func (s *ServiceMappingLoader) GetResourceConfig(u *unstructured.Unstructured) (*v1alpha1.ResourceConfig, error) {
 	sm, err := s.GetServiceMapping(u.GroupVersionKind().Group)
 	if err != nil {
-		return nil, fmt.Errorf("error getting service mapping: %v", err)
+		return nil, fmt.Errorf("error getting service mapping: %w", err)
 	}
 	return GetResourceConfig(sm, u)
 }
@@ -91,7 +91,7 @@ func (s *ServiceMappingLoader) GetResourceConfig(u *unstructured.Unstructured) (
 func (s *ServiceMappingLoader) GetResourceConfigs(gvk schema.GroupVersionKind) ([]*v1alpha1.ResourceConfig, error) {
 	sm, err := s.GetServiceMapping(gvk.Group)
 	if err != nil {
-		return nil, fmt.Errorf("error getting service mapping for group '%v': %v", gvk.Group, err)
+		return nil, fmt.Errorf("error getting service mapping for group '%v': %w", gvk.Group, err)
 	}
 	return GetResourceConfigsForKind(sm, gvk.Kind), nil
 }
@@ -133,14 +133,14 @@ func GetResourceConfig(sm *v1alpha1.ServiceMapping, u *unstructured.Unstructured
 
 	l, err := getLocationalityOfResource(u)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v: %v", u.GetKind(), err)
+		return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v: %w", u.GetKind(), err)
 	}
 	for _, rc := range rcs {
 		if rc.Locationality == l {
 			return rc, nil
 		}
 	}
-	return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v given the locationality of the resource - %v: %v", u.GetKind(), l, err)
+	return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v given the locationality of the resource - %v: %w", u.GetKind(), l, err)
 }
 
 func GetResourceConfigsForKind(sm *v1alpha1.ServiceMapping, kind string) []*v1alpha1.ResourceConfig {
@@ -167,7 +167,7 @@ func GetResourceConfigsForTFType(sm *v1alpha1.ServiceMapping, tfType string) (*v
 func getLocationalityOfResource(u *unstructured.Unstructured) (string, error) {
 	location, found, err := unstructured.NestedString(u.Object, "spec", "location")
 	if err != nil || !found {
-		return "", fmt.Errorf("couldn't find location field: %v", err)
+		return "", fmt.Errorf("couldn't find location field: %w", err)
 	}
 
 	if location == gcp.Global {
@@ -258,7 +258,7 @@ func getComputeInstanceTFResource(u *unstructured.Unstructured, rcs []*v1alpha1.
 	// Otherwise, use TF resource compute_instance.
 	_, hasTemplate, err := unstructured.NestedMap(u.Object, "spec", "instanceTemplateRef")
 	if err != nil {
-		return nil, fmt.Errorf("instanceTemplateRef should be a map in Kind %v: %v", u.GetKind(), err)
+		return nil, fmt.Errorf("instanceTemplateRef should be a map in Kind %v: %w", u.GetKind(), err)
 	}
 	for _, rc := range rcs {
 		if rc.Name == "google_compute_instance_from_template" && hasTemplate {
@@ -269,5 +269,5 @@ func getComputeInstanceTFResource(u *unstructured.Unstructured, rcs []*v1alpha1.
 		}
 	}
 
-	return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v: %v", u.GetKind(), err)
+	return nil, fmt.Errorf("couldn't find the right ResourceConfig for Kind %v: %w", u.GetKind(), err)
 }

--- a/pkg/snippet/snippetgeneration/snippetgeneration.go
+++ b/pkg/snippet/snippetgeneration/snippetgeneration.go
@@ -126,7 +126,7 @@ func PathToSampleFileUsedForSnippets(resourceDirName string) (string, error) {
 	resourceDirPath := path.Join(samplesPath, resourceDirName)
 	dirExists, err := fileutil.DirExists(resourceDirPath)
 	if err != nil {
-		return "", fmt.Errorf("error: failed to determine if directory with name %v exists in %v: %v", resourceDirName, samplesPath, err)
+		return "", fmt.Errorf("error: failed to determine if directory with name %v exists in %v: %w", resourceDirName, samplesPath, err)
 	}
 	if !dirExists {
 		return "", fmt.Errorf("error: no directory with name %v found in %v", resourceDirName, samplesPath)
@@ -134,7 +134,7 @@ func PathToSampleFileUsedForSnippets(resourceDirName string) (string, error) {
 
 	hasSubdirs, err := fileutil.HasSubdirs(resourceDirPath)
 	if err != nil {
-		return "", fmt.Errorf("error determining if directory at %v has subdirectories: %v", resourceDirPath, err)
+		return "", fmt.Errorf("error determining if directory at %v has subdirectories: %w", resourceDirPath, err)
 	}
 
 	sampleDirPath := resourceDirPath
@@ -147,7 +147,7 @@ func PathToSampleFileUsedForSnippets(resourceDirName string) (string, error) {
 
 	fileNames, err := fileutil.FileNamesWithSuffixInDir(sampleDirPath, resourceDirName+".yaml")
 	if err != nil {
-		return "", fmt.Errorf("error getting files to use for generating snippets: %v", err)
+		return "", fmt.Errorf("error getting files to use for generating snippets: %w", err)
 	}
 	if len(fileNames) != 1 {
 		return "", fmt.Errorf("error getting exactly one file to use for generating snippets (dir=%q, suffix=%q); expected one, got %v", sampleDirPath, resourceDirName+".yaml", fileNames)
@@ -165,7 +165,7 @@ func pathToPreferredSamplesSubdirForResource(resourceDirPath string) (string, er
 	sampleSubdirPath := path.Join(resourceDirPath, sampleSubdirName)
 	dirExists, err := fileutil.DirExists(sampleSubdirPath)
 	if err != nil {
-		return "", fmt.Errorf("error: failed to determine if directory at %v exists: %v", sampleSubdirPath, err)
+		return "", fmt.Errorf("error: failed to determine if directory at %v exists: %w", sampleSubdirPath, err)
 	}
 	if !dirExists {
 		return "", fmt.Errorf("error: no directory found at %v", sampleSubdirPath)
@@ -176,11 +176,11 @@ func pathToPreferredSamplesSubdirForResource(resourceDirPath string) (string, er
 func SnippifyResourceConfig(resourceConfig []byte) (Snippet, error) {
 	kind, err := resourceKind(resourceConfig)
 	if err != nil {
-		return Snippet{}, fmt.Errorf("error parsing resource kind from resource config: %v", err)
+		return Snippet{}, fmt.Errorf("error parsing resource kind from resource config: %w", err)
 	}
 	config, err := snippifyResourceConfig(kind, resourceConfig)
 	if err != nil {
-		return Snippet{}, fmt.Errorf("error snippifying resource config: %v", err)
+		return Snippet{}, fmt.Errorf("error snippifying resource config: %w", err)
 	}
 	return Snippet{
 		Label:               "Config Connector " + kind,
@@ -193,7 +193,7 @@ func snippifyResourceConfig(kind string, config []byte) (string, error) {
 	var mapSlice goyaml.MapSlice
 	err := goyaml.Unmarshal(config, &mapSlice)
 	if err != nil {
-		return "", fmt.Errorf("error unmarshalling bytes: %v", err)
+		return "", fmt.Errorf("error unmarshalling bytes: %w", err)
 	}
 
 	newMapSlice := goyaml.MapSlice{}
@@ -210,7 +210,7 @@ func snippifyResourceConfig(kind string, config []byte) (string, error) {
 
 	out, err := goyaml.Marshal(newMapSlice)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling bytes to YAML: %v", err)
+		return "", fmt.Errorf("error marshalling bytes to YAML: %w", err)
 	}
 	return string(out), nil
 }
@@ -280,7 +280,7 @@ func resourceKind(config []byte) (string, error) {
 	u := &unstructured.Unstructured{}
 	err := yaml.Unmarshal(config, u)
 	if err != nil {
-		return "", fmt.Errorf("error unmarshalling bytes to CRD: %v", err)
+		return "", fmt.Errorf("error unmarshalling bytes to CRD: %w", err)
 	}
 	return u.GetKind(), nil
 }

--- a/pkg/test/controller/k8s.go
+++ b/pkg/test/controller/k8s.go
@@ -26,9 +26,10 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
 
+	"errors"
+
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	goerrors "errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -81,7 +82,7 @@ func assertEventNotRecorded(t *testing.T, c client.Client, kind, name, namespace
 	err := waitUntilEventRecorded(t, c, kind, name, namespace, reason)
 	if err == nil {
 		t.Errorf("expected event with reason '%v' to not be recorded for %v %v/%v, but it was", reason, kind, namespace, name)
-	} else if !goerrors.Is(err, wait.ErrWaitTimeout) {
+	} else if !errors.Is(err, wait.ErrWaitTimeout) {
 		t.Errorf("error waiting for event with reason '%v' to be recorded for %v %v/%v: %v", reason, kind, namespace, name, err)
 	}
 }
@@ -132,7 +133,7 @@ func WaitForUnstructDeleteToFinish(t *testing.T, kubeClient client.Client, origU
 		if err == nil {
 			return false, nil
 		}
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return true, err

--- a/pkg/test/controller/k8s.go
+++ b/pkg/test/controller/k8s.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	goerrors "errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -80,7 +81,7 @@ func assertEventNotRecorded(t *testing.T, c client.Client, kind, name, namespace
 	err := waitUntilEventRecorded(t, c, kind, name, namespace, reason)
 	if err == nil {
 		t.Errorf("expected event with reason '%v' to not be recorded for %v %v/%v, but it was", reason, kind, namespace, name)
-	} else if err != wait.ErrWaitTimeout {
+	} else if !goerrors.Is(err, wait.ErrWaitTimeout) {
 		t.Errorf("error waiting for event with reason '%v' to be recorded for %v %v/%v: %v", reason, kind, namespace, name, err)
 	}
 }

--- a/pkg/test/controller/reconcile.go
+++ b/pkg/test/controller/reconcile.go
@@ -74,7 +74,7 @@ func startTestManager(env *envtest.Environment, testType test.TestType, whCfgs [
 		MetricsBindAddress: "0",
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating manager: %v", err)
+		return nil, nil, fmt.Errorf("error creating manager: %w", err)
 	}
 	if testType == test.IntegrationTestType {
 		server := mgr.GetWebhookServer()
@@ -100,7 +100,7 @@ func startMgr(mgr manager.Manager, mgrStartErrHandler func(string, ...interface{
 	go func() {
 		defer wg.Done()
 		if err := mgr.Start(ctx); err != nil {
-			mgrStartErrHandler("unable to start manager: %v", err)
+			mgrStartErrHandler("unable to start manager: %w", err)
 		}
 	}()
 	stop := func() {
@@ -217,7 +217,7 @@ tryAgain:
 
 	if expectedErrorRegex == nil {
 		if err != nil {
-			t.Fatalf("reconcile returned unexpected error: %v", err)
+			t.Fatal(fmt.Errorf("reconcile returned unexpected error: %w", err))
 		}
 	} else {
 		if err == nil || !expectedErrorRegex.MatchString(err.Error()) {
@@ -253,7 +253,7 @@ func EnsureNamespaceExists(c client.Client, name string) error {
 	ns.SetName(name)
 	if err := c.Create(context.Background(), ns); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("error creating namespace %v: %v", name, err)
+			return fmt.Errorf("error creating namespace %v: %w", name, err)
 		}
 	}
 	return nil

--- a/pkg/test/environment/environment.go
+++ b/pkg/test/environment/environment.go
@@ -66,7 +66,7 @@ func startTestEnvironment(testType test.TestType, crds []*apiextensions.CustomRe
 	}
 	_, err := env.Start()
 	if err != nil {
-		return nil, fmt.Errorf("error starting test environment: %v", err)
+		return nil, fmt.Errorf("error starting test environment: %w", err)
 	}
 	return env, nil
 }

--- a/pkg/test/resourcefixture/resourcefixture.go
+++ b/pkg/test/resourcefixture/resourcefixture.go
@@ -163,7 +163,7 @@ func readGroupVersionKind(t *testing.T, config []byte) (schema.GroupVersionKind,
 	u := &unstructured.Unstructured{}
 	err := yaml.Unmarshal(config, u)
 	if err != nil {
-		return schema.GroupVersionKind{}, fmt.Errorf("error unmarshalling bytes to CRD: %v", err)
+		return schema.GroupVersionKind{}, fmt.Errorf("error unmarshalling bytes to CRD: %w", err)
 	}
 	return u.GroupVersionKind(), nil
 }

--- a/pkg/test/webhook/configs.go
+++ b/pkg/test/webhook/configs.go
@@ -23,7 +23,7 @@ import (
 func GetTestCommonWebhookConfigs() ([]webhook.WebhookConfig, error) {
 	whCfgs, err := webhook.GetCommonWebhookConfigs()
 	if err != nil {
-		return nil, fmt.Errorf("error getting common wehbook configs: %v", err)
+		return nil, fmt.Errorf("error getting common wehbook configs: %w", err)
 	}
 	res := make([]webhook.WebhookConfig, 0)
 	for _, config := range whCfgs {

--- a/pkg/util/fileutil/fileutil.go
+++ b/pkg/util/fileutil/fileutil.go
@@ -44,7 +44,7 @@ func HasSubdirs(path string) (bool, error) {
 func SubdirsIn(path string) ([]string, error) {
 	fileInfos, err := ioutil.ReadDir(path)
 	if err != nil {
-		return []string{}, fmt.Errorf("error reading directory '%v': %v", path, err)
+		return []string{}, fmt.Errorf("error reading directory '%v': %w", path, err)
 	}
 	subdirNames := make([]string, 0)
 	for _, fi := range fileInfos {
@@ -60,7 +60,7 @@ func SubdirsIn(path string) ([]string, error) {
 func FileNamesWithSuffixInDir(path, suffix string) (names []string, err error) {
 	fileInfos, err := ioutil.ReadDir(path)
 	if err != nil {
-		return []string{}, fmt.Errorf("error reading directory '%v': %v", path, err)
+		return []string{}, fmt.Errorf("error reading directory '%v': %w", path, err)
 	}
 	names = make([]string, 0)
 	for _, fi := range fileInfos {
@@ -77,7 +77,7 @@ func FileNamesWithSuffixInDir(path, suffix string) (names []string, err error) {
 // NewEmptyFile creates an empty file at the given path.
 func NewEmptyFile(path string) (*os.File, error) {
 	if err := ensureParentDirectoryExists(path); err != nil {
-		return nil, fmt.Errorf("error ensuring parent directory of %v exists: %v", path, err)
+		return nil, fmt.Errorf("error ensuring parent directory of %v exists: %w", path, err)
 	}
 	return os.Create(path)
 }
@@ -85,7 +85,7 @@ func NewEmptyFile(path string) (*os.File, error) {
 func ensureParentDirectoryExists(path string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("error creating directory %v and its parents: %v", dir, err)
+		return fmt.Errorf("error creating directory %v and its parents: %w", dir, err)
 	}
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,10 +22,10 @@ import (
 func Marshal(raw interface{}, processed interface{}) error {
 	b, err := json.Marshal(raw)
 	if err != nil {
-		return fmt.Errorf("error marshaling as JSON: %v", err)
+		return fmt.Errorf("error marshaling as JSON: %w", err)
 	}
 	if err := json.Unmarshal(b, processed); err != nil {
-		return fmt.Errorf("error unmarshaling into processed object: %v", err)
+		return fmt.Errorf("error unmarshaling into processed object: %w", err)
 	}
 	return nil
 }

--- a/pkg/webhook/cert/generator/selfsigned.go
+++ b/pkg/webhook/cert/generator/selfsigned.go
@@ -74,17 +74,17 @@ func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, erro
 	if !valid {
 		signingKey, err = NewPrivateKey()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create the CA private key: %v", err)
+			return nil, fmt.Errorf("failed to create the CA private key: %w", err)
 		}
 		signingCert, err = NewSelfSignedCACert(cert.Config{CommonName: "webhook-cert-ca"}, signingKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create the CA cert: %v", err)
+			return nil, fmt.Errorf("failed to create the CA cert: %w", err)
 		}
 	}
 
 	key, err := NewPrivateKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the private key: %v", err)
+		return nil, fmt.Errorf("failed to create the private key: %w", err)
 	}
 	signedCert, err := newSignedCert(
 		cert.Config{
@@ -94,7 +94,7 @@ func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, erro
 		key, signingCert, signingKey,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the cert: %v", err)
+		return nil, fmt.Errorf("failed to create the cert: %w", err)
 	}
 	return &Artifacts{
 		Key:    encodePrivateKeyPEM(key),

--- a/pkg/webhook/cert/writer/error.go
+++ b/pkg/webhook/cert/writer/error.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package writer
 
+import "errors"
+
 type notFoundError struct {
 	err error
 }
@@ -25,8 +27,7 @@ func (e notFoundError) Error() string {
 }
 
 func isNotFound(err error) bool {
-	_, ok := err.(notFoundError)
-	return ok
+	return errors.As(err, &notFoundError{})
 }
 
 type alreadyExistError struct {
@@ -38,6 +39,5 @@ func (e alreadyExistError) Error() string {
 }
 
 func isAlreadyExists(err error) bool {
-	_, ok := err.(alreadyExistError)
-	return ok
+	return errors.As(err, &alreadyExistError{})
 }

--- a/pkg/webhook/container_annotation_handler.go
+++ b/pkg/webhook/container_annotation_handler.go
@@ -61,12 +61,12 @@ func (a *containerAnnotationHandler) Handle(ctx context.Context, req admission.R
 	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
 		klog.Error(err)
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding object: %v", err))
+			fmt.Errorf("error decoding object: %w", err))
 	}
 	ns := &corev1.Namespace{}
 	if err := a.client.Get(ctx, apimachinerytypes.NamespacedName{Name: obj.GetNamespace()}, ns); err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error getting Namespace %v: %v", obj.GetNamespace(), err))
+			fmt.Errorf("error getting Namespace %v: %w", obj.GetNamespace(), err))
 	}
 	if dclmetadata.IsDCLBasedResourceKind(obj.GroupVersionKind(), a.serviceMetadataLoader) {
 		return handleContainerAnnotationsForDCLBasedResources(obj, ns, a.dclSchemaLoader, a.serviceMetadataLoader)
@@ -84,7 +84,7 @@ func handleContainerAnnotationsForDCLBasedResources(obj *unstructured.Unstructur
 	containers, err := dclcontainer.GetContainersForGVK(gvk, serviceMetadataLoader, dclSchemaLoader)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error getting containers supported by GroupVersionKind %v: %v", gvk, err))
+			fmt.Errorf("error getting containers supported by GroupVersionKind %v: %w", gvk, err))
 	}
 
 	// TODO(b/186159460): Delete this if-block once all resources support
@@ -96,7 +96,7 @@ func handleContainerAnnotationsForDCLBasedResources(obj *unstructured.Unstructur
 	hierarchicalRefs, err := dcl.GetHierarchicalReferencesForGVK(gvk, serviceMetadataLoader, dclSchemaLoader)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %v", gvk, err))
+			fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %w", gvk, err))
 	}
 	return setDefaultHierarchicalReference(obj, ns, hierarchicalRefs, containers)
 }
@@ -105,7 +105,7 @@ func handleContainerAnnotationsForTFBasedResources(obj *unstructured.Unstructure
 	rc, err := smLoader.GetResourceConfig(obj)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error getting ResourceConfig for kind %v: %v", obj.GetKind(), err))
+			fmt.Errorf("error getting ResourceConfig for kind %v: %w", obj.GetKind(), err))
 	}
 
 	// TODO(b/193177782): Delete this if-block once all resources support
@@ -119,7 +119,7 @@ func handleContainerAnnotationsForTFBasedResources(obj *unstructured.Unstructure
 func setDefaultContainerAnnotation(obj *unstructured.Unstructured, ns *corev1.Namespace, containers []corekccv1alpha1.Container) admission.Response {
 	newObj := obj.DeepCopy()
 	if err := k8s.SetDefaultContainerAnnotation(newObj, ns, containers); err != nil {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error setting container annotation: %v", err))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("error setting container annotation: %w", err))
 	}
 	return constructPatchResponse(obj, newObj)
 }
@@ -127,14 +127,14 @@ func setDefaultContainerAnnotation(obj *unstructured.Unstructured, ns *corev1.Na
 func setDefaultHierarchicalReference(obj *unstructured.Unstructured, ns *corev1.Namespace, hierarchicalRefs []corekccv1alpha1.HierarchicalReference, containers []corekccv1alpha1.Container) admission.Response {
 	resource, err := k8s.NewResource(obj)
 	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error converting object to k8s resource: %v", err))
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error converting object to k8s resource: %w", err))
 	}
 	if err := k8s.SetDefaultHierarchicalReference(resource, ns, hierarchicalRefs, containers); err != nil {
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error setting hierarchical reference: %v", err))
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error setting hierarchical reference: %w", err))
 	}
 	newObj, err := resource.MarshalAsUnstructured()
 	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error marshalling k8s resource to unstructured: %v", err))
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("error marshalling k8s resource to unstructured: %w", err))
 	}
 	return constructPatchResponse(obj, newObj)
 }

--- a/pkg/webhook/container_annotation_handler_test.go
+++ b/pkg/webhook/container_annotation_handler_test.go
@@ -1049,8 +1049,8 @@ func TestHandleContainerAnnotationsForDCLBasedResources(t *testing.T) {
 				// Add the following to the list of fake DCL schemas to allow for our
 				// test to test resources that reference hierarchical resources
 				// (e.g. "Cloudresourcemanager/Project").
-				"cloudresourcemanager_ga_project": &openapi.Schema{},
-				"cloudresourcemanager_ga_folder":  &openapi.Schema{},
+				"cloudresourcemanager_ga_project": {},
+				"cloudresourcemanager_ga_folder":  {},
 			}
 			dclSchemaLoader := testdclschemaloader.New(dclSchemaMap)
 			response := handleContainerAnnotationsForDCLBasedResources(tc.obj, tc.ns, dclSchemaLoader, smLoader)

--- a/pkg/webhook/iam_defaulter.go
+++ b/pkg/webhook/iam_defaulter.go
@@ -56,7 +56,7 @@ func (a *iamDefaulter) Handle(ctx context.Context, req admission.Request) admiss
 	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
 		klog.Error(err)
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding object: %v", err))
+			fmt.Errorf("error decoding object: %w", err))
 	}
 
 	if !isIAMResource(obj) {
@@ -72,7 +72,7 @@ func defaultAPIVersionForIAMResourceRef(obj *unstructured.Unstructured,
 	resourceRef, found, err := unstructured.NestedMap(obj.Object, iamResourceRefPath...)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error getting '%v': %v", iamResourceRefField, err))
+			fmt.Errorf("error getting '%v': %w", iamResourceRefField, err))
 	}
 	if !found {
 		return admission.Errored(http.StatusBadRequest,
@@ -97,14 +97,14 @@ func defaultAPIVersionForIAMResourceRef(obj *unstructured.Unstructured,
 	apiVersion, err := apiVersionForKind(kind, smLoader, serviceMetadataLoader)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error determining apiVersion for kind '%v': %v", kind, err))
+			fmt.Errorf("error determining apiVersion for kind '%v': %w", kind, err))
 	}
 
 	resourceRef["apiVersion"] = apiVersion
 	newObj := obj.DeepCopy()
 	if err := unstructured.SetNestedMap(newObj.Object, resourceRef, iamResourceRefPath...); err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error setting '%v': %v", iamResourceRefField, err))
+			fmt.Errorf("error setting '%v': %w", iamResourceRefField, err))
 	}
 	return constructPatchResponse(obj, newObj)
 

--- a/pkg/webhook/iam_defaulter_test.go
+++ b/pkg/webhook/iam_defaulter_test.go
@@ -106,7 +106,7 @@ func TestDefaultAPIVersionForIAMResourceRef(t *testing.T) {
 	}
 
 	iamTemplates := map[string]map[string]interface{}{
-		"IAMPolicy": map[string]interface{}{
+		"IAMPolicy": {
 			"apiVersion": v1beta1.IAMPolicyGVK.GroupVersion().String(),
 			"kind":       v1beta1.IAMPolicyGVK.Kind,
 			"metadata": map[string]interface{}{
@@ -123,7 +123,7 @@ func TestDefaultAPIVersionForIAMResourceRef(t *testing.T) {
 				},
 			},
 		},
-		"IAMPartialPolicy": map[string]interface{}{
+		"IAMPartialPolicy": {
 			"apiVersion": v1beta1.IAMPartialPolicyGVK.GroupVersion().String(),
 			"kind":       v1beta1.IAMPartialPolicyGVK.Kind,
 			"metadata": map[string]interface{}{
@@ -142,7 +142,7 @@ func TestDefaultAPIVersionForIAMResourceRef(t *testing.T) {
 				},
 			},
 		},
-		"IAMPolicyMember": map[string]interface{}{
+		"IAMPolicyMember": {
 			"apiVersion": v1beta1.IAMPolicyMemberGVK.GroupVersion().String(),
 			"kind":       v1beta1.IAMPolicyMemberGVK.Kind,
 			"metadata": map[string]interface{}{
@@ -153,7 +153,7 @@ func TestDefaultAPIVersionForIAMResourceRef(t *testing.T) {
 				"role":   "role",
 			},
 		},
-		"IAMAuditConfig": map[string]interface{}{
+		"IAMAuditConfig": {
 			"apiVersion": v1beta1.IAMAuditConfigGVK.GroupVersion().String(),
 			"kind":       v1beta1.IAMAuditConfigGVK.Kind,
 			"metadata": map[string]interface{}{

--- a/pkg/webhook/iam_validator.go
+++ b/pkg/webhook/iam_validator.go
@@ -61,7 +61,7 @@ func (a *iamValidatorHandler) Handle(ctx context.Context, req admission.Request)
 	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
 		klog.Error(err)
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding object: %v", err))
+			fmt.Errorf("error decoding object: %w", err))
 	}
 	switch {
 	case isIAMPolicy(obj):
@@ -115,7 +115,7 @@ func (a *iamValidatorHandler) Handle(ctx context.Context, req admission.Request)
 func toIAMPolicy(obj *unstructured.Unstructured) (*v1beta1.IAMPolicy, error) {
 	policy := &v1beta1.IAMPolicy{}
 	if err := util.Marshal(obj, policy); err != nil {
-		return nil, fmt.Errorf("error parsing %v into IAM Policy object: %v", obj.GetName(), err)
+		return nil, fmt.Errorf("error parsing %v into IAM Policy object: %w", obj.GetName(), err)
 	}
 	return policy, nil
 }
@@ -123,7 +123,7 @@ func toIAMPolicy(obj *unstructured.Unstructured) (*v1beta1.IAMPolicy, error) {
 func toIAMPartialPolicy(obj *unstructured.Unstructured) (*v1beta1.IAMPartialPolicy, error) {
 	partialPolicy := &v1beta1.IAMPartialPolicy{}
 	if err := util.Marshal(obj, partialPolicy); err != nil {
-		return nil, fmt.Errorf("error parsing %v into IAMPartialPolicy object: %v", obj.GetName(), err)
+		return nil, fmt.Errorf("error parsing %v into IAMPartialPolicy object: %w", obj.GetName(), err)
 	}
 	return partialPolicy, nil
 }
@@ -131,7 +131,7 @@ func toIAMPartialPolicy(obj *unstructured.Unstructured) (*v1beta1.IAMPartialPoli
 func toIAMPolicyMember(obj *unstructured.Unstructured) (*v1beta1.IAMPolicyMember, error) {
 	policyMember := &v1beta1.IAMPolicyMember{}
 	if err := util.Marshal(obj, policyMember); err != nil {
-		return nil, fmt.Errorf("error parsing %v into IAM Policy Member object: %v", obj.GetName(), err)
+		return nil, fmt.Errorf("error parsing %v into IAM Policy Member object: %w", obj.GetName(), err)
 	}
 	return policyMember, nil
 }
@@ -139,7 +139,7 @@ func toIAMPolicyMember(obj *unstructured.Unstructured) (*v1beta1.IAMPolicyMember
 func toIAMAuditConfig(obj *unstructured.Unstructured) (*v1beta1.IAMAuditConfig, error) {
 	auditConfig := &v1beta1.IAMAuditConfig{}
 	if err := util.Marshal(obj, auditConfig); err != nil {
-		return nil, fmt.Errorf("error parsing %v into IAMAuditConfig object: %v", obj.GetName(), err)
+		return nil, fmt.Errorf("error parsing %v into IAMAuditConfig object: %w", obj.GetName(), err)
 	}
 	return auditConfig, nil
 }
@@ -165,13 +165,13 @@ func getResourceConfigs(smLoader *servicemappingloader.ServiceMappingLoader, gvk
 	if externalonlygvks.IsExternalOnlyGVK(gvk) {
 		rc, err := kcciamclient.GetResourceConfigForExternalOnlyGVK(gvk)
 		if err != nil {
-			return []*v1alpha1.ResourceConfig{}, fmt.Errorf("error getting ResourceConfig for GroupVersionKind %v: %v", gvk, err)
+			return []*v1alpha1.ResourceConfig{}, fmt.Errorf("error getting ResourceConfig for GroupVersionKind %v: %w", gvk, err)
 		}
 		return []*v1alpha1.ResourceConfig{rc}, nil
 	}
 	rcs, err := smLoader.GetResourceConfigs(gvk)
 	if err != nil {
-		return []*v1alpha1.ResourceConfig{}, fmt.Errorf("error getting ResourceConfig for GroupVersionKind %v: %v", gvk, err)
+		return []*v1alpha1.ResourceConfig{}, fmt.Errorf("error getting ResourceConfig for GroupVersionKind %v: %w", gvk, err)
 	}
 	if len(rcs) == 0 {
 		return []*v1alpha1.ResourceConfig{}, fmt.Errorf("couldn't find any ResourceConfig defined for GroupVersionKind %v", gvk)

--- a/pkg/webhook/iam_validator_test.go
+++ b/pkg/webhook/iam_validator_test.go
@@ -638,8 +638,7 @@ func newTestExternalOnlyRefPolicyMember() *v1beta1.IAMPolicyMember {
 }
 
 func newTestResourceRCs() []*v1alpha1.ResourceConfig {
-	return []*v1alpha1.ResourceConfig{
-		&v1alpha1.ResourceConfig{
+	return []*v1alpha1.ResourceConfig{{
 			Name: "google_resource_type",
 			Kind: "ResourceType",
 			IAMConfig: v1alpha1.IAMConfig{

--- a/pkg/webhook/iam_validator_test.go
+++ b/pkg/webhook/iam_validator_test.go
@@ -639,17 +639,17 @@ func newTestExternalOnlyRefPolicyMember() *v1beta1.IAMPolicyMember {
 
 func newTestResourceRCs() []*v1alpha1.ResourceConfig {
 	return []*v1alpha1.ResourceConfig{{
-			Name: "google_resource_type",
-			Kind: "ResourceType",
-			IAMConfig: v1alpha1.IAMConfig{
-				PolicyName:       "google_resource_type_iam_policy",
-				PolicyMemberName: "google_resource_type_iam_policy_member",
-				ReferenceField: v1alpha1.IAMReferenceField{
-					Name: "name",
-					Type: v1alpha1.IAMReferenceTypeName,
-				},
+		Name: "google_resource_type",
+		Kind: "ResourceType",
+		IAMConfig: v1alpha1.IAMConfig{
+			PolicyName:       "google_resource_type_iam_policy",
+			PolicyMemberName: "google_resource_type_iam_policy_member",
+			ReferenceField: v1alpha1.IAMReferenceField{
+				Name: "name",
+				Type: v1alpha1.IAMReferenceTypeName,
 			},
 		},
+	},
 	}
 }
 

--- a/pkg/webhook/immutable_fields_validator.go
+++ b/pkg/webhook/immutable_fields_validator.go
@@ -86,13 +86,13 @@ func (a *immutableFieldsValidatorHandler) Handle(ctx context.Context, req admiss
 	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
 		klog.Error(err)
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding object: %v", err))
+			fmt.Errorf("error decoding object: %w", err))
 	}
 	oldObj := &unstructured.Unstructured{}
 	if _, _, err := deserializer.Decode(req.AdmissionRequest.OldObject.Raw, nil, oldObj); err != nil {
 		klog.Error(err)
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error decoding old object: %v", err))
+			fmt.Errorf("error decoding old object: %w", err))
 	}
 
 	spec, ok := obj.Object["spec"].(map[string]interface{})
@@ -139,16 +139,16 @@ func validateImmutableFieldsForDCLBasedResource(obj, oldObj *unstructured.Unstru
 	containers, err := dclcontainer.GetContainersForGVK(gvk, serviceMetadataLoader, dclSchemaLoader)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error getting containers supported by GroupVersionKind %v: %v", gvk, err))
+			fmt.Errorf("error getting containers supported by GroupVersionKind %v: %w", gvk, err))
 	}
 	hierarchicalRefs, err := dcl.GetHierarchicalReferencesForGVK(gvk, serviceMetadataLoader, dclSchemaLoader)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError,
-			fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %v", gvk, err))
+			fmt.Errorf("error getting hierarchical references supported by GroupVersionKind %v: %w", gvk, err))
 	}
 	if err := validateContainerAnnotationsForResource(gvk.Kind, obj.GetAnnotations(), oldObj.GetAnnotations(), containers, hierarchicalRefs); err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error validating container annotations: %v", err))
+			fmt.Errorf("error validating container annotations: %w", err))
 	}
 	if isResourceIDModified(spec, oldSpec) {
 		return admission.Errored(http.StatusForbidden,
@@ -282,12 +282,12 @@ func validateImmutableFieldsForTFBasedResource(obj, oldObj *unstructured.Unstruc
 	rc, err := smLoader.GetResourceConfig(obj)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("couldn't get ResourceConfig for kind %v: %v", obj.GetKind(), err))
+			fmt.Errorf("couldn't get ResourceConfig for kind %v: %w", obj.GetKind(), err))
 	}
 
 	if err := validateContainerAnnotationsForResource(obj.GetKind(), obj.GetAnnotations(), oldObj.GetAnnotations(), rc.Containers, rc.HierarchicalReferences); err != nil {
 		return admission.Errored(http.StatusBadRequest,
-			fmt.Errorf("error validating container annotations: %v", err))
+			fmt.Errorf("error validating container annotations: %w", err))
 	}
 
 	r, ok := tfResourceMap[rc.Name]

--- a/pkg/webhook/register.go
+++ b/pkg/webhook/register.go
@@ -16,7 +16,6 @@ package webhook
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -57,7 +56,7 @@ func RegisterCommonWebhooks(mgr manager.Manager, nocacheClient client.Client) er
 	fmt.Println("starting up webhooks")
 	whCfgs, err := GetCommonWebhookConfigs()
 	if err != nil {
-		return fmt.Errorf("error getting common wehbook configs: %v", err)
+		return fmt.Errorf("error getting common wehbook configs: %w", err)
 	}
 	return register(
 		ValidatingWebhookConfigurationName,
@@ -307,7 +306,7 @@ func persistCertificatesToDisk(certWriter writer.CertWriter, svc *corev1.Service
 	dnsName := getDnsNameForService(svc)
 	artifacts, _, err := certWriter.EnsureCert(dnsName)
 	if err != nil {
-		return fmt.Errorf("error ensuring certificate: %v", err)
+		return fmt.Errorf("error ensuring certificate: %w", err)
 	}
 	if err := writeCertificates(artifacts, certDir, writer.ServerCertName, writer.ServerKeyName); err != nil {
 		return err
@@ -317,19 +316,19 @@ func persistCertificatesToDisk(certWriter writer.CertWriter, svc *corev1.Service
 
 func writeCertificates(artifacts *generator.Artifacts, dir, certName, keyName string) error {
 	if err := os.RemoveAll(dir); err != nil {
-		return fmt.Errorf("error removing cert dir '%v': %v", dir, err)
+		return fmt.Errorf("error removing cert dir '%v': %w", dir, err)
 	}
 	if err := os.MkdirAll(dir, 0777); err != nil {
-		return fmt.Errorf("error creating cert dir '%v': %v", dir, err)
+		return fmt.Errorf("error creating cert dir '%v': %w", dir, err)
 	}
 	perms := os.FileMode(0644)
 	certPath := path.Join(dir, certName)
-	if err := ioutil.WriteFile(certPath, artifacts.Cert, perms); err != nil {
-		return fmt.Errorf("error writing certificate to '%v': %v", certPath, err)
+	if err := os.WriteFile(certPath, artifacts.Cert, perms); err != nil {
+		return fmt.Errorf("error writing certificate to '%v': %w", certPath, err)
 	}
 	keyPath := path.Join(dir, keyName)
-	if err := ioutil.WriteFile(keyPath, artifacts.Key, perms); err != nil {
-		return fmt.Errorf("error writing key to '%v': %v", keyPath, err)
+	if err := os.WriteFile(keyPath, artifacts.Key, perms); err != nil {
+		return fmt.Errorf("error writing key to '%v': %w", keyPath, err)
 	}
 	return nil
 }

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -16,6 +16,7 @@ package yaml
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -27,13 +28,13 @@ func SplitYAML(yamlBytes []byte) ([][]byte, error) {
 	dec := goyaml.NewDecoder(r)
 	results := make([][]byte, 0)
 	var value map[string]interface{}
-	for eof := dec.Decode(&value); eof != io.EOF; eof = dec.Decode(&value) {
+	for eof := dec.Decode(&value); !errors.Is(eof, io.EOF); eof = dec.Decode(&value) {
 		if eof != nil {
 			return nil, eof
 		}
 		bytes, err := goyaml.Marshal(value)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling '%v' to YAML: %v", value, err)
+			return nil, fmt.Errorf("error marshalling '%v' to YAML: %w", value, err)
 		}
 		results = append(results, bytes)
 		value = make(map[string]interface{})

--- a/scripts/generate-go-crd-clients/generate-types-file.go
+++ b/scripts/generate-go-crd-clients/generate-types-file.go
@@ -287,7 +287,7 @@ func buildFieldProperties(r *resourceDefinition, crd *apiextensions.CustomResour
 	organizeSpecFieldDescriptions(specDescriptions, r)
 	statusDesc, err := fielddesc.GetStatusDescription(crd)
 	if err != nil {
-		return fmt.Errorf("error getting status descriptions: %v", err)
+		return fmt.Errorf("error getting status descriptions: %w", err)
 	}
 	statusDescriptions := dropRootAndFlattenChildrenDescriptions(statusDesc)
 	r.StatusNestedStructs = make(map[string][]*fieldProperties)

--- a/scripts/resource-autogen/servicemapping/servicemappingloader/servicemappingloader.go
+++ b/scripts/resource-autogen/servicemapping/servicemappingloader/servicemappingloader.go
@@ -44,12 +44,12 @@ func GetGeneratedSMMap() (map[string]v1alpha1.ServiceMapping, error) {
 	baseDirName := "/"
 	generatedSMDir, err := generatedembed.Assets.Open(baseDirName)
 	if err != nil {
-		return nil, fmt.Errorf("error reading generated files in ServiceMapping directory: %v", err)
+		return nil, fmt.Errorf("error reading generated files in ServiceMapping directory: %w", err)
 	}
 	defer generatedSMDir.Close()
 	generatedFiles, err := generatedSMDir.Readdir(0)
 	if err != nil {
-		return nil, fmt.Errorf("error reading generated files in ServiceMapping directory: %v", err)
+		return nil, fmt.Errorf("error reading generated files in ServiceMapping directory: %w", err)
 	}
 
 	serviceMappings := make(map[string]v1alpha1.ServiceMapping)
@@ -116,13 +116,13 @@ func fileToServiceMapping(filePath string) (*v1alpha1.ServiceMapping, error) {
 	file, err := generatedembed.Assets.Open(filePath)
 
 	if err != nil {
-		return nil, fmt.Errorf("error opening file '%v': %v", filePath, err)
+		return nil, fmt.Errorf("error opening file '%v': %w", filePath, err)
 	}
 	defer file.Close()
 
 	sm, err := readerToServiceMapping(file)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file '%v' to service mapping: %v", filePath, err)
+		return nil, fmt.Errorf("error reading file '%v' to service mapping: %w", filePath, err)
 	}
 	return sm, nil
 }
@@ -130,11 +130,11 @@ func fileToServiceMapping(filePath string) (*v1alpha1.ServiceMapping, error) {
 func readerToServiceMapping(r io.Reader) (*v1alpha1.ServiceMapping, error) {
 	bytes, err := io.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("error reading file: %v", err)
+		return nil, fmt.Errorf("error reading file: %w", err)
 	}
 	var sm v1alpha1.ServiceMapping
 	if err := yaml.Unmarshal(bytes, &sm); err != nil {
-		return nil, fmt.Errorf("error unmarshaling byte to service mapping: %v", err)
+		return nil, fmt.Errorf("error unmarshaling byte to service mapping: %w", err)
 	}
 	return &sm, nil
 }


### PR DESCRIPTION
Branching off from https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1186

Commits mostly cherry-picked for errorlint with some fixup.

This is mostly replacing a %v to %w directive where supported and getting around that where not.