### PR TITLE
chore: refactor job execution in compositions with a view to making it pluggable

### DIFF
--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -160,7 +160,7 @@ func (r *CompositionReconciler) runComposition(
 		InputGVK:      gvk,
 		ImageRegistry: r.ImageRegistry,
 		Composition:   types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
-		Resource:      crd.Spec.Names.Plural,
+		InputGVR:      gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
 		RESTMapper:    r.mgr.GetRESTMapper(),
 		Config:        r.mgr.GetConfig(),
 	}

--- a/experiments/compositions/composition/internal/controller/expander_applier.go
+++ b/experiments/compositions/composition/internal/controller/expander_applier.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +38,7 @@ type Applier struct {
 	InputCR         *unstructured.Unstructured
 	PlanCR          *compositionv1alpha1.Plan
 	Dryrun          bool
-	Resource        string
+	InputGVR        schema.GroupVersionResource
 	CompositionName string
 	ExpanderName    string
 	Name            string
@@ -56,7 +57,7 @@ func NewApplier(ctx context.Context, logger logr.Logger,
 		Dynamic:         r.Dynamic,
 		InputCR:         cr,
 		PlanCR:          plan,
-		Resource:        r.Resource,
+		InputGVR:        r.InputGVR,
 		CompositionName: r.Composition.Name,
 		ExpanderName:    expanderName,
 		Name:            r.Composition.Name + "-" + cr.GetName(),
@@ -139,7 +140,7 @@ func (a *Applier) getApplyOptions(prune bool) (applyset.Options, error) {
 	var options applyset.Options
 	force := true
 	patchOptions := metav1.PatchOptions{
-		FieldManager: a.Resource + "-controller",
+		FieldManager: a.InputGVR.Resource + "-controller",
 		Force:        &force,
 	}
 	if a.Dryrun {

--- a/experiments/compositions/composition/pkg/containerexecutor/jobcontainerexecutor/jobcontainerrunner.go
+++ b/experiments/compositions/composition/pkg/containerexecutor/jobcontainerexecutor/jobcontainerrunner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package jobcontainerexecutor
 
 import (
 	"bytes"
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -102,25 +103,25 @@ type JobFactory struct {
 	timeout              time.Duration
 }
 
-func NewJobFactory(ctx context.Context, logger logr.Logger,
-	r *ExpanderReconciler,
+func NewJobFactory(ctx context.Context, logger logr.Logger, client client.Client,
+	inputGVK schema.GroupVersionKind, inputGVR schema.GroupVersionResource,
+	compositionName string,
 	cr *unstructured.Unstructured, expanderName string,
 	planName string, imageRegistry string) *JobFactory {
 	return &JobFactory{
-		InputAPIGroup:        r.InputGVK.Group,
-		InputAPIVersion:      r.InputGVK.Version,
-		InputAPIResource:     r.Resource,
-		InputAPIName:         cr.GetName(),
-		InputAPINamespace:    cr.GetNamespace(),
-		CompositionName:      r.Composition.Name,
-		CompositionNamespace: r.Composition.Namespace,
-		ExpanderName:         expanderName,
-		PlanName:             planName,
-		ImageRegistry:        imageRegistry,
-		Name:                 r.Composition.Name + "-" + cr.GetName() + "-" + expanderName,
-		logger:               logger,
-		ctx:                  ctx,
-		client:               r.Client,
+		InputAPIGroup:     inputGVK.Group,
+		InputAPIVersion:   inputGVK.Version,
+		InputAPIResource:  inputGVR.Resource,
+		InputAPIName:      cr.GetName(),
+		InputAPINamespace: cr.GetNamespace(),
+		CompositionName:   compositionName,
+		ExpanderName:      expanderName,
+		PlanName:          planName,
+		ImageRegistry:     imageRegistry,
+		Name:              compositionName + "-" + cr.GetName() + "-" + expanderName,
+		logger:            logger,
+		ctx:               ctx,
+		client:            client,
 	}
 }
 


### PR DESCRIPTION
Starting by moving the code, then we can add a second implementation
to understand the underlying contract.
