### PR TITLE
tests: add step wise for CCC Pause

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	opv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
@@ -39,7 +40,6 @@ import (
 	"github.com/ghodss/yaml"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,8 +153,11 @@ func waitForReadySingleResource(t *Harness, u *unstructured.Unstructured) {
 	logger := log.FromContext(t.Ctx)
 
 	switch u.GroupVersionKind().GroupKind() {
-	case schema.GroupKind{Group: "core.cnrm.cloud.google.com", Kind: "ConfigConnectorContext"}:
-		logger.Info("ConfigConnectorContext object does not having status.conditions; assuming ready")
+	case opv1beta1.ConfigConnectorGroupVersionKind.GroupKind():
+		logger.Info("ConfigConnector object does not have status.conditions; assuming ready")
+		return
+	case opv1beta1.ConfigConnectorContextGroupVersionKind.GroupKind():
+		logger.Info("ConfigConnectorContext object does not have status.conditions; assuming ready")
 		return
 	}
 

--- a/tests/e2e/testdata/scenarios/README.md
+++ b/tests/e2e/testdata/scenarios/README.md
@@ -13,6 +13,11 @@ in turn.  After each object is applied, we run some golden checks:
 We also support a few "special actions", which are triggered by setting
 a top-level field `TEST` on the object:
 
+* Setting TEST: APPLY is a no op as this is the default value for the TEST field.
+
+* Setting TEST: APPLY-NO-WAIT will apply the object without waiting for the object
+  to be makred as ready. We will also not export the object.
+
 * Setting `TEST: DELETE` will delete the KCC object and wait for the deltion
   to complete; it will automatically skip
   the GCP export and the kube export.  It suffices to set
@@ -27,3 +32,7 @@ a top-level field `TEST` on the object:
   `cnrm.cloud.google.com/deletion-policy: abandon` annotation.  The KCC
   object will still be deleted from the kube-apiserver.  It suffices to set
   apiVersion / kind / namespace / name.
+
+* Setting `TEST: CHECK-LOG`along with `VALUE_PRESENT: your value` will apply the object
+  and inspect the http log to check that the value in VALUE_PRESENT appears. The step will
+  wait ~ seconds for that value to show up.

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/SCENARIO_README.MD
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/SCENARIO_README.MD
@@ -1,0 +1,11 @@
+This scenario meant to do the following:
+- Apply a CC to turn to instruct KCC to be in "Namespaced" mode
+- Apply a CCC to manage a namespace
+- Apply a KCC resource with a mutable field ("description"), in this case, ArtifactRegistryRepository
+>  NOTE: This resources should be managed by the CCC we created
+- Pause KCC by setting the CCC's object `actuationMode` to Paused.
+- Apply the same KCC resource and change the "description" field. Observe no change to the resource on the cloud provider.
+> NOTE: The way to assess that there is no change in the actual resource is by determinig that the http log 
+> file does not include any calls to the GCP provider. IOW, the log file is not present.
+- "Un pause" KCC by setting the CCC's object `actuationMode` to Reconciling.
+- Observe the resource from the cloud provider matches the previous intent.

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_http02.log
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_http02.log
@@ -1,0 +1,158 @@
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: repository not found: namespaces/${projectId}/repositories/artifactregistryrepository-sample-${uniqueId}"
+      }
+    ],
+    "message": "Requested entity was not found.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories?alt=json&repository_id=artifactregistryrepository-sample-${uniqueId}
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.OperationMetadata"
+  },
+  "name": "projects/${projectId}/locations/us-west1/operations/${operationID}"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.OperationMetadata"
+  },
+  "name": "projects/${projectId}/locations/us-west1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.Repository",
+    "description": "description 1",
+    "format": "DOCKER",
+    "labels": {
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "mode": "STANDARD_REPOSITORY",
+    "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}"
+  }
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_http05.log
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_http05.log
@@ -1,0 +1,96 @@
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json&updateMask=description
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "cleanupPolicies": {},
+  "description": "description 2",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 2",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 2",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object00.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 1
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: ${projectId}
+spec:
+  googleServiceAccount: kcc@${projectId}.iam.gserviceaccount.com

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object01.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 1
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: namespaced

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object02.yaml
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    label-one: value-one
+  name: artifactregistryrepository-sample-${uniqueId}
+  namespace: ${projectId}
+spec:
+  description: description 1
+  format: DOCKER
+  location: us-west1
+  mode: STANDARD_REPOSITORY
+  resourceID: artifactregistryrepository-sample-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  name: artifactregistryrepository-sample-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object03.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object03.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 2
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: ${projectId}
+spec:
+  actuationMode: Paused
+  googleServiceAccount: kcc@${projectId}.iam.gserviceaccount.com

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object05.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/_object05.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 3
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: ${projectId}
+spec:
+  actuationMode: Reconciling
+  googleServiceAccount: kcc@${projectId}.iam.gserviceaccount.com

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/script.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/script.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# step 0
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+spec:
+  googleServiceAccount: "kcc@${projectId}.iam.gserviceaccount.com"
+---
+# step 1
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: namespaced
+---
+# step 2
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  name: artifactregistryrepository-sample-${uniqueId}
+  labels:
+    label-one: "value-one"
+spec:
+  format: DOCKER
+  location: us-west1
+  description: "description 1"
+---
+# step 3
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+spec:
+  googleServiceAccount: "kcc@${projectId}.iam.gserviceaccount.com"
+  actuationMode: Paused
+---
+# step 4
+TEST: APPLY-NO-WAIT
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  name: artifactregistryrepository-sample-${uniqueId}
+  labels:
+    label-one: "value-one"
+spec:
+  format: DOCKER
+  location: us-west1
+  description: "description 2"
+---
+# step 5
+TEST: CHECK-LOG
+VALUE_PRESENT: "description 2"
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+spec:
+  googleServiceAccount: "kcc@${projectId}.iam.gserviceaccount.com"
+  actuationMode: Reconciling


### PR DESCRIPTION
Adds a first step wise based test for pause/ unpause with a CCC.

generated artifacts by running:

```bash
$ WRITE_GOLDEN_OUTPUT=1 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=real RUN_E2E=1 \
go test -test.count=1 -timeout 360s -v ./tests/e2e -run TestE2EScript 2>&1
```
