### PR TITLE
mockgcp: use hand-coded storage proto (partially revert 1250)

### DIFF
--- a/mockgcp/Makefile
+++ b/mockgcp/Makefile
@@ -55,7 +55,3 @@ generate-protos-from-openapi:
 	wget -O servicenetworking-api.json https://raw.githubusercontent.com/googleapis/google-api-go-client/main/servicenetworking/v1/servicenetworking-api.json
 	mkdir -p apis/mockgcp/cloud/servicenetworking/v1/
 	cd tools/gapic; go run . ../../servicenetworking-api.json > ../../apis/mockgcp/cloud/servicenetworking/v1/servicenetworking.proto
-
-	wget -O storage-v1.json https://raw.githubusercontent.com/googleapis/google-api-go-client/main/storage/v1/storage-api.json
-	mkdir -p apis/mockgcp/storage/v1/
-	cd tools/gapic; go run . --proto-version=2 ../../storage-v1.json > ../../apis/mockgcp/storage/v1/service.proto

--- a/mockgcp/apis/mockgcp/storage/v1/README.md
+++ b/mockgcp/apis/mockgcp/storage/v1/README.md
@@ -1,0 +1,5 @@
+This is a modified version of the v1 API, to add the service definition.
+
+service.proto is written by hand, though we have a version in the v2 API to work from.
+
+storage_resources.proto and storage.proto are referenced from third_party/googleapis/google/storage/v1/

--- a/mockgcp/apis/mockgcp/storage/v1/service.proto
+++ b/mockgcp/apis/mockgcp/storage/v1/service.proto
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package mockgcp.storage.v1;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+import "google/protobuf/empty.proto";
+
+import "mockgcp/storage/v1/storage.proto";
+import "mockgcp/storage/v1/storage_resources.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/storage/v1;storage";
+
+service Storage {
+  option (google.api.default_host) = "storage.googleapis.com";
+
+  // Returns metadata for the specified bucket.
+  rpc GetBucket(GetBucketRequest) returns (Bucket) {
+    option (google.api.http) = {
+      get: "/storage/v1/b/{bucket}"
+    };
+  }
+
+  // Creates a new bucket.
+  rpc InsertBucket(InsertBucketRequest) returns (Bucket) {
+    option (google.api.http) = {
+      post: "/storage/v1/b",
+      body: "bucket"
+    };
+  }
+
+  // Permanently deletes an empty bucket.
+  rpc DeleteBucket(DeleteBucketRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/storage/v1/b/{bucket}"
+    };
+  }
+
+  // Updates a bucket.
+  rpc PatchBucket(PatchBucketRequest) returns (Bucket) {
+    option (google.api.http) = {
+      patch: "/storage/v1/b/{bucket}"
+    };
+  }
+
+}

