### PR TITLE
tests: add a project-id annotation defaulter to mock-kubeapiserver

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -254,6 +254,11 @@ func NewHarness(ctx context.Context, t *testing.T) *Harness {
 
 		kccConfig.HTTPClient = &http.Client{Transport: roundTripper}
 
+		// Override the defaults: add our container-annotation defaulter
+		// (as we don't support webhooks)
+		kccConfig.Defaulters = append(kccConfig.Defaulters, k8s.NewStateIntoSpecDefaulter())
+		kccConfig.Defaulters = append(kccConfig.Defaulters, cnrmwebhook.NewContainerAnnotationDefaulter())
+
 		// Also hook the oauth2 library
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, kccConfig.HTTPClient)
 		h.Ctx = ctx

--- a/hack/compare-mock
+++ b/hack/compare-mock
@@ -11,7 +11,7 @@ RUN_TESTS=TestAllInSeries/$1
 
 # Run e2e tests against our mockgcp, capturing output
 ARTIFACTS=$(pwd)/artifactz/mocks \
-E2E_KUBE_TARGET=envtest \
+E2E_KUBE_TARGET=mock \
 E2E_GCP_TARGET=mock \
 GOLDEN_REQUEST_CHECKS=1 \
 WRITE_GOLDEN_OUTPUT=1 \

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -451,7 +451,7 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 
 func (r *Reconciler) handleDefaults(ctx context.Context, resource *dcl.Resource) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, resource); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
+++ b/pkg/controller/gsakeysecretgenerator/service_account_key_integration_test.go
@@ -187,7 +187,7 @@ func newTestReconciler(t *testing.T, mgr manager.Manager, crdPath string, provid
 	var immediateReconcileRequests chan event.GenericEvent = nil
 	var resourceWatcherRoutines *semaphore.Weighted = nil
 
-	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
+	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter()
 	reconciler, err := tf.NewReconciler(mgr, crd, provider, smLoader, immediateReconcileRequests, resourceWatcherRoutines, []k8s.Defaulter{stateIntoSpecDefaulter})
 	if err != nil {
 		t.Fatalf("error creating reconciler: %v", err)

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -168,7 +168,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) handleDefaults(ctx context.Context, auditConfig *iamv1beta1.IAMAuditConfig) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, auditConfig); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, auditConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 
 func (r *ReconcileIAMPartialPolicy) handleDefaults(ctx context.Context, pp *iamv1beta1.IAMPartialPolicy) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, pp); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, pp); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -179,7 +179,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 
 func (r *ReconcileIAMPolicy) handleDefaults(ctx context.Context, policy *iamv1beta1.IAMPolicy) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, policy); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, policy); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -181,7 +181,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *Reconciler) handleDefaults(ctx context.Context, policyMember *iamv1beta1.IAMPolicyMember) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, policyMember); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, policyMember); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -434,7 +434,7 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 
 func (r *Reconciler) handleDefaults(ctx context.Context, resource *krmtotf.Resource) error {
 	for _, defaulter := range r.defaulters {
-		if _, err := defaulter.ApplyDefaults(ctx, resource); err != nil {
+		if _, err := defaulter.ApplyDefaults(ctx, r.Client, resource); err != nil {
 			return err
 		}
 	}

--- a/pkg/k8s/defaulter.go
+++ b/pkg/k8s/defaulter.go
@@ -27,22 +27,19 @@ import (
 )
 
 type Defaulter interface {
-	ApplyDefaults(ctx context.Context, obj client.Object) (changed bool, err error)
+	ApplyDefaults(ctx context.Context, client client.Reader, obj client.Object) (changed bool, err error)
 }
 
 // StateIntoSpecDefaulter contains the required 'defaultValue' field and the
 // optional 'userOverride' field.
 type StateIntoSpecDefaulter struct {
-	client client.Client
 }
 
-func NewStateIntoSpecDefaulter(client client.Client) Defaulter {
-	return &StateIntoSpecDefaulter{
-		client: client,
-	}
+func NewStateIntoSpecDefaulter() Defaulter {
+	return &StateIntoSpecDefaulter{}
 }
 
-func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, resource client.Object) (changed bool, err error) {
+func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, client client.Reader, resource client.Object) (changed bool, err error) {
 	annotationValue := StateIntoSpecDefaultValueV1Beta1
 
 	cccNamespacedName := types.NamespacedName{
@@ -50,7 +47,7 @@ func (v *StateIntoSpecDefaulter) ApplyDefaults(ctx context.Context, resource cli
 		Name:      operatork8s.ConfigConnectorContextAllowedName,
 	}
 	ccc := &operatorv1beta1.ConfigConnectorContext{}
-	if err := v.client.Get(ctx, cccNamespacedName, ccc); err != nil {
+	if err := client.Get(ctx, cccNamespacedName, ccc); err != nil {
 		if apierrors.IsNotFound(err) {
 			ccc = nil
 		} else {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -185,7 +185,7 @@ func (r *TestReconciler) NewReconcilerForKind(kind string) reconcile.Reconciler 
 	var immediateReconcileRequests chan event.GenericEvent = nil //nolint:revive
 	var resourceWatcherRoutines *semaphore.Weighted = nil        //nolint:revive
 
-	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(r.mgr.GetClient())
+	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter()
 	defaulters := []k8s.Defaulter{stateIntoSpecDefaulter}
 
 	switch kind {


### PR DESCRIPTION
Because our mock-kubeapiserver doesn't support webhooks, we need to
find another way.  Defaulters are a good mechanism, and generally we
can now start to think about reducing our reliance on webhooks.
