### PR TITLE
tests: log if no samples

### DIFF
--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -234,8 +234,7 @@ func TestAll(t *testing.T) {
 	setup()
 	samples := LoadMatchingSamples(t, regexp.MustCompile(runTestsRegex), project)
 	if len(samples) == 0 {
-		t.Logf("No tests to run for pattern %s", runTestsRegex)
-		return
+		t.Fatalf("No tests to run for pattern %s", runTestsRegex)
 	}
 
 	// Sort the samples in descending order by number of resources. This is an attempt to start the samples that use

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -233,6 +233,11 @@ func TestAll(t *testing.T) {
 
 	setup()
 	samples := LoadMatchingSamples(t, regexp.MustCompile(runTestsRegex), project)
+	if len(samples) == 0 {
+		t.Logf("No tests to run for pattern %s", runTestsRegex)
+		return
+	}
+
 	// Sort the samples in descending order by number of resources. This is an attempt to start the samples that use
 	// a network and have many dependencies sooner since they will likely be the longest running.
 	sortSamplesInDescendingOrderByNumberOfResources(samples)


### PR DESCRIPTION
While running the samples tests it may be helpful to know if no samples load and exist early.