--- a/mockgcp/generated/mockgcp/cloud/secretmanager/v1/resources.pb.go
+++ b/mockgcp/generated/mockgcp/cloud/secretmanager/v1/resources.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mockgcp/generated/mockgcp/cloud/secretmanager/v1/service.pb.go
+++ b/mockgcp/generated/mockgcp/cloud/secretmanager/v1/service.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,14 +38,16 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Request message for [SecretManagerService.ListSecrets][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
+// Request message for
+// [SecretManagerService.ListSecrets][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 type ListSecretsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	// Required. The resource name of the project associated with the
-	// [Secrets][mockgcp.cloud.secretmanager.v1.Secret], in the format `projects/*`.
+	// [Secrets][mockgcp.cloud.secretmanager.v1.Secret], in the format
+	// `projects/*`.
 	Parent string `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent,omitempty"`
 	// Optional. The maximum number of results to be returned in a single page. If
 	// set to 0, the server decides the number of results to return. If the
@@ -122,17 +124,19 @@ func (x *ListSecretsRequest) GetFilter() string {
 	return ""
 }
 
-// Response message for [SecretManagerService.ListSecrets][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
+// Response message for
+// [SecretManagerService.ListSecrets][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 type ListSecretsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The list of [Secrets][mockgcp.cloud.secretmanager.v1.Secret] sorted in reverse by create_time (newest
-	// first).
+	// The list of [Secrets][mockgcp.cloud.secretmanager.v1.Secret] sorted in
+	// reverse by create_time (newest first).
 	Secrets []*Secret `protobuf:"bytes,1,rep,name=secrets,proto3" json:"secrets,omitempty"`
 	// A token to retrieve the next page of results. Pass this value in
-	// [ListSecretsRequest.page_token][mockgcp.cloud.secretmanager.v1.ListSecretsRequest.page_token] to retrieve the next page.
+	// [ListSecretsRequest.page_token][mockgcp.cloud.secretmanager.v1.ListSecretsRequest.page_token]
+	// to retrieve the next page.
 	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	// The total number of [Secrets][mockgcp.cloud.secretmanager.v1.Secret].
 	TotalSize int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
@@ -191,7 +195,8 @@ func (x *ListSecretsResponse) GetTotalSize() int32 {
 	return 0
 }
 
-// Request message for [SecretManagerService.CreateSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
+// Request message for
+// [SecretManagerService.CreateSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
 type CreateSecretRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -206,7 +211,8 @@ type CreateSecretRequest struct {
 	// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
 	// underscore (`_`) characters.
 	SecretId string `protobuf:"bytes,2,opt,name=secret_id,json=secretId,proto3" json:"secret_id,omitempty"`
-	// Required. A [Secret][mockgcp.cloud.secretmanager.v1.Secret] with initial field values.
+	// Required. A [Secret][mockgcp.cloud.secretmanager.v1.Secret] with initial
+	// field values.
 	Secret *Secret `protobuf:"bytes,3,opt,name=secret,proto3" json:"secret,omitempty"`
 }
 
@@ -263,16 +269,20 @@ func (x *CreateSecretRequest) GetSecret() *Secret {
 	return nil
 }
 
-// Request message for [SecretManagerService.AddSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
+// Request message for
+// [SecretManagerService.AddSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
 type AddSecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [Secret][mockgcp.cloud.secretmanager.v1.Secret] to associate with the
-	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format `projects/*/secrets/*`.
+	// Required. The resource name of the
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret] to associate with the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
+	// `projects/*/secrets/*`.
 	Parent string `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent,omitempty"`
-	// Required. The secret payload of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// Required. The secret payload of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	Payload *SecretPayload `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
 }
 
@@ -322,13 +332,16 @@ func (x *AddSecretVersionRequest) GetPayload() *SecretPayload {
 	return nil
 }
 
-// Request message for [SecretManagerService.GetSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.GetSecret].
+// Request message for
+// [SecretManagerService.GetSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.GetSecret].
 type GetSecretRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [Secret][mockgcp.cloud.secretmanager.v1.Secret], in the format `projects/*/secrets/*`.
+	// Required. The resource name of the
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret], in the format
+	// `projects/*/secrets/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 }
 
@@ -371,15 +384,17 @@ func (x *GetSecretRequest) GetName() string {
 	return ""
 }
 
-// Request message for [SecretManagerService.ListSecretVersions][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
+// Request message for
+// [SecretManagerService.ListSecretVersions][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 type ListSecretVersionsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [Secret][mockgcp.cloud.secretmanager.v1.Secret] associated with the
-	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] to list, in the format
-	// `projects/*/secrets/*`.
+	// Required. The resource name of the
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret] associated with the
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] to list, in
+	// the format `projects/*/secrets/*`.
 	Parent string `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent,omitempty"`
 	// Optional. The maximum number of results to be returned in a single page. If
 	// set to 0, the server decides the number of results to return. If the
@@ -456,19 +471,22 @@ func (x *ListSecretVersionsRequest) GetFilter() string {
 	return ""
 }
 
-// Response message for [SecretManagerService.ListSecretVersions][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
+// Response message for
+// [SecretManagerService.ListSecretVersions][mockgcp.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 type ListSecretVersionsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The list of [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] sorted in reverse by
-	// create_time (newest first).
+	// The list of [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion]
+	// sorted in reverse by create_time (newest first).
 	Versions []*SecretVersion `protobuf:"bytes,1,rep,name=versions,proto3" json:"versions,omitempty"`
 	// A token to retrieve the next page of results. Pass this value in
-	// [ListSecretVersionsRequest.page_token][mockgcp.cloud.secretmanager.v1.ListSecretVersionsRequest.page_token] to retrieve the next page.
+	// [ListSecretVersionsRequest.page_token][mockgcp.cloud.secretmanager.v1.ListSecretVersionsRequest.page_token]
+	// to retrieve the next page.
 	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
