### PR TITLE
ci: add dcl upgrade probe

### DIFF
--- a/.github/workflows/dcl-upgrade-probe.yaml
+++ b/.github/workflows/dcl-upgrade-probe.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+name: dcl-upgrade-probe
+on:
+  schedule:
+    # daily at 3 AM PST/ 11:00 UTC
+    - cron: '0 11 * * *'
+    # will run against the lastest commit on the default branch as per
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+  # push:
+  #   branches:
+  #     - master
+jobs:
+  upgrade-probe:
+    name: "upgrade-probe"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: upgrade dcl
+        run: make upgrade-dcl && make ready-pr


### PR DESCRIPTION
Add a cheap solution to know when the dcl upgrade (to latest) is broken. The test is `make upgrade-dcl && make ready-pr` and we'd run it as a daily cron against the latest commit of the main branch.

Fixes https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/1340