### PR TITLE
tests: handle a nil object when normalizing responses

### DIFF
--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -100,6 +100,9 @@ type objectWalker struct {
 }
 
 func (o *objectWalker) visitAny(v any, path string) (any, error) {
+	if v == nil {
+		return v, nil
+	}
 	switch v := v.(type) {
 	case map[string]any:
 		if err := o.visitMap(v, path); err != nil {
@@ -113,7 +116,7 @@ func (o *objectWalker) visitAny(v any, path string) (any, error) {
 	case string:
 		return o.visitString(v, path)
 	default:
-		return nil, fmt.Errorf("unhandled type %T", v)
+		return nil, fmt.Errorf("unhandled type at path %q: %T", path, v)
 	}
 }
 

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -385,7 +385,7 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 					addSetStringReplacement := func(path string, newValue string) {
 						jsonMutators = append(jsonMutators, func(obj map[string]any) {
 							if err := setStringAtPath(obj, path, newValue); err != nil {
-								t.Fatal(err)
+								t.Fatalf("error from setStringAtPath(%+v): %v", obj, err)
 							}
 						})
 					}


### PR DESCRIPTION
Probably shouldn't happen, but we shouldn't panic if it does.
