### PR TITLE
tests: add a project-id annotation defaulter to mock-kubeapiserver

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -82,6 +82,25 @@ jobs:
         with:
           name: artifacts
           path: /tmp/artifacts/
+  mockgcp-and-mockkube:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock tests"
+        run: |
+          ./scripts/github-actions/mockgcp-and-mockkube
+        env:
+          GOPATH: /home/runner/go
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: /tmp/artifacts/
   pause-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -267,6 +267,11 @@ func NewHarnessWithOptions(ctx context.Context, t *testing.T, opts *HarnessOptio
 
 		kccConfig.HTTPClient = &http.Client{Transport: roundTripper}
 
+		// Override the defaults: add our container-annotation defaulter
+		// (as we don't support webhooks)
+		kccConfig.Defaulters = append(kccConfig.Defaulters, k8s.NewStateIntoSpecDefaulter())
+		kccConfig.Defaulters = append(kccConfig.Defaulters, cnrmwebhook.NewContainerAnnotationDefaulter())
+
 		// Also hook the oauth2 library
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, kccConfig.HTTPClient)
 		h.Ctx = ctx

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -456,7 +456,7 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 
 func (r *Reconciler) handleDefaults(ctx context.Context, resource *dcl.Resource) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, resource); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -189,7 +189,7 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	var immediateReconcileRequests chan event.GenericEvent = nil
 	var resourceWatcherRoutines *semaphore.Weighted = nil
 
-	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
+	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter()
 	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter}, &testjitter.TestJitterGenerator{})
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -180,7 +180,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) handleDefaults(ctx context.Context, auditConfig *iamv1beta1.IAMAuditConfig) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, auditConfig); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, auditConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 
 func (r *ReconcileIAMPartialPolicy) handleDefaults(ctx context.Context, pp *iamv1beta1.IAMPartialPolicy) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, pp); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, pp); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -190,7 +190,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 
 func (r *ReconcileIAMPolicy) handleDefaults(ctx context.Context, policy *iamv1beta1.IAMPolicy) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, policy); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, policy); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -191,7 +191,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) handleDefaults(ctx context.Context, policyMember *iamv1beta1.IAMPolicyMember) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, policyMember); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, policyMember); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -69,6 +69,9 @@ type Config struct {
 	// StateIntoSpecUserOverride is an optional field. If specified, it is used
 	// as the default value for 'state-into-spec' annotation if unset.
 	StateIntoSpecUserOverride *string
+
+	// Defaulters allows overriding the default defaulters (for tests)
+	Defaulters []k8s.Defaulter
 }
 
 // Creates a new controller-runtime manager.Manager and starts all of the KCC controllers pointed at the
@@ -131,7 +134,7 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 		return nil, fmt.Errorf("error creating a DCL client config: %w", err)
 	}
 
-	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
+	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter()
 	controllerConfig := &controller.Config{
 		UserProjectOverride: config.UserProjectOverride,
 		BillingProject:      config.BillingProject,

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -449,7 +449,7 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 
 func (r *Reconciler) handleDefaults(ctx context.Context, resource *krmtotf.Resource) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, resource); err != nil {
 			return err
 		}
 	}

--- a/pkg/k8s/defaulter.go
+++ b/pkg/k8s/defaulter.go
@@ -27,22 +27,19 @@ import (
 )
 
 type Defaulter interface {
-	ApplyDefaults(ctx context.Context, obj client.Object) (changed bool, err error)
+	ApplyDefaults(ctx context.Context, client client.Reader, obj client.Object) (changed bool, err error)
 }
 
 // StateIntoSpecDefaulter contains the required 'defaultValue' field and the
 // optional 'userOverride' field.
 type StateIntoSpecDefaulter struct {
-	client client.Client
 }
 
-func NewStateIntoSpecDefaulter(client client.Client) Defaulter {
-	return &StateIntoSpecDefaulter{
-		client: client,
-	}
+func NewStateIntoSpecDefaulter() Defaulter {
+	return &StateIntoSpecDefaulter{}
 }
 
-func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, resource client.Object) (changed bool, err error) {
+func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, client client.Reader, resource client.Object) (changed bool, err error) {
 	annotationValue := StateIntoSpecDefaultValueV1Beta1
 
 	cccNamespacedName := types.NamespacedName{
@@ -50,7 +47,7 @@ func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, resource cli
 		Name:      operatork8s.ConfigConnectorContextAllowedName,
 	}
 	ccc := &operatorv1beta1.ConfigConnectorContext{}
-	if err := v.client.Get(ctx, cccNamespacedName, ccc); err != nil {
+	if err := client.Get(ctx, cccNamespacedName, ccc); err != nil {
 		if apierrors.IsNotFound(err) {
 			ccc = nil
 		} else {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -186,7 +186,7 @@ func (r *TestReconciler) NewReconcilerForKind(kind string) reconcile.Reconciler 
 	var immediateReconcileRequests chan event.GenericEvent = nil //nolint:revive
 	var resourceWatcherRoutines *semaphore.Weighted = nil        //nolint:revive
 
-	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(r.mgr.GetClient())
+	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter()
 	defaulters := []k8s.Defaulter{stateIntoSpecDefaulter}
 	jg := &testjitter.TestJitterGenerator{}
 

--- a/scripts/github-actions/mockgcp-and-mockkube
+++ b/scripts/github-actions/mockgcp-and-mockkube
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+cd ${REPO_ROOT}/
+echo "Running mock e2e tests..."
+E2E_KUBE_TARGET=mock \
+	RUN_E2E=1 E2E_GCP_TARGET=mock \
+	go test -test.count=1 -timeout 3600s -v ./tests/e2e


### PR DESCRIPTION
- tests: add a project-id annotation defaulter to mock-kubeapiserver
- tests: add test with mockgcp and mockkube