-	// The total number of [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// The total number of
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	TotalSize int32 `protobuf:"varint,3,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 }
 
@@ -525,13 +543,15 @@ func (x *ListSecretVersionsResponse) GetTotalSize() int32 {
 	return 0
 }
 
-// Request message for [SecretManagerService.GetSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
+// Request message for
+// [SecretManagerService.GetSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
 type GetSecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
+	// Required. The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
 	// `projects/*/secrets/*/versions/*`.
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
@@ -578,13 +598,15 @@ func (x *GetSecretVersionRequest) GetName() string {
 	return ""
 }
 
-// Request message for [SecretManagerService.UpdateSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
+// Request message for
+// [SecretManagerService.UpdateSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
 type UpdateSecretRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. [Secret][mockgcp.cloud.secretmanager.v1.Secret] with updated field values.
+	// Required. [Secret][mockgcp.cloud.secretmanager.v1.Secret] with updated field
+	// values.
 	Secret *Secret `protobuf:"bytes,1,opt,name=secret,proto3" json:"secret,omitempty"`
 	// Required. Specifies the fields to be updated.
 	UpdateMask *field_mask.FieldMask `protobuf:"bytes,2,opt,name=update_mask,json=updateMask,proto3" json:"update_mask,omitempty"`
@@ -636,13 +658,15 @@ func (x *UpdateSecretRequest) GetUpdateMask() *field_mask.FieldMask {
 	return nil
 }
 
-// Request message for [SecretManagerService.AccessSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
+// Request message for
+// [SecretManagerService.AccessSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 type AccessSecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
+	// Required. The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
 	// `projects/*/secrets/*/versions/*`.
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
@@ -689,13 +713,15 @@ func (x *AccessSecretVersionRequest) GetName() string {
 	return ""
 }
 
-// Response message for [SecretManagerService.AccessSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
+// Response message for
+// [SecretManagerService.AccessSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 type AccessSecretVersionResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
+	// The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] in the format
 	// `projects/*/secrets/*/versions/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Secret payload
@@ -748,18 +774,20 @@ func (x *AccessSecretVersionResponse) GetPayload() *SecretPayload {
 	return nil
 }
 
-// Request message for [SecretManagerService.DeleteSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
+// Request message for
+// [SecretManagerService.DeleteSecret][mockgcp.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
 type DeleteSecretRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [Secret][mockgcp.cloud.secretmanager.v1.Secret] to delete in the format
+	// Required. The resource name of the
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret] to delete in the format
 	// `projects/*/secrets/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Optional. Etag of the [Secret][mockgcp.cloud.secretmanager.v1.Secret]. The request succeeds if it matches
-	// the etag of the currently stored secret object. If the etag is omitted,
-	// the request succeeds.
+	// Optional. Etag of the [Secret][mockgcp.cloud.secretmanager.v1.Secret]. The
+	// request succeeds if it matches the etag of the currently stored secret
+	// object. If the etag is omitted, the request succeeds.
 	Etag string `protobuf:"bytes,2,opt,name=etag,proto3" json:"etag,omitempty"`
 }
 
@@ -809,18 +837,21 @@ func (x *DeleteSecretRequest) GetEtag() string {
 	return ""
 }
 
-// Request message for [SecretManagerService.DisableSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
+// Request message for
+// [SecretManagerService.DisableSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
 type DisableSecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to disable in the format
-	// `projects/*/secrets/*/versions/*`.
+	// Required. The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to disable in
+	// the format `projects/*/secrets/*/versions/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Optional. Etag of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches
-	// the etag of the currently stored secret version object. If the etag is
-	// omitted, the request succeeds.
+	// Optional. Etag of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request
+	// succeeds if it matches the etag of the currently stored secret version
+	// object. If the etag is omitted, the request succeeds.
 	Etag string `protobuf:"bytes,2,opt,name=etag,proto3" json:"etag,omitempty"`
 }
 
@@ -870,18 +901,21 @@ func (x *DisableSecretVersionRequest) GetEtag() string {
 	return ""
 }
 
-// Request message for [SecretManagerService.EnableSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
+// Request message for
+// [SecretManagerService.EnableSecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
 type EnableSecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to enable in the format
