### PR TITLE
WIP: support TagsTagBinding in direct actuation

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -485,6 +485,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 
 			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagKey"}:
 			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagValue"}:
+			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagBinding"}:
 
 			case schema.GroupKind{Group: "vertexai.cnrm.cloud.google.com", Kind: "VertexAITensorboard"}:
 

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -484,6 +484,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "storage.cnrm.cloud.google.com", Kind: "StorageBucket"}:
 
 			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagKey"}:
+			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagValue"}:
 
 			case schema.GroupKind{Group: "vertexai.cnrm.cloud.google.com", Kind: "VertexAITensorboard"}:
 

--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -39,6 +39,8 @@ import (
 	"github.com/ghodss/yaml"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -101,6 +103,10 @@ type CreateDeleteTestOptions struct { //nolint:revive
 	// SkipWaitForReady true is mainly used for Paused resources as we don't emit an event for those yet.
 	SkipWaitForReady bool
 
+	// CreateInOrder true means that we create each object and wait for the object to be ready.
+	// This requires that objects be sorted in creation order.
+	CreateInOrder bool
+
 	// DeleteInOrder true means that we delete each object and wait for deletion to complete.
 	// This requires that objects be sorted in deletion order.
 	DeleteInOrder bool
@@ -114,9 +120,12 @@ func RunCreateDeleteTest(t *Harness, opt CreateDeleteTestOptions) {
 		if err := t.GetClient().Create(ctx, u); err != nil {
 			t.Fatalf("error creating resource: %v", err)
 		}
+		if opt.CreateInOrder {
+			waitForReadySingleResource(t, u.GroupVersionKind(), k8s.GetNamespacedName(u))
+		}
 	}
 
-	if !opt.SkipWaitForReady {
+	if !opt.CreateInOrder && !opt.SkipWaitForReady {
 		waitForReady(t, opt.Create)
 	}
 
@@ -126,9 +135,12 @@ func RunCreateDeleteTest(t *Harness, opt CreateDeleteTestOptions) {
 			if err := t.GetClient().Patch(ctx, updateUnstruct, client.Apply, client.FieldOwner("kcc-tests"), client.ForceOwnership); err != nil {
 				t.Fatalf("error updating resource: %v", err)
 			}
+			if opt.CreateInOrder {
+				waitForReadySingleResource(t, updateUnstruct.GroupVersionKind(), k8s.GetNamespacedName(updateUnstruct))
+			}
 		}
 
-		if !opt.SkipWaitForReady {
+		if !opt.CreateInOrder && !opt.SkipWaitForReady {
 			waitForReady(t, opt.Updates)
 		}
 	}
@@ -143,22 +155,24 @@ func waitForReady(t *Harness, unstructs []*unstructured.Unstructured) {
 	var wg sync.WaitGroup
 	for _, u := range unstructs {
 		wg.Add(1)
-		go waitForReadySingleResource(t, &wg, u)
+		go func() {
+			defer wg.Done()
+			waitForReadySingleResource(t, u.GroupVersionKind(), k8s.GetNamespacedName(u))
+		}()
 	}
 	wg.Wait()
 }
 
-func waitForReadySingleResource(t *Harness, wg *sync.WaitGroup, u *unstructured.Unstructured) {
-	logger := log.FromContext(t.Ctx)
-
-	name := k8s.GetNamespacedName(u)
-	defer wg.Done()
+func waitForReadySingleResource(t *Harness, gvk schema.GroupVersionKind, id types.NamespacedName) {
 	err := wait.PollImmediate(1*time.Second, 35*time.Minute, func() (done bool, err error) {
 		done = true
-		logger.V(2).Info("Testing to see if resource is ready", "kind", u.GetKind(), "name", u.GetName())
-		err = t.GetClient().Get(t.Ctx, name, u)
+		log := log.FromContext(t.Ctx).WithValues("kind", gvk.Kind, "name", id.Name)
+		log.V(2).Info("Testing to see if resource is ready")
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		err = t.GetClient().Get(t.Ctx, id, u)
 		if err != nil {
-			logger.Info("Error getting resource", "kind", u.GetKind(), "name", u.GetName(), "error", err)
+			log.Info("Error getting resource", "error", err)
 			if t.Ctx.Err() != nil {
 				return false, t.Ctx.Err()
 			}
@@ -168,45 +182,45 @@ func waitForReadySingleResource(t *Harness, wg *sync.WaitGroup, u *unstructured.
 			return true, nil
 		}
 		if u.Object["status"] == nil {
-			logger.Info("resource does not yet have status", "kind", u.GetKind(), "name", u.GetName())
+			log.Info("resource does not yet have status")
 			return false, nil
 		}
 
 		if u.Object["status"].(map[string]interface{})["conditions"] == nil {
-			logger.Info("resource does not yet have conditions", "kind", u.GetKind(), "name", u.GetName())
+			log.Info("resource does not yet have conditions")
 			return false, nil
 		}
 		objectStatus := dynamic.GetObjectStatus(t.T, u)
 		if objectStatus.ObservedGeneration == nil {
-			logger.Info("resource does not yet have status.observedGeneration", "kind", u.GetKind(), "name", u.GetName())
+			log.Info("resource does not yet have status.observedGeneration")
 			return false, nil
 		}
 		if *objectStatus.ObservedGeneration < objectStatus.Generation {
-			logger.Info("resource status.observedGeneration is behind current generation",
-				"kind", u.GetKind(), "name", u.GetName(),
+			log.Info("resource status.observedGeneration is behind current generation",
 				"status.observedGeneration", *objectStatus.ObservedGeneration, "generation", objectStatus.Generation)
 			return false, nil
 		}
 		for _, c := range objectStatus.Conditions {
 			if c.Type == "Ready" && c.Status == "True" {
-				logger.Info("resource is ready", "kind", u.GetKind(), "name", u.GetName())
+				log.Info("resource is ready")
 				return true, nil
 			}
 		}
 		// This resource is not completely ready. Let's keep polling.
-		logger.Info("resource is not ready", "kind", u.GetKind(), "name", u.GetName(),
-			"conditions", objectStatus.Conditions)
+		log.Info("resource is not ready", "conditions", objectStatus.Conditions)
 		return false, nil
 	})
 	if err == nil {
 		return
 	}
 	if !errors.Is(err, wait.ErrWaitTimeout) {
-		t.Errorf("error while polling for ready on %v with name '%v': %v", u.GetKind(), u.GetName(), err)
+		t.Errorf("error while polling for ready on %v with name '%v': %v", gvk.Kind, id.Name, err)
 		return
 	}
-	baseMsg := fmt.Sprintf("timed out waiting for ready on %v with name '%v'", u.GetKind(), u.GetName())
-	if err := t.GetClient().Get(t.Ctx, name, u); err != nil {
+	baseMsg := fmt.Sprintf("timed out waiting for ready on %v with name '%v'", gvk.Kind, id.Name)
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	if err := t.GetClient().Get(t.Ctx, id, u); err != nil {
 		t.Errorf("%v, error retrieving final status.conditions: %v", baseMsg, err)
 		return
 	}
@@ -218,7 +232,8 @@ func DeleteResources(t *Harness, opts CreateDeleteTestOptions) {
 	logger := log.FromContext(t.Ctx)
 
 	unstructs := opts.Create
-	for _, u := range unstructs {
+	for i := len(unstructs) - 1; i >= 0; i-- {
+		u := unstructs[i]
 		logger.Info("Deleting resource", "kind", u.GetKind(), "name", u.GetName())
 		if err := t.GetClient().Delete(t.Ctx, u); err != nil {
 			t.Errorf("error deleting: %v", err)

--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -100,6 +100,10 @@ type CreateDeleteTestOptions struct { //nolint:revive
 
 	// SkipWaitForReady true is mainly used for Paused resources as we don't emit an event for those yet.
 	SkipWaitForReady bool
+
+	// DeleteInOrder true means that we delete each object and wait for deletion to complete.
+	// This requires that objects be sorted in deletion order.
+	DeleteInOrder bool
 }
 
 func RunCreateDeleteTest(t *Harness, opt CreateDeleteTestOptions) {
@@ -219,6 +223,9 @@ func DeleteResources(t *Harness, opts CreateDeleteTestOptions) {
 		if err := t.GetClient().Delete(t.Ctx, u); err != nil {
 			t.Errorf("error deleting: %v", err)
 		}
+		if opts.DeleteInOrder && !opts.SkipWaitForDelete {
+			waitForDeleteToComplete(t, u)
+		}
 	}
 
 	if opts.SkipWaitForDelete {
@@ -226,17 +233,24 @@ func DeleteResources(t *Harness, opts CreateDeleteTestOptions) {
 		return
 	}
 
+	if opts.DeleteInOrder {
+		// Already deleted
+		return
+	}
+
 	var wg sync.WaitGroup
 	for _, u := range unstructs {
 		wg.Add(1)
-		go waitForDeleteToComplete(t, &wg, u)
+		go func() {
+			defer wg.Done()
+			waitForDeleteToComplete(t, u)
+		}()
 	}
 	wg.Wait()
 }
 
-func waitForDeleteToComplete(t *Harness, wg *sync.WaitGroup, u *unstructured.Unstructured) {
+func waitForDeleteToComplete(t *Harness, u *unstructured.Unstructured) {
 	defer log.FromContext(t.Ctx).Info("Done waiting for resource to delete", "kind", u.GetKind(), "name", u.GetName())
-	defer wg.Done()
 	// Do a best-faith cleanup of the resources. Gives a 30 minute buffer for cleanup, though
 	// resources that can be cleaned up quicker exit earlier.
 	err := wait.PollImmediate(1*time.Second, 30*time.Minute, func() (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ replace github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp => ./mockgcp
 
 require (
 	cloud.google.com/go/apikeys v1.1.5
+	cloud.google.com/go/compute v1.23.3
 	cloud.google.com/go/profiler v0.1.0
+	cloud.google.com/go/resourcemanager v1.9.4
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0
 	github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp v0.0.0-00010101000000-000000000000
@@ -66,7 +68,6 @@ require (
 	bitbucket.org/creachadair/stringset v0.0.8 // indirect
 	cloud.google.com/go v0.111.0 // indirect
 	cloud.google.com/go/bigtable v1.19.0 // indirect
-	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect
 	cloud.google.com/go/longrunning v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
+cloud.google.com/go/resourcemanager v1.9.4 h1:JwZ7Ggle54XQ/FVYSBrMLOQIKoIT/uer8mmNvNLK51k=
+cloud.google.com/go/resourcemanager v1.9.4/go.mod h1:N1dhP9RFvo3lUfwtfLWVxfUWq8+KUQ+XLlHLH3BoFJ0=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=

--- a/mockgcp/common/httpmux/mux.go
+++ b/mockgcp/common/httpmux/mux.go
@@ -56,6 +56,7 @@ func NewServeMux(ctx context.Context, conn *grpc.ClientConn, handlers ...func(ct
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, marshaler),
 		runtime.WithOutgoingHeaderMatcher(outgoingHeaderMatcher),
 		runtime.WithForwardResponseOption(addGCPHeaders),
+		runtime.WithUnescapingMode(runtime.UnescapingModeAllExceptReserved),
 	)
 
 	for _, handler := range handlers {

--- a/mockgcp/mockresourcemanager/service.go
+++ b/mockgcp/mockresourcemanager/service.go
@@ -66,6 +66,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb_v1.RegisterProjectsServer(grpcServer, s.projectsV1)
 	pb_v3.RegisterProjectsServer(grpcServer, s.projectsV3)
 	pb_v3.RegisterTagKeysServer(grpcServer, &TagKeys{MockService: s})
+	pb_v3.RegisterTagValuesServer(grpcServer, &TagValues{MockService: s})
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
@@ -73,6 +74,7 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 		pb_v1.RegisterProjectsHandler,
 		pb_v3.RegisterProjectsHandler,
 		pb_v3.RegisterTagKeysHandler,
+		pb_v3.RegisterTagValuesHandler,
 		s.operations.RegisterOperationsPath("/v3/operations/{name}"))
 	if err != nil {
 		return nil, err

--- a/mockgcp/mockresourcemanager/tagbindings.go
+++ b/mockgcp/mockresourcemanager/tagbindings.go
@@ -1,0 +1,195 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockresourcemanager
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"k8s.io/klog/v2"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/resourcemanager/v3"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+)
+
+type TagBindings struct {
+	*MockService
+	pb.UnimplementedTagBindingsServer
+}
+
+func (s *TagBindings) ListTagBindings(ctx context.Context, req *pb.ListTagBindingsRequest) (*pb.ListTagBindingsResponse, error) {
+	if req.GetParent() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "parent is required")
+	}
+	parent, err := s.normalizeParent(ctx, req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []*pb.TagBinding
+
+	// We should verify that this is part of one of our projects, but ... it's a mock
+
+	tagBindingKind := (&pb.TagBinding{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, tagBindingKind, storage.ListOptions{}, func(obj proto.Message) error {
+		tagBinding := obj.(*pb.TagBinding)
+		klog.Infof("found=%+v", tagBinding)
+		if tagBinding.GetParent() == parent {
+			// NamespacedName is not returned, apparently
+			matches = append(matches, &pb.TagBinding{
+				Name:     tagBinding.Name,
+				Parent:   tagBinding.Parent,
+				TagValue: tagBinding.TagValue,
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("req=%+v, matches=%+v", req, matches)
+
+	return &pb.ListTagBindingsResponse{TagBindings: matches}, nil
+}
+
+func (s *TagBindings) normalizeParent(ctx context.Context, parent string) (string, error) {
+	if strings.HasPrefix(parent, "//cloudresourcemanager.googleapis.com/projects/") {
+		projectName, err := projects.ParseProjectName(strings.TrimPrefix(parent, "//cloudresourcemanager.googleapis.com/"))
+		if err != nil {
+			return "", err
+		}
+
+		project, err := s.projectsInternal.GetProject(projectName)
+		if err != nil {
+			return "", err
+		}
+		// This is normalized to a project number
+		parent = fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%d", project.Number)
+	} else {
+		return "", status.Errorf(codes.InvalidArgument, "parent %q is not valid", parent)
+	}
+	return parent, nil
+}
+
+func (s *TagBindings) CreateTagBinding(ctx context.Context, req *pb.CreateTagBindingRequest) (*longrunningpb.Operation, error) {
+	parent, err := s.normalizeParent(ctx, req.GetTagBinding().GetParent())
+	if err != nil {
+		return nil, err
+	}
+	req.TagBinding.Parent = parent
+
+	tagValueName, err := s.parseTagValueName(req.GetTagBinding().GetTagValue())
+	if err != nil {
+		return nil, err
+	}
+
+	tagValue := &pb.TagValue{}
+	if err := s.storage.Get(ctx, tagValueName.String(), tagValue); err != nil {
+		return nil, err
+	}
+
+	req.TagBinding.TagValueNamespacedName = tagValue.NamespacedName
+
+	if req.ValidateOnly {
+		return nil, fmt.Errorf("ValidateOnly not yet implemented")
+	}
+
+	name := &tagBindingName{
+		TagValueID: tagValueName.ID,
+		Parent:     parent,
+	}
+	req.TagBinding.Name = name.String()
+
+	fqn := name.String()
+
+	obj := proto.Clone(req.TagBinding).(*pb.TagBinding)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op, err := s.operations.DoneLRO(ctx, "", nil, obj)
+	if err != nil {
+		return nil, err
+	}
+	op.Name = "" // Name is empty for some reason on this API
+	return op, nil
+}
+
+func (s *TagBindings) DeleteTagBinding(ctx context.Context, req *pb.DeleteTagBindingRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseTagBindingName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	// We should verify that this is part of one of our projects, but ... it's a mock
+	deleted := &pb.TagBinding{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	op, err := s.operations.DoneLRO(ctx, "", nil, &emptypb.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	op.Name = "" // Name is empty for some reason on this API
+	return op, nil
+}
+
+type tagBindingName struct {
+	Parent     string
+	TagValueID int64
+}
+
+func (n *tagBindingName) String() string {
+	return fmt.Sprintf("tagBindings/%s/tagValues/%d", url.PathEscape(n.Parent), n.TagValueID)
+}
+
+// parseTagBindingName parses a string into a tagBindingName.
+// The expected form is tagBindings/<parent>/tagValues/<tagValueId>
+func (s *MockService) parseTagBindingName(name string) (*tagBindingName, error) {
+	tokens := strings.Split(name, "/")
+
+	klog.Infof("%q => tokens %+v", name, tokens)
+	if len(tokens) == 4 && tokens[0] == "tagBindings" && tokens[2] == "tagValues" {
+		tagValueID, err := strconv.ParseInt(tokens[3], 10, 64)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid (bad tagValueID)", name)
+		}
+		parent, err := url.PathUnescape(tokens[1])
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid (bad parent)", name)
+		}
+		name := &tagBindingName{
+			Parent:     parent,
+			TagValueID: tagValueID,
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockresourcemanager/tagvalues.go
+++ b/mockgcp/mockresourcemanager/tagvalues.go
@@ -77,7 +77,7 @@ func (s *TagValues) CreateTagValue(ctx context.Context, req *pb.CreateTagValueRe
 
 	namespacedName := ""
 
-	// We should verify that this is part of on of our projects, but ... it's a mock
+	// We should verify ownership on the key and the project/org, but ... it's a mock
 	tagKeyParent := parentTagKey.GetParent()
 	if strings.HasPrefix(tagKeyParent, "projects/") {
 		projectName, err := projects.ParseProjectName(tagKeyParent)
@@ -90,7 +90,8 @@ func (s *TagValues) CreateTagValue(ctx context.Context, req *pb.CreateTagValueRe
 		}
 		namespacedName = project.ID + "/" + parentTagKey.GetShortName() + "/" + req.GetTagValue().GetShortName()
 	} else if strings.HasPrefix(tagKeyParent, "organizations/") {
-		// TODO: Set namespacedName: {organizationId}/{tag_key_short_name}/{tag_value_short_name}
+		organizationID := strings.TrimPrefix(tagKeyParent, "organizations/")
+		namespacedName = organizationID + "/" + parentTagKey.GetShortName() + "/" + req.GetTagValue().GetShortName()
 	} else {
 		return nil, status.Errorf(codes.InvalidArgument, "parent %q is not valid", tagKeyParent)
 	}

--- a/mockgcp/mockresourcemanager/tagvalues.go
+++ b/mockgcp/mockresourcemanager/tagvalues.go
@@ -1,0 +1,224 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockresourcemanager
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/resourcemanager/v3"
+	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+)
+
+type TagValues struct {
+	*MockService
+	pb.UnimplementedTagValuesServer
+}
+
+func (s *TagValues) GetTagValue(ctx context.Context, req *pb.GetTagValueRequest) (*pb.TagValue, error) {
+	name, err := s.parseTagValueName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.TagValue{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "tagValue %q not found", name)
+		} else {
+			return nil, status.Errorf(codes.Internal, "error reading tagValue: %v", err)
+		}
+	}
+
+	// We should verify that this is part of on of our projects, but ... it's a mock
+
+	return obj, nil
+}
+
+func (s *TagValues) CreateTagValue(ctx context.Context, req *pb.CreateTagValueRequest) (*longrunningpb.Operation, error) {
+	parentName, err := s.parseTagKeyName(req.GetTagValue().GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	parentTagKey := &pb.TagKey{}
+	if err := s.storage.Get(ctx, parentName.String(), parentTagKey); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "tagKey %q not found", req.GetTagValue().GetParent())
+		} else {
+			return nil, status.Errorf(codes.Internal, "error reading tagKey: %v", err)
+		}
+	}
+
+	namespacedName := ""
+
+	// We should verify that this is part of on of our projects, but ... it's a mock
+	tagKeyParent := parentTagKey.GetParent()
+	if strings.HasPrefix(tagKeyParent, "projects/") {
+		projectName, err := projects.ParseProjectName(tagKeyParent)
+		if err != nil {
+			return nil, err
+		}
+		project, err := s.projectsInternal.GetProject(projectName)
+		if err != nil {
+			return nil, err
+		}
+		namespacedName = project.ID + "/" + parentTagKey.GetShortName() + "/" + req.GetTagValue().GetShortName()
+	} else if strings.HasPrefix(tagKeyParent, "organizations/") {
+		// TODO: Set namespacedName: {organizationId}/{tag_key_short_name}/{tag_value_short_name}
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "parent %q is not valid", tagKeyParent)
+	}
+
+	if req.ValidateOnly {
+		return nil, fmt.Errorf("ValidateOnly not yet implemented")
+	}
+
+	name := &tagValueName{
+		ID: time.Now().UnixNano(),
+	}
+
+	fqn := name.String()
+	now := timestamppb.Now()
+
+	obj := proto.Clone(req.TagValue).(*pb.TagValue)
+
+	obj.CreateTime = now
+	obj.UpdateTime = now
+	obj.NamespacedName = namespacedName
+	obj.Etag = base64.StdEncoding.EncodeToString(computeEtag(obj))
+	obj.Name = fqn
+	obj.Parent = parentTagKey.Name
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error creating tagValue: %v", err)
+	}
+
+	metadata := &pb.CreateTagValueMetadata{}
+	return s.operations.StartLRO(ctx, "", metadata, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *TagValues) UpdateTagValue(ctx context.Context, req *pb.UpdateTagValueRequest) (*longrunningpb.Operation, error) {
+	reqName := req.GetTagValue().GetName()
+	name, err := s.parseTagValueName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.ValidateOnly {
+		return nil, fmt.Errorf("ValidateOnly not yet implemented")
+	}
+
+	fqn := name.String()
+	obj := &pb.TagValue{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "tagValue %q not found", reqName)
+		}
+		return nil, status.Errorf(codes.Internal, "error reading tagValue: %v", err)
+	}
+
+	// We should verify that this is part of on of our projects, but ... it's a mock
+
+	paths := req.GetUpdateMask().GetPaths()
+	for _, path := range paths {
+		switch path {
+		case "description":
+			obj.Description = req.GetTagValue().GetDescription()
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
+		}
+	}
+	if len(paths) == 0 {
+		obj.Description = req.GetTagValue().GetDescription()
+	}
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error updating tagValue: %v", err)
+	}
+
+	metadata := &pb.UpdateTagValueMetadata{}
+	return s.operations.StartLRO(ctx, "", metadata, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *TagValues) DeleteTagValue(ctx context.Context, req *pb.DeleteTagValueRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseTagValueName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.TagValue{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "tagValue %q not found", name)
+		} else {
+			return nil, status.Errorf(codes.Internal, "error deleting tagValue: %v", err)
+		}
+	}
+
+	// We should verify that this is part of on of our projects, but ... it's a mock
+
+	metadata := &pb.DeleteTagValueMetadata{}
+	return s.operations.StartLRO(ctx, "", metadata, func() (proto.Message, error) {
+		return deleted, nil
+	})
+}
+
+type tagValueName struct {
+	ID int64
+}
+
+func (n *tagValueName) String() string {
+	return fmt.Sprintf("tagValues/%d", n.ID)
+}
+
+// parseTagValueName parses a string into a tagValueName.
+// The expected form is tagValues/<tagvalueName>
+func (s *MockService) parseTagValueName(name string) (*tagValueName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 2 && tokens[0] == "tagValues" {
+		n, err := strconv.ParseInt(tokens[1], 10, 64)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid (bad id)", name)
+		}
+		name := &tagValueName{
+			ID: n,
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/apikeys/v1alpha1"
@@ -110,7 +111,7 @@ func (m *model) client(ctx context.Context) (*api.Client, error) {
 }
 
 // AdapterForObject implements the Model interface.
-func (m *model) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+func (m *model) AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
 	gcp, err := m.client(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -234,7 +234,7 @@ func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 }
 
 // Update implements the Adapter interface.
-func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error) {
+func (a *adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
 	// TODO: Skip updates if no changes
 	// TODO: Where/how do we want to enforce immutability?
 	updateMask := &fieldmaskpb.FieldMask{}
@@ -254,12 +254,12 @@ func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error
 
 	if len(updateMask.Paths) == 0 {
 		klog.Warningf("unexpected empty update mask, desired: %v, actual: %v", a.desired, a.actual)
-		return nil, nil
+		return nil
 	}
 
 	key := &pb.Key{}
 	if err := keyMapping.Map(a.desired, key); err != nil {
-		return nil, err
+		return err
 	}
 
 	req := &pb.UpdateKeyRequest{
@@ -271,10 +271,10 @@ func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error
 
 	_, err := a.gcp.UpdateKey(ctx, req)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	// TODO: Return updated object
-	return nil, nil
+	// TODO: Return updated object status
+	return nil
 }
 
 func (a *adapter) fullyQualifiedName() string {

--- a/pkg/controller/direct/compute/client.go
+++ b/pkg/controller/direct/compute/client.go
@@ -1,0 +1,99 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"google.golang.org/api/compute/v1"
+	api "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+type gcpClient struct {
+	config controller.Config
+
+	gcp *compute.Service
+}
+
+func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+	gcpClient := &gcpClient{
+		config: *config,
+	}
+	client, err := gcpClient.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	gcpClient.gcp = client
+	return gcpClient, nil
+}
+
+func (a *gcpClient) waitForGlobalOperation(ctx context.Context, projectID string, opName string) (*compute.Operation, error) {
+	// TODO: Use server-side wait
+	// completed, err := a.gcp.GlobalOperations.Wait(a.projectID, op.Name).Context(ctx).Do()
+	// if err != nil {
+	// 	return fmt.Errorf("waiting for network creation: %w", err)
+	// }
+	// TODO: need to handle more Wait conditions?
+
+	// TODO: Backoff?
+	// TODO: Early-return and let the controller do it?
+
+	timeout := 5 * time.Minute // TODO: Configurable?
+	timeoutAt := time.Now().Add(timeout)
+	for {
+		op, err := a.gcp.GlobalOperations.Get(projectID, opName).Context(ctx).Do()
+		if err != nil {
+			return nil, fmt.Errorf("error getting operation: %w", err)
+		}
+		if op.Status == "DONE" {
+			return op, nil
+		}
+		if time.Now().After(timeoutAt) {
+			return nil, fmt.Errorf("timeout waiting for operation")
+		}
+
+		// TODO: Backoff?
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (m *gcpClient) client(ctx context.Context) (*api.Service, error) {
+	var opts []option.ClientOption
+	if m.config.UserAgent != "" {
+		opts = append(opts, option.WithUserAgent(m.config.UserAgent))
+	}
+	if m.config.HTTPClient != nil {
+		// TODO: Set UserAgent in this scenario (error is: WithHTTPClient is incompatible with gRPC dial options)
+		opts = append(opts, option.WithHTTPClient(m.config.HTTPClient))
+	}
+	if m.config.UserProjectOverride && m.config.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(m.config.BillingProject))
+	}
+
+	// TODO: support endpoints?
+	// if m.config.Endpoint != "" {
+	// 	opts = append(opts, option.WithEndpoint(m.config.Endpoint))
+	// }
+
+	gcpClient, err := api.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building compute client: %w", err)
+	}
+	return gcpClient, err
+}

--- a/pkg/controller/direct/compute/client.go
+++ b/pkg/controller/direct/compute/client.go
@@ -28,7 +28,6 @@ import (
 type gcpClient struct {
 	config controller.Config
 
-	networks         *api.NetworksClient
 	globalOperations *api.GlobalOperationsClient
 }
 
@@ -36,11 +35,6 @@ func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, e
 	gcpClient := &gcpClient{
 		config: *config,
 	}
-	networks, err := gcpClient.newNetworksClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	gcpClient.networks = networks
 	globalOperations, err := gcpClient.newGlobalOperationsClient(ctx)
 	if err != nil {
 		return nil, err
@@ -109,11 +103,23 @@ func (m *gcpClient) newNetworksClient(ctx context.Context) (*api.NetworksClient,
 	if err != nil {
 		return nil, err
 	}
-	gcpClient, err := api.NewNetworksRESTClient(ctx, opts...)
+	client, err := api.NewNetworksRESTClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("building compute client: %w", err)
 	}
-	return gcpClient, err
+	return client, err
+}
+
+func (m *gcpClient) newSubnetworksClient(ctx context.Context) (*api.SubnetworksClient, error) {
+	opts, err := m.options()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewSubnetworksRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building compute client: %w", err)
+	}
+	return client, err
 }
 
 func (m *gcpClient) newGlobalOperationsClient(ctx context.Context) (*api.GlobalOperationsClient, error) {

--- a/pkg/controller/direct/compute/network_controller.go
+++ b/pkg/controller/direct/compute/network_controller.go
@@ -1,0 +1,258 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	api "google.golang.org/api/compute/v1"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/compute/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+)
+
+// AddNetworkController creates a new controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func AddNetworkController(mgr manager.Manager, config *controller.Config) error {
+	gvk := krm.ComputeNetworkGVK
+
+	// TODO: Share gcp client (any value in doing so)?
+	ctx := context.TODO()
+	gcpClient, err := newGCPClient(ctx, config)
+	if err != nil {
+		return err
+	}
+	m := &model{gcpClient: gcpClient}
+	return directbase.Add(mgr, gvk, m)
+}
+
+type model struct {
+	*gcpClient
+}
+
+// model implements the Model interface.
+var _ directbase.Model = &model{}
+
+type adapter struct {
+	projectID string
+
+	// The account id that is used to generate the service account
+	// email address and a stable unique id. It is unique within a project,
+	// must be 6-30 characters long, and match the regular expression
+	// `[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035.
+	resourceID string
+
+	desired *krm.ComputeNetwork
+	actual  *api.Network
+
+	*gcpClient
+}
+
+// adapter implements the Adapter interface.
+var _ directbase.Adapter = &adapter{}
+
+// AdapterForObject implements the Model interface.
+func (m *model) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	// TODO: Just fetch this object?
+	obj := &krm.ComputeNetwork{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	projectID := obj.Annotations["cnrm.cloud.google.com/project-id"]
+	if projectID == "" {
+		return nil, fmt.Errorf("unable to determine project")
+	}
+
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("unable to determine resourceID")
+	}
+
+	return &adapter{
+		projectID:  projectID,
+		resourceID: resourceID,
+		desired:    obj,
+		gcpClient:  m.gcpClient,
+	}, nil
+}
+
+// Find implements the Adapter interface.
+func (a *adapter) Find(ctx context.Context) (bool, error) {
+	if a.resourceID == "" {
+		return false, nil
+	}
+
+	network, err := a.gcp.Networks.Get(a.projectID, a.resourceID).Context(ctx).Do()
+	if err != nil {
+		if IsNotFound(err) {
+			klog.Warningf("network was not found: %v", err)
+			return false, nil
+		}
+		return false, err
+	}
+
+	// u := &krm.ComputeNetwork{}
+	// if err := networkToKRM(network, u); err != nil {
+	// 	return false, err
+	// }
+	a.actual = network
+
+	return true, nil
+}
+
+// func networkToKRM(in *api.Network, out *krm.ComputeNetwork) error {
+// 	out.Spec.
+// 	out.Spec.DisplayName = PtrTo(in.DisplayName)
+// 	out.Spec.Description = PtrTo(in.Description)
+// 	out.Status.Email = PtrTo(in.Email)
+// 	// out.Status.ProjectId = in.GetProjectId()
+// 	out.Status.UniqueId = PtrTo(in.UniqueId)
+// 	// out.Status.Oauth2ClientId = in.GetOauth2ClientId()
+// 	// out.Status.Disabled = in.GetDisabled()
+// 	return nil
+// }
+
+// Delete implements the Adapter interface.
+func (a *adapter) Delete(ctx context.Context) (bool, error) {
+	// TODO: Delete via status selfLink?
+	_, err := a.gcp.Networks.Delete(a.projectID, a.resourceID).Context(ctx).Do()
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("deleting network: %w", err)
+	}
+
+	return true, nil
+}
+
+// Create implements the Adapter interface.
+func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating object", "u", u)
+
+	network := &api.Network{
+		// IPv4Range:                             a.desired.Spec.IPv4Range,
+		AutoCreateSubnetworks: ValueOf(a.desired.Spec.AutoCreateSubnetworks),
+		Description:           ValueOf(a.desired.Spec.Description),
+		EnableUlaInternalIpv6: ValueOf(a.desired.Spec.EnableUlaInternalIpv6),
+		InternalIpv6Range:     ValueOf(a.desired.Spec.InternalIpv6Range),
+		// TODO: Should be int64
+		Mtu:                                   int64(ValueOf(a.desired.Spec.Mtu)),
+		Name:                                  a.resourceID,
+		NetworkFirewallPolicyEnforcementOrder: ValueOf(a.desired.Spec.NetworkFirewallPolicyEnforcementOrder),
+	}
+
+	// TODO: RoutingConfig
+	// 	// RoutingConfig: The network-level routing configuration for this
+	// // network. Used by Cloud Router to determine what type of network-wide
+	// // routing behavior to enforce.
+	// RoutingConfig *NetworkRoutingConfig `json:"routingConfig,omitempty"`
+
+	op, err := a.gcp.Networks.Insert(a.projectID, network).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("creating network: %w", err)
+	}
+	// TODO: Return created object status
+
+	completed, err := a.waitForGlobalOperation(ctx, a.projectID, op.Name)
+	if err != nil {
+		return fmt.Errorf("waiting for network creation: %w", err)
+	}
+	if completed.Status != "DONE" {
+		return fmt.Errorf("network creation failed: %q", completed.Status)
+	}
+
+	// Can we get this from the operation?
+	created, err := a.gcp.Networks.Get(a.projectID, a.resourceID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("getting network after creation: %w", err)
+	}
+	log.V(2).Info("created network", "network", created)
+
+	status := &krm.ComputeNetworkStatus{}
+	if err := networkStatusToKRM(created, status); err != nil {
+		return err
+	}
+
+	return setStatus(u, status)
+}
+
+func networkStatusToKRM(in *api.Network, out *krm.ComputeNetworkStatus) error {
+	out.SelfLink = PtrTo(in.SelfLink)
+	out.GatewayIpv4 = PtrTo(in.GatewayIPv4)
+	return nil
+}
+
+// Update implements the Adapter interface.
+func (a *adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+	// TODO: Skip updates at the higher level if no changes?
+	updateMask := &fieldmaskpb.FieldMask{}
+	update := &api.Network{}
+	update.RoutingConfig = &api.NetworkRoutingConfig{}
+
+	// routingConfig.routingMode is the only field that can be updated
+	actualRoutingConfig := a.actual.RoutingConfig
+	if actualRoutingConfig == nil {
+		actualRoutingConfig = &api.NetworkRoutingConfig{}
+	}
+	if ValueOf(a.desired.Spec.RoutingMode) != actualRoutingConfig.RoutingMode {
+		updateMask.Paths = append(updateMask.Paths, "routingConfig.routingMode")
+		update.RoutingConfig.RoutingMode = ValueOf(a.desired.Spec.RoutingMode)
+	}
+
+	network := &api.Network{
+		Name: a.resourceID,
+		// TODO: RoutingConfig
+		// 	RoutingConfig: &api.NetworkRoutingConfig{
+		// 		RoutingMode: a.desired.Spec.RoutingMode,
+		// 	},
+	}
+	// TODO: Where/how do we want to enforce immutability?
+
+	if len(updateMask.Paths) != 0 {
+		_, err := a.gcp.Networks.Patch(a.projectID, a.resourceID, network).Context(ctx).Do()
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO: Return updated object status
+	return nil
+}
+
+func (a *adapter) fullyQualifiedName() string {
+	// The resource name of the service account.
+	//
+	// Use one of the following formats:
+	//
+	// * `projects/{PROJECT_ID}/networks/{EMAIL_ADDRESS}`
+	// * `projects/{PROJECT_ID}/networks/{UNIQUE_ID}`
+	//
+
+	email := a.resourceID + "@" + a.projectID + ".iam.gnetwork.com"
+	return fmt.Sprintf("projects/%s/networks/%s", a.projectID, email)
+}

--- a/pkg/controller/direct/compute/network_controller.go
+++ b/pkg/controller/direct/compute/network_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/compute/v1beta1"
@@ -69,7 +70,7 @@ type networkAdapter struct {
 var _ directbase.Adapter = &networkAdapter{}
 
 // AdapterForObject implements the Model interface.
-func (m *networkModel) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+func (m *networkModel) AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
 	networks, err := m.newNetworksClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/compute/subnetwork_controller.go
+++ b/pkg/controller/direct/compute/subnetwork_controller.go
@@ -1,0 +1,310 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	api "cloud.google.com/go/compute/apiv1"
+	pb "cloud.google.com/go/compute/apiv1/computepb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/compute/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+)
+
+// AddSubnetworkController creates a new controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func AddSubnetworkController(mgr manager.Manager, config *controller.Config) error {
+	gvk := krm.ComputeSubnetworkGVK
+
+	// TODO: Share gcp client (any value in doing so)?
+	ctx := context.TODO()
+	gcpClient, err := newGCPClient(ctx, config)
+	if err != nil {
+		return err
+	}
+	m := &networkModel{gcpClient: gcpClient}
+	return directbase.Add(mgr, gvk, m)
+}
+
+type subnetworkModel struct {
+	*gcpClient
+}
+
+// model implements the Model interface.
+var _ directbase.Model = &subnetworkModel{}
+
+type subnetworkAdapter struct {
+	projectID string
+
+	desired *krm.ComputeSubnetwork
+	actual  *pb.Subnetwork
+
+	*gcpClient
+	subnetworks *api.SubnetworksClient
+}
+
+// adapter implements the Adapter interface.
+var _ directbase.Adapter = &subnetworkAdapter{}
+
+// AdapterForObject implements the Model interface.
+func (m *subnetworkModel) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	subnetworks, err := m.newSubnetworksClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Just fetch this object?
+	obj := &krm.ComputeSubnetwork{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	desired := obj.Spec.DeepCopy()
+
+	projectID := obj.Annotations["cnrm.cloud.google.com/project-id"]
+	if projectID == "" {
+		return nil, fmt.Errorf("unable to determine project")
+	}
+
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("unable to determine resourceID")
+	}
+	desired.ResourceID = &resourceID
+
+	if desired.Region == "" {
+		return nil, fmt.Errorf("unable to determine region")
+	}
+
+	networkURL := desired.NetworkRef.External
+	// TODO: Refs
+	if networkURL == "" {
+		return nil, fmt.Errorf("unable to determine networkURL")
+	}
+
+	return &subnetworkAdapter{
+		projectID:   projectID,
+		desired:     obj,
+		gcpClient:   m.gcpClient,
+		subnetworks: subnetworks,
+	}, nil
+}
+
+// Find implements the Adapter interface.
+func (a *subnetworkAdapter) Find(ctx context.Context) (bool, error) {
+	if ValueOf(a.desired.Spec.ResourceID) == "" {
+		return false, nil
+	}
+
+	req := &pb.GetSubnetworkRequest{
+		Project:    a.projectID,
+		Region:     a.desired.Spec.Region,
+		Subnetwork: *a.desired.Spec.ResourceID,
+	}
+	subnetwork, err := a.subnetworks.Get(ctx, req)
+	if err != nil {
+		if IsNotFound(err) {
+			klog.Warningf("subnetwork was not found: %v", err)
+			return false, nil
+		}
+		return false, err
+	}
+
+	a.actual = subnetwork
+
+	return true, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *subnetworkAdapter) Delete(ctx context.Context) (bool, error) {
+	// TODO: Delete via status selfLink?
+	req := &pb.DeleteSubnetworkRequest{
+		Project:    a.projectID,
+		Region:     a.desired.Spec.Region,
+		Subnetwork: *a.desired.Spec.ResourceID,
+	}
+
+	op, err := a.subnetworks.Delete(ctx, req)
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("deleting subnetwork: %w", err)
+	}
+
+	completed, err := a.waitForGlobalOperation(ctx, a.projectID, op.Name())
+	if err != nil {
+		return false, fmt.Errorf("waiting for subnetwork deletion: %w", err)
+	}
+	// TODO: Move this check to wait?
+	if completed.GetStatus() != pb.Operation_DONE {
+		return false, fmt.Errorf("subnetwork deletion failed: %q", completed.GetStatus())
+	}
+
+	return true, nil
+}
+
+func mapComputeSubnetworkSpecToCloud(in *krm.ComputeSubnetworkSpec, out *pb.Subnetwork) error {
+	subnetwork := &pb.Subnetwork{
+		Description: in.Description,
+		// EnableFlowLogs:          in.EnableFwLogs,
+		IpCidrRange:             &in.IpCidrRange,
+		Ipv6AccessType:          in.Ipv6AccessType,
+		Name:                    in.ResourceID,
+		Network:                 &in.NetworkRef.External,
+		PrivateIpGoogleAccess:   in.PrivateIpGoogleAccess,
+		PrivateIpv6GoogleAccess: in.PrivateIpv6GoogleAccess,
+		Purpose:                 in.Purpose,
+		Region:                  &in.Region,
+		Role:                    in.Role,
+		StackType:               in.StackType,
+	}
+
+	for _, secondaryRange := range in.SecondaryIpRange {
+		in := secondaryRange
+		out := &pb.SubnetworkSecondaryRange{
+			RangeName:   &in.RangeName,
+			IpCidrRange: &in.IpCidrRange,
+		}
+		subnetwork.SecondaryIpRanges = append(subnetwork.SecondaryIpRanges, out)
+	}
+	if in.LogConfig != nil {
+		subnetwork.LogConfig = &pb.SubnetworkLogConfig{
+			AggregationInterval: in.LogConfig.AggregationInterval,
+			FilterExpr:          in.LogConfig.FilterExpr,
+			Metadata:            in.LogConfig.Metadata,
+			MetadataFields:      in.LogConfig.MetadataFields,
+		}
+
+		// TODO: Should be explicit?
+		subnetwork.LogConfig.Enable = PtrTo(true)
+
+		// TODO: Should be float32
+		if in.LogConfig.FlowSampling != nil {
+			flowSampling := float32(*in.LogConfig.FlowSampling)
+			subnetwork.LogConfig.FlowSampling = &flowSampling
+		}
+	}
+
+	return nil
+}
+
+// Create implements the Adapter interface.
+func (a *subnetworkAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating object", "u", u)
+
+	subnetwork := &pb.Subnetwork{}
+	if err := mapComputeSubnetworkSpecToCloud(&a.desired.Spec, subnetwork); err != nil {
+		return err
+	}
+
+	req := &pb.InsertSubnetworkRequest{
+		SubnetworkResource: subnetwork,
+		Project:            a.projectID,
+		Region:             a.desired.Spec.Region,
+	}
+	op, err := a.subnetworks.Insert(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating subnetwork: %w", err)
+	}
+	// TODO: Return created object status
+
+	completed, err := a.waitForGlobalOperation(ctx, a.projectID, op.Name())
+	if err != nil {
+		return fmt.Errorf("waiting for subnetwork creation: %w", err)
+	}
+	if completed.GetStatus() != pb.Operation_DONE {
+		return fmt.Errorf("subnetwork creation failed: %q", completed.GetStatus())
+	}
+
+	// Can we get this from the operation?
+	created, err := a.subnetworks.Get(ctx, &pb.GetSubnetworkRequest{Project: a.projectID, Region: a.desired.Spec.Region, Subnetwork: *a.desired.Spec.ResourceID})
+	if err != nil {
+		return fmt.Errorf("getting subnetwork after creation: %w", err)
+	}
+	log.V(2).Info("created subnetwork", "subnetwork", created)
+
+	status := &krm.ComputeSubnetworkStatus{}
+	if err := subnetworkStatusToKRM(created, status); err != nil {
+		return err
+	}
+
+	return setStatus(u, status)
+}
+
+func subnetworkStatusToKRM(in *pb.Subnetwork, out *krm.ComputeSubnetworkStatus) error {
+	out.CreationTimestamp = in.CreationTimestamp
+	out.ExternalIpv6Prefix = in.ExternalIpv6Prefix
+	out.GatewayAddress = in.GatewayAddress
+	out.InternalIpv6Prefix = in.InternalIpv6Prefix
+	out.Ipv6CidrRange = in.Ipv6CidrRange
+	out.SelfLink = (in.SelfLink)
+
+	return nil
+}
+
+// Update implements the Adapter interface.
+func (a *subnetworkAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+	// TODO: Skip updates at the higher level if no changes?
+
+	subnetwork := &pb.Subnetwork{}
+	if err := mapComputeSubnetworkSpecToCloud(&a.desired.Spec, subnetwork); err != nil {
+		return err
+	}
+
+	// TODO: Where/how do we want to enforce immutability?
+
+	// TODO: Compute update mask, only with spec
+	// updateMask := &fieldmaskpb.FieldMask{}
+	shouldUpdate := true // len(updateMask.Paths) != 0
+	update := subnetwork
+
+	if shouldUpdate {
+		req := &pb.PatchSubnetworkRequest{
+			Region:             a.desired.Spec.Region,
+			Subnetwork:         *a.desired.Spec.ResourceID,
+			Project:            a.projectID,
+			SubnetworkResource: update,
+		}
+		op, err := a.subnetworks.Patch(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		completed, err := a.waitForGlobalOperation(ctx, a.projectID, op.Name())
+		if err != nil {
+			return fmt.Errorf("waiting for subnetwork updte: %w", err)
+		}
+		// TODO: Move this check to wait?
+		if completed.GetStatus() != pb.Operation_DONE {
+			return fmt.Errorf("subnetwork update failed: %q", completed.GetStatus())
+		}
+
+	}
+
+	// TODO: Return updated object status
+	return nil
+}

--- a/pkg/controller/direct/compute/subnetwork_controller.go
+++ b/pkg/controller/direct/compute/subnetwork_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/compute/v1beta1"
@@ -66,7 +67,7 @@ type subnetworkAdapter struct {
 var _ directbase.Adapter = &subnetworkAdapter{}
 
 // AdapterForObject implements the Model interface.
-func (m *subnetworkModel) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+func (m *subnetworkModel) AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
 	subnetworks, err := m.newSubnetworksClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/compute/utils.go
+++ b/pkg/controller/direct/compute/utils.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/googleapis/gax-go/v2/apierror"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+func setStatus(u *unstructured.Unstructured, typedStatus any) error {
+	// TODO: Just fetch this object?
+	status, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedStatus)
+	if err != nil {
+		return fmt.Errorf("error converting status to unstructured: %w", err)
+	}
+	// TODO: Merge to avoid overwriting conditions?
+	u.Object["status"] = status
+
+	return nil
+}
+
+func ValueOf[T any](p *T) T {
+	var v T
+	if p != nil {
+		v = *p
+	}
+	return v
+}
+
+func PtrTo[T any](t T) *T {
+	return &t
+}
+
+func areSame[T comparable](l, r *T) bool {
+	if l == nil {
+		return r == nil
+	}
+	if r == nil {
+		return l == nil
+	}
+	return *l == *r
+}
+
+// HasHTTPCode returns true if the given error is an HTTP response with the given code.
+func HasHTTPCode(err error, code int) bool {
+	if err == nil {
+		return false
+	}
+	apiError := &apierror.APIError{}
+	if errors.As(err, &apiError) {
+		if apiError.HTTPCode() == code {
+			return true
+		}
+	} else {
+		klog.Warningf("unexpected error type %T", err)
+	}
+	return false
+}
+
+// IsNotFound returns true if the given error is an HTTP 404.
+func IsNotFound(err error) bool {
+	return HasHTTPCode(err, 404)
+}

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -261,7 +261,7 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 			return false, r.handleUpdateFailed(ctx, u, fmt.Errorf("error creating: %w", err))
 		}
 	} else {
-		if _, err = adapter.Update(ctx); err != nil {
+		if err := adapter.Update(ctx, u); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))
 				return r.handleUnresolvableDeps(ctx, u, unwrappedErr)

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -204,7 +204,7 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 		return false, fmt.Errorf("unknown actuation mode %v", am)
 	}
 
-	adapter, err := r.Reconciler.model.AdapterForObject(ctx, u)
+	adapter, err := r.Reconciler.model.AdapterForObject(ctx, r.Reconciler.Client, u)
 	if err != nil {
 		return false, r.handleUpdateFailed(ctx, u, err)
 	}

--- a/pkg/controller/direct/directbase/interfaces.go
+++ b/pkg/controller/direct/directbase/interfaces.go
@@ -18,12 +18,13 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Model is the entry-point for our per-object reconcilers
 type Model interface {
 	// AdapterForObject builds an operation object for reconciling the object u
-	AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (Adapter, error)
+	AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (Adapter, error)
 }
 
 // Adapter performs a single reconciliation on a single object.

--- a/pkg/controller/direct/directbase/interfaces.go
+++ b/pkg/controller/direct/directbase/interfaces.go
@@ -46,5 +46,5 @@ type Adapter interface {
 
 	// Update updates an existing GCP object.
 	// This should only be called when Find has previously returned true.
-	Update(ctx context.Context) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, u *unstructured.Unstructured) error
 }

--- a/pkg/controller/direct/iam/serviceaccount_controller.go
+++ b/pkg/controller/direct/iam/serviceaccount_controller.go
@@ -1,0 +1,255 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	api "google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+)
+
+// AddServiceAccountController creates a new controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func AddServiceAccountController(mgr manager.Manager, config *controller.Config) error {
+	gvk := krm.IAMServiceAccountGVK
+
+	return directbase.Add(mgr, gvk, &model{config: *config})
+}
+
+type model struct {
+	config controller.Config
+}
+
+// model implements the Model interface.
+var _ directbase.Model = &model{}
+
+type adapter struct {
+	projectID string
+
+	// The account id that is used to generate the service account
+	// email address and a stable unique id. It is unique within a project,
+	// must be 6-30 characters long, and match the regular expression
+	// `[a-z]([-a-z0-9]*[a-z0-9])` to comply with RFC1035.
+	accountID string
+
+	desired *krm.IAMServiceAccount
+	actual  *krm.IAMServiceAccount
+
+	gcp *api.Service
+}
+
+// adapter implements the Adapter interface.
+var _ directbase.Adapter = &adapter{}
+
+func (m *model) client(ctx context.Context) (*api.Service, error) {
+	var opts []option.ClientOption
+	if m.config.UserAgent != "" {
+		opts = append(opts, option.WithUserAgent(m.config.UserAgent))
+	}
+	if m.config.HTTPClient != nil {
+		// TODO: Set UserAgent in this scenario (error is: WithHTTPClient is incompatible with gRPC dial options)
+		opts = append(opts, option.WithHTTPClient(m.config.HTTPClient))
+	}
+	if m.config.UserProjectOverride && m.config.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(m.config.BillingProject))
+	}
+
+	// TODO: support endpoints?
+	// if m.config.Endpoint != "" {
+	// 	opts = append(opts, option.WithEndpoint(m.config.Endpoint))
+	// }
+
+	gcpClient, err := api.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building iam client: %w", err)
+	}
+	return gcpClient, err
+}
+
+// AdapterForObject implements the Model interface.
+func (m *model) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	gcp, err := m.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Just fetch this object?
+	obj := &krm.IAMServiceAccount{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	projectID := obj.Annotations["cnrm.cloud.google.com/project-id"]
+	if projectID == "" {
+		return nil, fmt.Errorf("unable to determine project")
+	}
+
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("unable to determine resourceID")
+	}
+
+	return &adapter{
+		projectID: projectID,
+		accountID: resourceID,
+		desired:   obj,
+		gcp:       gcp,
+	}, nil
+}
+
+// Find implements the Adapter interface.
+func (a *adapter) Find(ctx context.Context) (bool, error) {
+	if a.accountID == "" {
+		return false, nil
+	}
+
+	serviceAccount, err := a.gcp.Projects.ServiceAccounts.Get(a.fullyQualifiedName()).Context(ctx).Do()
+	if err != nil {
+		if IsNotFound(err) {
+			klog.Warningf("serviceaccount was not found: %v", err)
+			return false, nil
+		}
+		return false, err
+	}
+
+	u := &krm.IAMServiceAccount{}
+	if err := serviceAccountToKRM(serviceAccount, u); err != nil {
+		return false, err
+	}
+	a.actual = u
+
+	return true, nil
+}
+
+func serviceAccountToKRM(in *api.ServiceAccount, out *krm.IAMServiceAccount) error {
+	out.Spec.DisplayName = PtrTo(in.DisplayName)
+	out.Spec.Description = PtrTo(in.Description)
+	out.Status.Email = PtrTo(in.Email)
+	// out.Status.ProjectId = in.GetProjectId()
+	out.Status.UniqueId = PtrTo(in.UniqueId)
+	// out.Status.Oauth2ClientId = in.GetOauth2ClientId()
+	// out.Status.Disabled = in.GetDisabled()
+	return nil
+}
+
+// Delete implements the Adapter interface.
+func (a *adapter) Delete(ctx context.Context) (bool, error) {
+	// TODO: Delete via status selfLink?
+	_, err := a.gcp.Projects.ServiceAccounts.Delete(a.fullyQualifiedName()).Context(ctx).Do()
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("deleting serviceaccount: %w", err)
+	}
+
+	return true, nil
+}
+
+// Create implements the Adapter interface.
+func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating object", "u", u)
+
+	// The [ServiceAccount][google.iam.admin.v1.ServiceAccount] resource to
+	// create. Currently, only the following values are user assignable:
+	// `display_name` and `description`.
+	serviceAccount := &api.ServiceAccount{
+		DisplayName: ValueOf(a.desired.Spec.DisplayName),
+		Description: ValueOf(a.desired.Spec.Description),
+	}
+
+	req := &api.CreateServiceAccountRequest{
+		// Name:           a.fullyQualifiedName(),
+		AccountId:      a.accountID,
+		ServiceAccount: serviceAccount,
+	}
+
+	parent := "projects/" + a.projectID
+	created, err := a.gcp.Projects.ServiceAccounts.Create(parent, req).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("creating serviceaccount: %w", err)
+	}
+	log.V(2).Info("created serviceaccount", "serviceaccount", created)
+	// TODO: Return created object
+	return nil
+}
+
+// Update implements the Adapter interface.
+func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error) {
+	// TODO: Skip updates at the higher level if no changes?
+	updateMask := &fieldmaskpb.FieldMask{}
+
+	// TODO: I think we can do this with a helper
+	if !areSame(a.desired.Spec.DisplayName, a.actual.Spec.DisplayName) {
+		updateMask.Paths = append(updateMask.Paths, "display_name")
+	}
+	if !areSame(a.desired.Spec.Description, a.actual.Spec.Description) {
+		updateMask.Paths = append(updateMask.Paths, "description")
+	}
+
+	if len(updateMask.Paths) == 0 {
+		klog.Warningf("unexpected empty update mask, desired: %v, actual: %v", a.desired, a.actual)
+		return nil, nil
+	}
+
+	// TODO: Where/how do we want to enforce immutability?
+
+	// Currently, only the following fields are updatable:
+	// display_name .
+	sa := &api.ServiceAccount{
+		DisplayName: ValueOf(a.desired.Spec.DisplayName),
+		Description: ValueOf(a.desired.Spec.Description),
+	}
+	req := &api.PatchServiceAccountRequest{
+		UpdateMask:     strings.Join(updateMask.GetPaths(), ","),
+		ServiceAccount: sa,
+	}
+
+	_, err := a.gcp.Projects.ServiceAccounts.Patch(a.fullyQualifiedName(), req).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	// TODO: Return updated object
+	return nil, nil
+}
+
+func (a *adapter) fullyQualifiedName() string {
+	// The resource name of the service account.
+	//
+	// Use one of the following formats:
+	//
+	// * `projects/{PROJECT_ID}/serviceAccounts/{EMAIL_ADDRESS}`
+	// * `projects/{PROJECT_ID}/serviceAccounts/{UNIQUE_ID}`
+	//
+
+	email := a.accountID + "@" + a.projectID + ".iam.gserviceaccount.com"
+	return fmt.Sprintf("projects/%s/serviceAccounts/%s", a.projectID, email)
+}

--- a/pkg/controller/direct/iam/serviceaccount_controller.go
+++ b/pkg/controller/direct/iam/serviceaccount_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/iam/v1beta1"
@@ -91,7 +92,7 @@ func (m *model) client(ctx context.Context) (*api.Service, error) {
 }
 
 // AdapterForObject implements the Model interface.
-func (m *model) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+func (m *model) AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
 	gcp, err := m.client(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/iam/serviceaccount_controller.go
+++ b/pkg/controller/direct/iam/serviceaccount_controller.go
@@ -203,7 +203,7 @@ func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 }
 
 // Update implements the Adapter interface.
-func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error) {
+func (a *adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
 	// TODO: Skip updates at the higher level if no changes?
 	updateMask := &fieldmaskpb.FieldMask{}
 
@@ -217,7 +217,7 @@ func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error
 
 	if len(updateMask.Paths) == 0 {
 		klog.Warningf("unexpected empty update mask, desired: %v, actual: %v", a.desired, a.actual)
-		return nil, nil
+		return nil
 	}
 
 	// TODO: Where/how do we want to enforce immutability?
@@ -235,10 +235,10 @@ func (a *adapter) Update(ctx context.Context) (*unstructured.Unstructured, error
 
 	_, err := a.gcp.Projects.ServiceAccounts.Patch(a.fullyQualifiedName(), req).Context(ctx).Do()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	// TODO: Return updated object
-	return nil, nil
+	// TODO: Return updated object status
+	return nil
 }
 
 func (a *adapter) fullyQualifiedName() string {

--- a/pkg/controller/direct/iam/utils.go
+++ b/pkg/controller/direct/iam/utils.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"errors"
+
+	"github.com/googleapis/gax-go/v2/apierror"
+	"k8s.io/klog/v2"
+)
+
+func ValueOf[T any](p *T) T {
+	var v T
+	if p != nil {
+		v = *p
+	}
+	return v
+}
+
+func PtrTo[T any](t T) *T {
+	return &t
+}
+
+func areSame[T comparable](l, r *T) bool {
+	if l == nil {
+		return r == nil
+	}
+	if r == nil {
+		return l == nil
+	}
+	return *l == *r
+}
+
+// HasHTTPCode returns true if the given error is an HTTP response with the given code.
+func HasHTTPCode(err error, code int) bool {
+	if err == nil {
+		return false
+	}
+	apiError := &apierror.APIError{}
+	if errors.As(err, &apiError) {
+		if apiError.HTTPCode() == code {
+			return true
+		}
+	} else {
+		klog.Warningf("unexpected error type %T", err)
+	}
+	return false
+}
+
+// IsNotFound returns true if the given error is an HTTP 404.
+func IsNotFound(err error) bool {
+	return HasHTTPCode(err, 404)
+}

--- a/pkg/controller/direct/resourcemanager/client.go
+++ b/pkg/controller/direct/resourcemanager/client.go
@@ -78,3 +78,15 @@ func (m *gcpClient) newTagValuesClient(ctx context.Context) (*api.TagValuesClien
 	}
 	return client, err
 }
+
+func (m *gcpClient) newTagBindingsClient(ctx context.Context) (*api.TagBindingsClient, error) {
+	opts, err := m.options()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewTagBindingsRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building tag bindings client: %w", err)
+	}
+	return client, err
+}

