### PR TITLE
feat: pause resource actuation

### DIFF
--- a/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectorcontexts.yaml
+++ b/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectorcontexts.yaml
@@ -45,6 +45,16 @@ spec:
           spec:
             description: ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext
             properties:
+              actuationMode:
+                description: The actuation mode of Config Connector controls how resources
+                  are actuated onto the cloud provider. This can be either 'Reconciling'
+                  or 'Paused'. The default is 'Reconciling' where resources get actuated.
+                  In 'Paused', k8s resources are still reconciled with the api server
+                  but not actuated onto the cloud provider.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
               billingProject:
                 description: Specifies the project to use for preconditions, quota
                   and billing. Should only be used when requestProjectPolicy is set

--- a/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectors.yaml
+++ b/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectors.yaml
@@ -44,6 +44,19 @@ spec:
           spec:
             description: ConfigConnectorSpec defines the desired state of ConfigConnector
             properties:
+              actuationMode:
+                description: The actuation mode of Config Connector controls how resources
+                  are actuated onto the cloud provider. This can be either 'Reconciling'
+                  or 'Paused'. In 'Paused', k8s resources are still reconciled with
+                  the api server but not actuated onto the cloud provider. If Config
+                  Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext
+                  (CCC) takes precedence. If CCC doesn't define a value but ConfigConnecor
+                  (CC) does, we defer to that value. Otherwise, the default is 'Reconciling'
+                  where resources get actuated.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
               credentialSecretName:
                 description: The Kubernetes secret that contains the Google Service
                   Account Key's credentials to be used by ConfigConnector to authenticate

--- a/operator/pkg/apis/core/v1beta1/configconnector_types.go
+++ b/operator/pkg/apis/core/v1beta1/configconnector_types.go
@@ -40,6 +40,16 @@ type ConfigConnectorSpec struct {
 	// When in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.
 	//+kubebuilder:validation:Enum=cluster;namespaced
 	Mode string `json:"mode,omitempty"`
+
+	// The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+	// This can be either 'Reconciling' or 'Paused'.
+	// In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+	// If Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.
+	// If CCC doesn't define a value but ConfigConnecor (CC) does, we defer to that value. Otherwise,
+	// the default is 'Reconciling' where resources get actuated.
+	//+kubebuilder:validation:Enum=Reconciling;Paused
+	//+kubebuilder:validation:Optional
+	Actuation ActuationMode `json:"actuationMode,omitempty"`
 }
 
 // ConfigConnectorStatus defines the observed state of ConfigConnector

--- a/operator/pkg/apis/core/v1beta1/configconnectorcontext_types.go
+++ b/operator/pkg/apis/core/v1beta1/configconnectorcontext_types.go
@@ -54,6 +54,12 @@ type ConfigConnectorContextSpec struct {
 	//+kubebuilder:validation:Enum=absent;merge
 	//+kubebuilder:validation:Optional
 	StateIntoSpec *string `json:"stateIntoSpec,omitempty"`
+	// The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+	// This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
+	// In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+	//+kubebuilder:validation:Enum=Reconciling;Paused
+	//+kubebuilder:validation:Optional
+	Actuation ActuationMode `json:"actuationMode,omitempty"`
 }
 
 // ConfigConnectorContextStatus defines the observed state of ConfigConnectorContext

--- a/operator/pkg/apis/core/v1beta1/modes.go
+++ b/operator/pkg/apis/core/v1beta1/modes.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+// ActuationMode enum defines the possible actuation values that ConfigConnect (CC)
+// and ConfigConnectorContext (CCC) can specify.
+type ActuationMode string
+
+const (
+	Reconciling ActuationMode = "Reconciling"
+	Paused      ActuationMode = "Paused"
+)
+
+func DefaultActuationMode() ActuationMode {
+	return Reconciling
+}

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
+
 	tfprovider "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/tf/provider"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -31,7 +31,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
-
 	tfprovider "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/tf/provider"
 
 	corev1 "k8s.io/api/core/v1"
@@ -85,18 +84,18 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 		// the calls to AddToScheme(..) will modify the internal maps
 		opts.Scheme = runtime.NewScheme()
 	}
-	// Disable the cache. The cache causes problems in namespaced mode when trying
-	// to read resources in our system namespace.
-	opts.NewClient = nocache.NoCacheClientFunc
 	opts.BaseContext = func() context.Context {
 		return ctx
 	}
+	if err := addSchemes(opts.Scheme); err != nil {
+		return nil, fmt.Errorf("error adding schemes: %w", err)
+	}
+
+	// only cache CC and CCC resources
+	opts.Cache.ByObject = nocache.ByCCandCCC
 	mgr, err := manager.New(restConfig, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new manager: %w", err)
-	}
-	if err := addSchemes(mgr); err != nil {
-		return nil, err
 	}
 
 	// Bootstrap the Google Terraform provider
