### PR TITLE
tests: add switch board

### DIFF
--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/lifecyclehandler"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/metrics"
@@ -170,6 +171,13 @@ func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinit
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res reconcile.Result, err error) {
+	if sb := kontroller.GetSwitchBoard(); sb != nil {
+		if !sb.IsSystemRunning() {
+			// the system is not running anymore so we don't reconcile anymore
+			return reconcile.Result{}, nil
+		}
+	}
+
 	r.schemaRefMu.RLock()
 	defer r.schemaRefMu.RUnlock()
 	r.logger.Info("starting reconcile", "resource", req.NamespacedName)

--- a/pkg/controller/deletiondefender/controller.go
+++ b/pkg/controller/deletiondefender/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/go-logr/logr"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -98,6 +99,13 @@ func NewReconciler(mgr manager.Manager, crd *apiextensions.CustomResourceDefinit
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res reconcile.Result, err error) {
+	if sb := kontroller.GetSwitchBoard(); sb != nil {
+		if !sb.IsSystemRunning() {
+			// the system is not running anymore so we don't reconcile anymore
+			return reconcile.Result{}, nil
+		}
+	}
+
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(r.gvk)
 

--- a/pkg/controller/switch.go
+++ b/pkg/controller/switch.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"sync"
+)
+
+type SwitchBoard struct {
+	systemRunning bool
+	lock          sync.RWMutex
+}
+
+func NewSwitch() *SwitchBoard {
+	return &SwitchBoard{systemRunning: true}
+}
+
+func (r *SwitchBoard) Stop() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.systemRunning = false
+}
+
+func (r *SwitchBoard) IsSystemRunning() bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	return r.systemRunning
+}
+
+func GetSwitchBoard() *SwitchBoard {
+	return mainSwitch
+}
+
+func SetSwitchBoard(s *SwitchBoard) {
+	mainSwitch = s
+}
+
+var mainSwitch *SwitchBoard

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/lifecyclehandler"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/metrics"
@@ -153,6 +154,13 @@ func NewReconciler(mgr manager.Manager,
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res reconcile.Result, err error) {
+	if sb := kontroller.GetSwitchBoard(); sb != nil {
+		if !sb.IsSystemRunning() {
+			// the system is not running anymore so we don't reconcile anymore
+			return reconcile.Result{}, nil
+		}
+	}
+
 	r.schemaRefMu.RLock()
 	defer r.schemaRefMu.RUnlock()
 	r.logger.Info("starting reconcile", "resource", req.NamespacedName)

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/config/tests/samples/create"
 	opcorev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
 	testcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/controller"
 	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
@@ -141,6 +142,10 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 
 			t.Run(fixture.Name, func(t *testing.T) {
 				ctx := addTestTimeout(ctx, t, subtestTimeout)
+
+				// todo acpana: revist for parallel execution
+				switchBoard := kontroller.NewSwitch()
+				kontroller.SetSwitchBoard(switchBoard)
 
 				uniqueID := testvariable.NewUniqueID()
 
@@ -558,6 +563,8 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 						h.CompareGoldenFile(expectedPath, got, normalizers...)
 					}
 				}
+
+				switchBoard.Stop()
 			})
 		}
 	})


### PR DESCRIPTION
If we can short circuit the reconcile loop, we *should* avoid any panics that we've seen in the CI when we cancel a context because the test is finished. This patch allows us to signal to controllers that we don't want them to do any more work.

Follow ups:
* [ ] add to other controllers
* [ ] log if short circuiting