### PR TITLE
test: fail the test if no test case was run

### DIFF
--- a/pkg/test/resourcefixture/test_runner.go
+++ b/pkg/test/resourcefixture/test_runner.go
@@ -38,6 +38,10 @@ func RunTests(ctx context.Context, t *testing.T, shouldRun ShouldRunFunc, testCa
 		}
 		filtered = append(filtered, tc)
 	}
+	if len(filtered) == 0 {
+		t.Errorf("No test case were run")
+		return
+	}
 
 	// Run tests grouped by the group of the GVK
 	groups := sets.NewString()


### PR DESCRIPTION
It is confusing that the test says "PASS" when in fact no test case was tested.

```
$ go test -timeout 2400s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdat
eDelete -run-tests abc                                                                    
{"severity":"info","timestamp":"2024-04-03T01:31:17.685Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/deny-unknown-fields"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.685Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/iam-validation"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.685Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/iam-defaulter"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.685Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/container-annotation-handler"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.692Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/management-conflict-annotation-defaulter"}      
{"severity":"info","timestamp":"2024-04-03T01:31:17.692Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/generic-defaulter"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.692Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/resource-validation"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.692Z","logger":"controller-runtime.webhook.webhooks","msg":"Starting webhook server"}                     
{"severity":"info","timestamp":"2024-04-03T01:31:17.693Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.693Z","logger":"controller-runtime.webhook","msg":"Serving webhook server","host":"127.0.0.1","port":34587}
{"severity":"info","timestamp":"2024-04-03T01:31:17.693Z","logger":"controller-runtime.certwatcher","msg":"Starting certificate watcher"}
=== RUN   TestCreateNoChangeUpdateDelete
=== PAUSE TestCreateNoChangeUpdateDelete
=== CONT  TestCreateNoChangeUpdateDelete
--- PASS: TestCreateNoChangeUpdateDelete (0.11s)
PASS
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","msg":"Stopping and waiting for non leader election runnables"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","msg":"Stopping and waiting for leader election runnables"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","msg":"Stopping and waiting for caches"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","msg":"Stopping and waiting for webhooks"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","logger":"controller-runtime.webhook","msg":"Shutting down webhook server with timeout of 1 minute"}
{"severity":"info","timestamp":"2024-04-03T01:31:17.810Z","msg":"Wait completed, proceeding to shutdown the manager"}
ok      github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      13.673s
```
