### PR TITLE
chore: run tests in ./tests as part of github actions

### DIFF
--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -18,7 +18,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 make -C operator test
-UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/... ./scripts/generate-go-crd-clients/... ./scripts/resource-autogen/... | grep -v mocktests)
+UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/... ./scripts/generate-go-crd-clients/... ./scripts/resource-autogen/... ./tests/... | grep -v mocktests)
 if [ -z ${GITHUB_ACTION+x} ]; then
     go run gotest.tools/gotestsum@latest --format testname -- ${UNIT_TEST_PACKAGES} -coverprofile cover.out -count=1
 else


### PR DESCRIPTION
The linter tests are inexpensive, we should run them as unit tests.

We probably want to run the mockgcp tests separately by default,
as they are not speedy enough to be considered unit tests.  Today,
we skip them anyway because we don't set RUN_E2E; if we make them
easy to run by default we likely want to skip them here.
