### PR TITLE
Refactor: rewrite SplitYAML to be more conventional

### DIFF
--- a/operator/scripts/utils/yaml.go
+++ b/operator/scripts/utils/yaml.go
@@ -66,11 +66,16 @@ func SplitYAML(yamlBytes []byte) ([][]byte, error) {
 	r := bytes.NewReader(yamlBytes)
 	dec := goyaml.NewDecoder(r)
 	results := make([][]byte, 0)
-	var value map[string]interface{}
-	for eof := dec.Decode(&value); errors.Is(eof, io.EOF); eof = dec.Decode(&value) {
-		if eof != nil {
-			return nil, eof
+	for {
+		var value map[string]interface{}
+		err := dec.Decode(&value)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("error decoding yaml: %w", err)
 		}
+
 		bytes, err := goyaml.Marshal(value)
 		if err != nil {
 			return nil, fmt.Errorf("error marshalling '%v' to YAML: %w", value, err)


### PR DESCRIPTION
I think the behaviour here changes in the lint-fixes; refactor to
follow the normal pattern so this is more self-evident code.