--- a/pkg/controller/direct/resourcemanager/client.go
+++ b/pkg/controller/direct/resourcemanager/client.go
@@ -66,3 +66,15 @@ func (m *gcpClient) newTagKeysClient(ctx context.Context) (*api.TagKeysClient, e
 	}
 	return client, err
 }
+
+func (m *gcpClient) newTagValuesClient(ctx context.Context) (*api.TagValuesClient, error) {
+	opts, err := m.options()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewTagValuesRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building tag values client: %w", err)
+	}
+	return client, err
+}

--- a/pkg/controller/direct/resourcemanager/client.go
+++ b/pkg/controller/direct/resourcemanager/client.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+
+	api "cloud.google.com/go/resourcemanager/apiv3"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"google.golang.org/api/option"
+)
+
+type gcpClient struct {
+	config controller.Config
+}
+
+func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+	gcpClient := &gcpClient{
+		config: *config,
+	}
+	return gcpClient, nil
+}
+
+func (m *gcpClient) options() ([]option.ClientOption, error) {
+	var opts []option.ClientOption
+	if m.config.UserAgent != "" {
+		opts = append(opts, option.WithUserAgent(m.config.UserAgent))
+	}
+	if m.config.HTTPClient != nil {
+		// TODO: Set UserAgent in this scenario (error is: WithHTTPClient is incompatible with gRPC dial options)
+		opts = append(opts, option.WithHTTPClient(m.config.HTTPClient))
+	}
+	if m.config.UserProjectOverride && m.config.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(m.config.BillingProject))
+	}
+
+	// TODO: support endpoints?
+	// if m.config.Endpoint != "" {
+	// 	opts = append(opts, option.WithEndpoint(m.config.Endpoint))
+	// }
+
+	return opts, nil
+}
+
+func (m *gcpClient) newTagKeysClient(ctx context.Context) (*api.TagKeysClient, error) {
+	opts, err := m.options()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewTagKeysRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building tag keys client: %w", err)
+	}
+	return client, err
+}

