### PR TITLE
chore: don't use caching for go task in lint github action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21.5
+          cache: false # because of https://github.com/golangci/golangci-lint-action/issues/135
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:


### PR DESCRIPTION
This seems to cause double caching.

https://github.com/golangci/golangci-lint-action/issues/135
