### PR TITLE
chore:lint: enable go-vet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,7 @@ linters:
     # - goimports
     # - gosec
     # - gosimple
-    # - govet
+    - govet
     # - importas
     # - ineffassign
     # - misspell


### PR DESCRIPTION
Enables go-vet for golang-ci.

This should be free for us since we already run vet as part of make test:

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/09c6b365bb1e416e555f86f27011047e449e70dc/Makefile#L42