### PR TITLE
Make goimports cover the entire repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ manifests: generate
 fmt:
 	mockgcp/dev/fix-gofmt
 	make -C operator fmt
-	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg cmd scripts config/tests
+	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg cmd scripts tests config/tests experiments
 	# 04bfe4ee9ca5764577b029acc6a1957fd1997153 includes fix to not log "Skipped" for each skipped file
 	GOFLAGS= go run github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153 -c "Google LLC" -l apache \
 	-ignore ".build/**" -ignore "vendor/**" -ignore "third_party/**" \

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	testvariable "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture/variable"
 	"hash/fnv"
 	"io"
 	"io/ioutil"
@@ -37,6 +36,7 @@ import (
 	testcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/controller"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture"
+	testvariable "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture/variable"
 	testyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/yaml"
 
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Added tests/ and experiments/ folders to goimports command.
I think it is simpler and easier to maintain if we enforce goimports across the entire repository but it seems to modify generated files that don't have a good import grouping rule. So I manually picked two more folders to cover.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
