### PR TITLE
skip alpha resources in TestOutputOnlyFieldsAreUnderObservedState

### DIFF
--- a/pkg/k8s/allowlist_test.go
+++ b/pkg/k8s/allowlist_test.go
@@ -76,6 +76,10 @@ func TestOutputOnlyFieldsAreUnderObservedState(t *testing.T) {
 	}
 	for _, crd := range crds {
 		for _, version := range crd.Spec.Versions {
+			if version.Name == k8s.KCCAPIVersionV1Alpha1 {
+				// we don't check for v1alpha1 resources.
+				continue
+			}
 			gvk := k8sschema.GroupVersionKind{
 				Group:   crd.Spec.Group,
 				Version: version.Name,


### PR DESCRIPTION
We don't need to check v1alpha1 resources.

A side note:
When we promote a resource from v1alpha1 to v1beta1, we make all changes to v1alpha1 schema first, so that the updated v1alpha1 and v1beta1 have the same schema. Therefore it is possible for v1alpha1 resources to have observedState field during the resource version promotion.