### PR TITLE
Add a step in dynamic test to verify status fields after creation

### DIFF
--- a/pkg/k8s/allowlist.go
+++ b/pkg/k8s/allowlist.go
@@ -16,6 +16,8 @@ package k8s
 
 import (
 	"slices"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // v1beta1KindsWithStateIntoSpecMergeSupport contains all the existing v1beta1
@@ -231,8 +233,25 @@ var v1beta1KindsWithStateIntoSpecMergeSupport = []string{
 	"VPCAccessConnector",
 }
 
+// v1beta1KindsWithOutputOnlyFieldsUnderStatus contains all the existing v1beta1
+// kinds that have computed fields directly under 'status' in the schema. This
+// list includes all the kinds in v1beta1KindsWithStateIntoSpecMergeSupport and
+// 'ComputeNetworkFirewallPolicyAssociation'.
+// Any newly supported v1beta1 kinds should NOT have computed fields directly
+// under 'status' in the schema.
+var v1beta1KindsWithOutputOnlyFieldsUnderStatus = append(v1beta1KindsWithStateIntoSpecMergeSupport,
+	"ComputeNetworkFirewallPolicyAssociation")
+
 func SupportsStateIntoSpecMergeInKind(kind string) bool {
 	return isValueInAllowlist(kind, v1beta1KindsWithStateIntoSpecMergeSupport)
+}
+
+func OutputOnlyFieldsAreUnderObservedState(gvk schema.GroupVersionKind) bool {
+	if gvk.Version != KCCAPIVersionV1Beta1 {
+		return false
+	}
+
+	return !slices.Contains(v1beta1KindsWithOutputOnlyFieldsUnderStatus, gvk.Kind)
 }
 
 func isValueInAllowlist(value string, allowlist []string) bool {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
In dynamic test workflow, add a step to verify the `status` fields are populated correctly for newly supported CRDs. This is in preparation for #1353 (currently reverted).

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

`go test -timeout 1200s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests pubsubtopic` passed