### PR TITLE
[WIP] Identify output-only fields under 'spec' for TF-based resources

### DIFF
--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -63,15 +63,6 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 	if len(outputOnlySpecFieldsOriginal) > 0 && version == k8s.KCCAPIVersionV1Beta1 {
 		outputOnlySpecFieldsWithoutIgnored := removeIgnoredFieldsFromOutputOnlySpecFields(resourceConfig, outputOnlySpecFieldsOriginal)
 		outputOnlySpecFieldsWithoutObserved := removeConfiguredObservedFieldsFromOutputOnlySpecFields(resourceConfig, outputOnlySpecFieldsWithoutIgnored)
-		//parentIsList := false
-		//for _, v := range outputOnlySpecFieldsWithoutIgnored {
-		//	if strings.Contains(v, "is a list") {
-		//		parentIsList = true
-		//	}
-		//}
-		//if parentIsList {
-		//	fmt.Println("resource contains output-only spec field under a list")
-		//}
 		outputOnlySpecFieldsWithoutList := make([]string, 0)
 		for _, v := range outputOnlySpecFieldsWithoutObserved {
 			if !strings.Contains(v, "is a list") {

--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -65,7 +65,7 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 		outputOnlySpecFieldsWithoutObserved := removeConfiguredObservedFieldsFromOutputOnlySpecFields(resourceConfig, outputOnlySpecFieldsWithoutIgnored)
 		outputOnlySpecFieldsWithoutList := make([]string, 0)
 		for _, v := range outputOnlySpecFieldsWithoutObserved {
-			if !strings.Contains(v, "is a list") {
+			if !strings.Contains(v, "is a list") && !strings.Contains(v, "it is sensitive") {
 				outputOnlySpecFieldsWithoutList = append(outputOnlySpecFieldsWithoutList, v)
 			}
 		}
@@ -212,6 +212,9 @@ func outputOnlySubfieldsInTFObjectSchema(parent string, s map[string]*schema.Sch
 		}
 		if v.Computed && !isConfigurableField(v) {
 			outputPath := path
+			if v.Sensitive {
+				outputPath = fmt.Sprintf("%v, it is sensitive", outputPath)
+			}
 			if v.Type == schema.TypeList {
 				outputPath = fmt.Sprintf("%v, itself is a list", outputPath)
 			}

--- a/pkg/crd/crdgeneration/tf2crdgeneration.go
+++ b/pkg/crd/crdgeneration/tf2crdgeneration.go
@@ -75,7 +75,7 @@ func GenerateTF2CRD(sm *corekccv1alpha1.ServiceMapping, resourceConfig *corekccv
 			sort.Strings(outputOnlySpecFieldsWithoutList)
 		}
 		for _, v := range outputOnlySpecFieldsWithoutList {
-			fmt.Printf("        - %v\n", v)
+			fmt.Printf("        - %v\n", lowerCamelCasePathToSnakeCase(v))
 		}
 		fmt.Printf("Unprocessed list of fields: %+v\n", outputOnlySpecFieldsOriginal)
 	}
@@ -472,6 +472,34 @@ func snakeCasePathToCamelCase(s string) string {
 		result = result + fieldInCamelCase
 	}
 	return result
+}
+
+func lowerCamelCasePathToSnakeCase(s string) string {
+	fields := strings.Split(s, ".")
+	result := ""
+	for _, field := range fields {
+		fieldInCamelCase := lowerCamelCaseToSnakeCase(field)
+		if result != "" {
+			result = result + "."
+		}
+		result = result + fieldInCamelCase
+	}
+	return result
+}
+
+func lowerCamelCaseToSnakeCase(input string) string {
+	out := ""
+	for index, runeValue := range input {
+		if runeValue >= 'A' && runeValue <= 'Z' {
+			if index > 0 {
+				out += "_"
+			}
+			out += string(runeValue - 'A' + 'a')
+		} else {
+			out += string(runeValue)
+		}
+	}
+	return out
 }
 
 // removeFieldIfExist attempts to remove a field from the provided json schema.

--- a/result20240430.txt
+++ b/result20240430.txt
@@ -1,0 +1,375 @@
+google_bigquery_job has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: load.destinationEncryptionConfiguration.kmsKeyVersion
+- path: copy.destinationEncryptionConfiguration.kmsKeyVersion
+- path: query.destinationEncryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [load.destinationEncryptionConfiguration.kmsKeyVersion copy.destinationEncryptionConfiguration.kmsKeyVersion query.destinationEncryptionConfiguration.kmsKeyVersion]
+google_bigquery_table has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: encryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [encryptionConfiguration.kmsKeyVersion]
+google_certificate_manager_certificate has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: managed.state
+- path: managed.authorizationAttemptInfo
+- path: managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.provisioningIssue
+- path: managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list
+- path: managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list
+Unprocessed list of fields: [managed.state managed.authorizationAttemptInfo managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list managed.provisioningIssue managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list]
+google_cloudbuild_trigger has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: build.artifacts.objects.timing
+- path: pubsubConfig.state
+- path: pubsubConfig.subscription
+- path: webhookConfig.state
+Unprocessed list of fields: [build.artifacts.objects.timing pubsubConfig.state pubsubConfig.subscription webhookConfig.state]
+google_compute_snapshot has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: snapshotEncryptionKey.sha256
+Unprocessed list of fields: [snapshotEncryptionKey.sha256]
+google_compute_instance has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: bootDisk.diskEncryptionKeySha256
+- path: attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list
+Unprocessed list of fields: [networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256 attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+google_compute_instance_from_template has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: bootDisk.diskEncryptionKeySha256
+- path: attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list
+Unprocessed list of fields: [networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256 attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+google_compute_node_template has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: nodeTypeFlexibility.localSsd
+Unprocessed list of fields: [nodeTypeFlexibility.localSsd]
+google_compute_reservation has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: specificReservation.inUseCount
+Unprocessed list of fields: [specificReservation.inUseCount]
+google_compute_ha_vpn_gateway has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list
+Unprocessed list of fields: [vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list]
+google_compute_instance_template has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list
+Unprocessed list of fields: [networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list]
+google_compute_machine_image has output-only spec fields
+version v1alpha1
+- path: machineImageEncryptionKey.sha256
+Unprocessed list of fields: [machineImageEncryptionKey.sha256]
+google_compute_backend_service has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_region_backend_service has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_disk has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: sourceSnapshotEncryptionKey.sha256
+- path: sourceImageEncryptionKey.sha256
+- path: diskEncryptionKey.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 sourceImageEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_region_disk has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: sourceSnapshotEncryptionKey.sha256
+- path: diskEncryptionKey.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 diskEncryptionKey.sha256]
+maqiuyu... ignored... nodePool.managedInstanceGroupUrls, parent "nodePool" is a list
+maqiuyu... ignored... nodePool.instanceGroupUrls, parent "nodePool" is a list
+google_container_cluster has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: masterAuth.clusterCaCertificate
+- path: masterAuth.clientCertificate
+- path: masterAuth.clientKey
+- path: maintenancePolicy.dailyMaintenanceWindow.duration
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list
+- path: privateClusterConfig.peeringName
+- path: privateClusterConfig.privateEndpoint
+- path: privateClusterConfig.publicEndpoint
+Unprocessed list of fields: [masterAuth.clusterCaCertificate masterAuth.clientCertificate masterAuth.clientKey maintenancePolicy.dailyMaintenanceWindow.duration nodePool.managedInstanceGroupUrls, parent "nodePool" is a list nodePool.instanceGroupUrls, parent "nodePool" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list privateClusterConfig.peeringName privateClusterConfig.privateEndpoint privateClusterConfig.publicEndpoint]
+google_container_attached_cluster has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: fleet.membership
+Unprocessed list of fields: [fleet.membership]
+google_edgecontainer_cluster has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: fleet.membership
+- path: networking.networkType
+- path: controlPlaneEncryption.kmsKeyActiveVersion
+- path: controlPlaneEncryption.kmsKeyState
+- path: controlPlaneEncryption.kmsStatus
+- path: controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list
+- path: controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list
+Unprocessed list of fields: [fleet.membership networking.networkType controlPlaneEncryption.kmsKeyActiveVersion controlPlaneEncryption.kmsKeyState controlPlaneEncryption.kmsStatus controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list]
+google_edgecontainer_node_pool has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: localDiskEncryption.kmsKeyActiveVersion
+- path: localDiskEncryption.kmsKeyState
+Unprocessed list of fields: [localDiskEncryption.kmsKeyActiveVersion localDiskEncryption.kmsKeyState]
+google_memcache_instance has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: maintenancePolicy.createTime
+- path: maintenancePolicy.updateTime
+- path: memcacheParameters.id
+Unprocessed list of fields: [maintenancePolicy.createTime maintenancePolicy.updateTime memcacheParameters.id]
+google_monitoring_alert_policy has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: conditions.name, parent "conditions" is a list
+Unprocessed list of fields: [conditions.name, parent "conditions" is a list]
+google_pubsub_subscription has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+- path: cloudStorageConfig.state
+Unprocessed list of fields: [cloudStorageConfig.state]
+google_redis_instance has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: maintenancePolicy.createTime
+- path: maintenancePolicy.updateTime
+- path: maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list
+- path: persistenceConfig.rdbNextSnapshotTime
+Unprocessed list of fields: [maintenancePolicy.createTime maintenancePolicy.updateTime maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list persistenceConfig.rdbNextSnapshotTime]
+maqiuyu... ignored... settings.version
+google_sql_database_instance has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+Unprocessed list of fields: [settings.version]
+google_sql_user has output-only spec fields
+version v1beta1
+resource is stable and we should support the output-only spec fields in status
+resource contains output-only spec field under a list
+- path: passwordPolicy.status
+- path: passwordPolicy.status.locked, parent "passwordPolicy.status" is a list
+- path: passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list
+Unprocessed list of fields: [passwordPolicy.status passwordPolicy.status.locked, parent "passwordPolicy.status" is a list passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list]
+google_beyondcorp_app_connection has output-only spec fields
+version v1alpha1
+- path: gateway.ingressPort
+- path: gateway.uri
+Unprocessed list of fields: [gateway.ingressPort gateway.uri]
+google_cloudfunctions2_function has output-only spec fields
+version v1alpha1
+- path: eventTrigger.trigger
+- path: serviceConfig.uri
+- path: serviceConfig.gcfUri
+- path: buildConfig.build
+Unprocessed list of fields: [eventTrigger.trigger serviceConfig.uri serviceConfig.gcfUri buildConfig.build]
+google_dataform_repository has output-only spec fields
+version v1alpha1
+- path: gitRemoteSettings.tokenStatus
+Unprocessed list of fields: [gitRemoteSettings.tokenStatus]
+google_dialogflow_cx_flow has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: transitionRoutes.triggerFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: transitionRoutes.triggerFulfillment.messages.text.allowPlaybackInterruption
+- path: transitionRoutes.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: transitionRoutes.name, parent "transitionRoutes" is a list
+- path: eventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: eventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: eventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption
+- path: eventHandlers.name, parent "eventHandlers" is a list
+Unprocessed list of fields: [transitionRoutes.triggerFulfillment.messages.playAudio.allowPlaybackInterruption transitionRoutes.triggerFulfillment.messages.text.allowPlaybackInterruption transitionRoutes.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption transitionRoutes.name, parent "transitionRoutes" is a list eventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption eventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption eventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption eventHandlers.name, parent "eventHandlers" is a list]
+google_dialogflow_cx_intent has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: trainingPhrases.id, parent "trainingPhrases" is a list
+Unprocessed list of fields: [trainingPhrases.id, parent "trainingPhrases" is a list]
+google_dialogflow_cx_page has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: transitionRoutes.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: transitionRoutes.triggerFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: transitionRoutes.triggerFulfillment.messages.text.allowPlaybackInterruption
+- path: transitionRoutes.name, parent "transitionRoutes" is a list
+- path: form.parameters.fillBehavior.initialPromptFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.initialPromptFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.initialPromptFulfillment.messages.text.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: form.parameters.fillBehavior.repromptEventHandlers.name, parent "form.parameters.fillBehavior.repromptEventHandlers" is a list
+- path: entryFulfillment.messages.text.allowPlaybackInterruption
+- path: entryFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: entryFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: eventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption
+- path: eventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption
+- path: eventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption
+- path: eventHandlers.name, parent "eventHandlers" is a list
+Unprocessed list of fields: [transitionRoutes.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption transitionRoutes.triggerFulfillment.messages.playAudio.allowPlaybackInterruption transitionRoutes.triggerFulfillment.messages.text.allowPlaybackInterruption transitionRoutes.name, parent "transitionRoutes" is a list form.parameters.fillBehavior.initialPromptFulfillment.messages.outputAudioText.allowPlaybackInterruption form.parameters.fillBehavior.initialPromptFulfillment.messages.playAudio.allowPlaybackInterruption form.parameters.fillBehavior.initialPromptFulfillment.messages.text.allowPlaybackInterruption form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption form.parameters.fillBehavior.repromptEventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption form.parameters.fillBehavior.repromptEventHandlers.name, parent "form.parameters.fillBehavior.repromptEventHandlers" is a list entryFulfillment.messages.text.allowPlaybackInterruption entryFulfillment.messages.outputAudioText.allowPlaybackInterruption entryFulfillment.messages.playAudio.allowPlaybackInterruption eventHandlers.triggerFulfillment.messages.outputAudioText.allowPlaybackInterruption eventHandlers.triggerFulfillment.messages.playAudio.allowPlaybackInterruption eventHandlers.triggerFulfillment.messages.text.allowPlaybackInterruption eventHandlers.name, parent "eventHandlers" is a list]
+google_bigquery_reservation has output-only spec fields
+version v1alpha1
+- path: autoscale.currentSlots
+Unprocessed list of fields: [autoscale.currentSlots]
+google_datastream_stream has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: sourceConfig.mysqlSourceConfig.excludeObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "sourceConfig.mysqlSourceConfig.excludeObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list
+- path: sourceConfig.mysqlSourceConfig.includeObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "sourceConfig.mysqlSourceConfig.includeObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: backfillAll.mysqlExcludedObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "backfillAll.mysqlExcludedObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list
+- path: backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+- path: backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list
+Unprocessed list of fields: [sourceConfig.mysqlSourceConfig.excludeObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "sourceConfig.mysqlSourceConfig.excludeObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list sourceConfig.mysqlSourceConfig.includeObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "sourceConfig.mysqlSourceConfig.includeObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "sourceConfig.oracleSourceConfig.excludeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "sourceConfig.oracleSourceConfig.includeObjects.oracleSchemas.oracleTables.oracleColumns" is a list sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "sourceConfig.postgresqlSourceConfig.excludeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "sourceConfig.postgresqlSourceConfig.includeObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list backfillAll.mysqlExcludedObjects.mysqlDatabases.mysqlTables.mysqlColumns.length, parent "backfillAll.mysqlExcludedObjects.mysqlDatabases.mysqlTables.mysqlColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.length, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.ordinalPosition, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.primaryKey, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.scale, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.encoding, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.nullable, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns.precision, parent "backfillAll.oracleExcludedObjects.oracleSchemas.oracleTables.oracleColumns" is a list backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.length, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.precision, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns.scale, parent "backfillAll.postgresqlExcludedObjects.postgresqlSchemas.postgresqlTables.postgresqlColumns" is a list]
+google_datastream_connection_profile has output-only spec fields
+version v1alpha1
+- path: mysqlProfile.sslConfig.clientKeySet
+- path: mysqlProfile.sslConfig.caCertificateSet
+- path: mysqlProfile.sslConfig.clientCertificateSet
+Unprocessed list of fields: [mysqlProfile.sslConfig.clientKeySet mysqlProfile.sslConfig.caCertificateSet mysqlProfile.sslConfig.clientCertificateSet]
+google_os_config_patch_deployment has output-only spec fields
+version v1alpha1
+- path: recurringSchedule.lastExecuteTime
+- path: recurringSchedule.nextExecuteTime
+Unprocessed list of fields: [recurringSchedule.lastExecuteTime recurringSchedule.nextExecuteTime]
+google_app_engine_domain_mapping has output-only spec fields
+version v1alpha1
+- path: sslSettings.pendingManagedCertificateId
+Unprocessed list of fields: [sslSettings.pendingManagedCertificateId]
+google_bigquery_connection has output-only spec fields
+version v1alpha1
+- path: azure.application
+- path: azure.clientId
+- path: azure.identity
+- path: azure.objectId
+- path: azure.redirectUri
+- path: aws.accessRole.identity
+- path: cloudResource.serviceAccountId
+- path: cloudSql.serviceAccountId
+Unprocessed list of fields: [azure.application azure.clientId azure.identity azure.objectId azure.redirectUri aws.accessRole.identity cloudResource.serviceAccountId cloudSql.serviceAccountId]
+google_cloudiot_device has output-only spec fields
+version v1alpha1
+- path: gatewayConfig.lastAccessedGatewayId
+- path: gatewayConfig.lastAccessedGatewayTime
+Unprocessed list of fields: [gatewayConfig.lastAccessedGatewayId gatewayConfig.lastAccessedGatewayTime]
+google_data_catalog_entry has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: gcsFilesetSpec.sampleGcsFileSpecs
+- path: gcsFilesetSpec.sampleGcsFileSpecs.filePath, parent "gcsFilesetSpec.sampleGcsFileSpecs" is a list
+- path: gcsFilesetSpec.sampleGcsFileSpecs.sizeBytes, parent "gcsFilesetSpec.sampleGcsFileSpecs" is a list
+Unprocessed list of fields: [gcsFilesetSpec.sampleGcsFileSpecs gcsFilesetSpec.sampleGcsFileSpecs.filePath, parent "gcsFilesetSpec.sampleGcsFileSpecs" is a list gcsFilesetSpec.sampleGcsFileSpecs.sizeBytes, parent "gcsFilesetSpec.sampleGcsFileSpecs" is a list]
+google_data_catalog_tag has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: fields.displayName, parent "fields" is a list
+- path: fields.order, parent "fields" is a list
+Unprocessed list of fields: [fields.displayName, parent "fields" is a list fields.order, parent "fields" is a list]
+google_data_catalog_tag_template has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: fields.name, parent "fields" is a list
+Unprocessed list of fields: [fields.name, parent "fields" is a list]
+google_identity_platform_inbound_saml_config has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: spConfig.spCertificates
+- path: spConfig.spCertificates.x509Certificate, parent "spConfig.spCertificates" is a list
+Unprocessed list of fields: [spConfig.spCertificates spConfig.spCertificates.x509Certificate, parent "spConfig.spCertificates" is a list]
+google_identity_platform_project_default_config has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: signIn.hashConfig
+- path: signIn.hashConfig.saltSeparator, parent "signIn.hashConfig" is a list
+- path: signIn.hashConfig.signerKey, parent "signIn.hashConfig" is a list
+- path: signIn.hashConfig.algorithm, parent "signIn.hashConfig" is a list
+- path: signIn.hashConfig.memoryCost, parent "signIn.hashConfig" is a list
+- path: signIn.hashConfig.rounds, parent "signIn.hashConfig" is a list
+Unprocessed list of fields: [signIn.hashConfig signIn.hashConfig.saltSeparator, parent "signIn.hashConfig" is a list signIn.hashConfig.signerKey, parent "signIn.hashConfig" is a list signIn.hashConfig.algorithm, parent "signIn.hashConfig" is a list signIn.hashConfig.memoryCost, parent "signIn.hashConfig" is a list signIn.hashConfig.rounds, parent "signIn.hashConfig" is a list]
+google_identity_platform_tenant_inbound_saml_config has output-only spec fields
+version v1alpha1
+resource contains output-only spec field under a list
+- path: spConfig.spCertificates
+- path: spConfig.spCertificates.x509Certificate, parent "spConfig.spCertificates" is a list
+Unprocessed list of fields: [spConfig.spCertificates spConfig.spCertificates.x509Certificate, parent "spConfig.spCertificates" is a list]
+google_apigee_addons_config has output-only spec fields
+version v1alpha1
+- path: addonsConfig.apiSecurityConfig.expiresAt
+- path: addonsConfig.connectorsPlatformConfig.expiresAt
+Unprocessed list of fields: [addonsConfig.apiSecurityConfig.expiresAt addonsConfig.connectorsPlatformConfig.expiresAt]
+google_workstations_workstation_cluster has output-only spec fields
+version v1alpha1
+- path: privateClusterConfig.clusterHostname
+- path: privateClusterConfig.serviceAttachmentUri
+Unprocessed list of fields: [privateClusterConfig.clusterHostname privateClusterConfig.serviceAttachmentUri]
+google_cloud_tasks_queue has output-only spec fields
+version v1alpha1
+- path: rateLimits.maxBurstSize
+- path: appEngineRoutingOverride.host
+Unprocessed list of fields: [rateLimits.maxBurstSize appEngineRoutingOverride.host]
+CRD manifests generated under '/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/config/crds/tmp_resources'

--- a/result2024043005.txt
+++ b/result2024043005.txt
@@ -1,0 +1,129 @@
+google_bigquery_table
+- path: encryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [encryptionConfiguration.kmsKeyVersion]
+google_bigquery_job
+- path: copy.destinationEncryptionConfiguration.kmsKeyVersion
+- path: load.destinationEncryptionConfiguration.kmsKeyVersion
+- path: query.destinationEncryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [copy.destinationEncryptionConfiguration.kmsKeyVersion load.destinationEncryptionConfiguration.kmsKeyVersion query.destinationEncryptionConfiguration.kmsKeyVersion]
+google_certificate_manager_certificate
+- path: managed.authorizationAttemptInfo, itself is a list
+- path: managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list
+- path: managed.provisioningIssue, itself is a list
+- path: managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list
+- path: managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list
+- path: managed.state
+Unprocessed list of fields: [managed.authorizationAttemptInfo, itself is a list managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list managed.provisioningIssue, itself is a list managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list managed.state]
+google_cloudbuild_trigger
+- path: webhookConfig.state
+- path: pubsubConfig.state
+- path: pubsubConfig.subscription
+- path: build.artifacts.objects.timing, itself is a list
+Unprocessed list of fields: [webhookConfig.state pubsubConfig.state pubsubConfig.subscription build.artifacts.objects.timing, itself is a list]
+google_compute_ha_vpn_gateway
+- path: vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list
+Unprocessed list of fields: [vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list]
+google_compute_instance_template
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list
+- path: networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list
+Unprocessed list of fields: [networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list]
+google_compute_instance
+- path: attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: bootDisk.diskEncryptionKeySha256
+Unprocessed list of fields: [attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256]
+google_compute_instance_from_template
+- path: networkInterface.ipv6AccessType, parent "networkInterface" is a list
+- path: networkInterface.name, parent "networkInterface" is a list
+- path: bootDisk.diskEncryptionKeySha256
+- path: attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list
+Unprocessed list of fields: [networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256 attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+google_compute_node_template
+- path: nodeTypeFlexibility.localSsd
+Unprocessed list of fields: [nodeTypeFlexibility.localSsd]
+google_compute_disk
+- path: sourceImageEncryptionKey.sha256
+- path: sourceSnapshotEncryptionKey.sha256
+- path: diskEncryptionKey.sha256
+Unprocessed list of fields: [sourceImageEncryptionKey.sha256 sourceSnapshotEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_region_disk
+- path: diskEncryptionKey.sha256
+- path: sourceSnapshotEncryptionKey.sha256
+Unprocessed list of fields: [diskEncryptionKey.sha256 sourceSnapshotEncryptionKey.sha256]
+google_compute_backend_service
+- path: iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_region_backend_service
+- path: iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_reservation
+- path: specificReservation.inUseCount
+Unprocessed list of fields: [specificReservation.inUseCount]
+google_compute_snapshot
+- path: snapshotEncryptionKey.sha256
+Unprocessed list of fields: [snapshotEncryptionKey.sha256]
+maqiuyu... ignored... nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list
+maqiuyu... ignored... nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list
+google_container_cluster
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions, itself is a list
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list
+- path: clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list
+- path: maintenancePolicy.dailyMaintenanceWindow.duration
+- path: privateClusterConfig.peeringName
+- path: privateClusterConfig.privateEndpoint
+- path: privateClusterConfig.publicEndpoint
+- path: masterAuth.clientCertificate
+- path: masterAuth.clientKey
+- path: masterAuth.clusterCaCertificate
+Unprocessed list of fields: [clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions, itself is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list maintenancePolicy.dailyMaintenanceWindow.duration privateClusterConfig.peeringName privateClusterConfig.privateEndpoint privateClusterConfig.publicEndpoint nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list masterAuth.clientCertificate masterAuth.clientKey masterAuth.clusterCaCertificate]
+google_container_attached_cluster
+- path: fleet.membership
+Unprocessed list of fields: [fleet.membership]
+google_edgecontainer_cluster
+- path: networking.networkType
+- path: fleet.membership
+- path: controlPlaneEncryption.kmsKeyActiveVersion
+- path: controlPlaneEncryption.kmsKeyState
+- path: controlPlaneEncryption.kmsStatus, itself is a list
+- path: controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list
+- path: controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list
+Unprocessed list of fields: [networking.networkType fleet.membership controlPlaneEncryption.kmsKeyActiveVersion controlPlaneEncryption.kmsKeyState controlPlaneEncryption.kmsStatus, itself is a list controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list]
+google_edgecontainer_node_pool
+- path: localDiskEncryption.kmsKeyActiveVersion
+- path: localDiskEncryption.kmsKeyState
+Unprocessed list of fields: [localDiskEncryption.kmsKeyActiveVersion localDiskEncryption.kmsKeyState]
+google_memcache_instance
+- path: maintenancePolicy.createTime
+- path: maintenancePolicy.updateTime
+- path: memcacheParameters.id
+Unprocessed list of fields: [maintenancePolicy.createTime maintenancePolicy.updateTime memcacheParameters.id]
+google_monitoring_alert_policy
+- path: conditions.name, parent "conditions" is a list
+Unprocessed list of fields: [conditions.name, parent "conditions" is a list]
+google_pubsub_subscription
+- path: cloudStorageConfig.state
+Unprocessed list of fields: [cloudStorageConfig.state]
+google_redis_instance
+- path: maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list
+- path: maintenancePolicy.createTime
+- path: maintenancePolicy.updateTime
+- path: persistenceConfig.rdbNextSnapshotTime
+Unprocessed list of fields: [maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list maintenancePolicy.createTime maintenancePolicy.updateTime persistenceConfig.rdbNextSnapshotTime]
+google_sql_user
+- path: passwordPolicy.status, itself is a list
+- path: passwordPolicy.status.locked, parent "passwordPolicy.status" is a list
+- path: passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list
+Unprocessed list of fields: [passwordPolicy.status, itself is a list passwordPolicy.status.locked, parent "passwordPolicy.status" is a list passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list]
+maqiuyu... ignored... settings.version
+google_sql_database_instance
+Unprocessed list of fields: [settings.version]
+CRD manifests generated under '/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/config/crds/tmp_resources'

--- a/result2024050104.txt
+++ b/result2024050104.txt
@@ -1,0 +1,115 @@
+google_bigquery_job
+      observedFields:
+        - copy.destinationEncryptionConfiguration.kmsKeyVersion
+        - load.destinationEncryptionConfiguration.kmsKeyVersion
+        - query.destinationEncryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [load.destinationEncryptionConfiguration.kmsKeyVersion query.destinationEncryptionConfiguration.kmsKeyVersion copy.destinationEncryptionConfiguration.kmsKeyVersion]
+google_bigquery_table
+      observedFields:
+        - encryptionConfiguration.kmsKeyVersion
+Unprocessed list of fields: [encryptionConfiguration.kmsKeyVersion]
+google_certificate_manager_certificate
+      observedFields:
+        - managed.state
+Unprocessed list of fields: [managed.authorizationAttemptInfo, itself is a list managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list managed.provisioningIssue, itself is a list managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list managed.state]
+google_cloudbuild_trigger
+      observedFields:
+        - pubsubConfig.state
+        - pubsubConfig.subscription
+        - webhookConfig.state
+Unprocessed list of fields: [pubsubConfig.state pubsubConfig.subscription build.artifacts.objects.timing, itself is a list webhookConfig.state]
+google_compute_snapshot
+      observedFields:
+        - snapshotEncryptionKey.sha256
+Unprocessed list of fields: [snapshotEncryptionKey.sha256]
+google_compute_node_template
+      observedFields:
+        - nodeTypeFlexibility.localSsd
+Unprocessed list of fields: [nodeTypeFlexibility.localSsd]
+google_compute_backend_service
+      observedFields:
+        - iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_region_backend_service
+      observedFields:
+        - iap.oauth2ClientSecretSha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_instance_template
+Unprocessed list of fields: [networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list]
+google_compute_reservation
+      observedFields:
+        - specificReservation.inUseCount
+Unprocessed list of fields: [specificReservation.inUseCount]
+google_compute_ha_vpn_gateway
+Unprocessed list of fields: [vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list]
+google_compute_disk
+      observedFields:
+        - diskEncryptionKey.sha256
+        - sourceImageEncryptionKey.sha256
+        - sourceSnapshotEncryptionKey.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 sourceImageEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_region_disk
+      observedFields:
+        - diskEncryptionKey.sha256
+        - sourceSnapshotEncryptionKey.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_instance
+      observedFields:
+        - bootDisk.diskEncryptionKeySha256
+Unprocessed list of fields: [networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256 attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+google_compute_instance_from_template
+      observedFields:
+        - bootDisk.diskEncryptionKeySha256
+Unprocessed list of fields: [attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list bootDisk.diskEncryptionKeySha256 networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list]
+ignored... nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list
+ignored... nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list
+observed~~~ masterAuth.clientCertificate
+google_container_cluster
+      observedFields:
+        - maintenancePolicy.dailyMaintenanceWindow.duration
+        - masterAuth.clientKey
+        - masterAuth.clusterCaCertificate
+        - privateClusterConfig.peeringName
+        - privateClusterConfig.privateEndpoint
+        - privateClusterConfig.publicEndpoint
+Unprocessed list of fields: [clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions, itself is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list maintenancePolicy.dailyMaintenanceWindow.duration masterAuth.clusterCaCertificate masterAuth.clientCertificate masterAuth.clientKey privateClusterConfig.peeringName privateClusterConfig.privateEndpoint privateClusterConfig.publicEndpoint nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list]
+google_container_attached_cluster
+      observedFields:
+        - fleet.membership
+Unprocessed list of fields: [fleet.membership]
+google_edgecontainer_cluster
+      observedFields:
+        - controlPlaneEncryption.kmsKeyActiveVersion
+        - controlPlaneEncryption.kmsKeyState
+        - fleet.membership
+        - networking.networkType
+Unprocessed list of fields: [fleet.membership controlPlaneEncryption.kmsKeyActiveVersion controlPlaneEncryption.kmsKeyState controlPlaneEncryption.kmsStatus, itself is a list controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list networking.networkType]
+google_edgecontainer_node_pool
+      observedFields:
+        - localDiskEncryption.kmsKeyActiveVersion
+        - localDiskEncryption.kmsKeyState
+Unprocessed list of fields: [localDiskEncryption.kmsKeyActiveVersion localDiskEncryption.kmsKeyState]
+google_memcache_instance
+      observedFields:
+        - maintenancePolicy.createTime
+        - maintenancePolicy.updateTime
+        - memcacheParameters.id
+Unprocessed list of fields: [maintenancePolicy.updateTime maintenancePolicy.createTime memcacheParameters.id]
+google_monitoring_alert_policy
+Unprocessed list of fields: [conditions.name, parent "conditions" is a list]
+google_pubsub_subscription
+      observedFields:
+        - cloudStorageConfig.state
+Unprocessed list of fields: [cloudStorageConfig.state]
+google_redis_instance
+      observedFields:
+        - maintenancePolicy.createTime
+        - maintenancePolicy.updateTime
+        - persistenceConfig.rdbNextSnapshotTime
+Unprocessed list of fields: [maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list maintenancePolicy.createTime maintenancePolicy.updateTime persistenceConfig.rdbNextSnapshotTime]
+ignored... settings.version
+google_sql_database_instance
+Unprocessed list of fields: [settings.version]
+google_sql_user
+Unprocessed list of fields: [passwordPolicy.status, itself is a list passwordPolicy.status.locked, parent "passwordPolicy.status" is a list passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list]
+CRD manifests generated under '/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/config/crds/tmp_resources'

--- a/result2024050105.txt
+++ b/result2024050105.txt
@@ -1,0 +1,115 @@
+google_bigquery_table
+      observedFields:
+        - encryption_configuration.kms_key_version
+Unprocessed list of fields: [encryptionConfiguration.kmsKeyVersion]
+google_bigquery_job
+      observedFields:
+        - copy.destination_encryption_configuration.kms_key_version
+        - load.destination_encryption_configuration.kms_key_version
+        - query.destination_encryption_configuration.kms_key_version
+Unprocessed list of fields: [copy.destinationEncryptionConfiguration.kmsKeyVersion query.destinationEncryptionConfiguration.kmsKeyVersion load.destinationEncryptionConfiguration.kmsKeyVersion]
+google_certificate_manager_certificate
+      observedFields:
+        - managed.state
+Unprocessed list of fields: [managed.state managed.authorizationAttemptInfo, itself is a list managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list managed.provisioningIssue, itself is a list managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list]
+google_cloudbuild_trigger
+      observedFields:
+        - pubsub_config.state
+        - pubsub_config.subscription
+        - webhook_config.state
+Unprocessed list of fields: [pubsubConfig.state pubsubConfig.subscription build.artifacts.objects.timing, itself is a list webhookConfig.state]
+google_compute_reservation
+      observedFields:
+        - specific_reservation.in_use_count
+Unprocessed list of fields: [specificReservation.inUseCount]
+google_compute_backend_service
+      observedFields:
+        - iap.oauth2_client_secret_sha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_region_backend_service
+      observedFields:
+        - iap.oauth2_client_secret_sha256
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256]
+google_compute_disk
+      observedFields:
+        - disk_encryption_key.sha256
+        - source_image_encryption_key.sha256
+        - source_snapshot_encryption_key.sha256
+Unprocessed list of fields: [diskEncryptionKey.sha256 sourceSnapshotEncryptionKey.sha256 sourceImageEncryptionKey.sha256]
+google_compute_region_disk
+      observedFields:
+        - disk_encryption_key.sha256
+        - source_snapshot_encryption_key.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_instance_template
+Unprocessed list of fields: [networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list]
+google_compute_ha_vpn_gateway
+Unprocessed list of fields: [vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list]
+google_compute_node_template
+      observedFields:
+        - node_type_flexibility.local_ssd
+Unprocessed list of fields: [nodeTypeFlexibility.localSsd]
+google_compute_snapshot
+      observedFields:
+        - snapshot_encryption_key.sha256
+Unprocessed list of fields: [snapshotEncryptionKey.sha256]
+google_compute_instance
+      observedFields:
+        - boot_disk.disk_encryption_key_sha256
+Unprocessed list of fields: [attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256]
+google_compute_instance_from_template
+      observedFields:
+        - boot_disk.disk_encryption_key_sha256
+Unprocessed list of fields: [networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list bootDisk.diskEncryptionKeySha256 attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+ignored... nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list
+ignored... nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list
+observed~~~ masterAuth.clientCertificate
+google_container_cluster
+      observedFields:
+        - maintenance_policy.daily_maintenance_window.duration
+        - master_auth.client_key
+        - master_auth.cluster_ca_certificate
+        - private_cluster_config.peering_name
+        - private_cluster_config.private_endpoint
+        - private_cluster_config.public_endpoint
+Unprocessed list of fields: [masterAuth.clientKey masterAuth.clusterCaCertificate masterAuth.clientCertificate nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list maintenancePolicy.dailyMaintenanceWindow.duration clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions, itself is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list privateClusterConfig.publicEndpoint privateClusterConfig.peeringName privateClusterConfig.privateEndpoint]
+google_container_attached_cluster
+      observedFields:
+        - fleet.membership
+Unprocessed list of fields: [fleet.membership]
+google_edgecontainer_cluster
+      observedFields:
+        - control_plane_encryption.kms_key_active_version
+        - control_plane_encryption.kms_key_state
+        - fleet.membership
+        - networking.network_type
+Unprocessed list of fields: [fleet.membership networking.networkType controlPlaneEncryption.kmsKeyState controlPlaneEncryption.kmsStatus, itself is a list controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsKeyActiveVersion]
+google_edgecontainer_node_pool
+      observedFields:
+        - local_disk_encryption.kms_key_active_version
+        - local_disk_encryption.kms_key_state
+Unprocessed list of fields: [localDiskEncryption.kmsKeyState localDiskEncryption.kmsKeyActiveVersion]
+google_memcache_instance
+      observedFields:
+        - maintenance_policy.create_time
+        - maintenance_policy.update_time
+        - memcache_parameters.id
+Unprocessed list of fields: [maintenancePolicy.createTime maintenancePolicy.updateTime memcacheParameters.id]
+google_monitoring_alert_policy
+Unprocessed list of fields: [conditions.name, parent "conditions" is a list]
+google_pubsub_subscription
+      observedFields:
+        - cloud_storage_config.state
+Unprocessed list of fields: [cloudStorageConfig.state]
+google_redis_instance
+      observedFields:
+        - maintenance_policy.create_time
+        - maintenance_policy.update_time
+        - persistence_config.rdb_next_snapshot_time
+Unprocessed list of fields: [maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list maintenancePolicy.createTime maintenancePolicy.updateTime persistenceConfig.rdbNextSnapshotTime]
+google_sql_user
+Unprocessed list of fields: [passwordPolicy.status, itself is a list passwordPolicy.status.locked, parent "passwordPolicy.status" is a list passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list]
+ignored... settings.version
+google_sql_database_instance
+Unprocessed list of fields: [settings.version]
+CRD manifests generated under '/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/config/crds/tmp_resources'

--- a/result2024050106.txt
+++ b/result2024050106.txt
@@ -1,0 +1,110 @@
+google_bigquery_job
+      observedFields:
+        - copy.destination_encryption_configuration.kms_key_version
+        - load.destination_encryption_configuration.kms_key_version
+        - query.destination_encryption_configuration.kms_key_version
+Unprocessed list of fields: [query.destinationEncryptionConfiguration.kmsKeyVersion copy.destinationEncryptionConfiguration.kmsKeyVersion load.destinationEncryptionConfiguration.kmsKeyVersion]
+google_bigquery_table
+      observedFields:
+        - encryption_configuration.kms_key_version
+Unprocessed list of fields: [encryptionConfiguration.kmsKeyVersion]
+google_certificate_manager_certificate
+      observedFields:
+        - managed.state
+Unprocessed list of fields: [managed.authorizationAttemptInfo, itself is a list managed.authorizationAttemptInfo.details, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.domain, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.failureReason, parent "managed.authorizationAttemptInfo" is a list managed.authorizationAttemptInfo.state, parent "managed.authorizationAttemptInfo" is a list managed.provisioningIssue, itself is a list managed.provisioningIssue.details, parent "managed.provisioningIssue" is a list managed.provisioningIssue.reason, parent "managed.provisioningIssue" is a list managed.state]
+google_cloudbuild_trigger
+      observedFields:
+        - pubsub_config.state
+        - pubsub_config.subscription
+        - webhook_config.state
+Unprocessed list of fields: [build.artifacts.objects.timing, itself is a list webhookConfig.state pubsubConfig.state pubsubConfig.subscription]
+google_compute_node_template
+      observedFields:
+        - node_type_flexibility.local_ssd
+Unprocessed list of fields: [nodeTypeFlexibility.localSsd]
+google_compute_backend_service
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256, it is sensitive]
+google_compute_region_backend_service
+Unprocessed list of fields: [iap.oauth2ClientSecretSha256, it is sensitive]
+google_compute_ha_vpn_gateway
+Unprocessed list of fields: [vpnInterfaces.ipAddress, parent "vpnInterfaces" is a list]
+google_compute_disk
+      observedFields:
+        - disk_encryption_key.sha256
+        - source_image_encryption_key.sha256
+        - source_snapshot_encryption_key.sha256
+Unprocessed list of fields: [diskEncryptionKey.sha256 sourceImageEncryptionKey.sha256 sourceSnapshotEncryptionKey.sha256]
+google_compute_region_disk
+      observedFields:
+        - disk_encryption_key.sha256
+        - source_snapshot_encryption_key.sha256
+Unprocessed list of fields: [sourceSnapshotEncryptionKey.sha256 diskEncryptionKey.sha256]
+google_compute_reservation
+      observedFields:
+        - specific_reservation.in_use_count
+Unprocessed list of fields: [specificReservation.inUseCount]
+google_compute_snapshot
+      observedFields:
+        - snapshot_encryption_key.sha256
+Unprocessed list of fields: [snapshotEncryptionKey.sha256]
+google_compute_instance
+      observedFields:
+        - boot_disk.disk_encryption_key_sha256
+Unprocessed list of fields: [attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list bootDisk.diskEncryptionKeySha256 networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list]
+google_compute_instance_from_template
+      observedFields:
+        - boot_disk.disk_encryption_key_sha256
+Unprocessed list of fields: [bootDisk.diskEncryptionKeySha256 networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.name, parent "networkInterface" is a list attachedDisk.diskEncryptionKeySha256, parent "attachedDisk" is a list]
+google_compute_instance_template
+Unprocessed list of fields: [networkInterface.ipv6AccessConfig.publicPtrDomainName, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.externalIpv6PrefixLength, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.ipv6AccessConfig.name, parent "networkInterface.ipv6AccessConfig" is a list networkInterface.name, parent "networkInterface" is a list networkInterface.ipv6AccessType, parent "networkInterface" is a list networkInterface.accessConfig.publicPtrDomainName, parent "networkInterface.accessConfig" is a list]
+ignored... nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list
+ignored... nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list
+observed~~~ masterAuth.clientCertificate
+google_container_cluster
+      observedFields:
+        - maintenance_policy.daily_maintenance_window.duration
+        - master_auth.cluster_ca_certificate
+        - private_cluster_config.peering_name
+        - private_cluster_config.private_endpoint
+        - private_cluster_config.public_endpoint
+Unprocessed list of fields: [masterAuth.clusterCaCertificate masterAuth.clientCertificate masterAuth.clientKey, it is sensitive nodePool.managedInstanceGroupUrls, itself is a list, parent "nodePool" is a list nodePool.instanceGroupUrls, itself is a list, parent "nodePool" is a list privateClusterConfig.publicEndpoint privateClusterConfig.peeringName privateClusterConfig.privateEndpoint clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions, itself is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.autoUpgradeStartTime, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions.description, parent "clusterAutoscaling.autoProvisioningDefaults.management.upgradeOptions" is a list maintenancePolicy.dailyMaintenanceWindow.duration]
+google_container_attached_cluster
+      observedFields:
+        - fleet.membership
+Unprocessed list of fields: [fleet.membership]
+google_edgecontainer_cluster
+      observedFields:
+        - control_plane_encryption.kms_key_active_version
+        - control_plane_encryption.kms_key_state
+        - fleet.membership
+        - networking.network_type
+Unprocessed list of fields: [controlPlaneEncryption.kmsKeyActiveVersion controlPlaneEncryption.kmsKeyState controlPlaneEncryption.kmsStatus, itself is a list controlPlaneEncryption.kmsStatus.code, parent "controlPlaneEncryption.kmsStatus" is a list controlPlaneEncryption.kmsStatus.message, parent "controlPlaneEncryption.kmsStatus" is a list fleet.membership networking.networkType]
+google_edgecontainer_node_pool
+      observedFields:
+        - local_disk_encryption.kms_key_active_version
+        - local_disk_encryption.kms_key_state
+Unprocessed list of fields: [localDiskEncryption.kmsKeyActiveVersion localDiskEncryption.kmsKeyState]
+google_memcache_instance
+      observedFields:
+        - maintenance_policy.create_time
+        - maintenance_policy.update_time
+        - memcache_parameters.id
+Unprocessed list of fields: [memcacheParameters.id maintenancePolicy.createTime maintenancePolicy.updateTime]
+google_monitoring_alert_policy
+Unprocessed list of fields: [conditions.name, parent "conditions" is a list]
+google_pubsub_subscription
+      observedFields:
+        - cloud_storage_config.state
+Unprocessed list of fields: [cloudStorageConfig.state]
+google_redis_instance
+      observedFields:
+        - maintenance_policy.create_time
+        - maintenance_policy.update_time
+        - persistence_config.rdb_next_snapshot_time
+Unprocessed list of fields: [persistenceConfig.rdbNextSnapshotTime maintenancePolicy.weeklyMaintenanceWindow.duration, parent "maintenancePolicy.weeklyMaintenanceWindow" is a list maintenancePolicy.createTime maintenancePolicy.updateTime]
+ignored... settings.version
+google_sql_database_instance
+Unprocessed list of fields: [settings.version]
+google_sql_user
+Unprocessed list of fields: [passwordPolicy.status, itself is a list passwordPolicy.status.locked, parent "passwordPolicy.status" is a list passwordPolicy.status.passwordExpirationTime, parent "passwordPolicy.status" is a list]
+CRD manifests generated under '/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/k8s-config-connector/config/crds/tmp_resources'


### PR DESCRIPTION
Currently, we are identifying output-only `spec` fields that meet the following criteria:
1. CRD contains a v1beta1 version.
    -> We want to focus on more important CRDs (i.e. v1beta1 is more important).
3. CRD is generated based on a TF resource.
    -> DCL-based resources don't have output-only spec fields unless they are subfields under a spec list.
5. Field is not sensitive.
    -> Further discussion will be needed to determine the strategy to handle sensitive, output-only field.
7. Field is not ignored.
    -> Ignored fields are not `spec` fields.
9. Field is not already observed.
    -> Observed field shouldn't be duplicated.
11. Field doesn't contain any list parent.
    -> Duplicating a subfield under a list may result in the size increase of the CR, which may eventually hit the etcd size limit.
13. Field itself is not a list.
    -> Duplicating a list may result in the size increase of the CR, which may eventually hit the etcd size limit.

This PR is a playground-ish PR, and will be closed after #1675 is merged. It was uploaded for posterity.