-	// `projects/*/secrets/*/versions/*`.
+	// Required. The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to enable in
+	// the format `projects/*/secrets/*/versions/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Optional. Etag of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches
-	// the etag of the currently stored secret version object. If the etag is
-	// omitted, the request succeeds.
+	// Optional. Etag of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request
+	// succeeds if it matches the etag of the currently stored secret version
+	// object. If the etag is omitted, the request succeeds.
 	Etag string `protobuf:"bytes,2,opt,name=etag,proto3" json:"etag,omitempty"`
 }
 
@@ -931,18 +965,21 @@ func (x *EnableSecretVersionRequest) GetEtag() string {
 	return ""
 }
 
-// Request message for [SecretManagerService.DestroySecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
+// Request message for
+// [SecretManagerService.DestroySecretVersion][mockgcp.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
 type DestroySecretVersionRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Required. The resource name of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to destroy in the format
-	// `projects/*/secrets/*/versions/*`.
+	// Required. The resource name of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to destroy in
+	// the format `projects/*/secrets/*/versions/*`.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Optional. Etag of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request succeeds if it matches
-	// the etag of the currently stored secret version object. If the etag is
-	// omitted, the request succeeds.
+	// Optional. Etag of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. The request
+	// succeeds if it matches the etag of the currently stored secret version
+	// object. If the etag is omitted, the request succeeds.
 	Etag string `protobuf:"bytes,2,opt,name=etag,proto3" json:"etag,omitempty"`
 }
 

--- a/mockgcp/generated/mockgcp/cloud/secretmanager/v1/service_grpc.pb.go
+++ b/mockgcp/generated/mockgcp/cloud/secretmanager/v1/service_grpc.pb.go
@@ -26,51 +26,61 @@ const _ = grpc.SupportPackageIsVersion7
 type SecretManagerServiceClient interface {
 	// Lists [Secrets][mockgcp.cloud.secretmanager.v1.Secret].
 	ListSecrets(ctx context.Context, in *ListSecretsRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error)
-	// Creates a new [Secret][mockgcp.cloud.secretmanager.v1.Secret] containing no [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// Creates a new [Secret][mockgcp.cloud.secretmanager.v1.Secret] containing no
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	CreateSecret(ctx context.Context, in *CreateSecretRequest, opts ...grpc.CallOption) (*Secret, error)
-	// Creates a new [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
-	// it to an existing [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Creates a new [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]
+	// containing secret data and attaches it to an existing
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	AddSecretVersion(ctx context.Context, in *AddSecretVersionRequest, opts ...grpc.CallOption) (*SecretVersion, error)
 	// Gets metadata for a given [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	GetSecret(ctx context.Context, in *GetSecretRequest, opts ...grpc.CallOption) (*Secret, error)
-	// Updates metadata of an existing [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Updates metadata of an existing
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	UpdateSecret(ctx context.Context, in *UpdateSecretRequest, opts ...grpc.CallOption) (*Secret, error)
 	// Deletes a [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	DeleteSecret(ctx context.Context, in *DeleteSecretRequest, opts ...grpc.CallOption) (*empty.Empty, error)
-	// Lists [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
-	// data.
+	// Lists [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion]. This
+	// call does not return secret data.
 	ListSecretVersions(ctx context.Context, in *ListSecretVersionsRequest, opts ...grpc.CallOption) (*ListSecretVersionsResponse, error)
-	// Gets metadata for a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// Gets metadata for a
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
 	// created [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	GetSecretVersion(ctx context.Context, in *GetSecretVersionRequest, opts ...grpc.CallOption) (*SecretVersion, error)
-	// Accesses a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.
+	// Accesses a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// This call returns the secret data.
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
 	// created [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	AccessSecretVersion(ctx context.Context, in *AccessSecretVersionRequest, opts ...grpc.CallOption) (*AccessSecretVersionResponse, error)
 	// Disables a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
 	// [DISABLED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
 	DisableSecretVersion(ctx context.Context, in *DisableSecretVersionRequest, opts ...grpc.CallOption) (*SecretVersion, error)
 	// Enables a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
 	// [ENABLED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
 	EnableSecretVersion(ctx context.Context, in *EnableSecretVersionRequest, opts ...grpc.CallOption) (*SecretVersion, error)
 	// Destroys a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
-	// [DESTROYED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
-	// secret data.
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// [DESTROYED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]
+	// and irrevocably destroys the secret data.
 	DestroySecretVersion(ctx context.Context, in *DestroySecretVersionRequest, opts ...grpc.CallOption) (*SecretVersion, error)
 	// Sets the access control policy on the specified secret. Replaces any
 	// existing policy.
 	//
-	// Permissions on [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] are enforced according
-	// to the policy set on the associated [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Permissions on
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] are enforced
+	// according to the policy set on the associated
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	SetIamPolicy(ctx context.Context, in *iampb.SetIamPolicyRequest, opts ...grpc.CallOption) (*iampb.Policy, error)
 	// Gets the access control policy for a secret.
 	// Returns empty policy if the secret exists and does not have a policy set.