--- a/pkg/controller/direct/resourcemanager/tagbinding_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagbinding_controller.go
@@ -1,0 +1,276 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	api "cloud.google.com/go/resourcemanager/apiv3"
+	pb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+	"google.golang.org/api/iterator"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+)
+
+// AddTagBindingController creates a new controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func AddTagBindingController(mgr manager.Manager, config *controller.Config) error {
+	gvk := krm.TagsTagBindingGVK
+
+	// TODO: Share gcp client (any value in doing so)?
+	ctx := context.TODO()
+	gcpClient, err := newGCPClient(ctx, config)
+	if err != nil {
+		return err
+	}
+	m := &tagBindingModel{gcpClient: gcpClient}
+	return directbase.Add(mgr, gvk, m)
+}
+
+type tagBindingModel struct {
+	*gcpClient
+}
+
+// model implements the Model interface.
+var _ directbase.Model = &tagBindingModel{}
+
+type tagBindingAdapter struct {
+	resourceID string
+
+	desired *krm.TagsTagBinding
+	actual  *pb.TagBinding
+
+	tagBindingsClient *api.TagBindingsClient
+}
+
+// adapter implements the Adapter interface.
+var _ directbase.Adapter = &tagBindingAdapter{}
+
+// AdapterForObject implements the Model interface.
+func (m *tagBindingModel) AdapterForObject(ctx context.Context, client client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	tagBindingsClient, err := m.newTagBindingsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Just fetch this object?
+	obj := &krm.TagsTagBinding{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	// Resolve the parent ref
+	if obj.Spec.ParentRef.Name != "" {
+		return nil, fmt.Errorf("refs in parent are not yet implemented")
+	}
+
+	// Resolve the tagValue ref
+	if obj.Spec.TagValueRef.Name != "" {
+		parentObj := &unstructured.Unstructured{}
+		parentObj.SetGroupVersionKind(krm.TagsTagValueGVK)
+		key := types.NamespacedName{
+			Name:      obj.Spec.TagValueRef.Name,
+			Namespace: obj.Spec.TagValueRef.Namespace,
+		}
+		if key.Namespace == "" {
+			key.Namespace = obj.GetNamespace()
+		}
+		if err := client.Get(ctx, key, parentObj); err != nil {
+			return nil, fmt.Errorf("getting tagValueRef %v: %w", key, err)
+		}
+		name, _, err := unstructured.NestedString(parentObj.Object, "status", "name")
+		if err != nil {
+			return nil, fmt.Errorf("getting status.name: %w", err)
+		}
+		if name == "" {
+			// TODO: Return correct dependency-not-ready value
+			return nil, fmt.Errorf("not ready")
+		}
+		external := "tagValues/" + name
+		obj.Spec.TagValueRef = v1alpha1.ResourceRef{
+			External: external,
+		}
+	}
+
+	// TODO: validate that tagValueRef.External is well-formed if the user provided it
+
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	// // resourceID is server-generated, no fallback
+	// // TODO: How do we do resource acquisition - maybe by shortname?
+	// resourceID = strings.TrimPrefix(resourceID, "tagBindings/")
+
+	return &tagBindingAdapter{
+		resourceID:        resourceID,
+		desired:           obj,
+		tagBindingsClient: tagBindingsClient,
+	}, nil
+}
+
+// Find implements the Adapter interface.
+func (a *tagBindingAdapter) Find(ctx context.Context) (bool, error) {
+	if a.resourceID == "" {
+		return false, nil
+	}
+
+	parent := a.desired.Spec.ParentRef.External
+	if parent == "" {
+		return false, fmt.Errorf("parent is empty")
+	}
+	tagValue := a.desired.Spec.TagValueRef.External
+	if tagValue == "" {
+		return false, fmt.Errorf("tagValue is empty")
+	}
+
+	req := &pb.ListTagBindingsRequest{
+		Parent: parent,
+	}
+
+	tagBindingIterator := a.tagBindingsClient.ListTagBindings(ctx, req)
+
+	var found []*pb.TagBinding
+	for {
+		// Its second return value is iterator.Done if there are no more
+		// // results. Once Next returns Done, all subsequent calls will return Done.
+		next, err := tagBindingIterator.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return false, fmt.Errorf("listing tagBindings: %w", err)
+		}
+		if next.TagValue == tagValue {
+			found = append(found, next)
+		}
+	}
+
+	if len(found) == 0 {
+		return false, nil
+	}
+	if len(found) > 1 {
+		return false, fmt.Errorf("found multiple values matching tagValue %q", tagValue)
+	}
+	a.actual = found[0]
+
+	return true, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *tagBindingAdapter) Delete(ctx context.Context) (bool, error) {
+	// Already deletd
+	if a.resourceID == "" {
+		return false, nil
+	}
+
+	// TODO: Delete via status selfLink?
+	req := &pb.DeleteTagBindingRequest{
+		Name: a.fullyQualifiedName(),
+	}
+
+	op, err := a.tagBindingsClient.DeleteTagBinding(ctx, req)
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("deleting tagBinding: %w", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		return false, fmt.Errorf("tagBinding deletion failed: %w", err)
+	}
+	// TODO: Do we need to check that it was deleted?
+
+	return true, nil
+}
+
+// Create implements the Adapter interface.
+func (a *tagBindingAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating object", "u", u)
+
+	parent := a.desired.Spec.ParentRef.External
+	if parent == "" {
+		return fmt.Errorf("parent is empty")
+	}
+	tagValue := a.desired.Spec.TagValueRef.External
+	if tagValue == "" {
+		return fmt.Errorf("tagValue is empty")
+	}
+
+	tagBinding := &pb.TagBinding{
+		Parent:   parent,
+		TagValue: tagValue,
+	}
+
+	req := &pb.CreateTagBindingRequest{
+		TagBinding: tagBinding,
+	}
+
+	log.Info("creating tagBinding", "request", req)
+
+	op, err := a.tagBindingsClient.CreateTagBinding(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating tagBinding: %w", err)
+	}
+
+	created, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("tagBinding creation failed: %w", err)
+	}
+
+	log.V(2).Info("created tagbinding", "tagbinding", created)
+
+	resourceID := strings.TrimPrefix(created.Name, "tagBindings/")
+	if err := unstructured.SetNestedField(u.Object, resourceID, "spec", "resourceID"); err != nil {
+		return fmt.Errorf("setting spec.resourceID: %w", err)
+	}
+
+	status := &krm.TagsTagBindingStatus{}
+	if err := tagBindingStatusToKRM(created, status); err != nil {
+		return err
+	}
+
+	return setStatus(u, status)
+}
+
+func tagBindingStatusToKRM(in *pb.TagBinding, out *krm.TagsTagBindingStatus) error {
+	name := in.Name
+	out.Name = &name
+	return nil
+}
+
+// Update implements the Adapter interface.
+func (a *tagBindingAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+	// TODO: Where/how do we want to enforce immutability?
+
+	// TODO: Make this an error if anything has changed
+
+	// TODO: Return updated object status
+	return nil
+}
+
+func (a *tagBindingAdapter) fullyQualifiedName() string {
+	return fmt.Sprintf("tagBindings/%s", a.resourceID)
+}

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -1,0 +1,252 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	api "cloud.google.com/go/resourcemanager/apiv3"
+	pb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+)
+
+// AddTagKeyController creates a new controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func AddTagKeyController(mgr manager.Manager, config *controller.Config) error {
+	gvk := krm.TagsTagKeyGVK
+
+	// TODO: Share gcp client (any value in doing so)?
+	ctx := context.TODO()
+	gcpClient, err := newGCPClient(ctx, config)
+	if err != nil {
+		return err
+	}
+	m := &tagKeyModel{gcpClient: gcpClient}
+	return directbase.Add(mgr, gvk, m)
+}
+
+type tagKeyModel struct {
+	*gcpClient
+}
+
+// model implements the Model interface.
+var _ directbase.Model = &tagKeyModel{}
+
+type tagKeyAdapter struct {
+	resourceID string
+
+	desired *krm.TagsTagKey
+	actual  *pb.TagKey
+
+	*gcpClient
+	tagKeysClient *api.TagKeysClient
+}
+
+// adapter implements the Adapter interface.
+var _ directbase.Adapter = &tagKeyAdapter{}
+
+// AdapterForObject implements the Model interface.
+func (m *tagKeyModel) AdapterForObject(ctx context.Context, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	tagKeysClient, err := m.newTagKeysClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Just fetch this object?
+	obj := &krm.TagsTagKey{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	// resourceID is server-generated, no fallback
+	// TODO: How do we do resource acquisition - maybe by shortname?
+	resourceID = strings.TrimPrefix(resourceID, "tagKeys/")
+
+	return &tagKeyAdapter{
+		resourceID:    resourceID,
+		desired:       obj,
+		gcpClient:     m.gcpClient,
+		tagKeysClient: tagKeysClient,
+	}, nil
+}
+
+// Find implements the Adapter interface.
+func (a *tagKeyAdapter) Find(ctx context.Context) (bool, error) {
+	if a.resourceID == "" {
+		return false, nil
+	}
+
+	req := &pb.GetTagKeyRequest{
+		Name: a.fullyQualifiedName(),
+	}
+	tagKey, err := a.tagKeysClient.GetTagKey(ctx, req)
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	a.actual = tagKey
+
+	return true, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *tagKeyAdapter) Delete(ctx context.Context) (bool, error) {
+	// Already deletd
+	if a.resourceID == "" {
+		return false, nil
+	}
+
+	// TODO: Delete via status selfLink?
+	req := &pb.DeleteTagKeyRequest{
+		Name: a.fullyQualifiedName(),
+	}
+
+	op, err := a.tagKeysClient.DeleteTagKey(ctx, req)
+	if err != nil {
+		if IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("deleting tagKey: %w", err)
+	}
+
+	if _, err := op.Wait(ctx); err != nil {
+		return false, fmt.Errorf("tagKey deletion failed: %w", err)
+	}
+	// TODO: Do we need to check that it was deleted?
+
+	return true, nil
+}
+
+// Create implements the Adapter interface.
+func (a *tagKeyAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating object", "u", u)
+
+	// TODO: Should be ref
+	parent := a.desired.Spec.Parent
+	tagKey := &pb.TagKey{
+		Parent:      parent,
+		ShortName:   a.desired.Spec.ShortName,
+		Description: ValueOf(a.desired.Spec.Description),
+		PurposeData: a.desired.Spec.PurposeData,
+	}
+
+	if s := ValueOf(a.desired.Spec.Purpose); s != "" {
+		purpose, ok := pb.Purpose_value[s]
+		if !ok {
+			return fmt.Errorf("unknown purpose %q", s)
+		}
+		tagKey.Purpose = pb.Purpose(purpose)
+	}
+	req := &pb.CreateTagKeyRequest{
+		TagKey: tagKey,
+	}
+
+	op, err := a.tagKeysClient.CreateTagKey(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating tagKey: %w", err)
+	}
+
+	created, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("tagKey creation failed: %w", err)
+	}
+
+	log.V(2).Info("created tagkey", "tagkey", created)
+
+	resourceID := created.Name
+	if err := unstructured.SetNestedField(u.Object, resourceID, "spec", "resourceID"); err != nil {
+		return fmt.Errorf("setting spec.resourceID: %w", err)
+	}
+
+	status := &krm.TagsTagKeyStatus{}
+	if err := tagKeyStatusToKRM(created, status); err != nil {
+		return err
+	}
+
+	return setStatus(u, status)
+}
+
+func tagKeyStatusToKRM(in *pb.TagKey, out *krm.TagsTagKeyStatus) error {
+	out.NamespacedName = &in.NamespacedName
+	// TODO: Should be metav1.Time (?)
+	out.CreateTime = timeToKRMString(in.GetCreateTime())
+	out.UpdateTime = timeToKRMString(in.GetUpdateTime())
+	return nil
+}
+
+func timeToKRMString(t *timestamppb.Timestamp) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.AsTime().Format(time.RFC3339Nano)
+	return &s
+}
+
+// Update implements the Adapter interface.
+func (a *tagKeyAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+	// TODO: Skip updates at the higher level if no changes?
+	updateMask := &fieldmaskpb.FieldMask{}
+	update := &pb.TagKey{}
+	update.Name = a.fullyQualifiedName()
+
+	// description is the only field that can be updated
+	if ValueOf(a.desired.Spec.Description) != a.actual.GetDescription() {
+		updateMask.Paths = append(updateMask.Paths, "description")
+		update.Description = ValueOf(a.desired.Spec.Description)
+	}
+
+	// TODO: Where/how do we want to enforce immutability?
+
+	if len(updateMask.Paths) != 0 {
+		req := &pb.UpdateTagKeyRequest{
+			TagKey:     update,
+			UpdateMask: updateMask,
+		}
+
+		op, err := a.tagKeysClient.UpdateTagKey(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		if _, err := op.Wait(ctx); err != nil {
+			return fmt.Errorf("tagKey update failed: %w", err)
+		}
+		// TODO: Do we need to check that the operation succeeeded?
+	}
+
+	// TODO: Return updated object status
+	return nil
+}
+
+func (a *tagKeyAdapter) fullyQualifiedName() string {
+	return fmt.Sprintf("tagKeys/%s", a.resourceID)
+}

--- a/pkg/controller/direct/resourcemanager/utils.go
+++ b/pkg/controller/direct/resourcemanager/utils.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/googleapis/gax-go/v2/apierror"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+func setStatus(u *unstructured.Unstructured, typedStatus any) error {
+	// TODO: Just fetch this object?
+	status, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedStatus)
+	if err != nil {
+		return fmt.Errorf("error converting status to unstructured: %w", err)
+	}
+	// TODO: Merge to avoid overwriting conditions?
+	u.Object["status"] = status
+
+	return nil
+}
+
+func ValueOf[T any](p *T) T {
+	var v T
+	if p != nil {
+		v = *p
+	}
+	return v
+}
+
+func PtrTo[T any](t T) *T {
+	return &t
+}
+
+func areSame[T comparable](l, r *T) bool {
+	if l == nil {
+		return r == nil
+	}
+	if r == nil {
+		return l == nil
+	}
+	return *l == *r
+}
+
+// HasHTTPCode returns true if the given error is an HTTP response with the given code.
+func HasHTTPCode(err error, code int) bool {
+	if err == nil {
+		return false
+	}
+	apiError := &apierror.APIError{}
+	if errors.As(err, &apiError) {
+		if apiError.HTTPCode() == code {
+			return true
+		}
+	} else {
+		klog.Warningf("unexpected error type %T", err)
+	}
+	return false
+}
+
+// IsNotFound returns true if the given error is an HTTP 404.
+func IsNotFound(err error) bool {
+	return HasHTTPCode(err, 404)
+}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -215,6 +215,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 			}
 			return schemaUpdater, nil
 
