### PR TITLE
WIP: tests: Verify the kubernetes watches we open

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -120,7 +120,7 @@ func NewHarness(ctx context.Context, t *testing.T) *Harness {
 	// manager tries to bind to the same port.
 	kccConfig.ManagerOptions.HealthProbeBindAddress = "0"
 	// supply a concrete client to disable the default behavior of caching
-	kccConfig.ManagerOptions.NewClient = nocache.NoCacheClientFunc
+	kccConfig.ManagerOptions.Cache.ByObject = nocache.ByCCandCCC
 	kccConfig.StateIntoSpecDefaultValue = k8s.StateIntoSpecDefaultValueV1Beta1
 
 	var webhooks []cnrmwebhook.Config

--- a/pkg/test/controller/reconcile.go
+++ b/pkg/test/controller/reconcile.go
@@ -64,15 +64,15 @@ func StartTestManagerInstance(env *envtest.Environment, testType test.Type, whCf
 }
 
 func startTestManager(env *envtest.Environment, testType test.Type, whCfgs []cnrmwebhook.Config) (manager.Manager, func(), error) {
-	mgr, err := manager.New(env.Config, manager.Options{
+	opt := manager.Options{
 		Port:    env.WebhookInstallOptions.LocalServingPort,
 		Host:    env.WebhookInstallOptions.LocalServingHost,
 		CertDir: env.WebhookInstallOptions.LocalServingCertDir,
-		// supply a concrete client to disable the default behavior of caching
-		NewClient: nocache.NoCacheClientFunc,
 		// Disable metrics server for testing
 		MetricsBindAddress: "0",
-	})
+	}
+	opt.Cache.ByObject = nocache.ByCCandCCC
+	mgr, err := manager.New(env.Config, opt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating manager: %w", err)
 	}


### PR DESCRIPTION
We want to check that we aren't opening full watches on all objects,
also that we aren't opening a full and a metadata-only watch.
