### PR TITLE
chore:ci: bump golangci-lint and add make target

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54.1 # should match the version in Makefile
+          version: v1.54.2 # should match the version in Makefile

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ensure:
 
 # Should run all needed commands before any PR is sent out.
 .PHONY: ready-pr
-ready-pr: manifests resource-docs generate-go-client
+ready-pr: lint manifests resource-docs generate-go-client
 
 # Upgrades dcl dependencies
 .PHONY: upgrade-dcl

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ UNMANAGED_DETECTOR_IMG ?= gcr.io/${PROJECT_ID}/unmanageddetector:${SHORT_SHA}
 GOLANGCI_LINT_CACHE := $(shell pwd)/.tmp/golangci-lint
 # When updating this, make sure to update the corresponding action in
 # ./github/workflows/lint.yaml
-GOLANGCI_LINT_VERSION := v1.54.1
+GOLANGCI_LINT_VERSION := v1.54.2
 
 # Use Docker BuildKit when building images to allow usage of 'setcap' in
 # multi-stage builds (https://github.com/moby/moby/issues/38132)


### PR DESCRIPTION
It seems that 1.54.1 had one issue with handling non existing VCS information for binaries. 1.54.2 fixes that. I'm also adding the `lint` target as a required for `ready-pr` so devs get an early signal if there's an issue.