### PR TITLE
refactor:chore:lint missed err wrap

### DIFF
--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -172,7 +172,7 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 		r.log.Info("error getting ConfigConnector object", "name", nn.Name, "reconcile error", reconcileErr)
 		return fmt.Errorf("error getting ConfigConnector object %v: %w", nn.Name, err)
 	}
-	msg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
+	msg := fmt.Errorf("error during reconciliation: %w", reconcileErr).Error()
 	r.recordEvent(cc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
 	cc.SetCommonStatus(v1alpha1.CommonStatus{
 		Healthy: false,

--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -172,7 +172,7 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 		r.log.Info("error getting ConfigConnector object", "name", nn.Name, "reconcile error", reconcileErr)
 		return fmt.Errorf("error getting ConfigConnector object %v: %w", nn.Name, err)
 	}
-	msg := fmt.Sprintf(k8s.ReconcileErrMsgTmpl, reconcileErr)
+	msg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
 	r.recordEvent(cc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
 	cc.SetCommonStatus(v1alpha1.CommonStatus{
 		Healthy: false,

--- a/operator/pkg/controllers/configconnector/configconnector_controller_test.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller_test.go
@@ -83,7 +83,7 @@ func TestHandleReconcileFailed(t *testing.T) {
 		t.Errorf("error handling failed reconciliation: %v", err)
 	}
 
-	expectedErrMsg := fmt.Sprintf(k8s.ReconcileErrMsgTmpl, reconcileErr)
+	expectedErrMsg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
 	mockEventRecorder.AssertEventRecorded(kind, nn, v1.EventTypeWarning, k8s.UpdateFailed, expectedErrMsg)
 
 	newCC := &corev1beta1.ConfigConnector{}

--- a/operator/pkg/controllers/configconnector/configconnector_controller_test.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller_test.go
@@ -83,7 +83,7 @@ func TestHandleReconcileFailed(t *testing.T) {
 		t.Errorf("error handling failed reconciliation: %v", err)
 	}
 
-	expectedErrMsg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
+	expectedErrMsg := "error during reconciliation: reconciliation error"
 	mockEventRecorder.AssertEventRecorded(kind, nn, v1.EventTypeWarning, k8s.UpdateFailed, expectedErrMsg)
 
 	newCC := &corev1beta1.ConfigConnector{}

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -176,7 +176,7 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 		return fmt.Errorf("error getting ConfigConnectorContext object %v/%v: %w", nn.Namespace, nn.Name, err)
 	}
 
-	msg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
+	msg := fmt.Errorf("error during reconciliation: %w", reconcileErr).Error()
 	r.recorder.Event(ccc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
 	r.log.Info("surfacing error messages in status...", "namespace", nn.Namespace, "name", nn.Name, "error", msg)
 	ccc.SetCommonStatus(v1alpha1.CommonStatus{

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -176,7 +176,7 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 		return fmt.Errorf("error getting ConfigConnectorContext object %v/%v: %w", nn.Namespace, nn.Name, err)
 	}
 
-	msg := fmt.Sprintf(k8s.ReconcileErrMsgTmpl, reconcileErr)
+	msg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
 	r.recorder.Event(ccc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
 	r.log.Info("surfacing error messages in status...", "namespace", nn.Namespace, "name", nn.Name, "error", msg)
 	ccc.SetCommonStatus(v1alpha1.CommonStatus{

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
@@ -573,7 +573,7 @@ func TestHandleReconcileFailed(t *testing.T) {
 		t.Errorf("error handling failed reconciliation: %v", err)
 	}
 
-	expectedErrMsg := fmt.Sprintf(k8s.ReconcileErrMsgTmpl, reconcileErr)
+	expectedErrMsg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
 	mockEventRecorder.AssertEventRecorded(kind, nn, v1.EventTypeWarning, k8s.UpdateFailed, expectedErrMsg)
 
 	newCCC := &corev1beta1.ConfigConnectorContext{}

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
@@ -573,7 +573,7 @@ func TestHandleReconcileFailed(t *testing.T) {
 		t.Errorf("error handling failed reconciliation: %v", err)
 	}
 
-	expectedErrMsg := fmt.Errorf(k8s.ReconcileErrMsgTmpl, reconcileErr).Error()
+	expectedErrMsg := "error during reconciliation: reconciliation error"
 	mockEventRecorder.AssertEventRecorded(kind, nn, v1.EventTypeWarning, k8s.UpdateFailed, expectedErrMsg)
 
 	newCCC := &corev1beta1.ConfigConnectorContext{}

--- a/operator/pkg/k8s/constants.go
+++ b/operator/pkg/k8s/constants.go
@@ -45,7 +45,6 @@ const (
 	UpToDate                             = "UpToDate"
 	UpToDateMessage                      = "ConfigConnector is up to date"
 	UpdateFailed                         = "UpdateFailed"
-	ReconcileErrMsgTmpl                  = "error during reconciliation: %w"
 	ControllerManagerService             = "cnrm-manager"
 	NamespacedManagerServicePrefix       = "cnrm-manager-"
 	NamespacedManagerServiceTmpl         = "cnrm-manager-${NAMESPACE?}"

--- a/operator/pkg/k8s/constants.go
+++ b/operator/pkg/k8s/constants.go
@@ -45,7 +45,7 @@ const (
 	UpToDate                             = "UpToDate"
 	UpToDateMessage                      = "ConfigConnector is up to date"
 	UpdateFailed                         = "UpdateFailed"
-	ReconcileErrMsgTmpl                  = "error during reconciliation: %v"
+	ReconcileErrMsgTmpl                  = "error during reconciliation: %w"
 	ControllerManagerService             = "cnrm-manager"
 	NamespacedManagerServicePrefix       = "cnrm-manager-"
 	NamespacedManagerServiceTmpl         = "cnrm-manager-${NAMESPACE?}"


### PR DESCRIPTION
Small err wrap that fooled the errorlint linter. Although if it did fool it, not sure we should fix it 😝 .