### PR TITLE
Correct the path for storage proto

### DIFF
--- a/mockgcp/Makefile
+++ b/mockgcp/Makefile
@@ -56,5 +56,5 @@ generate-protos-from-openapi:
 	cd tools/gapic; go run . ../../servicenetworking-api.json > ../../apis/mockgcp/cloud/servicenetworking/v1/servicenetworking.proto
 
 	wget -O storage-v1.json https://raw.githubusercontent.com/googleapis/google-api-go-client/main/storage/v1/storage-api.json
-	mkdir -p apis/mockgcp/cloud/storage/v1/
+	mkdir -p apis/mockgcp/storage/v1/
 	cd tools/gapic; go run . --proto-version=2 ../../storage-v1.json > ../../apis/mockgcp/storage/v1/service.proto


### PR DESCRIPTION
### Change description

Fix a path to store the generated storage proto from openapi


### Tests you have done 

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
