### PR TITLE
mockgcp: fix a few more extra-wrappings of errors

### DIFF
--- a/mockgcp/mockapikeys/key.go
+++ b/mockgcp/mockapikeys/key.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	longrunning "google.golang.org/genproto/googleapis/longrunning"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -85,7 +83,7 @@ func (s *APIKeysV2) CreateKey(ctx context.Context, req *pb.CreateKeyRequest) (*l
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating key: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockbilling/billingv1.go
+++ b/mockgcp/mockbilling/billingv1.go
@@ -83,7 +83,7 @@ func (s *BillingV1) UpdateProjectBillingInfo(ctx context.Context, req *pb.Update
 	obj.ProjectId = projectName.ProjectID
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating projectBillingInfo: %v", err)
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mockcertificatemanager/v1.go
+++ b/mockgcp/mockcertificatemanager/v1.go
@@ -60,7 +60,7 @@ func (s *CertificateManagerV1) CreateCertificate(ctx context.Context, req *pb.Cr
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating certificate: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)
@@ -150,7 +150,7 @@ func (s *CertificateManagerV1) CreateCertificateMap(ctx context.Context, req *pb
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating certificate map: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)
@@ -239,7 +239,7 @@ func (s *CertificateManagerV1) CreateDnsAuthorization(ctx context.Context, req *
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating dns authorization: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)
@@ -329,7 +329,7 @@ func (s *CertificateManagerV1) CreateCertificateMapEntry(ctx context.Context, re
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating certificate map entry: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockcloudfunctions/v1.go
+++ b/mockgcp/mockcloudfunctions/v1.go
@@ -59,7 +59,7 @@ func (s *CloudFunctionsV1) CreateFunction(ctx context.Context, req *pb.CreateFun
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating function: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockcompute/disksv1.go
+++ b/mockgcp/mockcompute/disksv1.go
@@ -100,7 +100,7 @@ func (s *DisksV1) Update(ctx context.Context, req *pb.UpdateDiskRequest) (*pb.Op
 	proto.Merge(obj, req.GetDiskResource())
 
 	if err := s.storage.Update(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error updating disk: %v", err)
+		return nil, err
 	}
 
 	return s.newLRO(ctx, name.Project.ID)

--- a/mockgcp/mockcompute/networksv1.go
+++ b/mockgcp/mockcompute/networksv1.go
@@ -66,7 +66,7 @@ func (s *NetworksV1) Insert(ctx context.Context, req *pb.InsertNetworkRequest) (
 	obj.Kind = PtrTo("compute#network")
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating network: %v", err)
+		return nil, err
 	}
 
 	return s.newLRO(ctx, name.Project.ID)

--- a/mockgcp/mockcompute/regiondisksv1.go
+++ b/mockgcp/mockcompute/regiondisksv1.go
@@ -100,7 +100,7 @@ func (s *RegionalDisksV1) Update(ctx context.Context, req *pb.UpdateRegionDiskRe
 	proto.Merge(obj, req.GetDiskResource())
 
 	if err := s.storage.Update(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error updating disk: %v", err)
+		return nil, err
 	}
 
 	return s.newLRO(ctx, name.Project.ID)

--- a/mockgcp/mockcompute/subnetsv1.go
+++ b/mockgcp/mockcompute/subnetsv1.go
@@ -64,7 +64,7 @@ func (s *SubnetsV1) Insert(ctx context.Context, req *pb.InsertSubnetworkRequest)
 	obj.Kind = PtrTo("compute#subsubnet")
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating subnet: %v", err)
+		return nil, err
 	}
 
 	return s.newLRO(ctx, name.Project.ID)

--- a/mockgcp/mockedgecontainer/cluster.go
+++ b/mockgcp/mockedgecontainer/cluster.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	"google.golang.org/genproto/googleapis/longrunning"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/edgecontainer/v1"
@@ -53,7 +51,7 @@ func (s *EdgeContainerV1) CreateCluster(ctx context.Context, req *pb.CreateClust
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating cluster: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockedgecontainer/nodepool.go
+++ b/mockgcp/mockedgecontainer/nodepool.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	"google.golang.org/genproto/googleapis/longrunning"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/edgecontainer/v1"
@@ -53,7 +51,7 @@ func (s *EdgeContainerV1) CreateNodePool(ctx context.Context, req *pb.CreateNode
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating nodePool: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockedgenetwork/network.go
+++ b/mockgcp/mockedgenetwork/network.go
@@ -58,7 +58,7 @@ func (s *EdgenetworkV1) CreateNetwork(ctx context.Context, req *pb.CreateNetwork
 	}
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating network: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockedgenetwork/subnet.go
+++ b/mockgcp/mockedgenetwork/subnet.go
@@ -59,7 +59,7 @@ func (s *EdgenetworkV1) CreateSubnet(ctx context.Context, req *pb.CreateSubnetRe
 	}
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating subnet: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockgkemulticloud/attachedcluster.go
+++ b/mockgcp/mockgkemulticloud/attachedcluster.go
@@ -59,7 +59,7 @@ func (s *GKEMulticloudV1) CreateAttachedCluster(ctx context.Context, req *pb.Cre
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating attachedCluster: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockiam/serviceaccounts.go
+++ b/mockgcp/mockiam/serviceaccounts.go
@@ -123,7 +123,7 @@ func (s *ServerV1) CreateServiceAccount(ctx context.Context, req *pb.CreateServi
 
 	fqn := name.String()
 	if err := s.storage.Create(ctx, fqn, sa); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating serviceaccount: %v", err)
+		return nil, err
 	}
 
 	return sa, nil

--- a/mockgcp/mocknetworkservices/networkservices.go
+++ b/mockgcp/mocknetworkservices/networkservices.go
@@ -62,7 +62,7 @@ func (s *NetworkServicesServer) CreateMesh(ctx context.Context, req *pb.CreateMe
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating mesh: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockprivateca/capool.go
+++ b/mockgcp/mockprivateca/capool.go
@@ -59,7 +59,7 @@ func (s *PrivateCAV1) CreateCaPool(ctx context.Context, req *pb.CreateCaPoolRequ
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating caPool: %v", err)
+		return nil, err
 	}
 
 	return s.operations.NewLRO(ctx)

--- a/mockgcp/mockresourcemanager/projects_internal.go
+++ b/mockgcp/mockresourcemanager/projects_internal.go
@@ -205,7 +205,7 @@ func (s *ProjectsInternal) mutateProject(ctx context.Context, name string, mutat
 
 	obj, err := s.projectsInternal.tryGetProject(ctx, projectName)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error reading project: %v", err)
+		return nil, err
 	}
 	if obj == nil {
 		return nil, status.Error(codes.PermissionDenied, "permission denied")

--- a/mockgcp/mockresourcemanager/tagkeys.go
+++ b/mockgcp/mockresourcemanager/tagkeys.go
@@ -100,7 +100,7 @@ func (s *TagKeys) CreateTagKey(ctx context.Context, req *pb.CreateTagKeyRequest)
 	obj.Name = fqn
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating tagKey: %v", err)
+		return nil, err
 	}
 
 	metadata := &pb.CreateTagKeyMetadata{}
@@ -145,7 +145,7 @@ func (s *TagKeys) UpdateTagKey(ctx context.Context, req *pb.UpdateTagKeyRequest)
 	}
 
 	if err := s.storage.Update(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error updating tagKey: %v", err)
+		return nil, err
 	}
 
 	metadata := &pb.UpdateTagKeyMetadata{}

--- a/mockgcp/mocksecretmanager/secrets.go
+++ b/mockgcp/mocksecretmanager/secrets.go
@@ -71,7 +71,7 @@ func (s *SecretsV1) CreateSecret(ctx context.Context, req *pb.CreateSecretReques
 	}
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
-		return nil, status.Errorf(codes.Internal, "error creating secret: %v", err)
+		return nil, err
 	}
 
 	return obj, nil

--- a/mockgcp/mocksecretmanager/secretversions.go
+++ b/mockgcp/mocksecretmanager/secretversions.go
@@ -127,7 +127,7 @@ func (s *SecretsV1) AddSecretVersion(ctx context.Context, req *pb.AddSecretVersi
 	if err := s.storage.Create(ctx, secretVersionObj.Name, secretVersionObj); err != nil {
 		// TODO: Delete secret data?
 		// TODO: Owner ref?
-		return nil, status.Errorf(codes.Internal, "error creating secret version: %v", err)
+		return nil, err
 	}
 	klog.Infof("created SecretManagerSecretVersion %v", secretVersionObj.Name)
 

--- a/mockgcp/mockserviceusage/serviceusagev1.go
+++ b/mockgcp/mockserviceusage/serviceusagev1.go
@@ -68,7 +68,7 @@ func (s *ServiceUsageV1) EnableService(ctx context.Context, req *pb.EnableServic
 		}
 
 		if err := s.storage.Create(ctx, fqn, service); err != nil {
-			return nil, status.Errorf(codes.Internal, "error creating service: %v", err)
+			return nil, err
 		}
 
 		return s.operations.NewLRO(ctx)


### PR DESCRIPTION
Errors from storage Create/Update should not be wrapped.