+		case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagBinding"}:
+			if err := resourcemanager.AddTagBindingController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
 		default:
 			return nil, fmt.Errorf("requested direct reconciler for %v, but it is not supported", gvk.GroupKind())
 		}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -24,6 +24,7 @@ import (
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/deletiondefender"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/apikeys"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/compute"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iam"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/gsakeysecretgenerator"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/auditconfig"
@@ -185,6 +186,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 
 		case schema.GroupKind{Group: "iam.cnrm.cloud.google.com", Kind: "IAMServiceAccount"}:
 			if err := iam.AddServiceAccountController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
+		case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeNetwork"}:
+			if err := compute.AddNetworkController(r.mgr, config); err != nil {
 				return nil, err
 			}
 			return schemaUpdater, nil

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -209,6 +209,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 			}
 			return schemaUpdater, nil
 
+		case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagValue"}:
+			if err := resourcemanager.AddTagValueController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
 		default:
 			return nil, fmt.Errorf("requested direct reconciler for %v, but it is not supported", gvk.GroupKind())
 		}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -24,6 +24,7 @@ import (
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/deletiondefender"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/apikeys"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iam"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/gsakeysecretgenerator"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/auditconfig"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/partialpolicy"
@@ -181,6 +182,13 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 				return nil, err
 			}
 			return schemaUpdater, nil
