### PR TITLE
ci: exclude **.md from presubmits

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -17,8 +17,12 @@ name: Presubmit
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.md"
   push:
     branches: ["master"]
+    paths-ignore:
+      - "**.md"
 
 jobs:
   validations:


### PR DESCRIPTION
Per a suggestion from @gemmahou , we can skip presubmits for PRs that are mostly doc changes (like README updates, docs, etc.)

Note per https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths if the diff contains additional files the workflows trigger.