### PR TITLE
Fix deletion lock for Tags Key/Value

### DIFF
--- a/pkg/krmtotf/fetchlivestate.go
+++ b/pkg/krmtotf/fetchlivestate.go
@@ -77,8 +77,13 @@ func hasEmptySelfLink(resource *Resource) bool {
 // Due to their API design, the allowlisted resources are deletable even if their parents are not ready.
 // See b/306583728#comment8 for details.
 func ShouldCheckParentReadyForDelete(resource *Resource, parent *k8s.Resource) bool {
-	allowlist := []string{"AlloyDBInstance", "EdgeContainerNodePool"}
-	return !slices.Contains(allowlist, resource.Kind) || !isDeletionFailureDueToExistingDependent(parent)
+	allowlist := []string{"AlloyDBInstance", "EdgeContainerNodePool", "TagsTagValue"}
+	// If the resource kind in allowlist, we skip checking parent.
+	if slices.Contains(allowlist, resource.Kind) {
+		return false
+	}
+	// Skip checking parent with nested resource deletion error.
+	return !isDeletionFailureDueToExistingDependent(parent)
 }
 
 func isDeletionFailureDueToExistingDependent(r *k8s.Resource) bool {


### PR DESCRIPTION
Change ShouldCheckParentReadyForDelete to skip immediately for resource kinds in allowlist.

### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"

* For Google internal contributors, you can specify an internal tracking ticket number:

For example: "Fixes b/302708148"

-->
Fixes b/328565395

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