+
+		case schema.GroupKind{Group: "iam.cnrm.cloud.google.com", Kind: "IAMServiceAccount"}:
+			if err := iam.AddServiceAccountController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
 		default:
 			return nil, fmt.Errorf("requested direct reconciler for %v, but it is not supported", gvk.GroupKind())
 		}

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/apikeys"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/compute"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iam"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/resourcemanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/gsakeysecretgenerator"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/auditconfig"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/partialpolicy"
@@ -198,6 +199,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 
 		case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeSubnetwork"}:
 			if err := compute.AddSubnetworkController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
+		case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagKey"}:
+			if err := resourcemanager.AddTagKeyController(r.mgr, config); err != nil {
 				return nil, err
 			}
 			return schemaUpdater, nil

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -196,6 +196,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 			}
 			return schemaUpdater, nil
 
+		case schema.GroupKind{Group: "compute.cnrm.cloud.google.com", Kind: "ComputeSubnetwork"}:
+			if err := compute.AddSubnetworkController(r.mgr, config); err != nil {
+				return nil, err
+			}
+			return schemaUpdater, nil
+
 		default:
 			return nil, fmt.Errorf("requested direct reconciler for %v, but it is not supported", gvk.GroupKind())
 		}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/_http.log
@@ -1,0 +1,862 @@
+POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For keyname resources.",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For valuename resources.",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=211
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The caller does not have permission",
+        "reason": "forbidden"
+      }
+    ],
+    "message": "The caller does not have permission",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projectid",
+  "parent": {
+    "id": "811985825579",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=209
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=304
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.ProjectCreationStatus",
+    "gettable": true,
+    "ready": true
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.Project",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "labels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "lifecycleState": "ACTIVE",
+    "name": "projectid",
+    "parent": {
+      "id": "811985825579",
+      "type": "organization"
+    },
+    "projectId": "project-${uniqueId}",
+    "projectNumber": "53277142975"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=477
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "projectid",
+  "parent": {
+    "id": "811985825579",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "53277142975"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=481
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "projectid",
+  "parent": {
+    "id": "811985825579",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "53277142975"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+  "tagValue": "tagValues/${tagValueID}"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagBinding",
+    "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
+    "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+    "tagValue": "tagValues/${tagValueID}",
+    "tagValueNamespacedName": "${organizationID}/keyname${uniqueId}/valuename"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "tagBindings": [
+    {
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "tagValue": "tagValues/${tagValueID}"
+    }
+  ]
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "tagBindings": [
+    {
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "tagValue": "tagValues/${tagValueID}"
+    }
+  ]
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "tagBindings": [
+    {
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "tagValue": "tagValues/${tagValueID}"
+    }
+  ]
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=498
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "projectid",
+  "parent": {
+    "id": "811985825579",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "53277142975"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=3897
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/_http.log
@@ -242,241 +242,12 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-403 Forbidden
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=211
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 403,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The caller does not have permission",
-        "reason": "forbidden"
-      }
-    ],
-    "message": "The caller does not have permission",
-    "status": "PERMISSION_DENIED"
-  }
-}
-
----
-
-POST https://cloudresourcemanager.googleapis.com/v1/projects?alt=json&prettyPrint=false
-Content-Type: application/json
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-{
-  "labels": {
-    "cnrm-test": "true",
-    "managed-by-cnrm": "true"
-  },
-  "name": "projectid",
-  "parent": {
-    "id": "811985825579",
-    "type": "organization"
-  },
-  "projectId": "project-${uniqueId}"
-}
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=209
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "name": "operations/${operationID}"
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v1/operations/${operationID}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=304
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "done": true,
-  "metadata": {
-    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.ProjectCreationStatus",
-    "gettable": true,
-    "ready": true
-  },
-  "name": "operations/${operationID}",
-  "response": {
-    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.Project",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "labels": {
-      "cnrm-test": "true",
-      "managed-by-cnrm": "true"
-    },
-    "lifecycleState": "ACTIVE",
-    "name": "projectid",
-    "parent": {
-      "id": "811985825579",
-      "type": "organization"
-    },
-    "projectId": "project-${uniqueId}",
-    "projectNumber": "53277142975"
-  }
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=477
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "labels": {
-    "cnrm-test": "true",
-    "managed-by-cnrm": "true"
-  },
-  "lifecycleState": "ACTIVE",
-  "name": "projectid",
-  "parent": {
-    "id": "811985825579",
-    "type": "organization"
-  },
-  "projectId": "project-${uniqueId}",
-  "projectNumber": "53277142975"
-}
-
----
-
-GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "billingAccountName": "",
-  "billingEnabled": false,
-  "name": "projects/project-${uniqueId}/billingInfo",
-  "projectId": "project-${uniqueId}"
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=481
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "labels": {
-    "cnrm-test": "true",
-    "managed-by-cnrm": "true"
-  },
-  "lifecycleState": "ACTIVE",
-  "name": "projectid",
-  "parent": {
-    "id": "811985825579",
-    "type": "organization"
-  },
-  "projectId": "project-${uniqueId}",
-  "projectNumber": "53277142975"
-}
-
----
-
-GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "billingAccountName": "",
-  "billingEnabled": false,
-  "name": "projects/project-${uniqueId}/billingInfo",
-  "projectId": "project-${uniqueId}"
-}
-
----
-
 POST https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
 {
-  "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+  "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
   "tagValue": "tagValues/${tagValueID}"
 }
 
