### PR TITLE
mockgcp: support options on httpmux

### DIFF
--- a/mockgcp/common/httpmux/mux.go
+++ b/mockgcp/common/httpmux/mux.go
@@ -25,13 +25,20 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type Options struct {
+	// If EmitUnpopulated is true, we will send empty proto fields (false / "" / 0 etc)
+	// Some older APIs do this (e.g. cloudbilling)
+	// While it likely doesn't matter, it makes golden testing easier to match.
+	EmitUnpopulated bool
+}
+
 // NewServeMux constructs an http server with our error handling etc
-func NewServeMux(ctx context.Context, conn *grpc.ClientConn, handlers ...func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error) (*runtime.ServeMux, error) {
+func NewServeMux(ctx context.Context, conn *grpc.ClientConn, opt Options, handlers ...func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error) (*runtime.ServeMux, error) {
 	resolver := &protoResolver{}
 	marshaler := &runtime.HTTPBodyMarshaler{
 		Marshaler: &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
-				EmitUnpopulated: false,
+				EmitUnpopulated: opt.EmitUnpopulated,
 				Resolver:        resolver,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{

--- a/mockgcp/mockaiplatform/service.go
+++ b/mockgcp/mockaiplatform/service.go
@@ -56,7 +56,8 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn, pb.RegisterTensorboardServiceHandler,
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
+		pb.RegisterTensorboardServiceHandler,
 		s.operations.RegisterOperationsPath("/v1beta1/{prefix=**}/operations/{name}"))
 	if err != nil {
 		return nil, err

--- a/mockgcp/mockapikeys/service.go
+++ b/mockgcp/mockapikeys/service.go
@@ -57,7 +57,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn,
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
 		pb.RegisterApiKeysHandler,
 		s.operations.RegisterOperationsPath("/v2/operations/{name}"),
 	)

--- a/mockgcp/mockbilling/service.go
+++ b/mockgcp/mockbilling/service.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/billing/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
@@ -57,11 +57,10 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux := runtime.NewServeMux()
-
-	if err := pb.RegisterCloudBillingHandler(ctx, mux, conn); err != nil {
-		return nil, err
+	options := httpmux.Options{
+		// This API sends e.g. billingEnabled: false, billingAccountName: ""
+		EmitUnpopulated: true,
 	}
-
-	return mux, nil
+	return httpmux.NewServeMux(ctx, conn, options,
+		pb.RegisterCloudBillingHandler)
 }

--- a/mockgcp/mockiam/service.go
+++ b/mockgcp/mockiam/service.go
@@ -58,5 +58,6 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	return httpmux.NewServeMux(ctx, conn, pb.RegisterIAMHandler)
+	return httpmux.NewServeMux(ctx, conn, httpmux.Options{},
+		pb.RegisterIAMHandler)
 }

--- a/mockgcp/mockresourcemanager/service.go
+++ b/mockgcp/mockresourcemanager/service.go
@@ -69,7 +69,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn,
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
 		pb_v1.RegisterProjectsHandler,
 		pb_v3.RegisterProjectsHandler,
 		pb_v3.RegisterTagKeysHandler,


### PR DESCRIPTION
We want to send empty values on e.g. the cloudbilling API
