### PR TITLE
Don't upload artifacts for pause test

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -86,18 +86,11 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - name: "Run mock tests"
+      - name: "Run pause tests"
         run: |
           ./scripts/github-actions/ga-pause-test.sh
         env:
           GOPATH: /home/runner/go
-          ARTIFACTS: /tmp/artifacts
-      - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: /tmp/artifacts/
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
There's no artifacts file to upload for pause test: https://screenshot.googleplex.com/BRn7vRxPpCVQUpo.png

Also I noticed that the GH presubmit/pause-test failed in some PRs([job](https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/8635527978/job/23673443666?pr=1498)). Unsure about the root cause but seems the error comes from [http_recorder.go](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/204782804df09f0ec10187bcdc7b13891b0203b7/pkg/test/http_recorder.go#L126). Removing `ARTIFACTS` env variable would be a quick fix.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
