### PR TITLE
Set displayName to be mutable-but-unreadable in AlloyDBCluster

### DIFF
--- a/config/servicemappings/alloydb.yaml
+++ b/config/servicemappings/alloydb.yaml
@@ -69,6 +69,7 @@ spec:
         targetField: cluster_id
       mutableButUnreadableFields:
         - initial_user
+        - display_name
       hierarchicalReferences:
         - type: project
           key: projectRef

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
@@ -17,17 +17,15 @@ kind: AlloyDBCluster
 metadata:
   name: alloydbcluster-${uniqueId}
 spec:
+  displayName: test alloydb cluster
   location: us-central1
   networkConfig:
     networkRef: 
       name: default
- 
   projectRef:
     external: ${projectId}
-
   initialUser:
     user: postgres
     password:
       value: postgres
-
   resourceID: alloydbcluster${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/dependencies.yaml
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#apiVersion: compute.cnrm.cloud.google.com/v1beta1
-#kind: ComputeNetwork
-#metadata:
-#  name: computenetwork-${uniqueId}
-#spec:
-#  resourceID: computenetwork${uniqueId}
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
@@ -17,11 +17,11 @@ kind: AlloyDBCluster
 metadata:
   name: alloydbcluster-${uniqueId}
 spec:
+  displayName: test alloydb cluster 2
   location: us-central1
   networkConfig:
     networkRef: 
       name: default
-
   projectRef:
     external: ${projectId}
   automatedBackupPolicy:

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/alloydb/resource_alloydb_cluster.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/alloydb/resource_alloydb_cluster.go
@@ -721,9 +721,16 @@ func resourceAlloydbClusterRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("network_config", flattenAlloydbClusterNetworkConfig(res["networkConfig"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Cluster: %s", err)
 	}
-	if err := d.Set("display_name", flattenAlloydbClusterDisplayName(res["displayName"], d, config)); err != nil {
-		return fmt.Errorf("Error reading Cluster: %s", err)
-	}
+	// Comment out the reading of the "display_name" field until the returned
+	// "displayName" contains the correct display name value.
+	// The returned "displayName" here is always an empty string so it is an
+	// incorrect reflection of the live state.
+	// Commenting it out so Config Connector can treat "displayName" as a
+	// mutable-but-unreadable field to correctly populate the value of it.
+	//
+	//if err := d.Set("display_name", flattenAlloydbClusterDisplayName(res["displayName"], d, config)); err != nil {
+	//	return fmt.Errorf("Error reading Cluster: %s", err)
+	//}
 	if err := d.Set("database_version", flattenAlloydbClusterDatabaseVersion(res["databaseVersion"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Cluster: %s", err)
 	}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/308185711

Make `spec.displayName` mutable-but-unreadable to work around the always empty displayName in AlloyDBCluster.

Diffbase: #1395 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Added `spec.displayName` in testdata for basicalloydbcluster and ran the following command:

`go test -timeout 1200s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests basicalloydbcluster`

It passed.