### PR TITLE
[WIP] Test SQLInstance after sensitive fields are not populated.

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -238,6 +238,8 @@ func validateCreate(ctx context.Context, t *testing.T, testContext testrunner.Te
 	if err := kubeClient.Get(ctx, testContext.NamespacedName, reconciledUnstruct); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
+
+	t.Logf("created resource unstructured \n%+v\r", reconciledUnstruct)
 	gcpUnstruct, err := resourceContext.Get(ctx, t, reconciledUnstruct, systemContext.TFProvider, kubeClient, systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter)
 	if err != nil {
 		t.Fatalf("unexpected error when GETting '%v': %v", initialUnstruct.GetName(), err)
@@ -367,11 +369,14 @@ func testUpdate(ctx context.Context, t *testing.T, testContext testrunner.TestCo
 		t.Fatalf("unexpected generation increase %v", generationIncrease)
 	}
 
+	t.Logf("updated resource unstructured \n%+v\r", reconciledUnstruct)
+
 	// Check labels match on update
 	gcpUnstruct, err := resourceContext.Get(ctx, t, reconciledUnstruct, systemContext.TFProvider, kubeClient, systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter)
 	if err != nil {
 		t.Fatalf("unexpected error when GETting '%v': %v", updateUnstruct.GetName(), err)
 	}
+	t.Logf("updated resource is %v\r", gcpUnstruct)
 	if resourceContext.SupportsLabels(systemContext.SMLoader) {
 		testcontroller.AssertLabelsMatchAndHaveManagedLabel(t, gcpUnstruct.GetLabels(), testContext.UpdateUnstruct.GetLabels())
 	}
@@ -529,9 +534,9 @@ func testReconcileCreateNoChangeUpdateDelete(ctx context.Context, t *testing.T, 
 	resourceCleanup := systemContext.Reconciler.BuildCleanupFunc(ctx, testContext.CreateUnstruct, getResourceCleanupPolicy())
 	defer resourceCleanup()
 	testCreate(ctx, t, testContext, systemContext, resourceContext)
-	testNoChange(ctx, t, testContext, systemContext, resourceContext)
+	//testNoChange(ctx, t, testContext, systemContext, resourceContext)
 	testUpdate(ctx, t, testContext, systemContext, resourceContext)
-	testDriftCorrection(ctx, t, testContext, systemContext, resourceContext)
+	//testDriftCorrection(ctx, t, testContext, systemContext, resourceContext)
 	testDelete(ctx, t, testContext, systemContext, resourceContext)
 }
 

--- a/pkg/krmtotf/tftokrm.go
+++ b/pkg/krmtotf/tftokrm.go
@@ -520,6 +520,9 @@ func convertTFMapToKCCMap(state map[string]interface{}, prevSpec map[string]inte
 					continue
 				}
 				if tfresource.IsSensitiveConfigurableField(schema) {
+					if rc.Name == "google_sql_database_instance" {
+						continue
+					}
 					val := stateVal.(string)
 					ret[key] = corekccv1alpha1.SensitiveField{
 						Value: &val,

--- a/pkg/krmtotf/tftokrm.go
+++ b/pkg/krmtotf/tftokrm.go
@@ -520,7 +520,10 @@ func convertTFMapToKCCMap(state map[string]interface{}, prevSpec map[string]inte
 					continue
 				}
 				if tfresource.IsSensitiveConfigurableField(schema) {
-					if rc.Name == "google_sql_database_instance" {
+					switch rc.Name {
+					case "google_sql_database_instance",
+						"google_compute_backend_service",
+						"google_compute_region_backend_service":
 						continue
 					}
 					val := stateVal.(string)

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/create.yaml
@@ -15,12 +15,19 @@
 apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   labels:
     label-one: "value-one"
-  name: sqlinstance-sample-${uniqueId}
+  name: sqlinstance-maqiuyu-202403
 spec:
   region: us-central1
   databaseVersion: MYSQL_5_7
   instanceType: CLOUD_SQL_INSTANCE
   settings:
     tier: db-n1-standard-1
+  rootPassword:
+    valueFrom:
+      secretKeyRef:
+        key: password
+        name: secret-maqiuyu-202403

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/dependencies.yaml
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: sql.cnrm.cloud.google.com/v1beta1
-kind: SQLInstance
+apiVersion: v1
+kind: Secret
 metadata:
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
-  labels:
-    label-one: "value-one"
-    newkey: "newval"
-  name: sqlinstance-maqiuyu-202403
-spec:
-  region: us-central1
-  databaseVersion: MYSQL_5_7
-  instanceType: CLOUD_SQL_INSTANCE
-  settings:
-    tier: db-n1-standard-4
+  name: secret-maqiuyu-202403
+data:
+  password: cGFzc3dvcmQ=
+


### PR DESCRIPTION
This is to test #1342 only. Should be abandoned after #1342 is merged.
Ran the following command and verified in the updated unstructured that the rootPassword no longer existed.
```
go test -timeout 1200s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests mysqlinstance
```