### PR TITLE
docs: clarify field usage

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computedisks.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computedisks.compute.cnrm.cloud.google.com.yaml
@@ -397,8 +397,9 @@ spec:
                 type: string
               resourcePolicies:
                 items:
-                  description: Resource policies applied to this disk for automatic
-                    snapshot creations.
+                  description: |-
+                    Resource policies applied to this disk for automatic snapshot creations.
+                    This field only applies for zonal compute disk resources.
                   oneOf:
                   - not:
                       required:

--- a/config/servicemappings/compute.yaml
+++ b/config/servicemappings/compute.yaml
@@ -316,6 +316,7 @@ spec:
         - tfField: resource_policies
           description: |-
             Resource policies applied to this disk for automatic snapshot creations.
+            This field only applies for zonal compute disk resources.
           gvk:
             kind: ComputeResourcePolicy
             version: v1beta1

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computedisk.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computedisk.md
@@ -760,7 +760,8 @@ allows for an update of Throughput every 4 hours. To update your hyperdisk more 
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}Resource policies applied to this disk for automatic snapshot creations.{% endverbatim %}</p>
+            <p>{% verbatim %}Resource policies applied to this disk for automatic snapshot creations.
+This field only applies for zonal compute disk resources.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Clarifies field `spec.resourcePolicies` only applies for zonal ComputeDisk resources.

internal: b/324925137