### PR TITLE
chore: update github actions to use go version in go.mod

### DIFF
--- a/.github/workflows/dcl-upgrade-probe.yaml
+++ b/.github/workflows/dcl-upgrade-probe.yaml
@@ -31,10 +31,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version-file: 'go.mod'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/license-lint.yaml
+++ b/.github/workflows/license-lint.yaml
@@ -32,10 +32,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version-file: 'go.mod'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.5
+          go-version-file: 'go.mod'
           cache: false # because of https://github.com/golangci/golangci-lint-action/issues/135
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'src/k8s-config-connector/go.mod'
       - name: "Run validations"
         run: |
           cd ./src/k8s-config-connector
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'go.mod'
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
       - name: "Run unit tests"
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'go.mod'
       - name: "Run mock tests"
         run: |
           ./scripts/github-actions/ga-mock-test.sh
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'go.mod'
       - name: "Run mock tests"
         run: |
           ./scripts/github-actions/ga-pause-test.sh

--- a/.github/workflows/upgrade-operator.yaml
+++ b/.github/workflows/upgrade-operator.yaml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'go.mod'
       - name: "Set env"
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
This avoids having to repeat the go version, and in general we want to
keep them in sync.
