### PR TITLE
vcr: Update vcr hook and matcher to avoid potential failures

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -297,6 +297,11 @@ func NewHarness(ctx context.Context, t *testing.T) *Harness {
 		}
 		testgcp.TestKCCAttachedClusterProject.Set("mock-project")
 		h.Project = project
+	} else if os.Getenv("E2E_GCP_TARGET") == "vcr" && os.Getenv("VCR_MODE") == "replay" {
+		h.Project = testgcp.GCPProject{
+			ProjectID:     "example-project",
+			ProjectNumber: 12345678,
+		}
 	} else {
 		h.Project = testgcp.GetDefaultProject(t)
 	}


### PR DESCRIPTION
### Change description
1. Update vcr hook to record failed requests (404, 400, 403) but replace the internal error message. My initial idea was that removing them would speed up vcr replay, but in some cases, missing those requests would cause an "interaction not found" issue in replay mode.
2. Update vcr matcher to sort request json body before comparing. json can be same but reordered
3. Update to use example-project in replay mode

### Tests you have done

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
