### PR TITLE
chore: generate logginglogmetric krm exports

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_generated_object_explicitlogmetric.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_generated_object_explicitlogmetric.golden.yaml
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: logginglogmetric-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 2.5
+      - 5
+  filter: resource.type=gae_app AND severity>=ERROR
+  metricDescriptor:
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_generated_object_exponentiallogmetric.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_generated_object_exponentiallogmetric.golden.yaml
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: logginglogmetric-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  bucketOptions:
+    exponentialBuckets:
+      growthFactor: 3.5
+      numFiniteBuckets: 5
+      scale: 0.7
+  filter: resource.type=gae_app AND severity<=ERROR
+  metricDescriptor:
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.request)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/linearlogmetric/_generated_object_linearlogmetric.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/linearlogmetric/_generated_object_linearlogmetric.golden.yaml
@@ -1,0 +1,79 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{"spec":{"metricDescriptor":{"launchStage":"PRELAUNCH","metadata":{"ingestDelay":"3.5s","samplePeriod":"3.5s"}}}}'
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: logginglogmetric-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  bucketOptions:
+    linearBuckets:
+      numFiniteBuckets: 4
+      offset: 0.5
+      width: 2.5
+  description: An updated sample log metric
+  disabled: true
+  filter: resource.type=gae_app AND severity>=ERROR
+  labelExtractors:
+    hasMass: REGEXP_EXTRACT(jsonPayload.request, ".*([1-9]).*")
+    mass: EXTRACT(jsonPayload.request)
+    sku: EXTRACT(jsonPayload.id)
+  metricDescriptor:
+    displayName: updated-sample-descriptor
+    labels:
+    - description: amount of matter
+      key: mass
+      valueType: STRING
+    - description: whether the item has a mass
+      key: hasMass
+      valueType: BOOL
+    - description: identifying number for item
+      key: sku
+      valueType: INT64
+    launchStage: PRELAUNCH
+    metadata:
+      ingestDelay: 3.5s
+      samplePeriod: 3.5s
+    metricKind: DELTA
+    unit: s
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: An updated sample log metric
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
Sample commands used for generation:

```bash
$ WRITE_GOLDEN_OUTPUT=1 GOLDEN_OBJECT_CHECKS=1 BILLING_ACCOUNT_ID="REDACTED" ORGANIZATION_ID="REDACTED" E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=real go test -test.count=1 -timeout 600s -v ./tests/e2e -run TestAllInSeries/fixtures/linearlogmetric
```