@@ -495,8 +266,8 @@ X-Xss-Protection: 0
   "done": true,
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagBinding",
-    "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
-    "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+    "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+    "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
     "tagValue": "tagValues/${tagValueID}",
     "tagValueNamespacedName": "${organizationID}/keyname${uniqueId}/valuename"
   }
@@ -504,7 +275,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -522,8 +293,8 @@ X-Xss-Protection: 0
 {
   "tagBindings": [
     {
-      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
-      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
       "tagValue": "tagValues/${tagValueID}"
     }
   ]
@@ -531,7 +302,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -549,8 +320,8 @@ X-Xss-Protection: 0
 {
   "tagBindings": [
     {
-      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
-      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
       "tagValue": "tagValues/${tagValueID}"
     }
   ]
@@ -558,7 +329,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings/?alt=json&pageSize=300&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -576,8 +347,8 @@ X-Xss-Protection: 0
 {
   "tagBindings": [
     {
-      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}",
-      "parent": "//cloudresourcemanager.googleapis.com/projects/53277142975",
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
       "tagValue": "tagValues/${tagValueID}"
     }
   ]
@@ -585,7 +356,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F53277142975/tagValues/${tagValueID}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -606,84 +377,6 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.protobuf.Empty"
   }
 }
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=498
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "labels": {
-    "cnrm-test": "true",
-    "managed-by-cnrm": "true"
-  },
-  "lifecycleState": "ACTIVE",
-  "name": "projectid",
-  "parent": {
-    "id": "811985825579",
-    "type": "organization"
-  },
-  "projectId": "project-${uniqueId}",
-  "projectNumber": "53277142975"
-}
-
----
-
-GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "billingAccountName": "",
-  "billingEnabled": false,
-  "name": "projects/project-${uniqueId}/billingInfo",
-  "projectId": "project-${uniqueId}"
-}
-
----
-
-DELETE https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Server-Timing: gfet4t7; dur=3897
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{}
 
 ---
 

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/create.yaml
@@ -18,6 +18,7 @@ metadata:
   name: tagstagbinding-${uniqueId}
 spec:
   parentRef:
