### PR TITLE
Add initialUser to primary cluster for AlloyDB secondary instance sample

### DIFF
--- a/config/samples/resources/alloydbinstance/secondary-instance/alloydb_v1beta1_alloydbcluster.yaml
+++ b/config/samples/resources/alloydbinstance/secondary-instance/alloydb_v1beta1_alloydbcluster.yaml
@@ -23,6 +23,10 @@ spec:
       name: alloydbinstance-dep-secondary
   projectRef:
     external: ${PROJECT_ID?}
+  initialUser:
+    user: "postgres"
+    password:
+      value: "postgres"
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
@@ -659,6 +659,10 @@ spec:
       name: alloydbinstance-dep-secondary
   projectRef:
     external: ${PROJECT_ID?}
+  initialUser:
+    user: "postgres"
+    password:
+      value: "postgres"
 ---
 apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
 kind: AlloyDBCluster


### PR DESCRIPTION
Added initalUser to the primary cluster resource used in secondary-instance example
Fixes the test failure for AlloyDB secondary-instance


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ N/A] Perform necessary E2E testing for changed resources.
