### PR TITLE
doc: update new resource guide

### DIFF
--- a/README.NewResourceFromTerraform.md
+++ b/README.NewResourceFromTerraform.md
@@ -295,10 +295,6 @@ ServiceMappings file. Add the `ResourceConfig` for your resource:
         - master_auth.client_certificate
     ```
 
-    After you generated CRD following the next step, you might need to revisit this step.
-    Generally speaking, if a CRD status field is GCP API related (i.e. not a KCC status field),
-    you should add it to the `observedFields`.
-
 ## Generate the CRD
 
 1.  Run `make manifests`.


### PR DESCRIPTION
This effectively reverts #1299, which is obsolete after #1465.