### PR TITLE
e2e: activate aiplatform.googleapis.com in test projects

### DIFF
--- a/scripts/shared-vars-public.sh
+++ b/scripts/shared-vars-public.sh
@@ -31,6 +31,7 @@ KUSTOMIZE_VERSION=3.5.4
 # Supported GCP services API endpoints in Config Connector
 SUPPORTED_SERVICES=(
   accesscontextmanager.googleapis.com
+  aiplatform.googleapis.com
   alloydb.googleapis.com
   anthos.googleapis.com
   anthosaudit.googleapis.com


### PR DESCRIPTION
Needed for the vertexai tests.
