### PR TITLE
chore: update to controller-tools 0.14.0

### DIFF
--- a/experiments/compositions/composition/Makefile
+++ b/experiments/compositions/composition/Makefile
@@ -61,11 +61,13 @@ manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefin
 .PHONY: generate
 generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w api cmd internal tests
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
 	GOFLAGS= go run github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153 -c "Google LLC" -l apache ./
+	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w api cmd internal tests
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -187,7 +189,7 @@ deploy-kind: release-kind-manifests docker-build docker-build-inline
 	kubectl --context kind-${KIND_CLUSTER} get pods -A
 
 .PHONY: e2e-test
-e2e-test: release-kind-manifests docker-build docker-build-inline
+e2e-test: release-kind-manifests docker-build docker-build-inline fmt
 	cd tests/testcases/ && go test -v -timeout 3600s -run ./... --images=${IMG},${INLINE_IMG},${JINJA_IMG}
 
 ##@ Deployment

--- a/experiments/compositions/composition/Makefile
+++ b/experiments/compositions/composition/Makefile
@@ -55,12 +55,12 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+	go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -225,12 +225,11 @@ $(LOCALBIN):
 ## Tool Binaries
 KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -240,12 +239,6 @@ $(KUSTOMIZE): $(LOCALBIN)
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
 	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/experiments/compositions/composition/api/v1alpha1/zz_generated.deepcopy.go
+++ b/experiments/compositions/composition/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/experiments/compositions/composition/api/v1alpha1/zz_generated.deepcopy.go
+++ b/experiments/compositions/composition/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -111,7 +111,7 @@ func (in *CompositionStatus) DeepCopyInto(out *CompositionStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]metav1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: compositions.composition.google.com
 spec:
   group: composition.google.com
@@ -34,14 +34,19 @@ spec:
         description: Composition is the Schema for the compositions API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -59,8 +64,10 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: Type indicates what expander to use jinja - jinja2
-                        expander none - No expander
+                      description: |-
+                        Type indicates what expander to use
+                          jinja - jinja2 expander
+                          none - No expander
                       enum:
                       - jinja2
                       - none
@@ -123,47 +130,47 @@ spec:
             description: CompositionStatus defines the observed state of Composition
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -177,11 +184,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_contexts.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_contexts.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: contexts.composition.google.com
 spec:
   group: composition.google.com
@@ -34,14 +34,19 @@ spec:
         description: Context is the Schema for the contexts API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
@@ -17,7 +17,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: plans.composition.google.com
 spec:
   group: composition.google.com
@@ -34,14 +34,19 @@ spec:
         description: Plan is the Schema for the plans API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/experiments/compositions/composition/release/kind/crds.yaml
+++ b/experiments/compositions/composition/release/kind/crds.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: compositions.composition.google.com
 spec:
   group: composition.google.com
@@ -33,14 +33,19 @@ spec:
         description: Composition is the Schema for the compositions API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -58,8 +63,10 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: Type indicates what expander to use jinja - jinja2
-                        expander none - No expander
+                      description: |-
+                        Type indicates what expander to use
+                          jinja - jinja2 expander
+                          none - No expander
                       enum:
                       - jinja2
                       - none
@@ -122,47 +129,47 @@ spec:
             description: CompositionStatus defines the observed state of Composition
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -176,11 +183,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -203,7 +211,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: contexts.composition.google.com
 spec:
   group: composition.google.com
@@ -220,14 +228,19 @@ spec:
         description: Context is the Schema for the contexts API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -251,7 +264,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: plans.composition.google.com
 spec:
   group: composition.google.com
@@ -268,14 +281,19 @@ spec:
         description: Plan is the Schema for the plans API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/experiments/compositions/composition/release/kind/operator.yaml
+++ b/experiments/compositions/composition/release/kind/operator.yaml
@@ -29,7 +29,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: compositions.composition.google.com
 spec:
   group: composition.google.com
@@ -46,14 +46,19 @@ spec:
         description: Composition is the Schema for the compositions API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -71,8 +76,10 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: Type indicates what expander to use jinja - jinja2
-                        expander none - No expander
+                      description: |-
+                        Type indicates what expander to use
+                          jinja - jinja2 expander
+                          none - No expander
                       enum:
                       - jinja2
                       - none
@@ -135,47 +142,47 @@ spec:
             description: CompositionStatus defines the observed state of Composition
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -189,11 +196,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -216,7 +224,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: contexts.composition.google.com
 spec:
   group: composition.google.com
@@ -233,14 +241,19 @@ spec:
         description: Context is the Schema for the contexts API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -264,7 +277,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: plans.composition.google.com
 spec:
   group: composition.google.com
@@ -281,14 +294,19 @@ spec:
         description: Plan is the Schema for the plans API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object


### PR DESCRIPTION
### Change description

chore: update to controller-tools 0.14.0
same as https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1473

Doing it on latest baseline and ran tests


### Tests you have done

