### PR TITLE
tests: wait for cache to sync

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -483,6 +483,9 @@ func NewHarness(ctx context.Context, t *testing.T) *Harness {
 		}
 	}()
 
+	// Given the informers a chance to sync
+	mgr.GetCache().WaitForCacheSync(ctx)
+
 	return h
 }
 

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -301,6 +301,9 @@ func setup() {
 			logging.Fatal(err, "error starting manager")
 		}
 	}()
+
+	// Given the informers a chance to sync
+	mgr.GetCache().WaitForCacheSync(ctx)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
As we've turned on caching for CC & CCC I think we should wait on the informer caches to sync. This may actually reduce the flakes (from the `pause-tests` which are some of the only e2e tests today that test the fetching of CC/ CCC) .