### PR TITLE
CCC: Switch Enum values for spec.stateIntoSpec to upper camel case

### DIFF
--- a/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectorcontexts.yaml
+++ b/operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectorcontexts.yaml
@@ -87,8 +87,8 @@ spec:
                   after a successful reconciliation if those unspecified fields are
                   computed/defaulted by the API.
                 enum:
-                - absent
-                - merge
+                - Absent
+                - Merge
                 type: string
             required:
             - googleServiceAccount

--- a/operator/pkg/apis/core/v1beta1/configconnectorcontext_types.go
+++ b/operator/pkg/apis/core/v1beta1/configconnectorcontext_types.go
@@ -51,9 +51,9 @@ type ConfigConnectorContextSpec struct {
 	// 'merge' means that unspecified fields in the resource spec are populated
 	// after a successful reconciliation if those unspecified fields are
 	// computed/defaulted by the API.
-	//+kubebuilder:validation:Enum=absent;merge
+	//+kubebuilder:validation:Enum=Absent;Merge
 	//+kubebuilder:validation:Optional
-	StateIntoSpec *string `json:"stateIntoSpec,omitempty"`
+	StateIntoSpec *StateIntoSpecValue `json:"stateIntoSpec,omitempty"`
 	// The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
 	// This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
 	// In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
@@ -61,6 +61,13 @@ type ConfigConnectorContextSpec struct {
 	//+kubebuilder:validation:Optional
 	Actuation ActuationMode `json:"actuationMode,omitempty"`
 }
+
+type StateIntoSpecValue string
+
+const (
+	StateIntoSpecMerge  StateIntoSpecValue = "Merge"
+	StateIntoSpecAbsent StateIntoSpecValue = "Absent"
+)
 
 // ConfigConnectorContextStatus defines the observed state of ConfigConnectorContext
 type ConfigConnectorContextStatus struct {

--- a/operator/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -100,7 +100,7 @@ func (in *ConfigConnectorContextSpec) DeepCopyInto(out *ConfigConnectorContextSp
 	*out = *in
 	if in.StateIntoSpec != nil {
 		in, out := &in.StateIntoSpec, &out.StateIntoSpec
-		*out = new(string)
+		*out = new(StateIntoSpecValue)
 		**out = **in
 	}
 }


### PR DESCRIPTION
This follows the KRM conventions.