@@ -234,51 +244,61 @@ func (c *secretManagerServiceClient) TestIamPermissions(ctx context.Context, in 
 type SecretManagerServiceServer interface {
 	// Lists [Secrets][mockgcp.cloud.secretmanager.v1.Secret].
 	ListSecrets(context.Context, *ListSecretsRequest) (*ListSecretsResponse, error)
-	// Creates a new [Secret][mockgcp.cloud.secretmanager.v1.Secret] containing no [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// Creates a new [Secret][mockgcp.cloud.secretmanager.v1.Secret] containing no
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	CreateSecret(context.Context, *CreateSecretRequest) (*Secret, error)
-	// Creates a new [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] containing secret data and attaches
-	// it to an existing [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Creates a new [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]
+	// containing secret data and attaches it to an existing
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	AddSecretVersion(context.Context, *AddSecretVersionRequest) (*SecretVersion, error)
 	// Gets metadata for a given [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	GetSecret(context.Context, *GetSecretRequest) (*Secret, error)
-	// Updates metadata of an existing [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Updates metadata of an existing
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	UpdateSecret(context.Context, *UpdateSecretRequest) (*Secret, error)
 	// Deletes a [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	DeleteSecret(context.Context, *DeleteSecretRequest) (*empty.Empty, error)
-	// Lists [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion]. This call does not return secret
-	// data.
+	// Lists [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion]. This
+	// call does not return secret data.
 	ListSecretVersions(context.Context, *ListSecretVersionsRequest) (*ListSecretVersionsResponse, error)
-	// Gets metadata for a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// Gets metadata for a
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
 	// created [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	GetSecretVersion(context.Context, *GetSecretVersionRequest) (*SecretVersion, error)
-	// Accesses a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion]. This call returns the secret data.
+	// Accesses a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
+	// This call returns the secret data.
 	//
 	// `projects/*/secrets/*/versions/latest` is an alias to the most recently
 	// created [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	AccessSecretVersion(context.Context, *AccessSecretVersionRequest) (*AccessSecretVersionResponse, error)
 	// Disables a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
 	// [DISABLED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
 	DisableSecretVersion(context.Context, *DisableSecretVersionRequest) (*SecretVersion, error)
 	// Enables a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
 	// [ENABLED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
 	EnableSecretVersion(context.Context, *EnableSecretVersionRequest) (*SecretVersion, error)
 	// Destroys a [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion].
 	//
-	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
-	// [DESTROYED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DESTROYED] and irrevocably destroys the
-	// secret data.
+	// Sets the [state][mockgcp.cloud.secretmanager.v1.SecretVersion.state] of the
+	// [SecretVersion][mockgcp.cloud.secretmanager.v1.SecretVersion] to
+	// [DESTROYED][mockgcp.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]
+	// and irrevocably destroys the secret data.
 	DestroySecretVersion(context.Context, *DestroySecretVersionRequest) (*SecretVersion, error)
 	// Sets the access control policy on the specified secret. Replaces any
 	// existing policy.
 	//
-	// Permissions on [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] are enforced according
-	// to the policy set on the associated [Secret][mockgcp.cloud.secretmanager.v1.Secret].
+	// Permissions on
+	// [SecretVersions][mockgcp.cloud.secretmanager.v1.SecretVersion] are enforced
+	// according to the policy set on the associated
+	// [Secret][mockgcp.cloud.secretmanager.v1.Secret].
 	SetIamPolicy(context.Context, *iampb.SetIamPolicyRequest) (*iampb.Policy, error)
 	// Gets the access control policy for a secret.
 	// Returns empty policy if the secret exists and does not have a policy set.


### PR DESCRIPTION
Temporary fix for https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1250#issuecomment-2057929418