### PR TITLE
compute_network.patch

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computenetworks.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computenetworks.compute.cnrm.cloud.google.com.yaml
@@ -79,7 +79,7 @@ spec:
                 type: string
               enableUlaInternalIpv6:
                 description: |-
-                  Immutable. Enable ULA internal ipv6 on this network. Enabling this feature will assign
+                  Enable ULA internal ipv6 on this network. Enabling this feature will assign
                   a /48 from google defined ULA prefix fd20::/20.
                 type: boolean
               internalIpv6Range:

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetwork_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetwork_types.go
@@ -55,7 +55,7 @@ type ComputeNetworkSpec struct {
 	// +optional
 	Description *string `json:"description,omitempty"`
 
-	/* Immutable. Enable ULA internal ipv6 on this network. Enabling this feature will assign
+	/* Enable ULA internal ipv6 on this network. Enabling this feature will assign
 	a /48 from google defined ULA prefix fd20::/20. */
 	// +optional
 	EnableUlaInternalIpv6 *bool `json:"enableUlaInternalIpv6,omitempty"`

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/create.yaml
@@ -23,3 +23,4 @@ metadata:
 spec:
   routingMode: REGIONAL
   autoCreateSubnetworks: false
+  enableUlaInternalIpv6: false

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/update.yaml
@@ -23,3 +23,4 @@ metadata:
 spec:
   routingMode: GLOBAL
   autoCreateSubnetworks: false
+  enableUlaInternalIpv6: true

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenetwork.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenetwork.md
@@ -142,7 +142,7 @@ recreated to modify this field.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">boolean</code></p>
-            <p>{% verbatim %}Immutable. Enable ULA internal ipv6 on this network. Enabling this feature will assign
+            <p>{% verbatim %}Enable ULA internal ipv6 on this network. Enabling this feature will assign
 a /48 from google defined ULA prefix fd20::/20.{% endverbatim %}</p>
         </td>
     </tr>

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_network.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_network.go
@@ -85,7 +85,7 @@ recreated to modify this field.`,
 			"enable_ula_internal_ipv6": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Description: `Enable ULA internal ipv6 on this network. Enabling this feature will assign
 a /48 from google defined ULA prefix fd20::/20.`,
 			},


### PR DESCRIPTION

### Change description

Change ForceNew to false for the field enable_ula_internal_ipv6. The Compute API allows this field to be enabled/disabled on-the-fly.

Fixes b/332834635

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