-    name: project-${uniqueId}
+    # TODO: projectId should work
+    external: //cloudresourcemanager.googleapis.com/projects/${projectNumber}
   tagValueRef:
     name: tagstagvalue-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagbinding/tagbindingbasic/dependencies.yaml
@@ -30,12 +30,3 @@ spec:
   parentRef:
     name: tagstagkey-${uniqueId}
   shortName: valuename
----
-apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-kind: Project
-metadata:
-  name: project-${uniqueId}
-spec:
-  name: projectid
-  organizationRef:
-    external: ${TEST_ORG_ID}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyorgbasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyorgbasic/_http.log
@@ -4,7 +4,7 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
 
 {
   "description": "For keyname resources.",
-  "parent": "organizations/123450001",
+  "parent": "organizations/${organizationID}",
   "shortName": "keyname${uniqueId}"
 }
 
@@ -23,7 +23,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -48,15 +48,15 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For keyname resources.",
     "etag": "abcdef0123A=",
-    "name": "tagKeys/${tagKeyId}",
-    "namespacedName": "123450001/keyname${uniqueId}",
-    "parent": "organizations/123450001",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
     "shortName": "keyname${uniqueId}",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
@@ -64,7 +64,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -83,16 +83,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
-  "namespacedName": "123450001/keyname${uniqueId}",
-  "parent": "organizations/123450001",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
   "shortName": "keyname${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -111,16 +111,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
-  "namespacedName": "123450001/keyname${uniqueId}",
-  "parent": "organizations/123450001",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
   "shortName": "keyname${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -139,16 +139,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
-  "namespacedName": "123450001/keyname${uniqueId}",
-  "parent": "organizations/123450001",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
   "shortName": "keyname${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -167,7 +167,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -192,15 +192,15 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For keyname resources.",
     "etag": "abcdef0123A=",
-    "name": "tagKeys/${tagKeyId}",
-    "namespacedName": "123450001/keyname${uniqueId}",
-    "parent": "organizations/123450001",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
     "shortName": "keyname${uniqueId}",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_http.log
@@ -1,0 +1,417 @@
+POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For keyname resources.",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For valuename resources.",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "namespacedName": "${organizationID}/keyname${uniqueId}",
+    "parent": "organizations/${organizationID}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_http.log
@@ -92,6 +92,34 @@ X-Xss-Protection: 0
 
 ---
 
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "namespacedName": "${organizationID}/keyname${uniqueId}",
+  "parent": "organizations/${organizationID}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
 POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
@@ -118,34 +146,6 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
   },
   "name": "operations/${operationID}"
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "For keyname resources.",
-  "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyID}",
-  "namespacedName": "${organizationID}/keyname${uniqueId}",
-  "parent": "organizations/${organizationID}",
-  "shortName": "keyname${uniqueId}",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
@@ -1,0 +1,417 @@
+POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For keyname resources.",
+  "parent": "projects/${projectId}",
+  "shortName": "keyname${uniqueId}"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationId}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyId}",
+    "namespacedName": "${projectId}/keyname${uniqueId}",
+    "parent": "projects/${projectNumber}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+{
+  "description": "For valuename resources.",
+  "parent": "tagKeys/${tagKeyId}",
+  "shortName": "valuename"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationId}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueId}",
+    "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyId}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyId}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyId}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For valuename resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
+  "parent": "tagKeys/${tagKeyId}",
+  "shortName": "valuename",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationId}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For valuename resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueId}",
+    "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
+    "parent": "tagKeys/${tagKeyId}",
+    "shortName": "valuename",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "For keyname resources.",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyId}",
+  "namespacedName": "${projectId}/keyname${uniqueId}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "keyname${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationId}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "For keyname resources.",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyId}",
+    "namespacedName": "${projectId}/keyname${uniqueId}",
+    "parent": "projects/${projectNumber}",
+    "shortName": "keyname${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
@@ -23,7 +23,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -48,13 +48,13 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For keyname resources.",
     "etag": "abcdef0123A=",
