### PR TITLE
tests: Add a simple test to verify that we don't have fooUrlRef

### DIFF
--- a/tests/apichecks/crds_test.go
+++ b/tests/apichecks/crds_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/crdloader"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/klog/v2"
+)
+
+func TestCRDsDoNotHaveFooUrlRef(t *testing.T) {
+	crds, err := crdloader.LoadAllCRDs()
+	if err != nil {
+		t.Fatalf("error loading crds: %v", err)
+	}
+
+	for _, crd := range crds {
+		for _, version := range crd.Spec.Versions {
+			visitCRDVersion(version, func(fieldPath string) {
+				lower := strings.ToLower(fieldPath)
+				if strings.HasSuffix(lower, "urlref") && !strings.HasSuffix(lower, ".urlref") {
+					// Prefer network_ref to network_url_ref
+					// While we allow url_ref, network_url_ref is odd;
+					// _url indicates the data type / representation of the field,
+					// and we don't want two "types" in our field name.
+					t.Errorf("invalid field name %q in %q; prefer fooRef to fooUrlRef", fieldPath, crd.Name)
+				}
+			})
+		}
+	}
+}
+
+func visitCRDVersion(version apiextensions.CustomResourceDefinitionVersion, callback func(fieldPath string)) {
+	visitProps(version.Schema.OpenAPIV3Schema, "", callback)
+}
+
+func visitProps(props *apiextensions.JSONSchemaProps, fieldPath string, callback func(fieldPath string)) {
+	callback(fieldPath)
+
+	switch props.Type {
+	case "object":
+		for k := range props.Properties {
+			child := props.Properties[k]
+			visitProps(&child, fieldPath+"."+k, callback)
+		}
+
+	case "array":
+		if props.Items != nil {
+			for _, child := range props.Items.JSONSchemas {
+				visitProps(&child, fieldPath+"[]", callback)
+			}
+			if props.Items.Schema != nil {
+				visitProps(props.Items.Schema, fieldPath+"[]", callback)
+			}
+		}
+
+	case "string", "boolean", "integer", "number":
+		// No child properties
+	default:
+		klog.Fatalf("unhandled props.Type %q in %+v", props.Type, props)
+	}
+}


### PR DESCRIPTION
We decided that fooUrlRef should probably be fooRef instead, except in
the (pre-existing) case of urlRef.

Add a simple test to warn us if we deviate from the guideline.
