### PR TITLE
Add Events and update Status for Composition CR when processing.

### DIFF
--- a/experiments/compositions/composition/.gitignore
+++ b/experiments/compositions/composition/.gitignore
@@ -1,6 +1,6 @@
 
 # test logs
-tests/testcases/test-logs/*
+test-logs/*
 
 # Binaries for programs and plugins
 *.exe

--- a/experiments/compositions/composition/api/v1/composition_types.go
+++ b/experiments/compositions/composition/api/v1/composition_types.go
@@ -172,6 +172,7 @@ func (s *Composition) Validate() bool {
 			Message:            message,
 			Reason:             "ExpanderValidationFailed",
 			Type:               string(ValidationFailed),
+			Status:             metav1.ConditionTrue,
 		})
 		return false
 	}

--- a/experiments/compositions/composition/cmd/main.go
+++ b/experiments/compositions/composition/cmd/main.go
@@ -98,6 +98,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		ImageRegistry: imageRegistry,
+		Recorder:      mgr.GetEventRecorderFor("composition"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Composition")
 		os.Exit(1)

--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -19,19 +19,22 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/go-logr/logr"
+	compositionv1 "google.com/composition/api/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	compositionv1 "google.com/composition/api/v1"
 )
 
 var inputAPIControllers sync.Map
@@ -40,6 +43,7 @@ var inputAPIControllers sync.Map
 type CompositionReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
+	Recorder      record.EventRecorder
 	mgr           ctrl.Manager
 	ImageRegistry string
 }
@@ -74,20 +78,29 @@ func (r *CompositionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// on deleted requests.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	oldStatus := composition.Status
+
+	// Try updating status before returning
+	defer func() {
+		if !reflect.DeepEqual(oldStatus, composition.Status) {
+			if err := r.Client.Status().Update(ctx, &composition); err != nil {
+				logger.Error(err, "unable to update Composition status")
+			}
+		}
+	}()
 
 	logger = logger.WithName(composition.Name).WithName(fmt.Sprintf("%d", composition.Generation))
 
 	logger.Info("Validating Compostion object")
 	if !composition.Validate() {
 		logger.Info("Validation Failed")
-		if err := r.Client.Status().Update(ctx, &composition); err != nil {
-			logger.Error(err, "unable to update Composition status")
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{}, fmt.Errorf("Validation failed")
 	}
 
+	composition.Status.ClearCondition(compositionv1.Error)
 	logger.Info("Processing Composition object")
 	if err := r.runComposition(ctx, composition, logger); err != nil {
+		logger.Info("Error processing Composition")
 		return ctrl.Result{}, err
 	}
 
@@ -101,8 +114,18 @@ func (r *CompositionReconciler) runComposition(
 	logger = logger.WithName(c.Spec.InputAPIGroup)
 	err := r.Client.Get(ctx, types.NamespacedName{Name: c.Spec.InputAPIGroup, Namespace: ""}, &crd)
 	if err != nil {
-		// You will likely want to create an Event for the user to understand why their reconcile is failing.
-		logger.Error(err, "failed to get an InputAPI CRD object")
+		reason := "FailedGettingFacadeCRD"
+		if apierrors.IsNotFound(err) {
+			reason = "MissingFacadeCRD"
+		}
+		c.Status.Conditions = append(c.Status.Conditions, metav1.Condition{
+			LastTransitionTime: metav1.Now(),
+			Message:            err.Error(),
+			Reason:             reason,
+			Type:               string(compositionv1.Error),
+		})
+		logger.Error(err, "failed to get an Facade CRD object")
+		r.Recorder.Event(&c, "Warning", "MissingFacadeCRD", fmt.Sprintf("Failed to get Facade CRD: %s", c.Spec.InputAPIGroup))
 		return err
 	}
 
@@ -140,9 +163,16 @@ func (r *CompositionReconciler) runComposition(
 	}
 
 	if err := expanderController.SetupWithManager(r.mgr, cr); err != nil {
+		c.Status.Conditions = append(c.Status.Conditions, metav1.Condition{
+			LastTransitionTime: metav1.Now(),
+			Message:            err.Error(),
+			Reason:             "InternalError",
+			Type:               string(compositionv1.Error),
+		})
 		logger.Error(err, "Failed to start reconciler for InputAPI CRD")
 		return err
 	}
+	r.Recorder.Event(&c, "Normal", "InputReconcilerStarted", fmt.Sprintf("Reconciler started for Facade CR: %s", c.Spec.InputAPIGroup))
 
 	return nil
 }

--- a/experiments/compositions/composition/release/kind/crds.yaml
+++ b/experiments/compositions/composition/release/kind/crds.yaml
@@ -90,12 +90,13 @@ spec:
                                 type: string
                               name:
                                 type: string
+                              nameSuffix:
+                                type: string
                               version:
                                 type: string
                             required:
                             - group
                             - kind
-                            - name
                             type: object
                         required:
                         - fieldRef

--- a/experiments/compositions/composition/release/kind/operator.yaml
+++ b/experiments/compositions/composition/release/kind/operator.yaml
@@ -103,12 +103,13 @@ spec:
                                 type: string
                               name:
                                 type: string
+                              nameSuffix:
+                                type: string
                               version:
                                 type: string
                             required:
                             - group
                             - kind
-                            - name
                             type: object
                         required:
                         - fieldRef

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/facade_crd.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/facade_crd.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pconfigs.facade.foocorp.com
+spec:
+  group: facade.foocorp.com
+  names:
+    kind: PConfig
+    listKind: PConfigList
+    plural: pconfigs
+    singular: pconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the pconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PConfig spec
+            properties:
+              project:
+                type: string
+            required:
+            - project
+            type: object
+          status:
+            description: PConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/input.yaml
@@ -1,0 +1,40 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: composition.google.com/v1
+kind: Composition
+metadata:
+  name: projectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.foocorp.com
+  expanders:
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ managedProject }}
+        billingAccountRef:
+          external: "010101-ABABCD-BCAB11"
+        folderRef:
+          external: "000000111100"

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/output.yaml
@@ -1,0 +1,14 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/fixed_composition.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/fixed_composition.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: composition.google.com/v1
+kind: Composition
+metadata:
+  name: projectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.foocorp.com
+  expanders:
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ managedProject }}
+        billingAccountRef:
+          external: "010101-ABABCD-BCAB11"
+        folderRef:
+          external: "000000111100"

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/input.yaml
@@ -1,0 +1,83 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pconfigs.facade.foocorp.com
+spec:
+  group: facade.foocorp.com
+  names:
+    kind: PConfig
+    listKind: PConfigList
+    plural: pconfigs
+    singular: pconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the pconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PConfig spec
+            properties:
+              project:
+                type: string
+            required:
+            - project
+            type: object
+          status:
+            description: PConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: composition.google.com/v1
+kind: Composition
+metadata:
+  name: projectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.foocorp.com
+  expanders:
+  - type: jinja2
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% set managedProject = pconfigs.spec.project %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ managedProject }}
+        billingAccountRef:
+          external: "010101-ABABCD-BCAB11"
+        folderRef:
+          external: "000000111100"

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/output.yaml
@@ -1,0 +1,14 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/experiments/compositions/composition/tests/testclient/client.go
+++ b/experiments/compositions/composition/tests/testclient/client.go
@@ -60,9 +60,10 @@ type Client struct {
 	client.Client
 	name     string
 	testName string
+	logRoot  string
 }
 
-func New(ctx context.Context, t *testing.T, config *rest.Config, name, testName string) *Client {
+func New(ctx context.Context, t *testing.T, config *rest.Config, name, testName string, logRoot string) *Client {
 	c, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -80,6 +81,7 @@ func New(ctx context.Context, t *testing.T, config *rest.Config, name, testName 
 		Client:   c,
 		name:     name,
 		testName: testName,
+		logRoot:  logRoot,
 	}
 }
 
@@ -105,10 +107,10 @@ func (c *Client) WriteNamespacePodLogs(namespace string) {
 }
 
 func (c *Client) getFilePath(namespace, name, container string) string {
-	path := filepath.Join("test-logs", c.testName, namespace)
+	path := c.logRoot + filepath.Join("test-logs", c.testName, namespace)
 	os.MkdirAll(path, os.ModePerm)
 	filename := name + "." + container + ".txt"
-	return filepath.Join("test-logs", c.testName, namespace, filename)
+	return c.logRoot + filepath.Join("test-logs", c.testName, namespace, filename)
 }
 
 func (c *Client) ClearOldLogs() {
@@ -147,7 +149,7 @@ func (c *Client) WriteContainerLogs(namespace, name, container string) {
 }
 
 // MustCreate - create object
-func (c *Client) MustCreate(u *unstructured.Unstructured) {
+func (c *Client) MustCreate(u *unstructured.Unstructured, updateAllowed bool) {
 	c.T.Helper()
 
 	id := ExtractGVKNN(u)
@@ -158,7 +160,24 @@ func (c *Client) MustCreate(u *unstructured.Unstructured) {
 			c.T.Errorf("failed to create (absent) %q: %s", id, err)
 			c.T.FailNow()
 		}
-		c.T.Logf("WARN object exists. Reusing. %s", err)
+		if updateAllowed {
+			c.T.Logf("Updating already present %q on cluster %q", id, c)
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				readobj, err := c.Read(u)
+				if err != nil {
+					c.T.Errorf("failed reading %q when updating: %s", id, err)
+					return err
+				}
+				u.SetResourceVersion(readobj.GetResourceVersion())
+				return c.Update(c.Ctx, u)
+			})
+			if err != nil {
+				c.T.Errorf("failed to update %q: %s", id, err)
+				c.T.FailNow()
+			}
+		} else {
+			c.T.Logf("WARN object exists. Reusing. %s", err)
+		}
 	}
 }
 
@@ -215,6 +234,118 @@ func (c *Client) MustExist(objs []*unstructured.Unstructured, timeout time.Durat
 	})
 	if err != nil {
 		c.T.Errorf("objects absent on %q", c)
+		c.T.FailNow()
+	}
+}
+
+// MustHaveCondition - validate if the .status.conditions[] has the condition
+func (c *Client) MustHaveCondition(obj *unstructured.Unstructured, condition *metav1.Condition, timeout time.Duration) {
+	c.T.Helper()
+
+	toMatch := ExtractGVKNN(obj)
+	c.T.Logf("Checking condition %q present in object %q on cluster %q", condition.Type, toMatch, c)
+
+	unmatched := []*unstructured.Unstructured{obj}
+	errMissing := fmt.Errorf("condition missing")
+	errMismatch := fmt.Errorf("condition mismatch")
+
+	retryFrequency := getFrequency(c.T, opDuration, timeout)
+	err := retry.OnError(retryFrequency, func(err error) bool {
+		return apierrors.IsNotFound(err) || errors.Is(err, errMissing) || errors.Is(err, errMismatch)
+	}, func() (err error) {
+		match := func(obj *unstructured.Unstructured) error {
+			read, err := c.Read(obj)
+			if err != nil {
+				return err
+			}
+			conditions, ok, err := unstructured.NestedSlice(read.Object, "status", "conditions")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("%w: .status.conditions not found", errMissing)
+			}
+			found := false
+			for i := range conditions {
+				cond, ok := conditions[i].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("%w: .condition[%d] not of type map[string]interface{}", errMissing, i)
+				}
+				if condition.Type != cond["type"] {
+					continue
+				}
+				found = true
+				if condition.Reason != "" && condition.Reason != cond["reason"] {
+					return fmt.Errorf("%w: .condition.reason=%s not expected value %s", errMismatch, condition.Reason, cond["reason"])
+				}
+				if condition.Message != "" && condition.Message != cond["message"] {
+					return fmt.Errorf("%w: .condition.message=%s not expected value %s", errMismatch, condition.Message, cond["message"])
+				}
+				c.T.Logf("Has condition [%s, %s, %s]", cond["type"], cond["reason"], cond["message"])
+			}
+			if !found {
+				return fmt.Errorf("%w: .condition.type=%s not found", errMissing, condition.Type)
+			}
+			return nil
+		}
+		unmatched, err = c.recordFailed(match, unmatched)
+		return err
+	})
+	if err != nil {
+		c.T.Errorf("unexpected error: %v", err)
+		c.T.FailNow()
+	}
+}
+
+// MustNotHaveCondition - validate if the .status.conditions[] does not have the condition
+func (c *Client) MustNotHaveCondition(obj *unstructured.Unstructured, condition *metav1.Condition, timeout time.Duration) {
+	c.T.Helper()
+
+	toMatch := ExtractGVKNN(obj)
+	c.T.Logf("Checking condition %q not present in object %q on cluster %q", condition.Type, toMatch, c)
+
+	matched := []*unstructured.Unstructured{obj}
+	errMatches := fmt.Errorf("condition found")
+
+	retryFrequency := getFrequency(c.T, opDuration, timeout)
+	err := retry.OnError(retryFrequency, func(err error) bool {
+		return apierrors.IsNotFound(err) || errors.Is(err, errMatches)
+	}, func() (err error) {
+		match := func(obj *unstructured.Unstructured) error {
+			read, err := c.Read(obj)
+			if err != nil {
+				return err
+			}
+			conditions, ok, err := unstructured.NestedSlice(read.Object, "status", "conditions")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				// No condition array means condition doesnt exist
+				return nil
+			}
+			found := false
+			for i := range conditions {
+				c, ok := conditions[i].(map[string]interface{})
+				if !ok {
+					// shouldnt happen. we will skip over
+					continue
+				}
+				if condition.Type == c["type"] {
+					found = true
+					break
+				}
+			}
+			if found {
+				return fmt.Errorf("%w: .condition.type=%s found", errMatches, condition.Type)
+			}
+			return nil
+		}
+		matched, err = c.recordFailed(match, matched)
+		return err
+	})
+	if err != nil {
+		c.T.Errorf("unexpected error: %v", err)
 		c.T.FailNow()
 	}
 }

--- a/experiments/compositions/composition/tests/testclient/client.go
+++ b/experiments/compositions/composition/tests/testclient/client.go
@@ -260,31 +260,31 @@ func (c *Client) MustHaveCondition(obj *unstructured.Unstructured, condition *me
 			}
 			conditions, ok, err := unstructured.NestedSlice(read.Object, "status", "conditions")
 			if err != nil {
-				return err
+				return fmt.Errorf("getting status.conditions: %w", err)
 			}
 			if !ok {
-				return fmt.Errorf("%w: .status.conditions not found", errMissing)
+				return fmt.Errorf(".status.conditions not found: %w", errMissing)
 			}
 			found := false
 			for i := range conditions {
 				cond, ok := conditions[i].(map[string]interface{})
 				if !ok {
-					return fmt.Errorf("%w: .condition[%d] not of type map[string]interface{}", errMissing, i)
+					return fmt.Errorf(".condition[%d] not of type map[string]interface{}: %w", i, errMissing)
 				}
 				if condition.Type != cond["type"] {
 					continue
 				}
 				found = true
 				if condition.Reason != "" && condition.Reason != cond["reason"] {
-					return fmt.Errorf("%w: .condition.reason=%s not expected value %s", errMismatch, condition.Reason, cond["reason"])
+					return fmt.Errorf(".condition.reason=%s not expected value %s: %w", condition.Reason, cond["reason"], errMismatch)
 				}
 				if condition.Message != "" && condition.Message != cond["message"] {
-					return fmt.Errorf("%w: .condition.message=%s not expected value %s", errMismatch, condition.Message, cond["message"])
+					return fmt.Errorf(".condition.message=%s not expected value %s: %w", condition.Message, cond["message"], errMismatch)
 				}
 				c.T.Logf("Has condition [%s, %s, %s]", cond["type"], cond["reason"], cond["message"])
 			}
 			if !found {
-				return fmt.Errorf("%w: .condition.type=%s not found", errMissing, condition.Type)
+				return fmt.Errorf(".condition.type=%s not found: %w", condition.Type, errMissing)
 			}
 			return nil
 		}
@@ -337,7 +337,7 @@ func (c *Client) MustNotHaveCondition(obj *unstructured.Unstructured, condition 
 				}
 			}
 			if found {
-				return fmt.Errorf("%w: .condition.type=%s found", errMatches, condition.Type)
+				return fmt.Errorf(".condition.type=%s found. %w", condition.Type, errMatches)
 			}
 			return nil
 		}

--- a/experiments/compositions/composition/tests/utils/utils.go
+++ b/experiments/compositions/composition/tests/utils/utils.go
@@ -20,6 +20,7 @@ import (
 
 	compositionv1 "google.com/composition/api/v1"
 	"google.com/composition/internal/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -84,10 +85,30 @@ func GetUnstructuredObj(g, v, k, ns, n string) *unstructured.Unstructured {
 	return &cr
 }
 
+func GetCompositionObj(ns, n string) *unstructured.Unstructured {
+	return GetUnstructuredObj("composition.google.com", "v1", "Composition", ns, n)
+}
+
 func GetPlanObj(ns, n string) *unstructured.Unstructured {
 	return GetUnstructuredObj("composition.google.com", "v1", "Plan", ns, n)
 }
 
 func GetConfigMapObj(ns, n string) *unstructured.Unstructured {
 	return GetUnstructuredObj("", "v1", "ConfigMap", ns, n)
+}
+
+func GetValidationFailedCondition(reason, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Message: message,
+		Reason:  reason,
+		Type:    string(compositionv1.ValidationFailed),
+	}
+}
+
+func GetErrorCondition(reason, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Message: message,
+		Reason:  reason,
+		Type:    string(compositionv1.Error),
+	}
 }


### PR DESCRIPTION
### Change description

Add event recorder for Composition controller.
Update status of composition cr when reconciling fails.

Fixes #1522

### Tests Added

```
 go test -timeout 3600s -v -run "^TestSimpleCompositionStatusFacadeCRDMissing$" --images=gcr.io/allotrope-barni/composition:v0.0.1.alpha,gcr.io/allotrope-barni/manifests-inline:v0.0.1.alpha,gcr.io/allotrope-barni/expander-jinja2:v0.0.1.alpha
=== RUN   TestSimpleCompositionStatusFacadeCRDMissing
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    simple_test.go:139: Checking condition "Error" present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    client.go:284: Has condition [Error, MissingFacadeCRD, CustomResourceDefinition.apiextensions.k8s.io "pconfigs.facade.foocorp.com" not found]
    scenario.go:200: Loading manifests from: facade_crd.yaml
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    simple_test.go:147: Checking condition "Error" not present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:247: Checking absence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:266: Cleaning up intermediate Manifests: facade_crd.yaml
    scenario.go:268: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:270: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:258: Checking absence of objects [] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionStatusFacadeCRDMissing (6.10s)
PASS
ok      google.com/composition/tests/testcases  88.432s
❯ go test -timeout 3600s -v -run "^TestSimpleCompositionStatusValidation$" --images=gcr.io/allotrope-barni/composition:v0.0.1.alpha,gcr.io/allotrope-barni/manifests-inline:v0.0.1.alpha,gcr.io/allotrope-barni/expander-jinja2:v0.0.1.alpha
=== RUN   TestSimpleCompositionStatusValidation
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "Composition/default/projectconfigmap"] on "composition-e2e-0"
    simple_test.go:119: Checking condition "ValidationFailed" present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    client.go:284: Has condition [ValidationFailed, ExpanderValidationFailed, .spec.expanders[0] missing name]
    scenario.go:200: Loading manifests from: fixed_composition.yaml
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:188: Updating already present "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    simple_test.go:127: Checking condition "ValidationFailed" not present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:266: Cleaning up intermediate Manifests: fixed_composition.yaml
    scenario.go:268: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:268: WARN "Composition/default/projectconfigmap" not found on cluster "composition-e2e-0": compositions.composition.google.com "projectconfigmap" not found
    scenario.go:270: Checking absence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:258: Checking absence of objects [] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionStatusValidation (6.12s)
PASS
ok      google.com/composition/tests/testcases  87.353s
```

