### PR TITLE
vcr: Set up VCR recorder for DCL requests

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbbackup/fullalloydbbackup/dependencies.yaml
@@ -80,7 +80,7 @@ spec:
     name: alloydbcluster-${uniqueId}
   machineConfig:
     cpuCount: 2
-  resourceID: alloydbinstance${uniqueId}      
+  resourceID: alloydbinstance${uniqueId}
 ---
 apiVersion: kms.cnrm.cloud.google.com/v1beta1
 kind: KMSKeyRing

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-dcl.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-dcl.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-oauth.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-oauth.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-tf.yaml
@@ -1,21 +1,40 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 ---
 version: 2
 interactions:
     - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 175.034001ms
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -45,17 +64,17 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "4843562213390748277",
-              "name": "operation-1711584409839-614ad4cc06925-af0e9382-1dca5523",
+              "id": "62798008424150698",
+              "name": "operation-1712621637549-6159ecc573e73-7aad63ee-dece6c97",
               "operationType": "compute.nodeTemplates.insert",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "targetId": "6096640396835228277",
+              "targetId": "1738795569896830634",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:06:50.106-07:00",
-              "startTime": "2024-03-27T17:06:50.142-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584409839-614ad4cc06925-af0e9382-1dca5523",
+              "insertTime": "2024-04-08T17:13:57.909-07:00",
+              "startTime": "2024-04-08T17:13:57.953-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621637549-6159ecc573e73-7aad63ee-dece6c97",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"
             }
         headers:
