### PR TITLE
fix:test: regex against dir

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -116,7 +116,7 @@ func shouldRunBasedOnRunAndSkipRegexes(parentTestName string, fixture resourcefi
 
 	// If a run-tests regex has been provided and it doesn't match the test name, skip the test.
 	if runTestsRegex != "" {
-		if !regexp.MustCompile(runTestsRegex).MatchString(testName) {
+		if !regexp.MustCompile(runTestsRegex).MatchString(fixture.SourceDir) {
 			return false
 		}
 	}

--- a/pkg/test/resourcefixture/test_runner.go
+++ b/pkg/test/resourcefixture/test_runner.go
@@ -39,6 +39,10 @@ func RunTests(ctx context.Context, t *testing.T, shouldRun ShouldRunFunc, testCa
 		filtered = append(filtered, tc)
 	}
 
+	if len(filtered) == 0 {
+		t.Fatal("no tests to run")
+	}
+
 	// Run tests grouped by the group of the GVK
 	groups := sets.NewString()
 	for _, tc := range filtered {


### PR DESCRIPTION
It seems like the intent in https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/README.NewResourceFromTerraform.md#run-tests is that we can run tests under a folder. For instance:

```
pkg/test/resourcefixture/testdata/basic
├── pubsub
|   ├── v1beta1
|       ├── pubsubsubscription
|           ├── basicpubsubsubscription
|               └── create.yaml
|               └── dependencies.yaml
|               └── update.yaml
|           ├── bigquerypubsubsubscription
|               └── create.yaml
|               └── dependencies.yaml
|               └── update.yaml
```

It seems like we should be able to run `pubsub` but `run-tests` actually checks the NAME of the test. So if the test does not contain `pubsub` in it, it will not match the regex. This change mostly switches the matching to happen against the source directory (which contains the name of the test) as opposed to just the name.