### PR TITLE
Alloydb CRR cleanup for #1279

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbinstances.alloydb.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbinstances.alloydb.cnrm.cloud.google.com.yaml
@@ -132,7 +132,7 @@ spec:
                 type: string
               instanceTypeRef:
                 description: |-
-                  (Required) The type of instance.
+                  The type of instance.
                   Possible values: ["PRIMARY", "READ_POOL", "SECONDARY"]
                   For PRIMARY and SECONDARY instances, set the value to refer to the name of the associated cluster.
                   This is recommended because the instance type of primary and secondary instances is tied to the cluster type of the associated cluster.
@@ -373,7 +373,7 @@ spec:
                 type: string
               instanceTypeRef:
                 description: |-
-                  (Required) The type of instance.
+                  The type of instance.
                   Possible values: ["PRIMARY", "READ_POOL", "SECONDARY"]
                   For PRIMARY and SECONDARY instances, set the value to refer to the name of the associated cluster.
                   This is recommended because the instance type of primary and secondary instances is tied to the cluster type of the associated cluster.

--- a/config/samples/resources/alloydbbackup/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbbackup/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbcluster/restored-from-backup-cluster/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbinstance/primary-instance/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbinstance/primary-instance/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbinstance/read-instance/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbinstance/read-instance/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbinstance/zonal-instance/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbuser/database-user/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbuser/database-user/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/samples/resources/alloydbuser/iam-user/alloydb_v1beta1_alloydbinstance.yaml
+++ b/config/samples/resources/alloydbuser/iam-user/alloydb_v1beta1_alloydbinstance.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/servicemappings/alloydb.yaml
+++ b/config/servicemappings/alloydb.yaml
@@ -178,7 +178,7 @@ spec:
           parent: true
         - tfField: instance_type
           description: |-
-            (Required) The type of instance.
+            The type of instance.
             Possible values: ["PRIMARY", "READ_POOL", "SECONDARY"]
             For PRIMARY and SECONDARY instances, set the value to refer to the name of the associated cluster.
             This is recommended because the instance type of primary and secondary instances is tied to the cluster type of the associated cluster.

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbinstance_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbinstance_types.go
@@ -80,7 +80,7 @@ type AlloyDBInstanceSpec struct {
 	// +optional
 	InstanceType *string `json:"instanceType,omitempty"`
 
-	/* (Required) The type of instance.
+	/* The type of instance.
 	Possible values: ["PRIMARY", "READ_POOL", "SECONDARY"]
 	For PRIMARY and SECONDARY instances, set the value to refer to the name of the associated cluster.
 	This is recommended because the instance type of primary and secondary instances is tied to the cluster type of the associated cluster.

--- a/pkg/resourceoverrides/alloydb_instance.go
+++ b/pkg/resourceoverrides/alloydb_instance.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/crdutil"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/create.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/dependencies.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbsecondarycluster/update.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/create.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/dependencies.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbinstance/basicalloydbsecondaryinstance/update.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
@@ -220,7 +220,7 @@ The type of the instance. Possible values: [PRIMARY, READ_POOL, SECONDARY]{% end
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}(Required) The type of instance.
+            <p>{% verbatim %}The type of instance.
 Possible values: ["PRIMARY", "READ_POOL", "SECONDARY"]
 For PRIMARY and SECONDARY instances, set the value to refer to the name of the associated cluster.
 This is recommended because the instance type of primary and secondary instances is tied to the cluster type of the associated cluster.
@@ -459,7 +459,7 @@ updateTime: string
 
 ### Primary Instance
 ```yaml
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -530,7 +530,7 @@ spec:
 
 ### Read Instance
 ```yaml
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -708,7 +708,7 @@ spec:
 
 ### Zonal Instance
 ```yaml
-# Copyright 2024 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Change description
This performs minor clean ups missed in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1279

Fixed Copyright year for modified and new yaml files
Removed the word "Required" from the instanceTypeRef field description
Nit: Reorder import package 


- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
