### PR TITLE
chore:ci: further lint errors.is

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ on:
 permissions: read-all
 jobs:
   lint:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-22.04
     timeout-minutes: 7
     steps:
@@ -45,3 +45,19 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: v1.54.2 # should match the version in Makefile
+  handlint:
+    name: repo specific linters
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.5
+      - name: Run errors.is equality linter
+        run: |
+           ./scripts/linters/lint_errors_is.sh

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ fmt:
 
 .PHONY: lint
 lint:
+	./scripts/linters/lint_errors_is.sh
 	docker run --rm -v $(shell pwd):/app \
 		-v ${GOLANGCI_LINT_CACHE}:/root/.cache/golangci-lint \
 		-w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine \

--- a/scripts/linters/lint_errors_is.sh
+++ b/scripts/linters/lint_errors_is.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -o errexit
+set -o nounset
+set -o pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if grep -rInH "errors.Is" --include=\*.go --exclude-dir={third_party,.tmp,.build,bin} . | grep "{}"; then
+  printf "\n\nERROR: errors.Is is not used correctly\n"
+  exit 1
+fi
+
+echo "errors.Is is used correctly"


### PR DESCRIPTION
Inspired from https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1306, I hand rolled a check to make sure we don't use `errors.Is` on a "empty" error struct.