### PR TITLE
tests: Fix accesscontextmanager test data

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeter/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeter/dependencies.yaml
@@ -15,16 +15,11 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: project-${uniqueId}
 spec:
-  resourceID: ${TEST_DEPENDENT_FOLDER_PROJECT_ID}
-  name: "Dependent Project"
-  folderRef:
-    external: ${TEST_FOLDER_ID}
-  billingAccountRef:
-    external: ${TEST_BILLING_ACCOUNT_ID}
+  organizationRef:
+    external: "${TEST_ORG_ID}"
+  name: "project-${uniqueId}"
 ---
 apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
 kind: AccessContextManagerAccessLevel

--- a/pkg/test/resourcefixture/testdata/basic/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeterresource/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeterresource/dependencies.yaml
@@ -15,13 +15,8 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
-  annotations:
-    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: project-${uniqueId}
 spec:
-  resourceID: ${TEST_DEPENDENT_FOLDER_PROJECT_ID}
-  name: "Dependent Project"
-  folderRef:
-    external: ${TEST_FOLDER_ID}
-  billingAccountRef:
-    external: ${TEST_BILLING_ACCOUNT_ID}
+  organizationRef:
+    external: "${TEST_ORG_ID}"
+  name: "project-${uniqueId}"


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

This is mentioned in PR https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1281 ([comment](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1281/files#r1503617089)). For this resource, it's unnecessary to use the pre-created project. I think I addressed that in 1281, but it seems the change was reverted in a rebase.

test passed on 2/27 with this change: https://prow-gob.gcpnode.com/view/gs/cnrm-prow/pr-logs/pull/cnrm-review.googlesource.com_cnrm/68740/cnrm-test/1762679866815156224 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