```
...
...
 scenario.go:227: Verifying output
    scenario.go:228: Checking existence of objects ["ConfigMap/team-a/proj-a" "Plan/team-a/pconfigs-team-a-config"] on "composition-e2e-0"
    simple_test.go:73: Adding proj-b entry to Facade
    simple_test.go:80: Applying patch map["op":"add" "path":"/spec/projects/-" "value":"proj-b"] to "PConfig/team-a/team-a-config" on "composition-e2e-0"
    simple_test.go:84: Checking existence of objects ["ConfigMap/team-a/proj-b"] on "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:245: WARN "PConfig/team-a/team-a-config" not found on cluster "composition-e2e-0": the server could not find the requested resource (delete pconfigs.facade.foocorp.com team-a-config)
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:256: Deleting object "ConfigMap/team-a/proj-a" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/proj-a" not found on cluster "composition-e2e-0": configmaps "proj-a" not found
    scenario.go:256: Deleting object "Plan/team-a/pconfigs-team-a-config" on cluster "composition-e2e-0"
    scenario.go:256: WARN "Plan/team-a/pconfigs-team-a-config" not found on cluster "composition-e2e-0": plans.composition.google.com "pconfigs-team-a-config" not found
    scenario.go:258: Checking absence of objects ["ConfigMap/team-a/proj-a" "Plan/team-a/pconfigs-team-a-config"] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionAddFacadeField (23.29s)
=== RUN   TestSimpleCompositionDeleteFacadeField
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:175: Creating object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:227: Verifying output
    scenario.go:228: Checking existence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/proj-b" "Plan/team-a/pconfigs-team-a-config"] on "composition-e2e-0"
    simple_test.go:97: Removing proj-b entry from Facade
    simple_test.go:103: Applying patch map["op":"remove" "path":"/spec/projects/1"] to "PConfig/team-a/team-a-config" on "composition-e2e-0"
    simple_test.go:107: Checking absence of objects ["ConfigMap/team-a/proj-b"] on "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRole/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "ClusterRoleBinding/composition-facade-foocorp" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Namespace/team-a" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Context/team-a/context" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "PConfig/team-a/team-a-config" on cluster "composition-e2e-0"
    scenario.go:245: WARN "PConfig/team-a/team-a-config" not found on cluster "composition-e2e-0": the server could not find the requested resource (delete pconfigs.facade.foocorp.com team-a-config)
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "ClusterRole/composition-facade-foocorp" "ClusterRoleBinding/composition-facade-foocorp" "Composition/default/projectconfigmap" "Namespace/team-a" "Context/team-a/context" "PConfig/team-a/team-a-config"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:256: Deleting object "ConfigMap/team-a/proj-a" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/proj-a" not found on cluster "composition-e2e-0": configmaps "proj-a" not found
    scenario.go:256: Deleting object "ConfigMap/team-a/proj-b" on cluster "composition-e2e-0"
    scenario.go:256: WARN "ConfigMap/team-a/proj-b" not found on cluster "composition-e2e-0": configmaps "proj-b" not found
    scenario.go:256: Deleting object "Plan/team-a/pconfigs-team-a-config" on cluster "composition-e2e-0"
    scenario.go:256: WARN "Plan/team-a/pconfigs-team-a-config" not found on cluster "composition-e2e-0": plans.composition.google.com "pconfigs-team-a-config" not found
    scenario.go:258: Checking absence of objects ["ConfigMap/team-a/proj-a" "ConfigMap/team-a/proj-b" "Plan/team-a/pconfigs-team-a-config"] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionDeleteFacadeField (27.34s)
=== RUN   TestSimpleCompositionStatusValidation
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "Composition/default/projectconfigmap"] on "composition-e2e-0"
    simple_test.go:119: Checking condition "ValidationFailed" present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    client.go:285: Has condition [ValidationFailed, ExpanderValidationFailed, .spec.expanders[0] missing name]
    scenario.go:200: Loading manifests from: fixed_composition.yaml
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:188: Updating already present "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    simple_test.go:127: Checking condition "ValidationFailed" not present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:247: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com" "Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:266: Cleaning up intermediate Manifests: fixed_composition.yaml
    scenario.go:268: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:268: WARN "Composition/default/projectconfigmap" not found on cluster "composition-e2e-0": compositions.composition.google.com "projectconfigmap" not found
    scenario.go:270: Checking absence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:258: Checking absence of objects [] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionStatusValidation (6.12s)
=== RUN   TestSimpleCompositionStatusFacadeCRDMissing
    cluster.go:117: Reserved cluster composition-e2e-0
    scenario.go:211: Applying input
    scenario.go:188: Creating object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:219: Verifying input
    scenario.go:220: Checking existence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    simple_test.go:139: Checking condition "Error" present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    client.go:285: Has condition [Error, MissingFacadeCRD, CustomResourceDefinition.apiextensions.k8s.io "pconfigs.facade.foocorp.com" not found]
    scenario.go:200: Loading manifests from: facade_crd.yaml
    scenario.go:162: Creating object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    simple_test.go:147: Checking condition "Error" not present in object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:243: Cleaning up input
    scenario.go:245: Deleting object "Composition/default/projectconfigmap" on cluster "composition-e2e-0"
    scenario.go:247: Checking absence of objects ["Composition/default/projectconfigmap"] on "composition-e2e-0"
    scenario.go:266: Cleaning up intermediate Manifests: facade_crd.yaml
    scenario.go:268: Deleting object "CustomResourceDefinition/pconfigs.facade.foocorp.com" on cluster "composition-e2e-0"
    scenario.go:270: Checking absence of objects ["CustomResourceDefinition/pconfigs.facade.foocorp.com"] on "composition-e2e-0"
    scenario.go:254: Cleaning up output
    scenario.go:258: Checking absence of objects [] on "composition-e2e-0"
    cluster.go:123: Released cluster composition-e2e-0
--- PASS: TestSimpleCompositionStatusFacadeCRDMissing (4.09s)
PASS
ok      google.com/composition/tests/testcases  200.030s
```