### PR TITLE
tests: skip secondary-instance sample test for now

### DIFF
--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -220,6 +220,9 @@ var testDisabledList = map[string]bool{
 	// b/309167136
 	"alloydbbackup":                true,
 	"restored-from-backup-cluster": true,
+	// Similarly want to temporarily disable secondary-instance test
+	// until we can delay second creation until primary is ready
+	"secondary-instance": true,
 	// This sample test need physical rack which is not suitable for e2e testing due to
 	// limited budget.
 	"edgecontainercluster-local-control-plane":  true,


### PR DESCRIPTION
Until we can enforce that secondary instance should only be created
once primary is created.
