### PR TITLE
ci:refactor: reorder steps

### DIFF
--- a/.github/workflows/license-lint.yaml
+++ b/.github/workflows/license-lint.yaml
@@ -32,14 +32,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
       - name: license-lint
         run: |
           export GOPATH="$HOME/go"


### PR DESCRIPTION
We first must checkout the repo before we can use its `go.mod` file in the setup go step.