### PR TITLE
Provide an option to inherit Facade namespace for all objects

### DIFF
--- a/experiments/compositions/composition/api/v1alpha1/composition_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/composition_types.go
@@ -98,6 +98,17 @@ type Sinc struct {
 	//Image           string `json:"image" protobuf:"bytes,6,opt,name=image"`
 }
 
+type NamespaceMode string
+
+const (
+	// NamespaceModeNone is when nothing is set, this is the same as Inherit
+	NamespaceModeNone NamespaceMode = ""
+	// NamespaceModeInherit implies all the objects namespace is replaced with the  input api object's namespace
+	NamespaceModeInherit NamespaceMode = "inherit"
+	// NamespaceModeExplicit implies the objects in the template must have its namespace set
+	NamespaceModeExplicit NamespaceMode = "explicit"
+)
+
 // CompositionSpec defines the desired state of Composition
 type CompositionSpec struct {
 	// NOTE: Tighten the Composition API to include fields that are used in the controller
@@ -112,6 +123,11 @@ type CompositionSpec struct {
 	InputAPIGroup string `json:"inputAPIGroup,omitempty" protobuf:"bytes,3,name=inputAPIGroup"`
 	//+kubebuilder:validation:MinItems=1
 	Expanders []Expander `json:"expanders" protobuf:"bytes,5,rep,name=expanders"`
+	// Namespace mode indicates how compositions set the namespace of the objects from expanders.
+	// ""|inherit implies inherit the facade api's namespace. Only namespaced objects are allowed.
+	// explicit     implies the objects in the template must have the namespace set.
+	// +kubebuilder:validation:Enum=inherit;explicit
+	NamespaceMode NamespaceMode `json:"namespaceMode,omitempty" protobuf:"bytes,6,name=namespaceMode"`
 }
 
 // CompositionStatus defines the observed state of Composition

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
@@ -122,6 +122,15 @@ spec:
                 type: array
               inputAPIGroup:
                 type: string
+              namespaceMode:
+                description: |-
+                  Namespace mode indicates how compositions set the namespace of the objects from expanders.
+                  ""|inherit implies inherit the facade api's namespace. Only namespaced objects are allowed.
+                  explicit     implies the objects in the template must have the namespace set.
+                enum:
+                - inherit
+                - explicit
+                type: string
             required:
             - expanders
             type: object

--- a/experiments/compositions/composition/internal/controller/expander_reconciler.go
+++ b/experiments/compositions/composition/internal/controller/expander_reconciler.go
@@ -227,7 +227,7 @@ func (r *ExpanderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 
-		applier := NewApplier(ctx, logger, r, &plancr, &inputcr, expander.Name)
+		applier := NewApplier(ctx, logger, r, &plancr, &inputcr, &compositionCR, expander.Name)
 
 		err = applier.Load() // Load Manifests
 		if err != nil {

--- a/experiments/compositions/composition/release/kind/crds.yaml
+++ b/experiments/compositions/composition/release/kind/crds.yaml
@@ -89,7 +89,6 @@ spec:
                           name:
                             type: string
                           resourceRef:
-                            description: 'TODO(barney-s) : Remove proto annotations'
                             properties:
                               group:
                                 description: OPTION 2
@@ -121,6 +120,15 @@ spec:
                 minItems: 1
                 type: array
               inputAPIGroup:
+                type: string
+              namespaceMode:
+                description: |-
+                  Namespace mode indicates how compositions set the namespace of the objects from expanders.
+                  ""|inherit implies inherit the facade api's namespace. Only namespaced objects are allowed.
+                  explicit     implies the objects in the template must have the namespace set.
+                enum:
+                - inherit
+                - explicit
                 type: string
             required:
             - expanders

--- a/experiments/compositions/composition/release/kind/operator.yaml
+++ b/experiments/compositions/composition/release/kind/operator.yaml
@@ -102,7 +102,6 @@ spec:
                           name:
                             type: string
                           resourceRef:
-                            description: 'TODO(barney-s) : Remove proto annotations'
                             properties:
                               group:
                                 description: OPTION 2
@@ -134,6 +133,15 @@ spec:
                 minItems: 1
                 type: array
               inputAPIGroup:
+                type: string
+              namespaceMode:
+                description: |-
+                  Namespace mode indicates how compositions set the namespace of the objects from expanders.
+                  ""|inherit implies inherit the facade api's namespace. Only namespaced objects are allowed.
+                  explicit     implies the objects in the template must have the namespace set.
+                enum:
+                - inherit
+                - explicit
                 type: string
             required:
             - expanders

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
@@ -1,0 +1,173 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pconfigs.facade.foocorp.com
+spec:
+  group: facade.foocorp.com
+  names:
+    kind: PConfig
+    listKind: PConfigList
+    plural: pconfigs
+    singular: pconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the pconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PConfig spec
+            properties:
+              project:
+                type: string
+            required:
+            - project
+            type: object
+          status:
+            description: PConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: composition-facade-foocorp
+rules:
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - "*/status"
+  verbs:
+  - get
+  - update
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: composition-facade-foocorp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Composition
+metadata:
+  name: projectconfigmap
+  namespace: default
+spec:
+  namespaceMode: explicit
+  inputAPIGroup: pconfigs.facade.foocorp.com
+  expanders:
+  - type: jinja2
+    name: common
+    template: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: common-config
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+          key: {{ pconfigs.spec.project }}
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ managedProject }}
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+  - type: jinja2
+    name: clusterscope
+    template: |
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: {{ managedProject }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: foobar-foocorp
+      subjects:
+      - kind: ServiceAccount
+        name: foobar
+        namespace: foobar-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Context
+metadata:
+  name: context
+  namespace: team-a
+spec:
+  project: proj-a
+---
+apiVersion: facade.foocorp.com/v1alpha1
+kind: PConfig
+metadata:
+  name: team-a-config
+  namespace: team-a
+spec:
+  project: proj-a

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/output.yaml
@@ -1,0 +1,54 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-a
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: proj-a
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: pconfigs-team-a-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-config
+  namespace: team-a
+  labels:
+   createdby: "composition-namespaceconfigmap"
+data:
+  key1: value1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proj-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: foobar-foocorp
+subjects:
+- kind: ServiceAccount
+  name: foobar
+  namespace: foobar-system

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/input.yaml
@@ -1,0 +1,170 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pconfigs.facade.foocorp.com
+spec:
+  group: facade.foocorp.com
+  names:
+    kind: PConfig
+    listKind: PConfigList
+    plural: pconfigs
+    singular: pconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the pconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PConfig spec
+            properties:
+              project:
+                type: string
+            required:
+            - project
+            type: object
+          status:
+            description: PConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: composition-facade-foocorp
+rules:
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - "*/status"
+  verbs:
+  - get
+  - update
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: composition-facade-foocorp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Composition
+metadata:
+  name: projectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.foocorp.com
+  namespaceMode: inherit
+  expanders:
+  - type: jinja2
+    name: common
+    template: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: common-config
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+          key: {{ pconfigs.spec.project }}
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ managedProject }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ managedProject }}
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+  - type: jinja2
+    name: clusterscope
+    template: |
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: {{ managedProject }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: foobar-foocorp
+      subjects:
+      - kind: ServiceAccount
+        name: foobar
+        namespace: foobar-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Context
+metadata:
+  name: context
+  namespace: team-a
+spec:
+  project: proj-a
+---
+apiVersion: facade.foocorp.com/v1alpha1
+kind: PConfig
+metadata:
+  name: team-a-config
+  namespace: team-a
+spec:
+  project: proj-a

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/output.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-a
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: proj-a
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: pconfigs-team-a-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-config
+  namespace: team-a
+  labels:
+   createdby: "composition-namespaceconfigmap"
+data:
+  key1: value1

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -238,3 +238,33 @@ func TestSimplePlanStatusErrorFailedApplyingManifests(t *testing.T) {
 	// Verify the composition progresses after being unblocked
 	s.VerifyOutputExists()
 }
+
+func TestSimpleNamespaceInherit(t *testing.T) {
+	//t.Parallel()
+	s := scenario.New(t, "")
+	defer s.Cleanup()
+	s.Setup()
+
+	s.VerifyOutputExists()
+	s.VerifyOutputSpecMatches()
+
+	// Verify presence of an error because one of the manifests is cluster scoped
+	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
+	condition := utils.GetErrorCondition("FailedApplyingManifests", "")
+	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+}
+
+func TestSimpleNamespaceExplicit(t *testing.T) {
+	//t.Parallel()
+	s := scenario.New(t, "")
+	defer s.Cleanup()
+	s.Setup()
+
+	s.VerifyOutputExists()
+	s.VerifyOutputSpecMatches()
+
+	// Verify absence of an error because explicit allows cluster scoped
+	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
+	condition := utils.GetErrorCondition("FailedApplyingManifests", "")
+	s.C.MustNotHaveCondition(plan, condition, 2*scenario.CompositionReconcile)
+}


### PR DESCRIPTION
### Change description

- Provide an option to inherit (default) Facade namespace for all objects.
- For those templates (admin ones) that require cluster level or cross
namespace objects, the template must use `namespaceMode: explicit` and set
the namespaces explicitly for the required objects.
- Add tests
  - TestSimpleNamespaceInherit
  - TestSimpleNamespaceExplicit

### Tests you have done

```
=== RUN   TestSimpleNamespaceInherit
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:175: Creating object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:227: Verifying output
    scenario.go:228: Checking existence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config"] on "composition-e2e-0"
    scenario.go:235: Verifying output spec matches
    scenario.go:236: Matching specs of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config"] on "composition-e2e-0"
    simple_test.go:254: Checking condition "Error" present in object "Plan/team-a/pconfigs-team-a-config" on cluster "composition-e2e-0"
    client.go:285: Has condition [Error, FailedApplyingManifests, Expander: clusterscope, Message: Unable to apply all objects]
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:245: WARN "PConfig/team-a/team-a-config" not found on cluster "composition-e2e-0": the server could not find the requested resource (delete pconfigs.facade.foocorp.com team-a-config)
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:256: Deleting object "ConfigMap/team-a/proj-a" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/proj-a" not found on cluster "composition-e2e-0": configmaps "proj-a" not found
    scenario.go:256: Deleting object "ConfigMap/team-a/common-config" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/common-config" not found on cluster "composition-e2e-0": configmaps "common-config" not found
    scenario.go:258: Checking absence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config"] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleNamespaceInherit (51.49s)

❯ go test -timeout 3600s -v -run "^TestSimpleNamespaceExplicit$" --images=gcr.io/allotrope-barni/composition:v0.0.1.alpha,gcr.io/allotrope-barni/manifests-inline:v0.0.1.alpha,gcr.io/allotrope-barni/expander-jinja2:v0.0.1.alpha
=== RUN   TestSimpleNamespaceExplicit
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:175: Creating object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:227: Verifying output
    scenario.go:228: Checking existence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config" "ClusterRoleBinding/proj-a"] on "composition-e2e-0"
    scenario.go:235: Verifying output spec matches
    scenario.go:236: Matching specs of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config" "ClusterRoleBinding/proj-a"] on "composition-e2e-0"
    simple_test.go:269: Checking condition "Error" not present in object "Plan/team-a/pconfigs-team-a-config" on cluster "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:245: WARN "PConfig/team-a/team-a-config" not found on cluster "composition-e2e-0": the server could not find the requested resource (delete pconfigs.facade.foocorp.com team-a-config)
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:256: Deleting object "ConfigMap/team-a/proj-a" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/proj-a" not found on cluster "composition-e2e-0": configmaps "proj-a" not found
    scenario.go:256: Deleting object "ConfigMap/team-a/common-config" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/common-config" not found on cluster "composition-e2e-0": configmaps "common-config" not found
    scenario.go:256: Deleting object "ClusterRoleBinding/proj-a" on cluster "composition-e2e-0"
    scenario.go:258: Checking absence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/common-config" "ClusterRoleBinding/proj-a"] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleNamespaceExplicit (25.30s)
PASS
```