@@ -63,40 +82,7 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 415.843583ms
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584409839-614ad4cc06925-af0e9382-1dca5523?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"4843562213390748277","name":"operation-1711584409839-614ad4cc06925-af0e9382-1dca5523","operationType":"compute.nodeTemplates.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26","targetId":"6096640396835228277","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:06:50.106-07:00","startTime":"2024-03-27T17:06:50.142-07:00","endTime":"2024-03-27T17:06:50.450-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584409839-614ad4cc06925-af0e9382-1dca5523","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 139.343885ms
+        duration: 567.810226ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -111,9 +97,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621637549-6159ecc573e73-7aad63ee-dece6c97?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -123,34 +109,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: |
-            {
-              "kind": "compute#nodeTemplate",
-              "id": "6096640396835228277",
-              "creationTimestamp": "2024-03-27T17:06:50.116-07:00",
-              "name": "computenodetemplate-bopydlzuxy26",
-              "nodeAffinityLabels": {
-                "cnrm-test": "true",
-                "managed-by-cnrm": "true"
-              },
-              "status": "READY",
-              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "nodeTypeFlexibility": {
-                "cpus": "any",
-                "memory": "any"
-              },
-              "serverBinding": {
-                "type": "RESTART_NODE_ON_ANY_SERVER"
-              },
-              "cpuOvercommitType": "NONE"
-            }
+        body: '{"kind":"compute#operation","id":"62798008424150698","name":"operation-1712621637549-6159ecc573e73-7aad63ee-dece6c97","operationType":"compute.nodeTemplates.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26","targetId":"1738795569896830634","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:13:57.909-07:00","startTime":"2024-04-08T17:13:57.953-07:00","endTime":"2024-04-08T17:13:58.262-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621637549-6159ecc573e73-7aad63ee-dece6c97","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 139.403305ms
+        duration: 126.631912ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -180,12 +145,12 @@ interactions:
         body: |
             {
               "kind": "compute#nodeTemplate",
-              "id": "6096640396835228277",
-              "creationTimestamp": "2024-03-27T17:06:50.116-07:00",
+              "id": "1738795569896830634",
+              "creationTimestamp": "2024-04-08T17:13:57.919-07:00",
               "name": "computenodetemplate-bopydlzuxy26",
               "nodeAffinityLabels": {
-                "managed-by-cnrm": "true",
-                "cnrm-test": "true"
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
               },
               "status": "READY",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
@@ -204,8 +169,95 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 291.399689ms
+        duration: 160.797865ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 150.568907ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "compute#nodeTemplate",
+              "id": "1738795569896830634",
+              "creationTimestamp": "2024-04-08T17:13:57.919-07:00",
+              "name": "computenodetemplate-bopydlzuxy26",
+              "nodeAffinityLabels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "status": "READY",
+              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
+              "nodeTypeFlexibility": {
+                "cpus": "any",
+                "memory": "any"
+              },
+              "serverBinding": {
+                "type": "RESTART_NODE_ON_ANY_SERVER"
+              },
+              "cpuOvercommitType": "NONE"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 157.227755ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -235,91 +287,25 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "4564027878998084212",
-              "name": "operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd",
+              "id": "2310870129798887079",
+              "name": "operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9",
               "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
               "operationType": "compute.nodeGroups.insert",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
-              "targetId": "6032112866626164",
+              "targetId": "710152998448871079",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:06:51.906-07:00",
-              "startTime": "2024-03-27T17:06:51.969-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd"
+              "insertTime": "2024-04-08T17:14:00.024-07:00",
+              "startTime": "2024-04-08T17:14:00.065-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9"
             }
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 567.820777ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"4564027878998084212","name":"operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"6032112866626164","status":"RUNNING","user":"user@google.com","progress":0,"insertTime":"2024-03-27T17:06:51.906-07:00","startTime":"2024-03-27T17:06:51.969-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 287.896767ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"4564027878998084212","name":"operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"6032112866626164","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:06:51.906-07:00","startTime":"2024-03-27T17:06:51.969-07:00","endTime":"2024-03-27T17:07:00.018-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584411558-614ad4cdaa114-1320eae2-89aab2bd"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 144.386276ms
+        duration: 605.920187ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -334,9 +320,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26?alt=json
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -346,35 +332,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: |
-            {
-              "kind": "compute#nodeGroup",
-              "id": "6032112866626164",
-              "creationTimestamp": "2024-03-27T17:06:51.916-07:00",
-              "name": "computenodegroup-bopydlzuxy26",
-              "description": "A single sole-tenant node in the us-central1-b zone.",
-              "nodeTemplate": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
-              "status": "READY",
-              "size": 1,
-              "autoscalingPolicy": {
-                "mode": "OFF",
-                "minNodes": 0
-              },
-              "maintenancePolicy": "DEFAULT",
-              "fingerprint": "i80_NJrsYPc=",
-              "shareSettings": {
-                "shareType": "LOCAL"
-              },
-              "maintenanceInterval": "AS_NEEDED"
-            }
+        body: '{"kind":"compute#operation","id":"2310870129798887079","name":"operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"710152998448871079","status":"RUNNING","user":"user@google.com","progress":0,"insertTime":"2024-04-08T17:14:00.024-07:00","startTime":"2024-04-08T17:14:00.065-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 156.350135ms
+        duration: 168.649093ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -389,9 +353,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26?alt=json
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -401,35 +365,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: |
-            {
-              "kind": "compute#nodeGroup",
-              "id": "6032112866626164",
-              "creationTimestamp": "2024-03-27T17:06:51.916-07:00",
-              "name": "computenodegroup-bopydlzuxy26",
-              "description": "A single sole-tenant node in the us-central1-b zone.",
-              "nodeTemplate": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
-              "status": "READY",
-              "size": 1,
-              "autoscalingPolicy": {
-                "mode": "OFF",
-                "minNodes": 0
-              },
-              "maintenancePolicy": "DEFAULT",
-              "fingerprint": "i80_NJrsYPc=",
-              "shareSettings": {
-                "shareType": "LOCAL"
-              },
-              "maintenanceInterval": "AS_NEEDED"
-            }
+        body: '{"kind":"compute#operation","id":"2310870129798887079","name":"operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"710152998448871079","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:14:00.024-07:00","startTime":"2024-04-08T17:14:00.065-07:00","endTime":"2024-04-08T17:14:07.418-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621639728-6159ecc787c98-6adf7a73-5dc72da9"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 244.13485ms
+        duration: 165.327084ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -446,7 +388,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -458,32 +400,33 @@ interactions:
         uncompressed: true
         body: |
             {
-              "kind": "compute#nodeTemplate",
-              "id": "6096640396835228277",
-              "creationTimestamp": "2024-03-27T17:06:50.116-07:00",
-              "name": "computenodetemplate-bopydlzuxy26",
-              "nodeAffinityLabels": {
-                "cnrm-test": "true",
-                "managed-by-cnrm": "true"
-              },
+              "kind": "compute#nodeGroup",
+              "id": "710152998448871079",
+              "creationTimestamp": "2024-04-08T17:14:00.032-07:00",
+              "name": "computenodegroup-bopydlzuxy26",
+              "description": "A single sole-tenant node in the us-central1-b zone.",
+              "nodeTemplate": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
+              "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
               "status": "READY",
-              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "nodeTypeFlexibility": {
-                "cpus": "any",
-                "memory": "any"
+              "size": 1,
+              "autoscalingPolicy": {
+                "mode": "OFF",
+                "minNodes": 0
               },
-              "serverBinding": {
-                "type": "RESTART_NODE_ON_ANY_SERVER"
+              "maintenancePolicy": "DEFAULT",
+              "fingerprint": "1eJFBuUGwuc=",
+              "shareSettings": {
+                "shareType": "LOCAL"
               },
-              "cpuOvercommitType": "NONE"
+              "maintenanceInterval": "AS_NEEDED"
             }
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 105.216237ms
+        duration: 340.055457ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -513,8 +456,8 @@ interactions:
         body: |
             {
               "kind": "compute#nodeGroup",
-              "id": "6032112866626164",
-              "creationTimestamp": "2024-03-27T17:06:51.916-07:00",
+              "id": "710152998448871079",
+              "creationTimestamp": "2024-04-08T17:14:00.032-07:00",
               "name": "computenodegroup-bopydlzuxy26",
               "description": "A single sole-tenant node in the us-central1-b zone.",
               "nodeTemplate": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
@@ -527,7 +470,7 @@ interactions:
                 "minNodes": 0
               },
               "maintenancePolicy": "DEFAULT",
-              "fingerprint": "i80_NJrsYPc=",
+              "fingerprint": "1eJFBuUGwuc=",
               "shareSettings": {
                 "shareType": "LOCAL"
               },
@@ -538,8 +481,117 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 191.09825ms
+        duration: 322.139681ms
     - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "compute#nodeGroup",
+              "id": "710152998448871079",
+              "creationTimestamp": "2024-04-08T17:14:00.032-07:00",
+              "name": "computenodegroup-bopydlzuxy26",
+              "description": "A single sole-tenant node in the us-central1-b zone.",
+              "nodeTemplate": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
+              "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
+              "status": "READY",
+              "size": 1,
+              "autoscalingPolicy": {
+                "mode": "OFF",
+                "minNodes": 0
+              },
+              "maintenancePolicy": "DEFAULT",
+              "fingerprint": "1eJFBuUGwuc=",
+              "shareSettings": {
+                "shareType": "LOCAL"
+              },
+              "maintenanceInterval": "AS_NEEDED"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 155.926886ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "compute#nodeTemplate",
+              "id": "1738795569896830634",
+              "creationTimestamp": "2024-04-08T17:13:57.919-07:00",
+              "name": "computenodetemplate-bopydlzuxy26",
+              "nodeAffinityLabels": {
+                "managed-by-cnrm": "true",
+                "cnrm-test": "true"
+              },
+              "status": "READY",
+              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
+              "nodeTypeFlexibility": {
+                "cpus": "any",
+                "memory": "any"
+              },
+              "serverBinding": {
+                "type": "RESTART_NODE_ON_ANY_SERVER"
+              },
+              "cpuOvercommitType": "NONE"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 393.065166ms
+    - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -568,112 +620,25 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "3274958505268283974",
-              "name": "operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090",
+              "id": "413625617359648441",
+              "name": "operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523",
               "zone": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b",
               "operationType": "compute.nodeGroups.delete",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26",
-              "targetId": "6032112866626164",
+              "targetId": "710152998448871079",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:07:05.499-07:00",
-              "startTime": "2024-03-27T17:07:05.522-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090"
+              "insertTime": "2024-04-08T17:14:14.419-07:00",
+              "startTime": "2024-04-08T17:14:14.447-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523"
             }
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 519.590711ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"3274958505268283974","name":"operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"6032112866626164","status":"RUNNING","user":"user@google.com","progress":0,"insertTime":"2024-03-27T17:07:05.499-07:00","startTime":"2024-03-27T17:07:05.522-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 200.761686ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: |
-            {
-              "kind": "compute#nodeTemplate",
-              "id": "6096640396835228277",
-              "creationTimestamp": "2024-03-27T17:06:50.116-07:00",
-              "name": "computenodetemplate-bopydlzuxy26",
-              "nodeAffinityLabels": {
-                "managed-by-cnrm": "true",
-                "cnrm-test": "true"
-              },
-              "status": "READY",
-              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "nodeTypeFlexibility": {
-                "cpus": "any",
-                "memory": "any"
-              },
-              "serverBinding": {
-                "type": "RESTART_NODE_ON_ANY_SERVER"
-              },
-              "cpuOvercommitType": "NONE"
-            }
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 107.133148ms
+        duration: 437.842306ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -691,6 +656,72 @@ interactions:
             Content-Type:
                 - application/json
         url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 400 Bad Request
+        code: 400
+        duration: 316.263542ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"compute#operation","id":"413625617359648441","name":"operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"710152998448871079","status":"RUNNING","user":"user@google.com","progress":0,"insertTime":"2024-04-08T17:14:14.419-07:00","startTime":"2024-04-08T17:14:14.447-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 297.245596ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -703,8 +734,8 @@ interactions:
         body: |
             {
               "kind": "compute#nodeTemplate",
-              "id": "6096640396835228277",
-              "creationTimestamp": "2024-03-27T17:06:50.116-07:00",
+              "id": "1738795569896830634",
+              "creationTimestamp": "2024-04-08T17:13:57.919-07:00",
               "name": "computenodetemplate-bopydlzuxy26",
               "nodeAffinityLabels": {
                 "managed-by-cnrm": "true",
@@ -727,8 +758,128 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 123.095189ms
-    - id: 15
+        duration: 158.329946ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 400 Bad Request
+        code: 400
+        duration: 474.179588ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "compute#nodeTemplate",
+              "id": "1738795569896830634",
+              "creationTimestamp": "2024-04-08T17:13:57.919-07:00",
+              "name": "computenodetemplate-bopydlzuxy26",
+              "nodeAffinityLabels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "status": "READY",
+              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
+              "nodeTypeFlexibility": {
+                "cpus": "any",
+                "memory": "any"
+              },
+              "serverBinding": {
+                "type": "RESTART_NODE_ON_ANY_SERVER"
+              },
+              "cpuOvercommitType": "NONE"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 156.882627ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"compute#operation","id":"413625617359648441","name":"operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"710152998448871079","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:14:14.419-07:00","startTime":"2024-04-08T17:14:14.447-07:00","endTime":"2024-04-08T17:14:18.650-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1712621654152-6159ecd54938d-cc6c9e85-4a5a4523"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 111.469386ms
+    - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -757,17 +908,17 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "1242290117753244251",
-              "name": "operation-1711584435801-614ad4e4c8d47-b1a00223-89f5ff7e",
+              "id": "9205808780514244238",
+              "name": "operation-1712621665595-6159ece032f25-09acf537-1f3435d8",
               "operationType": "compute.nodeTemplates.delete",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26",
-              "targetId": "6096640396835228277",
+              "targetId": "1738795569896830634",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:07:16.021-07:00",
-              "startTime": "2024-03-27T17:07:16.060-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584435801-614ad4e4c8d47-b1a00223-89f5ff7e",
+              "insertTime": "2024-04-08T17:14:25.802-07:00",
+              "startTime": "2024-04-08T17:14:25.818-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621665595-6159ece032f25-09acf537-1f3435d8",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"
             }
         headers:
@@ -775,8 +926,8 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 358.478957ms
-    - id: 16
+        duration: 482.308828ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -791,8 +942,8 @@ interactions:
         form: {}
         headers:
             X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584435801-614ad4e4c8d47-b1a00223-89f5ff7e?alt=json&prettyPrint=false
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621665595-6159ece032f25-09acf537-1f3435d8?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -802,43 +953,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"kind":"compute#operation","id":"1242290117753244251","name":"operation-1711584435801-614ad4e4c8d47-b1a00223-89f5ff7e","operationType":"compute.nodeTemplates.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26","targetId":"6096640396835228277","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:07:16.021-07:00","startTime":"2024-03-27T17:07:16.060-07:00","endTime":"2024-03-27T17:07:16.558-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584435801-614ad4e4c8d47-b1a00223-89f5ff7e","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
+        body: '{"kind":"compute#operation","id":"9205808780514244238","name":"operation-1712621665595-6159ece032f25-09acf537-1f3435d8","operationType":"compute.nodeTemplates.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-bopydlzuxy26","targetId":"1738795569896830634","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:14:25.802-07:00","startTime":"2024-04-08T17:14:25.818-07:00","endTime":"2024-04-08T17:14:26.206-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621665595-6159ece032f25-09acf537-1f3435d8","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 149.154987ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"3274958505268283974","name":"operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090","zone":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b","operationType":"compute.nodeGroups.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/nodeGroups/computenodegroup-bopydlzuxy26","targetId":"6032112866626164","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:07:05.499-07:00","startTime":"2024-03-27T17:07:05.522-07:00","endTime":"2024-03-27T17:07:09.720-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/zones/us-central1-b/operations/operation-1711584425280-614ad4dac022e-6bb8abfb-5209c090"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 159.007954ms
+        duration: 137.286581ms

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodegroup-tf.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions:

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-dcl.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-dcl.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-oauth.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-oauth.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-tf.yaml
@@ -1,21 +1,40 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 ---
 version: 2
 interactions:
     - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 404.347543ms
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -45,17 +64,17 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "8384382365164177958",
-              "name": "operation-1711584457349-614ad4f95580f-7d92979e-c0c0deef",
+              "id": "9036898522900281691",
+              "name": "operation-1712621492192-6159ec3ad43f0-4e35f562-990c93c2",
               "operationType": "compute.nodeTemplates.insert",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d",
-              "targetId": "1988438877528459814",
+              "targetId": "640607960279103835",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:07:37.672-07:00",
-              "startTime": "2024-03-27T17:07:37.712-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584457349-614ad4f95580f-7d92979e-c0c0deef",
+              "insertTime": "2024-04-08T17:11:32.450-07:00",
+              "startTime": "2024-04-08T17:11:32.491-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621492192-6159ec3ad43f0-4e35f562-990c93c2",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"
             }
         headers:
@@ -63,40 +82,7 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 503.333228ms
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: compute.googleapis.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584457349-614ad4f95580f-7d92979e-c0c0deef?alt=json&prettyPrint=false
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"kind":"compute#operation","id":"8384382365164177958","name":"operation-1711584457349-614ad4f95580f-7d92979e-c0c0deef","operationType":"compute.nodeTemplates.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d","targetId":"1988438877528459814","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:07:37.672-07:00","startTime":"2024-03-27T17:07:37.712-07:00","endTime":"2024-03-27T17:07:38.077-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584457349-614ad4f95580f-7d92979e-c0c0deef","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
-        headers:
-            Content-Type:
-                - application/json; charset=UTF-8
-        status: 200 OK
-        code: 200
-        duration: 132.964901ms
+        duration: 431.808087ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -111,9 +97,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d?alt=json
+            X-Goog-Api-Client:
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621492192-6159ec3ad43f0-4e35f562-990c93c2?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -123,36 +109,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: |
-            {
-              "kind": "compute#nodeTemplate",
-              "id": "1988438877528459814",
-              "creationTimestamp": "2024-03-27T17:07:37.683-07:00",
-              "name": "computenodetemplate-2avqvi66hp2d",
-              "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
-              "nodeAffinityLabels": {
-                "memory_guarantee": "false",
-                "managed-by-cnrm": "true",
-                "cnrm-test": "true"
-              },
-              "status": "READY",
-              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d",
-              "nodeTypeFlexibility": {
-                "cpus": "96",
-                "memory": "any"
-              },
-              "serverBinding": {
-                "type": "RESTART_NODE_ON_ANY_SERVER"
-              },
-              "cpuOvercommitType": "NONE"
-            }
+        body: '{"kind":"compute#operation","id":"9036898522900281691","name":"operation-1712621492192-6159ec3ad43f0-4e35f562-990c93c2","operationType":"compute.nodeTemplates.insert","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d","targetId":"640607960279103835","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:11:32.450-07:00","startTime":"2024-04-08T17:11:32.491-07:00","endTime":"2024-04-08T17:11:32.803-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621492192-6159ec3ad43f0-4e35f562-990c93c2","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 110.104866ms
+        duration: 324.935084ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -182,14 +145,14 @@ interactions:
         body: |
             {
               "kind": "compute#nodeTemplate",
-              "id": "1988438877528459814",
-              "creationTimestamp": "2024-03-27T17:07:37.683-07:00",
+              "id": "640607960279103835",
+              "creationTimestamp": "2024-04-08T17:11:32.459-07:00",
               "name": "computenodetemplate-2avqvi66hp2d",
               "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
               "nodeAffinityLabels": {
+                "memory_guarantee": "false",
                 "cnrm-test": "true",
-                "managed-by-cnrm": "true",
-                "memory_guarantee": "false"
+                "managed-by-cnrm": "true"
               },
               "status": "READY",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
@@ -208,7 +171,7 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 137.374944ms
+        duration: 322.173105ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -238,13 +201,69 @@ interactions:
         body: |
             {
               "kind": "compute#nodeTemplate",
-              "id": "1988438877528459814",
-              "creationTimestamp": "2024-03-27T17:07:37.683-07:00",
+              "id": "640607960279103835",
+              "creationTimestamp": "2024-04-08T17:11:32.459-07:00",
               "name": "computenodetemplate-2avqvi66hp2d",
               "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
               "nodeAffinityLabels": {
+                "managed-by-cnrm": "true",
                 "cnrm-test": "true",
+                "memory_guarantee": "false"
+              },
+              "status": "READY",
+              "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d",
+              "nodeTypeFlexibility": {
+                "cpus": "96",
+                "memory": "any"
+              },
+              "serverBinding": {
+                "type": "RESTART_NODE_ON_ANY_SERVER"
+              },
+              "cpuOvercommitType": "NONE"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 305.83258ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: compute.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "compute#nodeTemplate",
+              "id": "640607960279103835",
+              "creationTimestamp": "2024-04-08T17:11:32.459-07:00",
+              "name": "computenodetemplate-2avqvi66hp2d",
+              "description": "Node template for sole tenant nodes running in us-central1, with 96vCPUs and any amount of memory on any machine type.",
+              "nodeAffinityLabels": {
                 "memory_guarantee": "false",
+                "cnrm-test": "true",
                 "managed-by-cnrm": "true"
               },
               "status": "READY",
@@ -264,8 +283,8 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 157.804199ms
-    - id: 5
+        duration: 148.545921ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -294,17 +313,17 @@ interactions:
         body: |
             {
               "kind": "compute#operation",
-              "id": "1811968627070011939",
-              "name": "operation-1711584460266-614ad4fc1dd26-f04486e1-6b047212",
+              "id": "7912875203233397080",
+              "name": "operation-1712621495291-6159ec3dc8fc8-6892be2e-e6ed0d67",
               "operationType": "compute.nodeTemplates.delete",
               "targetLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d",
-              "targetId": "1988438877528459814",
+              "targetId": "640607960279103835",
               "status": "RUNNING",
               "user": "user@google.com",
               "progress": 0,
-              "insertTime": "2024-03-27T17:07:40.494-07:00",
-              "startTime": "2024-03-27T17:07:40.514-07:00",
-              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584460266-614ad4fc1dd26-f04486e1-6b047212",
+              "insertTime": "2024-04-08T17:11:35.533-07:00",
+              "startTime": "2024-04-08T17:11:35.557-07:00",
+              "selfLink": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621495291-6159ec3dc8fc8-6892be2e-e6ed0d67",
               "region": "https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"
             }
         headers:
@@ -312,8 +331,8 @@ interactions:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 344.070566ms
-    - id: 6
+        duration: 385.899219ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -328,8 +347,8 @@ interactions:
         form: {}
         headers:
             X-Goog-Api-Client:
-                - gl-go/1.21.5 gdcl/0.160.0
-        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584460266-614ad4fc1dd26-f04486e1-6b047212?alt=json&prettyPrint=false
+                - gl-go/1.22.1 gdcl/0.160.0
+        url: https://compute.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621495291-6159ec3dc8fc8-6892be2e-e6ed0d67?alt=json&prettyPrint=false
         method: GET
       response:
         proto: HTTP/2.0
@@ -339,10 +358,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"kind":"compute#operation","id":"1811968627070011939","name":"operation-1711584460266-614ad4fc1dd26-f04486e1-6b047212","operationType":"compute.nodeTemplates.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d","targetId":"1988438877528459814","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-03-27T17:07:40.494-07:00","startTime":"2024-03-27T17:07:40.514-07:00","endTime":"2024-03-27T17:07:40.822-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1711584460266-614ad4fc1dd26-f04486e1-6b047212","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
+        body: '{"kind":"compute#operation","id":"7912875203233397080","name":"operation-1712621495291-6159ec3dc8fc8-6892be2e-e6ed0d67","operationType":"compute.nodeTemplates.delete","targetLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/nodeTemplates/computenodetemplate-2avqvi66hp2d","targetId":"640607960279103835","status":"DONE","user":"user@google.com","progress":100,"insertTime":"2024-04-08T17:11:35.533-07:00","startTime":"2024-04-08T17:11:35.557-07:00","endTime":"2024-04-08T17:11:35.861-07:00","selfLink":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1/operations/operation-1712621495291-6159ec3dc8fc8-6892be2e-e6ed0d67","region":"https://www.googleapis.com/compute/beta/projects/example-project/regions/us-central1"}'
         headers:
             Content-Type:
                 - application/json; charset=UTF-8
         status: 200 OK
         code: 200
-        duration: 149.299712ms
+        duration: 150.91417ms

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_computenodetemplate-tf.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions:

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-dcl.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions:

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-dcl.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-dcl.yaml
@@ -1,0 +1,2144 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 334.541759ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 262.602273ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 224.160043ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1448
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"issuancePolicy":{"allowedIssuanceModes":{"allowConfigBasedIssuance":false,"allowCsrBasedIssuance":true},"allowedKeyTypes":[{"rsa":{"maxModulusSize":128,"minModulusSize":64}},{"ellipticCurve":{"signatureAlgorithm":"ECDSA_P384"}}],"baselineValues":{"additionalExtensions":[{"critical":false,"objectId":{"objectIdPath":[1,7]},"value":"c3RyaW5nCg=="}],"aiaOcspServers":["string"],"caOptions":{"isCa":false,"maxIssuerPathLength":7},"keyUsage":{"baseKeyUsage":{"certSign":false,"contentCommitment":false,"crlSign":false,"dataEncipherment":false,"decipherOnly":false,"digitalSignature":false,"encipherOnly":false,"keyAgreement":false,"keyEncipherment":false},"extendedKeyUsage":{"clientAuth":false,"codeSigning":false,"emailProtection":false,"ocspSigning":false,"serverAuth":false,"timeStamping":false},"unknownExtendedKeyUsages":[{"objectIdPath":[1,7]}]},"policyIds":[{"objectIdPath":[1,7]}]},"identityConstraints":{"allowSubjectAltNamesPassthrough":false,"allowSubjectPassthrough":false,"celExpression":{"description":"Always false","expression":"false","location":"devops.ca_pool.json","title":"Sample expression"}},"maximumLifetime":"43200s","passthroughExtensions":{"additionalExtensions":[{"objectIdPath":[1,7]}],"knownExtensions":["BASE_KEY_USAGE"]}},"labels":{"cnrm-test":"true","label-two":"value-two","managed-by-cnrm":"true"},"name":"projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj","tier":"ENTERPRISE"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools?alt=json&caPoolId=privatecacapool-6keati6ocofj
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621084869-6159eab66038a-842cdb7b-66415c97",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:44.882453581Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "create",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": false
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 298.961076ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/operations/operation-1712621084869-6159eab66038a-842cdb7b-66415c97?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621084869-6159eab66038a-842cdb7b-66415c97",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:44.882453581Z",
+                "endTime": "2024-04-09T00:04:44.936644167Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "create",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": true,
+              "response": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.CaPool",
+                "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "tier": "ENTERPRISE",
+                "issuancePolicy": {
+                  "allowedKeyTypes": [
+                    {
+                      "rsa": {
+                        "minModulusSize": "64",
+                        "maxModulusSize": "128"
+                      }
+                    },
+                    {
+                      "ellipticCurve": {
+                        "signatureAlgorithm": "ECDSA_P384"
+                      }
+                    }
+                  ],
+                  "maximumLifetime": "43200s",
+                  "allowedIssuanceModes": {
+                    "allowCsrBasedIssuance": true
+                  },
+                  "baselineValues": {
+                    "keyUsage": {
+                      "unknownExtendedKeyUsages": [
+                        {
+                          "objectIdPath": [
+                            1,
+                            7
+                          ]
+                        }
+                      ]
+                    },
+                    "caOptions": {
+                      "isCa": false,
+                      "maxIssuerPathLength": 7
+                    },
+                    "policyIds": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ],
+                    "aiaOcspServers": [
+                      "string"
+                    ],
+                    "additionalExtensions": [
+                      {
+                        "objectId": {
+                          "objectIdPath": [
+                            1,
+                            7
+                          ]
+                        },
+                        "value": "c3RyaW5nCg=="
+                      }
+                    ]
+                  },
+                  "identityConstraints": {
+                    "celExpression": {
+                      "expression": "false",
+                      "title": "Sample expression",
+                      "description": "Always false",
+                      "location": "devops.ca_pool.json"
+                    },
+                    "allowSubjectPassthrough": false,
+                    "allowSubjectAltNamesPassthrough": false
+                  },
+                  "passthroughExtensions": {
+                    "knownExtensions": [
+                      "BASE_KEY_USAGE"
+                    ],
+                    "additionalExtensions": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 241.552345ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 235.359777ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 292.75059ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 268.974891ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 215.932608ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 222.288255ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 219.579404ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 207.864932ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 238.577976ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "64",
+                      "maxModulusSize": "128"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P384"
+                    }
+                  }
+                ],
+                "maximumLifetime": "43200s",
+                "allowedIssuanceModes": {
+                  "allowCsrBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": false,
+                    "maxIssuerPathLength": 7
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          7
+                        ]
+                      },
+                      "value": "c3RyaW5nCg=="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "false",
+                    "title": "Sample expression",
+                    "description": "Always false",
+                    "location": "devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": false,
+                  "allowSubjectAltNamesPassthrough": false
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "BASE_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        7
+                      ]
+                    }
+                  ]
+                }
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 221.564135ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1522
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"issuancePolicy":{"allowedIssuanceModes":{"allowConfigBasedIssuance":true,"allowCsrBasedIssuance":false},"allowedKeyTypes":[{"rsa":{"maxModulusSize":256,"minModulusSize":128}},{"ellipticCurve":{"signatureAlgorithm":"ECDSA_P256"}}],"baselineValues":{"additionalExtensions":[{"critical":true,"objectId":{"objectIdPath":[1,6]},"value":"bmV3LXN0cmluZwo="}],"aiaOcspServers":["new-string"],"caOptions":{"isCa":true,"maxIssuerPathLength":6},"keyUsage":{"baseKeyUsage":{"certSign":true,"contentCommitment":true,"crlSign":true,"dataEncipherment":true,"decipherOnly":true,"digitalSignature":true,"encipherOnly":true,"keyAgreement":true,"keyEncipherment":true},"extendedKeyUsage":{"clientAuth":true,"codeSigning":true,"emailProtection":true,"ocspSigning":true,"serverAuth":true,"timeStamping":true},"unknownExtendedKeyUsages":[{"objectIdPath":[1,6]}]},"policyIds":[{"objectIdPath":[1,6]}]},"identityConstraints":{"allowSubjectAltNamesPassthrough":true,"allowSubjectPassthrough":true,"celExpression":{"description":"Always true","expression":"true","location":"update_devops.ca_pool.json","title":"Updated expression"}},"maximumLifetime":"86400s","passthroughExtensions":{"additionalExtensions":[{"objectIdPath":[1,6]}],"knownExtensions":["EXTENDED_KEY_USAGE"]}},"labels":{"cnrm-test":"true","label-one":"value-one","label-two":"value-two","managed-by-cnrm":"true"},"name":"projects/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj","publishingOptions":{"publishCaCert":true,"publishCrl":true}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json&updateMask=issuancePolicy%2Clabels%2CpublishingOptions
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621090601-6159eabbd7bfb-681a5152-7a7cc01c",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:50.617532707Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "update",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": false
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 246.904182ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/operations/operation-1712621090601-6159eabbd7bfb-681a5152-7a7cc01c?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621090601-6159eabbd7bfb-681a5152-7a7cc01c",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:50.617532707Z",
+                "endTime": "2024-04-09T00:04:50.703025917Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "update",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": true,
+              "response": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.CaPool",
+                "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "tier": "ENTERPRISE",
+                "issuancePolicy": {
+                  "allowedKeyTypes": [
+                    {
+                      "rsa": {
+                        "minModulusSize": "128",
+                        "maxModulusSize": "256"
+                      }
+                    },
+                    {
+                      "ellipticCurve": {
+                        "signatureAlgorithm": "ECDSA_P256"
+                      }
+                    }
+                  ],
+                  "maximumLifetime": "86400s",
+                  "allowedIssuanceModes": {
+                    "allowConfigBasedIssuance": true
+                  },
+                  "baselineValues": {
+                    "keyUsage": {
+                      "baseKeyUsage": {
+                        "digitalSignature": true,
+                        "contentCommitment": true,
+                        "keyEncipherment": true,
+                        "dataEncipherment": true,
+                        "keyAgreement": true,
+                        "certSign": true,
+                        "crlSign": true,
+                        "encipherOnly": true,
+                        "decipherOnly": true
+                      },
+                      "extendedKeyUsage": {
+                        "serverAuth": true,
+                        "clientAuth": true,
+                        "codeSigning": true,
+                        "emailProtection": true,
+                        "timeStamping": true,
+                        "ocspSigning": true
+                      },
+                      "unknownExtendedKeyUsages": [
+                        {
+                          "objectIdPath": [
+                            1,
+                            6
+                          ]
+                        }
+                      ]
+                    },
+                    "caOptions": {
+                      "isCa": true,
+                      "maxIssuerPathLength": 6
+                    },
+                    "policyIds": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      }
+                    ],
+                    "aiaOcspServers": [
+                      "new-string"
+                    ],
+                    "additionalExtensions": [
+                      {
+                        "objectId": {
+                          "objectIdPath": [
+                            1,
+                            6
+                          ]
+                        },
+                        "critical": true,
+                        "value": "bmV3LXN0cmluZwo="
+                      }
+                    ]
+                  },
+                  "identityConstraints": {
+                    "celExpression": {
+                      "expression": "true",
+                      "title": "Updated expression",
+                      "description": "Always true",
+                      "location": "update_devops.ca_pool.json"
+                    },
+                    "allowSubjectPassthrough": true,
+                    "allowSubjectAltNamesPassthrough": true
+                  },
+                  "passthroughExtensions": {
+                    "knownExtensions": [
+                      "EXTENDED_KEY_USAGE"
+                    ],
+                    "additionalExtensions": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "publishingOptions": {
+                  "publishCaCert": true,
+                  "publishCrl": true
+                }
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 251.32759ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "128",
+                      "maxModulusSize": "256"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P256"
+                    }
+                  }
+                ],
+                "maximumLifetime": "86400s",
+                "allowedIssuanceModes": {
+                  "allowConfigBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "baseKeyUsage": {
+                      "digitalSignature": true,
+                      "contentCommitment": true,
+                      "keyEncipherment": true,
+                      "dataEncipherment": true,
+                      "keyAgreement": true,
+                      "certSign": true,
+                      "crlSign": true,
+                      "encipherOnly": true,
+                      "decipherOnly": true
+                    },
+                    "extendedKeyUsage": {
+                      "serverAuth": true,
+                      "clientAuth": true,
+                      "codeSigning": true,
+                      "emailProtection": true,
+                      "timeStamping": true,
+                      "ocspSigning": true
+                    },
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": true,
+                    "maxIssuerPathLength": 6
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "new-string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      },
+                      "critical": true,
+                      "value": "bmV3LXN0cmluZwo="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "true",
+                    "title": "Updated expression",
+                    "description": "Always true",
+                    "location": "update_devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": true,
+                  "allowSubjectAltNamesPassthrough": true
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "EXTENDED_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ]
+                }
+              },
+              "publishingOptions": {
+                "publishCaCert": true,
+                "publishCrl": true
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-one": "value-one",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 234.635348ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "128",
+                      "maxModulusSize": "256"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P256"
+                    }
+                  }
+                ],
+                "maximumLifetime": "86400s",
+                "allowedIssuanceModes": {
+                  "allowConfigBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "baseKeyUsage": {
+                      "digitalSignature": true,
+                      "contentCommitment": true,
+                      "keyEncipherment": true,
+                      "dataEncipherment": true,
+                      "keyAgreement": true,
+                      "certSign": true,
+                      "crlSign": true,
+                      "encipherOnly": true,
+                      "decipherOnly": true
+                    },
+                    "extendedKeyUsage": {
+                      "serverAuth": true,
+                      "clientAuth": true,
+                      "codeSigning": true,
+                      "emailProtection": true,
+                      "timeStamping": true,
+                      "ocspSigning": true
+                    },
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": true,
+                    "maxIssuerPathLength": 6
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "new-string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      },
+                      "critical": true,
+                      "value": "bmV3LXN0cmluZwo="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "true",
+                    "title": "Updated expression",
+                    "description": "Always true",
+                    "location": "update_devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": true,
+                  "allowSubjectAltNamesPassthrough": true
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "EXTENDED_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ]
+                }
+              },
+              "publishingOptions": {
+                "publishCaCert": true,
+                "publishCrl": true
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-one": "value-one",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 209.9045ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+              "tier": "ENTERPRISE",
+              "issuancePolicy": {
+                "allowedKeyTypes": [
+                  {
+                    "rsa": {
+                      "minModulusSize": "128",
+                      "maxModulusSize": "256"
+                    }
+                  },
+                  {
+                    "ellipticCurve": {
+                      "signatureAlgorithm": "ECDSA_P256"
+                    }
+                  }
+                ],
+                "maximumLifetime": "86400s",
+                "allowedIssuanceModes": {
+                  "allowConfigBasedIssuance": true
+                },
+                "baselineValues": {
+                  "keyUsage": {
+                    "baseKeyUsage": {
+                      "digitalSignature": true,
+                      "contentCommitment": true,
+                      "keyEncipherment": true,
+                      "dataEncipherment": true,
+                      "keyAgreement": true,
+                      "certSign": true,
+                      "crlSign": true,
+                      "encipherOnly": true,
+                      "decipherOnly": true
+                    },
+                    "extendedKeyUsage": {
+                      "serverAuth": true,
+                      "clientAuth": true,
+                      "codeSigning": true,
+                      "emailProtection": true,
+                      "timeStamping": true,
+                      "ocspSigning": true
+                    },
+                    "unknownExtendedKeyUsages": [
+                      {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      }
+                    ]
+                  },
+                  "caOptions": {
+                    "isCa": true,
+                    "maxIssuerPathLength": 6
+                  },
+                  "policyIds": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ],
+                  "aiaOcspServers": [
+                    "new-string"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectId": {
+                        "objectIdPath": [
+                          1,
+                          6
+                        ]
+                      },
+                      "critical": true,
+                      "value": "bmV3LXN0cmluZwo="
+                    }
+                  ]
+                },
+                "identityConstraints": {
+                  "celExpression": {
+                    "expression": "true",
+                    "title": "Updated expression",
+                    "description": "Always true",
+                    "location": "update_devops.ca_pool.json"
+                  },
+                  "allowSubjectPassthrough": true,
+                  "allowSubjectAltNamesPassthrough": true
+                },
+                "passthroughExtensions": {
+                  "knownExtensions": [
+                    "EXTENDED_KEY_USAGE"
+                  ],
+                  "additionalExtensions": [
+                    {
+                      "objectIdPath": [
+                        1,
+                        6
+                      ]
+                    }
+                  ]
+                }
+              },
+              "publishingOptions": {
+                "publishCaCert": true,
+                "publishCrl": true
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "label-one": "value-one",
+                "label-two": "value-two",
+                "managed-by-cnrm": "true"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 260.447066ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621093788-6159eabee1c29-9cfeb5bf-14719dce",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:53.798418711Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "delete",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": false
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 247.430864ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/operations/operation-1712621093788-6159eabee1c29-9cfeb5bf-14719dce?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "name": "projects/example-project/locations/us-central1/operations/operation-1712621093788-6159eabee1c29-9cfeb5bf-14719dce",
+              "metadata": {
+                "@type": "type.googleapis.com/google.cloud.security.privateca.v1.OperationMetadata",
+                "createTime": "2024-04-09T00:04:53.798418711Z",
+                "endTime": "2024-04-09T00:04:53.860290755Z",
+                "target": "projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj",
+                "verb": "delete",
+                "requestedCancellation": false,
+                "apiVersion": "v1"
+              },
+              "done": true,
+              "response": {
+                "@type": "type.googleapis.com/google.protobuf.Empty"
+              }
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 222.874584ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: privateca.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://privateca.googleapis.com/v1/projects/example-project/locations/us-central1/caPools/privatecacapool-6keati6ocofj?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 205.251003ms

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-oauth.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-oauth.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-oauth.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-tf.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-tf.yaml
+++ b/tests/e2e/testdata/vcr-cassette/TestAllInSeries_fixtures_privatecacapool-tf.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 interactions: []


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Setup VCR recorder for DCL and TF Oauth requests. Re-generate cassette files and save them under tests/e2e/testdata/vcr-cassette folder

Unfortunately we need 3 separate recorders for TF, DCL and Oauth, as they are using different transport. go-vcr package doesn't have a built-in way to save interactions from multiple recorders into a single cassette file. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