@@ -147,8 +146,7 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	return mgr, nil
 }
 
-func addSchemes(mgr manager.Manager) error {
-	scheme := mgr.GetScheme()
+func addSchemes(scheme *runtime.Scheme) error {
 	if err := corev1.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("error adding 'corev1' resources to the scheme: %w", err)
 	}

--- a/pkg/controller/kccmanager/nocache/clientbuilder.go
+++ b/pkg/controller/kccmanager/nocache/clientbuilder.go
@@ -15,11 +15,20 @@
 package nocache
 
 import (
+	opv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var NoCacheClientFunc = func(config *rest.Config, options client.Options) (client.Client, error) {
 	options.Cache = nil
 	return client.New(config, options)
+}
+
+// Fine grained cache controls for ConfigConnector and ConfigConnectorContext.
+var ByCCandCCC = map[client.Object]cache.ByObject{
+	&opv1beta1.ConfigConnector{}:        {},
+	&opv1beta1.ConfigConnectorContext{}: {},
 }

--- a/pkg/controller/mocktests/harness.go
+++ b/pkg/controller/mocktests/harness.go
@@ -126,8 +126,9 @@ func (h *Harness) WithObjects(initObjs ...*unstructured.Unstructured) {
 
 	k8s.RegisterType(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, "namespaces", meta.RESTScopeRoot)
 	k8s.RegisterType(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}, "secrets", meta.RESTScopeNamespace)
+	k8s.RegisterType(operatorv1beta1.ConfigConnectorGroupVersionKind, "configconnectors", meta.RESTScopeRoot)
+	k8s.RegisterType(operatorv1beta1.ConfigConnectorContextGroupVersionKind, "configconnectorcontexts", meta.RESTScopeNamespace)
 
-	k8s.RegisterType(schema.GroupVersionKind{Group: "core.cnrm.cloud.google.com", Version: "v1beta1", Kind: "ConfigConnectorContext"}, "configconnectorcontexts", meta.RESTScopeNamespace)
 	smLoader, err := servicemappingloader.New()
 	if err != nil {
 		h.Fatalf("error getting new service mapping loader: %v", err)

--- a/pkg/controller/resourceactuation/resourceactuation.go
+++ b/pkg/controller/resourceactuation/resourceactuation.go
@@ -15,13 +15,73 @@
 package resourceactuation
 
 import (
+	"context"
 	"fmt"
 
+	opv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	opk8s "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/reconciliationinterval"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// FetchLiveKCCState tries to fetch the ConfigConnector (CC) resource and the ConfigConnectorContext (CCC)
+// for the resource's namespace if running in Namespaced mode. It ignores not found errors for CC fetching
+// but errors out if KCC is running in Namespaced mode and no CCC is found for the namespace of the resource.
+func FetchLiveKCCState(ctx context.Context, c client.Client, resourceNN types.NamespacedName) (opv1beta1.ConfigConnector, opv1beta1.ConfigConnectorContext, error) {
+	var cc opv1beta1.ConfigConnector
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      opk8s.ConfigConnectorAllowedName,
+		Namespace: k8s.SystemNamespace,
+	}, &cc); err != nil {
+		if apierrors.IsNotFound(err) {
+			// if no CC exists, then by definition, KCC cannot be running in namespaced mode;
+			return opv1beta1.ConfigConnector{}, opv1beta1.ConfigConnectorContext{}, nil
+		}
+		return opv1beta1.ConfigConnector{}, opv1beta1.ConfigConnectorContext{}, err
+	}
+
+	if cc.Spec.Mode == opk8s.NamespacedMode {
+		var ccc opv1beta1.ConfigConnectorContext
+		if err := c.Get(ctx, types.NamespacedName{
+			Name:      opk8s.ConfigConnectorContextAllowedName,
+			Namespace: resourceNN.Namespace,
+		}, &ccc); err != nil {
+
+			// this should not happen but if we attempt to actuate a resource
+			// AND we are running in namespaced mode, not finding a CCC in that namespace
+			// is an error in the assumptions that KCC has (i.e. that there is a CCC defined
+			// that actively manages resources in that namespace).
+			return cc, opv1beta1.ConfigConnectorContext{}, err
+		}
+		return cc, ccc, nil
+	}
+
+	return cc, opv1beta1.ConfigConnectorContext{}, nil
+}
+
+// DecideActuationMode looks at CC and CCC to see if they specify an actuationMode.
+// - If both CC & CCC specify a actuationMode in Namespaced mode, we defer to the CCC's value.
+//   - If only CC specifies a actuationMode in Namespaced mode, we defer to the CC's value.
+//
+// - If both CC & CCC specify an actuationMode in cluster mode, the CCC specification is irrelevant.
+// - If neither CC nor CCC specify a actuationMode, we defer to the default value defined in apis.
+func DecideActuationMode(cc opv1beta1.ConfigConnector, ccc opv1beta1.ConfigConnectorContext) opv1beta1.ActuationMode {
+	if ccc.Spec.Actuation != "" && cc.Spec.Mode == opk8s.NamespacedMode {
+		return ccc.Spec.Actuation
+	}
+
+	// if no CCC exists or doesn't define a value, defer to the CC's value.
+	if cc.Spec.Actuation != "" {
+		return cc.Spec.Actuation
+	}
+
+	return opv1beta1.DefaultActuationMode()
+}
 
 // ShouldSkip skips a resource actuatation if the ReconcileIntervalInSecondsAnnotation = 0 and the KRM resource has not changed since its last UpToDate.
 // This will disable drift correction on corresponding GCP resources since the reconcileInterval is set to 0.

--- a/pkg/controller/resourceactuation/resourceactuation_test.go
+++ b/pkg/controller/resourceactuation/resourceactuation_test.go
@@ -18,11 +18,80 @@ import (
 	"strconv"
 	"testing"
 
+	opv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	opk8s "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourceactuation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestDecideActuationMode(t *testing.T) {
+	tests := []struct {
+		name                  string
+		cc                    opv1beta1.ConfigConnector
+		ccc                   opv1beta1.ConfigConnectorContext
+		expectedActuationMode opv1beta1.ActuationMode
+	}{
+		{
+			name: "both CC and CCC specify actuationMode in namespaced mode: defer to CCC",
+			cc: opv1beta1.ConfigConnector{
+				Spec: opv1beta1.ConfigConnectorSpec{
+					Mode:      opk8s.NamespacedMode,
+					Actuation: opv1beta1.Reconciling,
+				},
+			},
+			ccc: opv1beta1.ConfigConnectorContext{
+				Spec: opv1beta1.ConfigConnectorContextSpec{
+					Actuation: opv1beta1.Paused,
+				},
+			},
+			expectedActuationMode: opv1beta1.Paused,
+		},
+		{
+			name: "only CC specifies in namespaced mode: Use CC",
+			cc: opv1beta1.ConfigConnector{
+				Spec: opv1beta1.ConfigConnectorSpec{
+					Mode:      opk8s.NamespacedMode,
+					Actuation: opv1beta1.Paused,
+				},
+			},
+			ccc: opv1beta1.ConfigConnectorContext{
+				Spec: opv1beta1.ConfigConnectorContextSpec{},
+			},
+			expectedActuationMode: opv1beta1.Paused,
+		},
+		{
+			name: "both CC and CCC specify an actuationMode in cluster mode: ignore CCC",
+			cc: opv1beta1.ConfigConnector{
+				Spec: opv1beta1.ConfigConnectorSpec{
+					Mode:      opk8s.ClusterMode,
+					Actuation: opv1beta1.Reconciling,
+				},
+			},
+			ccc: opv1beta1.ConfigConnectorContext{
+				Spec: opv1beta1.ConfigConnectorContextSpec{
+					Actuation: opv1beta1.Paused,
+				},
+			},
+			expectedActuationMode: opv1beta1.Reconciling,
+		},
+		{
+			name:                  "neither CC nor CCC specify an actuationMode: Use default",
+			cc:                    opv1beta1.ConfigConnector{},
+			ccc:                   opv1beta1.ConfigConnectorContext{},
+			expectedActuationMode: opv1beta1.Reconciling,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualMode := resourceactuation.DecideActuationMode(test.cc, test.ccc)
+			if test.expectedActuationMode != actualMode {
+				t.Errorf("DecideActuationMode failed; got %v, want %v", actualMode, test.expectedActuationMode)
+			}
+		})
+	}
+}
 
 func TestShouldSkip(t *testing.T) {
 	testcases := []struct {


### PR DESCRIPTION
This PR proposes a way to support a `pause` mode for KCC. In particular, it adds new fields in the CC/ CCC specs to support an `actuationMode`. These values are then consumed before we actuate the GCP resources: see the tf controller.

Work that will come as separate PR(s)
- dcl (or direct) controller support for pausing actuation
- docs changes
- sone higher level e2e tests using golden logs

Abandoned ideas
- having a fully fledged simple reconciler for CC/ CCC to watch the resources and keep track of the `actuationMode` values

Renaming
- the `actuationMode` war originally `actuationAction` then `reconciliationMode`.