### PR TITLE
refactor: add a jitter generator

### DIFF
--- a/cmd/deletiondefender/main.go
+++ b/cmd/deletiondefender/main.go
@@ -22,6 +22,7 @@ import (
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp/profiler"
@@ -96,7 +97,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
+	if err := registration.Add(mgr, &controller.Deps{}, registration.RegisterDeletionDefenderController); err != nil {
 		log.Fatal(err, "error adding registration controller")
 	}
 

--- a/cmd/unmanageddetector/main.go
+++ b/cmd/unmanageddetector/main.go
@@ -21,6 +21,7 @@ import (
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp/profiler"
@@ -98,7 +99,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create
 	// controllers for all our resources.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterUnmanagedDetectorController, nil); err != nil {
+	if err := registration.Add(mgr, &controller.Deps{}, registration.RegisterUnmanagedDetectorController); err != nil {
 		logging.Fatal(err, "error adding registration controller")
 	}
 

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -47,6 +47,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	exportparameters "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/cmd/export/parameters"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
@@ -468,7 +469,7 @@ func NewHarness(ctx context.Context, t *testing.T) *Harness {
 	}
 
 	// Register the deletion defender controller.
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
+	if err := registration.Add(mgr, &controller.Deps{}, registration.RegisterDeletionDefenderController); err != nil {
 		t.Fatalf("error adding registration controller for deletion defender controllers: %v", err)
 	}
 	// Start the manager, Start(...) is a blocking operation so it needs to be done asynchronously.

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
@@ -291,7 +292,7 @@ func setup() {
 		logging.Fatal(err, "error creating new manager")
 	}
 	// Register the deletion defender controller
-	if err := registration.Add(mgr, nil, nil, nil, nil, registration.RegisterDeletionDefenderController, nil); err != nil {
+	if err := registration.Add(mgr, &controller.Deps{}, registration.RegisterDeletionDefenderController); err != nil {
 		logging.Fatal(err, "error adding registration controller for deletion defender controllers")
 	}
 	// start the manager, Start(...) is a blocking operation so it needs to be done asynchronously

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
@@ -48,4 +49,5 @@ type Deps struct {
 	DclConfig    *dcl.Config
 	DclConverter *conversion.Converter
 	Defaulters   []k8s.Defaulter
+	JitterGen    jitter.Generator
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -14,7 +14,15 @@
 
 package controller
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
+	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 type Config struct {
 	UserAgent string
@@ -31,4 +39,13 @@ type Config struct {
 	// HTTPClient allows us to specify the HTTP client to use with DCL.
 	// This is particularly useful in mocks/tests.
 	HTTPClient *http.Client
+}
+
+// Common controller dependencies.
+type Deps struct {
+	TfProvider   *tfschema.Provider
+	TfLoader     *servicemappingloader.ServiceMappingLoader
+	DclConfig    *dcl.Config
+	DclConverter *conversion.Converter
+	Defaulters   []k8s.Defaulter
 }

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -93,16 +93,20 @@ type Reconciler struct {
 	// Fields used for triggering reconciliations when dependencies are ready
 	immediateReconcileRequests chan event.GenericEvent
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
+	jitterGenerator            jitter.Generator
 }
 
 func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter,
-	dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, defaulters []k8s.Defaulter) (k8s.SchemaReferenceUpdater, error) {
+	dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, defaulters []k8s.Defaulter, jitterGenerator jitter.Generator) (k8s.SchemaReferenceUpdater, error) {
+	if jitterGenerator == nil {
+		return nil, fmt.Errorf("jitter generator not initialized")
+	}
 	kind := crd.Spec.Names.Kind
 	apiVersion := k8s.GetAPIVersionFromCRD(crd)
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(kind))
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	r, err := NewReconciler(mgr, crd, converter, dclConfig, serviceMappingLoader, immediateReconcileRequests, resourceWatcherRoutines, defaulters)
+	r, err := NewReconciler(mgr, crd, converter, dclConfig, serviceMappingLoader, immediateReconcileRequests, resourceWatcherRoutines, defaulters, jitterGenerator)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +130,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, conve
 	return r, nil
 }
 
-func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter, dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter) (*Reconciler, error) {
+func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, converter *conversion.Converter, dclConfig *mmdcl.Config, serviceMappingLoader *servicemappingloader.ServiceMappingLoader, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jitterGenerator jitter.Generator) (*Reconciler, error) {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(crd.Spec.Names.Kind))
 	gvk := schema.GroupVersionKind{
 		Group:   crd.Spec.Group,
@@ -161,6 +165,7 @@ func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinit
 		serviceMappingLoader:       serviceMappingLoader,
 		immediateReconcileRequests: immediateReconcileRequests,
 		resourceWatcherRoutines:    resourceWatcherRoutines,
+		jitterGenerator:            jitterGenerator,
 	}, nil
 }
 
@@ -217,7 +222,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	case v1beta1.Reconciling:
 		r.logger.V(2).Info("Actuating a resource as actuation mode is \"Reconciling\"", "resource", req.NamespacedName)
 	case v1beta1.Paused:
-		jitteredPeriod, err := jitter.GenerateJitteredReenqueuePeriod(r.schemaRef.GVK, nil, r.converter.MetadataLoader, u)
+		jitteredPeriod, err := r.jitterGenerator.JitteredReenqueue(r.schemaRef.GVK, u)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -246,7 +251,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	if requeue {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	jitteredPeriod, err := jitter.GenerateJitteredReenqueuePeriod(r.schemaRef.GVK, nil, r.converter.MetadataLoader, u)
+	jitteredPeriod, err := r.jitterGenerator.JitteredReenqueue(r.schemaRef.GVK, u)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("error generating reconcile interval for resource %v", resource.GetNamespacedName())
 	}
@@ -393,7 +398,7 @@ func (r *Reconciler) handleUnresolvableDeps(ctx context.Context, resource *k8s.R
 		// Decrement the number of active resource watches after
 		// the watch finishes
 		defer r.resourceWatcherRoutines.Release(1)
-		timeoutPeriod := jitter.GenerateWatchJitteredTimeoutPeriod()
+		timeoutPeriod := r.jitterGenerator.WatchJitteredTimeout()
 		ctx, cancel := context.WithTimeout(ctx, timeoutPeriod)
 		defer cancel()
 		logger.Info("starting wait with timeout on resource's reference", "timeout", timeoutPeriod)

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -37,10 +37,10 @@ import (
 
 // AddKeyReconciler creates a new controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the Manager is started.
-func AddKeyReconciler(mgr manager.Manager, config *controller.Config) error {
+func AddKeyReconciler(mgr manager.Manager, config *controller.Config, opts directbase.Deps) error {
 	gvk := krm.APIKeysKeyGVK
 
-	return directbase.Add(mgr, gvk, &model{config: *config})
+	return directbase.Add(mgr, gvk, &model{config: *config}, opts)
 }
 
 type model struct {

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -36,7 +36,7 @@ import (
 
 // AddTagKeyController creates a new controller and adds it to the Manager.
 // The Manager will set fields on the Controller and start it when the Manager is started.
-func AddTagKeyController(mgr manager.Manager, config *controller.Config) error {
+func AddTagKeyController(mgr manager.Manager, config *controller.Config, opts directbase.Deps) error {
 	gvk := krm.TagsTagKeyGVK
 
 	// TODO: Share gcp client (any value in doing so)?
@@ -46,7 +46,7 @@ func AddTagKeyController(mgr manager.Manager, config *controller.Config) error {
 		return err
 	}
 	m := &tagKeyModel{gcpClient: gcpClient}
-	return directbase.Add(mgr, gvk, m)
+	return directbase.Add(mgr, gvk, m, opts)
 }
 
 type tagKeyModel struct {

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -28,11 +28,13 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/tf"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	testcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/controller"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
+	testjitter "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/jitter"
 	testk8s "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/k8s"
 	testmain "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/main"
 	testvariable "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture/variable"
@@ -188,7 +190,7 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	var resourceWatcherRoutines *semaphore.Weighted = nil
 
 	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
-	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
+	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter}, &testjitter.TestJitterGenerator{})
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)
 	}
@@ -202,7 +204,7 @@ func newSecretGenerator(t *testing.T, mgr manager.Manager, crdPath string) recon
 	}
 	crd := dynamic.UnmarshalFileToCRD(t, crdPath)
 
-	reconciler := newReconciler(mgr, crd)
+	reconciler := newReconciler(mgr, crd, &jitter.SimpleJitterGenerator{})
 	return reconciler
 }
 

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourceactuation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourcewatcher"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/execution"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
@@ -64,12 +65,11 @@ var logger = klog.Log.WithName(controllerName)
 
 func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 	if deps.JitterGen == nil {
-		jg, err := jitter.NewDefaultGenerator(deps.TfLoader, deps.DclConverter.MetadataLoader)
-		if err != nil {
-			return err
+		var dclML metadata.ServiceMetadataLoader
+		if deps.DclConverter != nil {
+			dclML = deps.DclConverter.MetadataLoader
 		}
-
-		deps.JitterGen = jg
+		deps.JitterGen = jitter.NewDefaultGenerator(deps.TfLoader, dclML)
 	}
 
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/lifecyclehandler"
@@ -61,18 +62,26 @@ const controllerName = "iamauditconfig-controller"
 
 var logger = klog.Log.WithName(controllerName)
 
-func Add(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader,
-	converter *conversion.Converter, dclConfig *mmdcl.Config, defaulters []k8s.Defaulter) error {
+func Add(mgr manager.Manager, deps *kontroller.Deps) error {
+	if deps.JitterGen == nil {
+		jg, err := jitter.NewDefaultGenerator(deps.TfLoader, deps.DclConverter.MetadataLoader)
+		if err != nil {
+			return err
+		}
+
+		deps.JitterGen = jg
+	}
+
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	reconciler, err := NewReconciler(mgr, provider, smLoader, converter, dclConfig, immediateReconcileRequests, resourceWatcherRoutines, defaulters)
+	reconciler, err := NewReconciler(mgr, deps.TfProvider, deps.TfLoader, deps.DclConverter, deps.DclConfig, immediateReconcileRequests, resourceWatcherRoutines, deps.Defaulters, deps.JitterGen)
 	if err != nil {
 		return err
 	}
 	return add(mgr, reconciler)
 }
 
-func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter) (*Reconciler, error) {
+func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jg jitter.Generator) (*Reconciler, error) {
 	r := Reconciler{
 		LifecycleHandler: lifecyclehandler.NewLifecycleHandler(
 			mgr.GetClient(),
@@ -85,6 +94,7 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 		defaulters:                 defaulters,
 		immediateReconcileRequests: immediateReconcileRequests,
 		resourceWatcherRoutines:    resourceWatcherRoutines,
+		jitterGen:                  jg,
 	}
 	return &r, nil
 }
@@ -118,6 +128,8 @@ type Reconciler struct {
 	// Fields used for triggering reconciliations when dependencies are ready
 	immediateReconcileRequests chan event.GenericEvent
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
+
+	jitterGen jitter.Generator
 }
 
 type reconcileContext struct {
@@ -158,7 +170,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	if requeue {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	jitteredPeriod, err := jitter.GenerateJitteredReenqueuePeriod(iamv1beta1.IAMAuditConfigGVK, nil, nil, &auditConfig)
+	jitteredPeriod, err := r.jitterGen.JitteredReenqueue(iamv1beta1.IAMPolicyGVK, &auditConfig)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -342,7 +354,7 @@ func (r *reconcileContext) handleUnresolvableDeps(auditConfig *iamv1beta1.IAMAud
 		// Decrement the count of active resource watches after
 		// the watch finishes
 		defer r.Reconciler.resourceWatcherRoutines.Release(1)
-		timeoutPeriod := jitter.GenerateWatchJitteredTimeoutPeriod()
+		timeoutPeriod := r.Reconciler.jitterGen.WatchJitteredTimeout()
 		ctx, cancel := context.WithTimeout(context.TODO(), timeoutPeriod)
 		defer cancel()
 		logger.Info("starting wait with timeout on resource's reference", "timeout", timeoutPeriod)

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/lifecyclehandler"
@@ -64,11 +64,19 @@ var logger = klog.Log.WithName(controllerName)
 
 // Add creates a new IAM Policy Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and start it when the Manager is started.
-func Add(mgr manager.Manager, tfProvider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader,
-	converter *conversion.Converter, dclConfig *mmdcl.Config, defaulters []k8s.Defaulter) error {
+func Add(mgr manager.Manager, deps *kontroller.Deps) error {
+	if deps.JitterGen == nil {
+		jg, err := jitter.NewDefaultGenerator(deps.TfLoader, deps.DclConverter.MetadataLoader)
+		if err != nil {
+			return err
+		}
+
+		deps.JitterGen = jg
+	}
+
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	reconciler, err := NewReconciler(mgr, tfProvider, smLoader, converter, dclConfig, immediateReconcileRequests, resourceWatcherRoutines, defaulters)
+	reconciler, err := NewReconciler(mgr, deps.TfProvider, deps.TfLoader, deps.DclConverter, deps.DclConfig, immediateReconcileRequests, resourceWatcherRoutines, deps.Defaulters, deps.JitterGen)
 	if err != nil {
 		return err
 	}
@@ -76,14 +84,14 @@ func Add(mgr manager.Manager, tfProvider *tfschema.Provider, smLoader *servicema
 }
 
 // NewReconciler returns a new reconcile.Reconciler.
-func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter) (*ReconcileIAMPolicy, error) {
+func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jg jitter.Generator) (*ReconcileIAMPolicy, error) {
 	r := ReconcileIAMPolicy{
 		LifecycleHandler: lifecyclehandler.NewLifecycleHandler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor(controllerName),
 		),
 		Client:                     mgr.GetClient(),
-		iamClient:                  iamclient.New(provider, smLoader, mgr.GetClient(), converter, dclConfig),
+		iamClient:                  kcciamclient.New(provider, smLoader, mgr.GetClient(), converter, dclConfig),
 		config:                     mgr.GetConfig(),
 		defaulters:                 defaulters,
 		immediateReconcileRequests: immediateReconcileRequests,
@@ -92,6 +100,7 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 		ReconcilerMetrics: metrics.ReconcilerMetrics{
 			ResourceNameLabel: metrics.ResourceNameLabel,
 		},
+		jitterGen: jg,
 	}
 	return &r, nil
 }
@@ -126,6 +135,8 @@ type ReconcileIAMPolicy struct {
 	// Fields used for triggering reconciliations when dependencies are ready
 	immediateReconcileRequests chan event.GenericEvent
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
+
+	jitterGen jitter.Generator
 }
 
 type reconcileContext struct {
@@ -169,7 +180,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 	if requeue {
 		return reconcile.Result{Requeue: true}, nil
 	}
-	jitteredPeriod, err := jitter.GenerateJitteredReenqueuePeriod(iamv1beta1.IAMPolicyGVK, nil, nil, policy)
+	jitteredPeriod, err := r.jitterGen.JitteredReenqueue(iamv1beta1.IAMPolicyGVK, policy)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -275,7 +286,7 @@ func (r *reconcileContext) handleUpdateFailed(policy *iamv1beta1.IAMPolicy, orig
 	if err != nil {
 		logger.Error(err, "error converting IAMPolicy to k8s resource while handling event",
 			"resource", k8s.GetNamespacedName(policy), "event", k8s.UpdateFailed)
-		return fmt.Errorf("Update call failed: %w", origErr)
+		return fmt.Errorf("update call failed: %w", origErr)
 	}
 	return r.Reconciler.HandleUpdateFailed(r.Ctx, resource, origErr)
 }
@@ -342,7 +353,7 @@ func (r *reconcileContext) handleUnresolvableDeps(policy *iamv1beta1.IAMPolicy, 
 		// Decrement the count of active resource watches after
 		// the watch finishes
 		defer r.Reconciler.resourceWatcherRoutines.Release(1)
-		timeoutPeriod := jitter.GenerateWatchJitteredTimeoutPeriod()
+		timeoutPeriod := r.Reconciler.jitterGen.WatchJitteredTimeout()
 		ctx, cancel := context.WithTimeout(context.TODO(), timeoutPeriod)
 		defer cancel()
 		logger.Info("starting wait with timeout on resource's reference", "timeout", timeoutPeriod)
@@ -388,7 +399,7 @@ func isAPIServerUpdateRequired(policy *iamv1beta1.IAMPolicy) bool {
 }
 
 func toK8sResource(policy *iamv1beta1.IAMPolicy) (*k8s.Resource, error) {
-	iamclient.SetGVK(policy)
+	kcciamclient.SetGVK(policy)
 	resource := k8s.Resource{}
 	if err := util.Marshal(policy, &resource); err != nil {
 		return nil, fmt.Errorf("error marshalling IAMPolicy to k8s resource: %w", err)

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourceactuation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourcewatcher"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/execution"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
@@ -66,12 +67,11 @@ var logger = klog.Log.WithName(controllerName)
 // and start it when the Manager is started.
 func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 	if deps.JitterGen == nil {
-		jg, err := jitter.NewDefaultGenerator(deps.TfLoader, deps.DclConverter.MetadataLoader)
-		if err != nil {
-			return err
+		var dclML metadata.ServiceMetadataLoader
+		if deps.DclConverter != nil {
+			dclML = deps.DclConverter.MetadataLoader
 		}
-
-		deps.JitterGen = jg
+		deps.JitterGen = jitter.NewDefaultGenerator(deps.TfLoader, dclML)
 	}
 
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)

--- a/pkg/controller/jitter/jitter.go
+++ b/pkg/controller/jitter/jitter.go
@@ -15,6 +15,7 @@
 package jitter
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/reconciliationinterval"
@@ -27,19 +28,45 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// GenerateWatchJitteredTimeoutPeriod returns a wait duration to reenqueue the request between
-// 1/2 * MeanReconcileReenqueuePeriod and 3/2 * MeanReconcileReenqueuePeriod (not inclusive of
-// upper bound). The mean duration to reenqueue is MeanReconcileReenqueuePeriod.
-func GenerateWatchJitteredTimeoutPeriod() time.Duration {
-	return wait.Jitter(k8s.MeanReconcileReenqueuePeriod/2, k8s.JitterFactor)
+type Generator interface {
+	// WatchJitteredTimeout returns a wait duration to reenqueue the request between
+	// 1/2 * MeanReconcileReenqueuePeriod and 3/2 * MeanReconcileReenqueuePeriod (not inclusive of
+	// upper bound). The mean duration to reenqueue is MeanReconcileReenqueuePeriod.
+	//
+	// Use WatchJitteredTimeout whenever we need to wait for a resource to be ready.
+	WatchJitteredTimeout() time.Duration
+
+	// JitteredReenqueue returns a wait duration to reenqueue the request based
+	// on configured reconcile interval in TF servicemapping, DCL metadata, IAM resource config.
+	// The wait duration can be overridden with the reconcile interval configured as the object's annotation.
+	//
+	// Use JitteredReenqueue whenever we need to reenqueue a reconciliation.
+	JitteredReenqueue(gvk schema.GroupVersionKind, obj metav1.Object) (time.Duration, error)
 }
 
-// GenerateJitteredReenqueuePeriod returns a wait duration to reenqueue the request based
+type DefaultJitterGenerator struct {
+	tfLoader  *servicemappingloader.ServiceMappingLoader
+	dclLoader dclmetadata.ServiceMetadataLoader
+}
+
+var _ Generator = &DefaultJitterGenerator{}
+
+func NewDefaultGenerator(tfLoader *servicemappingloader.ServiceMappingLoader, dclLoader dclmetadata.ServiceMetadataLoader) (*DefaultJitterGenerator, error) {
+	if tfLoader == nil {
+		return nil, fmt.Errorf("no Terraform service mapping loader provided")
+	}
+	return &DefaultJitterGenerator{
+		tfLoader:  tfLoader,
+		dclLoader: dclLoader,
+	}, nil
+}
+
+// JitteredReenqueue returns a wait duration to reenqueue the request based
 // on configured reconcile interval in TF servicemapping, DCL metadata, IAM resource config.
 // The wait duration can be overridden with the reconcile interval configured as the object's annotation.
-func GenerateJitteredReenqueuePeriod(gvk schema.GroupVersionKind,
-	smLoader *servicemappingloader.ServiceMappingLoader,
-	serviceMetadataLoader dclmetadata.ServiceMetadataLoader, obj metav1.Object) (time.Duration, error) {
+//
+// Use JitteredReenqueue whenever we need to reenqueue a reconciliation.
+func (l *DefaultJitterGenerator) JitteredReenqueue(gvk schema.GroupVersionKind, obj metav1.Object) (time.Duration, error) {
 	if val, ok := k8s.GetAnnotation(k8s.ReconcileIntervalInSecondsAnnotation, obj); ok {
 		reconcileInterval, err := reconciliationinterval.MeanReconcileReenqueuePeriodFromAnnotation(val)
 		if err != nil {
@@ -47,5 +74,30 @@ func GenerateJitteredReenqueuePeriod(gvk schema.GroupVersionKind,
 		}
 		return wait.Jitter(reconcileInterval/2, k8s.JitterFactor), nil
 	}
-	return wait.Jitter(reconciliationinterval.MeanReconcileReenqueuePeriod(gvk, smLoader, serviceMetadataLoader)/2, k8s.JitterFactor), nil
+	return wait.Jitter(reconciliationinterval.MeanReconcileReenqueuePeriod(gvk, l.tfLoader, l.dclLoader)/2, k8s.JitterFactor), nil
 }
+
+// WatchJitteredTimeout returns a wait duration to reenqueue the request between
+// 1/2 * MeanReconcileReenqueuePeriod and 3/2 * MeanReconcileReenqueuePeriod (not inclusive of
+// upper bound). The mean duration to reenqueue is MeanReconcileReenqueuePeriod.
+//
+// Use WatchJitteredTimeout whenever we need to wait for a resource to be ready.
+func (l *DefaultJitterGenerator) WatchJitteredTimeout() time.Duration {
+	return wait.Jitter(k8s.MeanReconcileReenqueuePeriod/2, k8s.JitterFactor)
+}
+
+// SimpleJitterGenerator does not have any service mapping knowledge.
+type SimpleJitterGenerator struct {
+}
+
+// JitteredReenqueue not implemented as it relies on service mapping knowledge.
+func (*SimpleJitterGenerator) JitteredReenqueue(gvk schema.GroupVersionKind, obj metav1.Object) (time.Duration, error) {
+	return 0, fmt.Errorf("no service mapping knowledge")
+}
+
+// WatchJitteredTimeout implements Generator.
+func (*SimpleJitterGenerator) WatchJitteredTimeout() time.Duration {
+	return wait.Jitter(k8s.MeanReconcileReenqueuePeriod/2, k8s.JitterFactor)
+}
+
+var _ Generator = &SimpleJitterGenerator{}

--- a/pkg/controller/jitter/jitter.go
+++ b/pkg/controller/jitter/jitter.go
@@ -51,14 +51,11 @@ type DefaultJitterGenerator struct {
 
 var _ Generator = &DefaultJitterGenerator{}
 
-func NewDefaultGenerator(tfLoader *servicemappingloader.ServiceMappingLoader, dclLoader dclmetadata.ServiceMetadataLoader) (*DefaultJitterGenerator, error) {
-	if tfLoader == nil {
-		return nil, fmt.Errorf("no Terraform service mapping loader provided")
-	}
+func NewDefaultGenerator(tfLoader *servicemappingloader.ServiceMappingLoader, dclLoader dclmetadata.ServiceMetadataLoader) *DefaultJitterGenerator {
 	return &DefaultJitterGenerator{
 		tfLoader:  tfLoader,
 		dclLoader: dclLoader,
-	}, nil
+	}
 }
 
 // JitteredReenqueue returns a wait duration to reenqueue the request based

--- a/pkg/controller/jitter/jitter_test.go
+++ b/pkg/controller/jitter/jitter_test.go
@@ -37,10 +37,7 @@ func TestGenerateTFJitteredReenqueuePeriod(t *testing.T) {
 		Kind:    "Test1Foo",
 	}
 
-	jg, err := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), nil)
-	if err != nil {
-		t.Fatalf("got unexpected err %v, expected nil", err)
-	}
+	jg := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), nil)
 
 	duration, err := jg.JitteredReenqueue(gvk, &unstructured.Unstructured{})
 	if err != nil {
@@ -76,10 +73,7 @@ func TestGenerateDCLJitteredReenqueuePeriod(t *testing.T) {
 		},
 	}
 
-	jg, err := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), dclmetadata.NewFromServiceList(serviceList))
-	if err != nil {
-		t.Fatalf("got unexpected err %v, expected nil", err)
-	}
+	jg := jitter.NewDefaultGenerator(nil, dclmetadata.NewFromServiceList(serviceList))
 
 	duration, err := jg.JitteredReenqueue(gvk, &unstructured.Unstructured{})
 	if err != nil {
@@ -95,10 +89,7 @@ func TestGenerateIAMJitteredReenqueuePeriod(t *testing.T) {
 	t.Parallel()
 	gvk := iamv1beta1.IAMPolicyGVK
 
-	jg, err := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), nil)
-	if err != nil {
-		t.Fatalf("got unexpected err %v, expected nil", err)
-	}
+	jg := jitter.NewDefaultGenerator(nil, nil)
 
 	duration, err := jg.JitteredReenqueue(gvk, &unstructured.Unstructured{})
 	if err != nil {
@@ -123,10 +114,7 @@ func TestGenerateJitteredReenqueuePeriodFromAnnotation(t *testing.T) {
 	var iamPolicyMember3 iamv1beta1.IAMPolicyMember
 	k8s.SetAnnotation(k8s.ReconcileIntervalInSecondsAnnotation, "1.5", &iamPolicyMember3)
 
-	jg, err := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), nil)
-	if err != nil {
-		t.Fatalf("got unexpected err %v, expected nil", err)
-	}
+	jg := jitter.NewDefaultGenerator(nil, nil)
 
 	duration, err := jg.JitteredReenqueue(gvk, &iamPolicyMember1)
 	if err != nil {
@@ -188,10 +176,7 @@ func TestGenerateDefaultJitteredReenqueuePeriod(t *testing.T) {
 		},
 	}
 
-	jg, err := jitter.NewDefaultGenerator(servicemappingloader.NewFromServiceMappings(test.FakeServiceMappings()), dclmetadata.NewFromServiceList(serviceList))
-	if err != nil {
-		t.Fatalf("got unexpected err %v, expected nil", err)
-	}
+	jg := jitter.NewDefaultGenerator(nil, dclmetadata.NewFromServiceList(serviceList))
 
 	// Test default value for TF resources
 	duration, err := jg.JitteredReenqueue(gvk1, &unstructured.Unstructured{})

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -138,9 +138,17 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 		HTTPClient:          config.HTTPClient,
 		UserAgent:           gcp.KCCUserAgent,
 	}
+	rd := controller.Deps{
+		TfProvider:   provider,
+		TfLoader:     smLoader,
+		DclConfig:    dclConfig,
+		DclConverter: dclConverter,
+		Defaulters:   []k8s.Defaulter{stateIntoSpecDefaulter},
+	}
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, provider, smLoader, dclConfig, dclConverter, registration.RegisterDefaultController(controllerConfig), []k8s.Defaulter{stateIntoSpecDefaulter}); err != nil {
+	if err := registration.Add(mgr, &rd,
+		registration.RegisterDefaultController(controllerConfig)); err != nil {
 		return nil, fmt.Errorf("error adding registration controller: %w", err)
 	}
 	return mgr, nil

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -69,12 +69,7 @@ func Add(mgr manager.Manager, rd *controller.Deps, regFunc registrationFunc) err
 		if rd.DclConverter != nil {
 			dclML = rd.DclConverter.MetadataLoader
 		}
-		jg, err := jitter.NewDefaultGenerator(rd.TfLoader, dclML)
-		if err != nil {
-			return fmt.Errorf("could not create default jitter generator: %w", err)
-		}
-
-		rd.JitterGen = jg
+		rd.JitterGen = jitter.NewDefaultGenerator(rd.TfLoader, dclML)
 	}
 
 	r := &ReconcileRegistration{

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -60,17 +60,18 @@ var logger = crlog.Log.WithName(controllerName)
 
 // Add creates a new registration Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, p *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, dclConfig *dcl.Config, dclConverter *conversion.Converter, regFunc registrationFunc, defaulters []k8s.Defaulter) error {
+func Add(mgr manager.Manager, rd *controller.Deps, regFunc registrationFunc) error {
+
 	r := &ReconcileRegistration{
 		Client:           mgr.GetClient(),
-		provider:         p,
-		smLoader:         smLoader,
-		dclConfig:        dclConfig,
-		dclConverter:     dclConverter,
+		provider:         rd.TfProvider,
+		smLoader:         rd.TfLoader,
+		dclConfig:        rd.DclConfig,
+		dclConverter:     rd.DclConverter,
 		mgr:              mgr,
 		controllers:      make(map[string]map[string]controllerContext),
 		registrationFunc: regFunc,
-		defaulters:       defaulters,
+		defaulters:       rd.Defaulters,
 	}
 	c, err := crcontroller.New(controllerName, mgr,
 		crcontroller.Options{

--- a/pkg/test/jitter/jitter.go
+++ b/pkg/test/jitter/jitter.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testjitter
+
+import (
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// static jitter generator used for testing
+type TestJitterGenerator struct {
+}
+
+// JitteredReenqueue implements jitter.Generator.
+func (*TestJitterGenerator) JitteredReenqueue(gvk schema.GroupVersionKind, obj v1.Object) (time.Duration, error) {
+	return time.Second, nil
+}
+
+// WatchJitteredTimeout implements jitter.Generator.
+func (*TestJitterGenerator) WatchJitteredTimeout() time.Duration {
+	return time.Second
+}
+
+var _ jitter.Generator = &TestJitterGenerator{}


### PR DESCRIPTION
If we add a jitter generator as a dep to the controllers than we can dictate what generator to use for tests. In the final state, tests (pause step, e2e, etc) can use generators that don't timeout our tests.