### PR TITLE
logging: log to configured logger when registering controller

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -560,6 +560,7 @@ func filterLogs(log logr.Logger) logr.Logger {
 	f := &filterSink{sink: log.GetSink()}
 	f.IgnoreMessages = sets.New[string]()
 	f.IgnoreMessages.Insert("Registered controller")
+	f.IgnoreMessages.Insert("Registered deletion-defender controller")
 	f.IgnoreMessages.Insert("Starting Controller")
 	f.IgnoreMessages.Insert("Starting EventSource")
 	f.IgnoreMessages.Insert("Starting workers")

--- a/pkg/controller/deletiondefender/controller.go
+++ b/pkg/controller/deletiondefender/controller.go
@@ -72,7 +72,8 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition) error
 	if err != nil {
 		return fmt.Errorf("error creating new controller: %w", err)
 	}
-	logger.Info("Registered controller", "kind", kind, "apiVersion", apiVersion)
+	log := mgr.GetLogger()
+	log.Info("Registered deletion-defender controller", "kind", kind, "apiVersion", apiVersion)
 	return nil
 }
 

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -103,7 +103,8 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, provi
 	if err != nil {
 		return nil, fmt.Errorf("error creating new controller: %w", err)
 	}
-	logger.Info("Registered controller", "kind", kind, "apiVersion", apiVersion)
+	log := mgr.GetLogger()
+	log.Info("Registered controller", "kind", kind, "apiVersion", apiVersion)
 	return r, nil
 }
 


### PR DESCRIPTION
This should hopefully allow us to filter these messages in testing,
and it is also a step towards using the more coherent context-aware
logging introduced over the years.
