### PR TITLE
chore: avoid errors.Is, replace with IsFoo

### DIFF
--- a/pkg/controller/lifecyclehandler/handler.go
+++ b/pkg/controller/lifecyclehandler/handler.go
@@ -16,7 +16,6 @@ package lifecyclehandler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
@@ -185,11 +184,11 @@ func CausedByUnresolvableDeps(err error) (unwrappedErr error, ok bool) { //nolin
 
 func reasonForUnresolvableDeps(err error) (string, error) {
 	switch {
-	case errors.Is(err, &k8s.ReferenceNotReadyError{}) || errors.Is(err, &k8s.TransitiveDependencyNotReadyError{}):
+	case k8s.IsReferenceNotReadyError(err) || k8s.IsTransitiveDependencyNotReadyError(err):
 		return k8s.DependencyNotReady, nil
-	case errors.Is(err, &k8s.ReferenceNotFoundError{}) || errors.Is(err, &k8s.SecretNotFoundError{}) || errors.Is(err, &k8s.TransitiveDependencyNotFoundError{}):
+	case k8s.IsReferenceNotFoundError(err) || k8s.IsSecretNotFoundError(err) || k8s.IsTransitiveDependencyNotFoundError(err):
 		return k8s.DependencyNotFound, nil
-	case errors.Is(err, &k8s.KeyInSecretNotFoundError{}):
+	case k8s.IsKeyInSecretNotFoundError(err):
 		return k8s.DependencyInvalid, nil
 	default:
 		return "", fmt.Errorf("unrecognized error caused by unresolvable dependencies: %w", err)

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -52,6 +52,11 @@ func AsReferenceNotReadyError(err error) (unwrappedErr *ReferenceNotReadyError, 
 	return unwrappedErr, ok
 }
 
+func IsReferenceNotReadyError(err error) bool {
+	_, ok := AsReferenceNotReadyError(err)
+	return ok
+}
+
 type ReferenceNotFoundError struct {
 	RefResourceGVK schema.GroupVersionKind
 	RefResource    types.NamespacedName
@@ -72,14 +77,14 @@ func NewReferenceNotFoundErrorForResource(r *Resource) *ReferenceNotFoundError {
 	}
 }
 
-func IsReferenceNotFoundError(err error) bool {
-	_, ok := AsReferenceNotFoundError(err)
-	return ok
-}
-
 func AsReferenceNotFoundError(err error) (unwrappedErr *ReferenceNotFoundError, ok bool) {
 	ok = errors.As(err, &unwrappedErr)
 	return unwrappedErr, ok
+}
+
+func IsReferenceNotFoundError(err error) bool {
+	_, ok := AsReferenceNotFoundError(err)
+	return ok
 }
 
 type SecretNotFoundError struct {
@@ -97,6 +102,11 @@ func NewSecretNotFoundError(secret types.NamespacedName) *SecretNotFoundError {
 func AsSecretNotFoundError(err error) (unwrappedErr *SecretNotFoundError, ok bool) {
 	ok = errors.As(err, &unwrappedErr)
 	return unwrappedErr, ok
+}
+
+func IsSecretNotFoundError(err error) bool {
+	_, ok := AsSecretNotFoundError(err)
+	return ok
 }
 
 type KeyInSecretNotFoundError struct {
@@ -117,6 +127,11 @@ func AsKeyInSecretNotFoundError(err error) (unwrappedErr *KeyInSecretNotFoundErr
 	return unwrappedErr, ok
 }
 
+func IsKeyInSecretNotFoundError(err error) bool {
+	_, ok := AsKeyInSecretNotFoundError(err)
+	return ok
+}
+
 type TransitiveDependencyNotFoundError struct {
 	ResourceGVK schema.GroupVersionKind
 	Resource    types.NamespacedName
@@ -135,6 +150,11 @@ func AsTransitiveDependencyNotFoundError(err error) (unwrappedErr *TransitiveDep
 	return unwrappedErr, ok
 }
 
+func IsTransitiveDependencyNotFoundError(err error) bool {
+	_, ok := AsTransitiveDependencyNotFoundError(err)
+	return ok
+}
+
 type TransitiveDependencyNotReadyError struct {
 	ResourceGVK schema.GroupVersionKind
 	Resource    types.NamespacedName
@@ -151,6 +171,11 @@ func NewTransitiveDependencyNotReadyError(resourceGVK schema.GroupVersionKind, r
 func AsTransitiveDependencyNotReadyError(err error) (unwrappedErr *TransitiveDependencyNotReadyError, ok bool) {
 	ok = errors.As(err, &unwrappedErr)
 	return unwrappedErr, ok
+}
+
+func IsTransitiveDependencyNotReadyError(err error) bool {
+	_, ok := AsTransitiveDependencyNotReadyError(err)
+	return ok
 }
 
 type ServerGeneratedIDNotFoundError struct {


### PR DESCRIPTION
errors.Is performs an equality check, which is not normally what we want.
