### PR TITLE
Backporting https://github.com/GoogleCloudPlatform/magic-modules/pull/9463

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/provider/provider.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/provider/provider.go
@@ -1945,7 +1945,6 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
-	transport_tpg.HandleDCLCustomEndpointDefaults(d)
 
 	config := transport_tpg.Config{
 		Project:             d.Get("project").(string),
@@ -2034,6 +2033,12 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 			transport_tpg.DefaultBasePaths[key] = strings.ReplaceAll(basePath, "googleapis.com", config.UniverseDomain)
 		}
 	}
+
+	err = transport_tpg.SetEndpointDefaults(d)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	transport_tpg.HandleDCLCustomEndpointDefaults(d)
 
 	// Given that impersonate_service_account is a secondary auth method, it has
 	// no conflicts to worry about. We pull the env var in a DefaultFunc.

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/config.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/transport/config.go
@@ -653,7 +653,10 @@ func HandleSDKDefaults(d *schema.ResourceData) error {
 			"CLOUDSDK_CORE_REQUEST_REASON",
 		}, nil))
 	}
+	return nil
+}
 
+func SetEndpointDefaults(d *schema.ResourceData) error {
 	// Generated Products
 	if d.Get("access_approval_custom_endpoint") == "" {
 		d.Set("access_approval_custom_endpoint", MultiEnvDefault([]string{


### PR DESCRIPTION
### Change description

splits off the default API endpoint half of HandleSDKDefaults func into its own function and calls that new function after TPC universe domain is set. This allows the basepath defaults to use the new domain if set

The API custom/default endpoints are not used between when HandleSDKDefaults was called to after the TPC universe logic, so this reorder should be safe. HandleSDKDefaults is also not called anywhere else outside of the one use.

provider: fixed an issue where universe domains would not overwrite API endpoints

- [X] Run `make ready-pr` to ensure this PR is ready for review.
