### PR TITLE
tests: remove extra lines from our golden cluster test

### DIFF
--- a/pkg/tf/serialization/testdata/cluster.golden.tf
+++ b/pkg/tf/serialization/testdata/cluster.golden.tf
@@ -94,10 +94,6 @@ resource "google_container_cluster" "foo" {
   project         = "my-project"
   release_channel = {}
 
-  resource_labels = {
-    managed-by-cnrm = "true"
-  }
-
   subnetwork = "projects/my-project/regions/us-central1/subnetworks/default"
 
   workload_identity_config {


### PR DESCRIPTION
This golden test was ignoring extra lines in the golden output.  We
want to move to a stricter comparison model; start by removing these
lines so that it can be clearer.
