### PR TITLE
tests: cc pause step test

### DIFF
--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -135,7 +135,7 @@ func TestE2EScript(t *testing.T) {
 						// The object probably still exists (that's probably
 						// why we're using DELETE-NO-WAIT), so export the
 						// resource and the kube object.
-					case "CHECK-LOG":
+					case "WAIT-FOR-HTTP-REQUEST":
 						applyObject(h, obj)
 
 						val, ok := obj.Object["VALUE_PRESENT"]

--- a/tests/e2e/testdata/scenarios/README.md
+++ b/tests/e2e/testdata/scenarios/README.md
@@ -33,6 +33,6 @@ a top-level field `TEST` on the object:
   object will still be deleted from the kube-apiserver.  It suffices to set
   apiVersion / kind / namespace / name.
 
-* Setting `TEST: CHECK-LOG`along with `VALUE_PRESENT: your value` will apply the object
+* Setting `TEST: WAIT-FOR-HTTP-REQUEST`along with `VALUE_PRESENT: your value` will apply the object
   and inspect the http log to check that the value in VALUE_PRESENT appears. The step will
   wait ~ seconds for that value to show up.

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/SCENARIO_README.MD
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/SCENARIO_README.MD
@@ -1,0 +1,9 @@
+This scenario meant to do the following:
+- Apply a CC to turn to instruct KCC to be in "Cluster" mode
+- Apply a KCC resource with a mutable field ("description"), in this case, ArtifactRegistryRepository
+- Pause KCC by setting the CC's object `actuationMode` to Paused.
+- Apply the same KCC resource and change the "description" field. Observe no change to the resource on the cloud provider.
+> NOTE: The way to assess that there is no change in the actual resource is by determinig that the http log 
+> file does not include any calls to the GCP provider. IOW, the log file is not present.
+- "Un pause" KCC by setting the CC's object `actuationMode` to Reconciling.
+- Observe the resource from the cloud provider matches the previous intent.

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_http01.log
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_http01.log
@@ -1,0 +1,158 @@
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: repository not found: namespaces/${projectId}/repositories/artifactregistryrepository-sample-${uniqueId}"
+      }
+    ],
+    "message": "Requested entity was not found.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories?alt=json&repository_id=artifactregistryrepository-sample-${uniqueId}
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.OperationMetadata"
+  },
+  "name": "projects/${projectId}/locations/us-west1/operations/${operationID}"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.OperationMetadata"
+  },
+  "name": "projects/${projectId}/locations/us-west1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.devtools.artifactregistry.v1.Repository",
+    "description": "description 1",
+    "format": "DOCKER",
+    "labels": {
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "mode": "STANDARD_REPOSITORY",
+    "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}"
+  }
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_http04.log
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_http04.log
@@ -1,0 +1,96 @@
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 1",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json&updateMask=description
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "cleanupPolicies": {},
+  "description": "description 2",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 2",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://artifactregistry.googleapis.com/v1/projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "description 2",
+  "format": "DOCKER",
+  "labels": {
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "mode": "STANDARD_REPOSITORY",
+  "name": "projects/${projectId}/locations/us-west1/repositories/artifactregistryrepository-sample-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object00.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 1
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object01.yaml
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    label-one: value-one
+  name: artifactregistryrepository-sample-${uniqueId}
+  namespace: ${projectId}
+spec:
+  description: description 1
+  format: DOCKER
+  location: us-west1
+  mode: STANDARD_REPOSITORY
+  resourceID: artifactregistryrepository-sample-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  name: artifactregistryrepository-sample-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object02.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 2
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  actuationMode: Paused
+  mode: cluster

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object04.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/_object04.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 3
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  actuationMode: Reconciling
+  mode: cluster

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/script.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/script.yaml
@@ -55,7 +55,7 @@ spec:
   description: "description 2"
 ---
 # step 4
-TEST: CHECK-LOG
+TEST: WAIT-FOR-HTTP-REQUEST
 VALUE_PRESENT: "description 2"
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnector

--- a/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/script.yaml
+++ b/tests/e2e/testdata/scenarios/cc_pause_change_reconcile/script.yaml
@@ -1,0 +1,66 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# step 0
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster
+---
+# step 1
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  name: artifactregistryrepository-sample-${uniqueId}
+  labels:
+    label-one: "value-one"
+spec:
+  format: DOCKER
+  location: us-west1
+  description: "description 1"
+---
+# step 2
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster
+  actuationMode: Paused
+---
+# step 3
+TEST: APPLY-NO-WAIT
+apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+kind: ArtifactRegistryRepository
+metadata:
+  name: artifactregistryrepository-sample-${uniqueId}
+  labels:
+    label-one: "value-one"
+spec:
+  format: DOCKER
+  location: us-west1
+  description: "description 2"
+---
+# step 4
+TEST: CHECK-LOG
+VALUE_PRESENT: "description 2"
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster
+  actuationMode: Reconciling

--- a/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/script.yaml
+++ b/tests/e2e/testdata/scenarios/ccc_pause_change_reconcile/script.yaml
@@ -63,7 +63,7 @@ spec:
   description: "description 2"
 ---
 # step 5
-TEST: CHECK-LOG
+TEST: WAIT-FOR-HTTP-REQUEST
 VALUE_PRESENT: "description 2"
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext


### PR DESCRIPTION
Patch continues to add more step wise scenarios for pause. It also renames `CHECK-LOG` to ~ `WAIT-FOR-HTTP-REQUEST` as per https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1451#discussion_r1553626724