### PR TITLE
Added note for secondary instance creation

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
@@ -6,6 +6,9 @@
 {% block body %}
 
 
+
+Note: Secondary instances should only be created once the associated primary instance is ready and up to date
+
 <table>
 <thead>
 <tr>

--- a/scripts/generate-google3-docs/resource-reference/templates/alloydb_alloydbinstance.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/alloydb_alloydbinstance.tmpl
@@ -5,6 +5,9 @@
 {% block page_title %}{{ .Kind}}{% endblock %}
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
+
+Note: Secondary instances should only be created once the associated primary instance is ready and up to date
+
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Added note to ensure users create secondary instances only after primary instance is ready

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ N/A] Perform necessary E2E testing for changed resources.