-    "name": "tagKeys/${tagKeyId}",
+    "name": "tagKeys/${tagKeyID}",
     "namespacedName": "${projectId}/keyname${uniqueId}",
     "parent": "projects/${projectNumber}",
     "shortName": "keyname${uniqueId}",
@@ -64,7 +64,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -83,7 +83,7 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
+  "name": "tagKeys/${tagKeyID}",
   "namespacedName": "${projectId}/keyname${uniqueId}",
   "parent": "projects/${projectNumber}",
   "shortName": "keyname${uniqueId}",
@@ -92,7 +92,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -111,7 +111,7 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
+  "name": "tagKeys/${tagKeyID}",
   "namespacedName": "${projectId}/keyname${uniqueId}",
   "parent": "projects/${projectNumber}",
   "shortName": "keyname${uniqueId}",
@@ -126,7 +126,7 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
 
 {
   "description": "For valuename resources.",
-  "parent": "tagKeys/${tagKeyId}",
+  "parent": "tagKeys/${tagKeyID}",
   "shortName": "valuename"
 }
 
@@ -145,7 +145,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -170,15 +170,15 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For valuename resources.",
     "etag": "abcdef0123A=",
-    "name": "tagValues/${tagValueId}",
+    "name": "tagValues/${tagValueID}",
     "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-    "parent": "tagKeys/${tagKeyId}",
+    "parent": "tagKeys/${tagKeyID}",
     "shortName": "valuename",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
@@ -186,7 +186,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -205,16 +205,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For valuename resources.",
   "etag": "abcdef0123A=",
-  "name": "tagValues/${tagValueId}",
+  "name": "tagValues/${tagValueID}",
   "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-  "parent": "tagKeys/${tagKeyId}",
+  "parent": "tagKeys/${tagKeyID}",
   "shortName": "valuename",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -233,16 +233,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For valuename resources.",
   "etag": "abcdef0123A=",
-  "name": "tagValues/${tagValueId}",
+  "name": "tagValues/${tagValueID}",
   "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-  "parent": "tagKeys/${tagKeyId}",
+  "parent": "tagKeys/${tagKeyID}",
   "shortName": "valuename",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -261,16 +261,16 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For valuename resources.",
   "etag": "abcdef0123A=",
-  "name": "tagValues/${tagValueId}",
+  "name": "tagValues/${tagValueID}",
   "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-  "parent": "tagKeys/${tagKeyId}",
+  "parent": "tagKeys/${tagKeyID}",
   "shortName": "valuename",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
 
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueId}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -289,7 +289,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -314,15 +314,15 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For valuename resources.",
     "etag": "abcdef0123A=",
-    "name": "tagValues/${tagValueId}",
+    "name": "tagValues/${tagValueID}",
     "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-    "parent": "tagKeys/${tagKeyId}",
+    "parent": "tagKeys/${tagKeyID}",
     "shortName": "valuename",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
@@ -330,7 +330,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -349,7 +349,7 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "For keyname resources.",
   "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyId}",
+  "name": "tagKeys/${tagKeyID}",
   "namespacedName": "${projectId}/keyname${uniqueId}",
   "parent": "projects/${projectNumber}",
   "shortName": "keyname${uniqueId}",
@@ -358,7 +358,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyId}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
 
@@ -377,7 +377,7 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
   },
-  "name": "operations/${operationId}"
+  "name": "operations/${operationID}"
 }
 
 ---
@@ -402,13 +402,13 @@ X-Xss-Protection: 0
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
   },
-  "name": "operations/${operationId}",
+  "name": "operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "For keyname resources.",
     "etag": "abcdef0123A=",
-    "name": "tagKeys/${tagKeyId}",
+    "name": "tagKeys/${tagKeyID}",
     "namespacedName": "${projectId}/keyname${uniqueId}",
     "parent": "projects/${projectNumber}",
     "shortName": "keyname${uniqueId}",

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_http.log
@@ -1,6 +1,6 @@
-POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
+POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
 
 {
   "description": "For keyname resources.",
@@ -28,9 +28,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/UNKNOWN gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=operations%2F${operationID}
 
 200 OK
 Cache-Control: private
@@ -64,9 +65,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=tagKeys%2F${tagKeyID}
 
 200 OK
 Cache-Control: private
@@ -92,37 +94,9 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+POST https://cloudresourcemanager.googleapis.com/v3/tagValues?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "For keyname resources.",
-  "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyID}",
-  "namespacedName": "${projectId}/keyname${uniqueId}",
-  "parent": "projects/${projectNumber}",
-  "shortName": "keyname${uniqueId}",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
 
 {
   "description": "For valuename resources.",
@@ -150,9 +124,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/UNKNOWN gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=operations%2F${operationID}
 
 200 OK
 Cache-Control: private
@@ -186,9 +161,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=tagValues%2F${tagValueID}
 
 200 OK
 Cache-Control: private
@@ -214,65 +190,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "For valuename resources.",
-  "etag": "abcdef0123A=",
-  "name": "tagValues/${tagValueID}",
-  "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-  "parent": "tagKeys/${tagKeyID}",
-  "shortName": "valuename",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "For valuename resources.",
-  "etag": "abcdef0123A=",
-  "name": "tagValues/${tagValueID}",
-  "namespacedName": "${projectId}/keyname${uniqueId}/valuename",
-  "parent": "tagKeys/${tagKeyID}",
-  "shortName": "valuename",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=tagValues%2F${tagValueID}
 
 200 OK
 Cache-Control: private
@@ -294,9 +215,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/UNKNOWN gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=operations%2F${operationID}
 
 200 OK
 Cache-Control: private
@@ -330,37 +252,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "For keyname resources.",
-  "etag": "abcdef0123A=",
-  "name": "tagKeys/${tagKeyID}",
-  "namespacedName": "${projectId}/keyname${uniqueId}",
-  "parent": "projects/${projectNumber}",
-  "shortName": "keyname${uniqueId}",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
-Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/1.9.4 gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=tagKeys%2F${tagKeyID}
 
 200 OK
 Cache-Control: private
@@ -382,9 +277,10 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/dev
+x-goog-api-client: gl-go/1.22.1 gapic/UNKNOWN gax/2.12.0 rest/UNKNOWN
+x-goog-request-params: name=operations%2F${operationID}
 
 200 OK
 Cache-Control: private

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/create.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagValue
+metadata:
+  name: tagstagvalue-${uniqueId}
+spec:
+  description: For valuename resources.
+  parentRef:
+    name: tagstagkey-${uniqueId}
+  shortName: valuename

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/dependencies.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagKey
+metadata:
+  name: tagstagkey-${uniqueId}
+spec:
+  description: For keyname resources.
+  parent: projects/${projectId}
+  shortName: keyname${uniqueId}

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -83,9 +83,9 @@ func CompareGoldenFile(t *testing.T, p string, got string, normalizers ...func(s
 		}
 	}
 	want := string(wantBytes)
-	for _, normalizer := range normalizers {
-		want = normalizer(want)
-	}
+	// for _, normalizer := range normalizers {
+	// 	want = normalizer(want)
+	// }
 
 	if want == got {
 		return

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -130,7 +130,6 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 					primaryResource := bytesToUnstructured(t, fixture.Create, uniqueID, project)
 
 					opt := create.CreateDeleteTestOptions{CleanupResources: true}
-					opt.Create = append(opt.Create, primaryResource)
 
 					if fixture.Dependencies != nil {
 						dependencyYamls := testyaml.SplitYAML(t, fixture.Dependencies)
@@ -139,6 +138,8 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 							opt.Create = append(opt.Create, depUnstruct)
 						}
 					}
+
+					opt.Create = append(opt.Create, primaryResource)
 
 					if fixture.Update != nil {
 						u := bytesToUnstructured(t, fixture.Update, uniqueID, project)
@@ -272,6 +273,11 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 				opt.CleanupResources = false // We delete explicitly below
 				if testPause {
 					opt.SkipWaitForReady = true // Paused resources don't send out an event yet.
+				}
+				if os.Getenv("GOLDEN_REQUEST_CHECKS") != "" {
+					// If we're doing golden request checks, delete synchronously so that it is reproducible.
+					// Note that this does introduce a dependency that objects are ordered correctly for deletion.
+					opt.CreateInOrder = true
 				}
 				create.RunCreateDeleteTest(h, opt)
 

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -478,6 +478,8 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 					expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
 					normalizers := []func(string) string{}
 					normalizers = append(normalizers, h.IgnoreComments)
+					normalizers = append(normalizers, h.ReplaceString("organizations/"+testgcp.TestOrgID.Get(), "organizations/${organizationID}"))
+					normalizers = append(normalizers, h.ReplaceString(testgcp.TestOrgID.Get()+"/", "${organizationID}/"))
 					normalizers = append(normalizers, h.ReplaceString(uniqueID, "${uniqueId}"))
 					normalizers = append(normalizers, h.ReplaceString(project.ProjectID, "${projectId}"))
 					normalizers = append(normalizers, h.ReplaceString(fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}"))

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -479,13 +479,13 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 					// Remove headers that just aren't very relevant to testing
 					events.RemoveHTTPResponseHeader("Date")
 					events.RemoveHTTPResponseHeader("Alt-Svc")
+					events.RemoveHTTPResponseHeader("Server-Timing")
 
 					got := events.FormatHTTP()
 					expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
 					normalizers := []func(string) string{}
 					normalizers = append(normalizers, h.IgnoreComments)
-					normalizers = append(normalizers, h.ReplaceString("organizations/"+testgcp.TestOrgID.Get(), "organizations/${organizationID}"))
-					normalizers = append(normalizers, h.ReplaceString(testgcp.TestOrgID.Get()+"/", "${organizationID}/"))
+					normalizers = append(normalizers, h.ReplaceString(testgcp.TestOrgID.Get(), "${organizationID}"))
 					normalizers = append(normalizers, h.ReplaceString(uniqueID, "${uniqueId}"))
 					normalizers = append(normalizers, h.ReplaceString(project.ProjectID, "${projectId}"))
 					normalizers = append(normalizers, h.ReplaceString(fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}"))

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -310,6 +310,11 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 				if testPause {
 					opt.SkipWaitForDelete = true
 				}
+				if os.Getenv("GOLDEN_REQUEST_CHECKS") != "" {
+					// If we're doing golden request checks, delete synchronously so that it is reproducible.
+					// Note that this does introduce a dependency that objects are ordered correctly for deletion.
+					opt.DeleteInOrder = true
+				}
 				create.DeleteResources(h, opt)
 
 				// Verify events against golden file

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/klog/v2"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -42,6 +41,7 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -333,6 +333,10 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 							switch kind {
 							case "tensorboards":
 								pathIDs[id] = "${tensorboardID}"
+							case "tagKeys":
+								pathIDs[id] = "${tagKeyID}"
+							case "tagValues":
+								pathIDs[id] = "${tagValueID}"
 							case "operations":
 								operationIDs[id] = true
 								pathIDs[id] = "${operationID}"
@@ -375,6 +379,9 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 						name, _, _ := unstructured.NestedString(responseBody, "response", "name")
 						if strings.HasPrefix(name, "tagKeys/") {
 							pathIDs[name] = "tagKeys/${tagKeyID}"
+						}
+						if strings.HasPrefix(name, "tagValues/") {
+							pathIDs[name] = "tagValues/${tagValueId}"
 						}
 					}
 


### PR DESCRIPTION
- mockgcp: Implement TagsTagValue
- tests: run deletion in order when we're doing golden testing
- genapi: create direct IAM ServiceAccount controller
- Spike: ComputeNetwork controller
- Move to proto
- genapi: direct controller for ComputeSubnetwork
- genapi: Add support for TagsTagKey
- genapi: TagsTagValue
- tests: replace organization id in golden tests
- tests: support strictly ordered creation in golden tests
- golden output for tags
- fixup! tests: support strictly ordered creation in golden tests
- Fix NamespacedName for TagsTagValue
- golden output for tagbinding
- mockgcp: support for TagsTagBinding
- WIP: support TagsTagBinding in direct actuation
