### PR TITLE
tests: Split github actions jobs for tests/e2e

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -63,7 +63,7 @@ jobs:
           ./scripts/github-actions/ga-unit-test.sh
         env:
           GOPATH: /home/runner/go
-  mock-tests:
+  tests-e2e-samples:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -73,7 +73,26 @@ jobs:
           go-version-file: 'go.mod'
       - name: "Run mock tests"
         run: |
-          ./scripts/github-actions/ga-mock-test.sh
+          ./scripts/github-actions/tests-e2e-samples
+        env:
+          GOPATH: /home/runner/go
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: /tmp/artifacts/
+  tests-e2e-fixtures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock tests"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures
         env:
           GOPATH: /home/runner/go
           ARTIFACTS: /tmp/artifacts

--- a/scripts/github-actions/tests-e2e-fixtures
+++ b/scripts/github-actions/tests-e2e-fixtures
@@ -12,26 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -o errexit
 set -o nounset
 set -o pipefail
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-source ${REPO_ROOT}/scripts/shared-vars-public.sh
-cd ${REPO_ROOT}
-source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
-	fetch_tools && \
-	setup_envs
-
-cd ${REPO_ROOT}/mockgcp
-echo "Running tests in mockgcp..."
-go test -test.count=1 -timeout 3600s -v ./...
 
 cd ${REPO_ROOT}/
-echo "Running mock tests..."
-go test -test.count=1 -timeout 3600s -v ./pkg/controller/mocktests/...
 
-cd ${REPO_ROOT}/
-echo "Running mock e2e tests..."
+echo "Downloading envtest assets..."
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+
+echo "Running fixtures in tests/e2e..."
+
+RUN_E2E=1 \
 E2E_KUBE_TARGET=envtest \
-	RUN_E2E=1 E2E_GCP_TARGET=mock \
-	go test -test.count=1 -timeout 3600s -v ./tests/e2e
+E2E_GCP_TARGET=mock \
+  go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures

--- a/scripts/github-actions/tests-e2e-samples
+++ b/scripts/github-actions/tests-e2e-samples
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+cd ${REPO_ROOT}/
+
+echo "Downloading envtest assets..."
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+
+echo "Running fixtures in tests/e2e..."
+
+RUN_E2E=1 \
+E2E_KUBE_TARGET=envtest \
+E2E_GCP_TARGET=mock \
+  go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/samples


### PR DESCRIPTION
We were coming close to the 60 minute timeout; split into two to give
us some room.
