### PR TITLE
mockgcp: fix build error

### DIFF
--- a/mockgcp/mocklogging/service.go
+++ b/mockgcp/mocklogging/service.go
@@ -53,7 +53,7 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn,
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
 		pb.RegisterMetricsServiceV2Handler)
 	if err != nil {
 		return nil, err

--- a/mockgcp/mockmonitoring/service.go
+++ b/mockgcp/mockmonitoring/service.go
@@ -58,7 +58,8 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn, pb.RegisterDashboardsServiceHandler)
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
+		pb.RegisterDashboardsServiceHandler)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
# github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmonitoring
mockgcp/mockmonitoring/service.go:61:45: cannot use pb.RegisterDashboardsServiceHandler (value of type func(ctx context.Context, mux *"github.com/grpc-ecosystem/grpc-gateway/v2/runtime".ServeMux, conn *grpc.ClientConn) error) as httpmux.Options value in argument to httpmux.NewServeMux
# github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocklogging
mockgcp/mocklogging/service.go:57:3: cannot use pb.RegisterMetricsServiceV2Handler (value of type func(ctx context.Context, mux *"github.com/grpc-ecosystem/grpc-gateway/v2/runtime".ServeMux, conn *grpc.ClientConn) error) as httpmux.Options value in argument to httpmux.NewServeMux
FAIL    github.com/GoogleCloudPlatform/k8s-config-connector/tests/e2e [build failed]
FAIL
```
