### PR TITLE
chore: generate int64 instead of int in client types

### DIFF
--- a/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/accesscontextmanageraccesslevelcondition_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/accesscontextmanageraccesslevelcondition_types.go
@@ -141,7 +141,7 @@ type AccessContextManagerAccessLevelConditionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/accesscontextmanagergcpuseraccessbinding_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/accesscontextmanagergcpuseraccessbinding_types.go
@@ -60,7 +60,7 @@ type AccessContextManagerGCPUserAccessBindingStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1alpha1/zz_generated.deepcopy.go
@@ -156,7 +156,7 @@ func (in *AccessContextManagerAccessLevelConditionStatus) DeepCopyInto(out *Acce
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -275,7 +275,7 @@ func (in *AccessContextManagerGCPUserAccessBindingStatus) DeepCopyInto(out *Acce
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanageraccesslevel_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanageraccesslevel_types.go
@@ -196,7 +196,7 @@ type AccessContextManagerAccessLevelStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanageraccesspolicy_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanageraccesspolicy_types.go
@@ -58,7 +58,7 @@ type AccessContextManagerAccessPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Time the AccessPolicy was updated in UTC. */
 	// +optional

--- a/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeter_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeter_types.go
@@ -325,7 +325,7 @@ type AccessContextManagerServicePerimeterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Time the AccessPolicy was updated in UTC. */
 	// +optional

--- a/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeterresource_types.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1beta1/accesscontextmanagerserviceperimeterresource_types.go
@@ -52,7 +52,7 @@ type AccessContextManagerServicePerimeterResourceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/accesscontextmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/accesscontextmanager/v1beta1/zz_generated.deepcopy.go
@@ -137,7 +137,7 @@ func (in *AccessContextManagerAccessLevelStatus) DeepCopyInto(out *AccessContext
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -255,7 +255,7 @@ func (in *AccessContextManagerAccessPolicyStatus) DeepCopyInto(out *AccessContex
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -426,7 +426,7 @@ func (in *AccessContextManagerServicePerimeterResourceStatus) DeepCopyInto(out *
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -504,7 +504,7 @@ func (in *AccessContextManagerServicePerimeterStatus) DeepCopyInto(out *AccessCo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbbackup_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbbackup_types.go
@@ -96,7 +96,7 @@ type AlloyDBBackupStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* If true, indicates that the service is actively updating the resource. This can happen due to user-triggered updates or system actions like failover or maintenance. */
 	// +optional

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbcluster_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbcluster_types.go
@@ -86,7 +86,7 @@ type ClusterContinuousBackupConfig struct {
 
 	If not set, defaults to 14 days. */
 	// +optional
-	RecoveryWindowDays *int `json:"recoveryWindowDays,omitempty"`
+	RecoveryWindowDays *int64 `json:"recoveryWindowDays,omitempty"`
 }
 
 type ClusterEncryptionConfig struct {
@@ -130,7 +130,7 @@ type ClusterPassword struct {
 type ClusterQuantityBasedRetention struct {
 	/* The number of backups to retain. */
 	// +optional
-	Count *int `json:"count,omitempty"`
+	Count *int64 `json:"count,omitempty"`
 }
 
 type ClusterRestoreBackupSource struct {
@@ -155,19 +155,19 @@ type ClusterSecondaryConfig struct {
 type ClusterStartTimes struct {
 	/* Hours of day in 24 hour format. Should be from 0 to 23. An API may choose to allow the value "24:00:00" for scenarios like business closing time. */
 	// +optional
-	Hours *int `json:"hours,omitempty"`
+	Hours *int64 `json:"hours,omitempty"`
 
 	/* Minutes of hour of day. Currently, only the value 0 is supported. */
 	// +optional
-	Minutes *int `json:"minutes,omitempty"`
+	Minutes *int64 `json:"minutes,omitempty"`
 
 	/* Fractions of seconds in nanoseconds. Currently, only the value 0 is supported. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Seconds of minutes of the time. Currently, only the value 0 is supported. */
 	// +optional
-	Seconds *int `json:"seconds,omitempty"`
+	Seconds *int64 `json:"seconds,omitempty"`
 }
 
 type ClusterTimeBasedRetention struct {
@@ -336,7 +336,7 @@ type AlloyDBClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The system-generated UID of the resource. */
 	// +optional

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbinstance_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbinstance_types.go
@@ -38,13 +38,13 @@ import (
 type InstanceMachineConfig struct {
 	/* The number of CPU's in the VM instance. */
 	// +optional
-	CpuCount *int `json:"cpuCount,omitempty"`
+	CpuCount *int64 `json:"cpuCount,omitempty"`
 }
 
 type InstanceReadPoolConfig struct {
 	/* Read capacity, i.e. number of nodes in a read pool instance. */
 	// +optional
-	NodeCount *int `json:"nodeCount,omitempty"`
+	NodeCount *int64 `json:"nodeCount,omitempty"`
 }
 
 type AlloyDBInstanceSpec struct {
@@ -128,7 +128,7 @@ type AlloyDBInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Set to true if the current state of Instance does not match the user's intended state, and the service is actively updating the resource to reconcile them. This can happen due to user-triggered updates or system actions like failover or maintenance. */
 	// +optional

--- a/pkg/clients/generated/apis/alloydb/v1beta1/alloydbuser_types.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/alloydbuser_types.go
@@ -80,7 +80,7 @@ type AlloyDBUserStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/alloydb/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/alloydb/v1beta1/zz_generated.deepcopy.go
@@ -155,7 +155,7 @@ func (in *AlloyDBBackupStatus) DeepCopyInto(out *AlloyDBBackupStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {
@@ -382,7 +382,7 @@ func (in *AlloyDBClusterStatus) DeepCopyInto(out *AlloyDBClusterStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Uid != nil {
@@ -560,7 +560,7 @@ func (in *AlloyDBInstanceStatus) DeepCopyInto(out *AlloyDBInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {
@@ -704,7 +704,7 @@ func (in *AlloyDBUserStatus) DeepCopyInto(out *AlloyDBUserStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -861,7 +861,7 @@ func (in *ClusterContinuousBackupConfig) DeepCopyInto(out *ClusterContinuousBack
 	}
 	if in.RecoveryWindowDays != nil {
 		in, out := &in.RecoveryWindowDays, &out.RecoveryWindowDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1072,7 +1072,7 @@ func (in *ClusterQuantityBasedRetention) DeepCopyInto(out *ClusterQuantityBasedR
 	*out = *in
 	if in.Count != nil {
 		in, out := &in.Count, &out.Count
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1144,22 +1144,22 @@ func (in *ClusterStartTimes) DeepCopyInto(out *ClusterStartTimes) {
 	*out = *in
 	if in.Hours != nil {
 		in, out := &in.Hours, &out.Hours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minutes != nil {
 		in, out := &in.Minutes, &out.Minutes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Seconds != nil {
 		in, out := &in.Seconds, &out.Seconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1250,7 +1250,7 @@ func (in *InstanceMachineConfig) DeepCopyInto(out *InstanceMachineConfig) {
 	*out = *in
 	if in.CpuCount != nil {
 		in, out := &in.CpuCount, &out.CpuCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1271,7 +1271,7 @@ func (in *InstanceReadPoolConfig) DeepCopyInto(out *InstanceReadPoolConfig) {
 	*out = *in
 	if in.NodeCount != nil {
 		in, out := &in.NodeCount, &out.NodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewayapi_types.go
+++ b/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewayapi_types.go
@@ -67,7 +67,7 @@ type APIGatewayAPIStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewayapiconfig_types.go
+++ b/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewayapiconfig_types.go
@@ -143,7 +143,7 @@ type APIGatewayAPIConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The ID of the associated Service Config (https://cloud.google.com/service-infrastructure/docs/glossary#config). */
 	// +optional

--- a/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewaygateway_types.go
+++ b/pkg/clients/generated/apis/apigateway/v1alpha1/apigatewaygateway_types.go
@@ -69,7 +69,7 @@ type APIGatewayGatewayStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigateway/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/apigateway/v1alpha1/zz_generated.deepcopy.go
@@ -187,7 +187,7 @@ func (in *APIGatewayAPIConfigStatus) DeepCopyInto(out *APIGatewayAPIConfigStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServiceConfigId != nil {
@@ -293,7 +293,7 @@ func (in *APIGatewayAPIStatus) DeepCopyInto(out *APIGatewayAPIStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -417,7 +417,7 @@ func (in *APIGatewayGatewayStatus) DeepCopyInto(out *APIGatewayGatewayStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeaddonsconfig_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeaddonsconfig_types.go
@@ -114,7 +114,7 @@ type ApigeeAddonsConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeendpointattachment_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeendpointattachment_types.go
@@ -70,7 +70,7 @@ type ApigeeEndpointAttachmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeenvgroup_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeenvgroup_types.go
@@ -55,7 +55,7 @@ type ApigeeEnvgroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeenvgroupattachment_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeenvgroupattachment_types.go
@@ -58,7 +58,7 @@ type ApigeeEnvgroupAttachmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeinstance_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeinstance_types.go
@@ -93,7 +93,7 @@ type ApigeeInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Port number of the exposed Apigee endpoint. */
 	// +optional

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeeinstanceattachment_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeeinstanceattachment_types.go
@@ -58,7 +58,7 @@ type ApigeeInstanceAttachmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeenataddress_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeenataddress_types.go
@@ -55,7 +55,7 @@ type ApigeeNATAddressStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State of the NAT IP address. */
 	// +optional

--- a/pkg/clients/generated/apis/apigee/v1alpha1/apigeesyncauthorization_types.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/apigeesyncauthorization_types.go
@@ -61,7 +61,7 @@ type ApigeeSyncAuthorizationStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/apigee/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/apigee/v1alpha1/zz_generated.deepcopy.go
@@ -282,7 +282,7 @@ func (in *ApigeeAddonsConfigStatus) DeepCopyInto(out *ApigeeAddonsConfigStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -405,7 +405,7 @@ func (in *ApigeeEndpointAttachmentStatus) DeepCopyInto(out *ApigeeEndpointAttach
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -546,7 +546,7 @@ func (in *ApigeeEnvgroupAttachmentStatus) DeepCopyInto(out *ApigeeEnvgroupAttach
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -631,7 +631,7 @@ func (in *ApigeeEnvgroupStatus) DeepCopyInto(out *ApigeeEnvgroupStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -772,7 +772,7 @@ func (in *ApigeeInstanceAttachmentStatus) DeepCopyInto(out *ApigeeInstanceAttach
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -887,7 +887,7 @@ func (in *ApigeeInstanceStatus) DeepCopyInto(out *ApigeeInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Port != nil {
@@ -1010,7 +1010,7 @@ func (in *ApigeeNATAddressStatus) DeepCopyInto(out *ApigeeNATAddressStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -1133,7 +1133,7 @@ func (in *ApigeeSyncAuthorizationStatus) DeepCopyInto(out *ApigeeSyncAuthorizati
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/apigee/v1beta1/apigeeenvironment_types.go
+++ b/pkg/clients/generated/apis/apigee/v1beta1/apigeeenvironment_types.go
@@ -62,15 +62,15 @@ type ApigeeEnvironmentStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* Output only. Creation time of this environment as milliseconds since epoch. */
 	// +optional
-	CreatedAt *int `json:"createdAt,omitempty"`
+	CreatedAt *int64 `json:"createdAt,omitempty"`
 
 	/* Output only. Last modification time of this environment as milliseconds since epoch. */
 	// +optional
-	LastModifiedAt *int `json:"lastModifiedAt,omitempty"`
+	LastModifiedAt *int64 `json:"lastModifiedAt,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. State of the environment. Values other than ACTIVE means the resource is not ready to use. Possible values: STATE_UNSPECIFIED, CREATING, ACTIVE, DELETING */
 	// +optional

--- a/pkg/clients/generated/apis/apigee/v1beta1/apigeeorganization_types.go
+++ b/pkg/clients/generated/apis/apigee/v1beta1/apigeeorganization_types.go
@@ -108,7 +108,7 @@ type ApigeeOrganizationStatus struct {
 
 	/* Output only. Time that the Apigee organization was created in milliseconds since epoch. */
 	// +optional
-	CreatedAt *int `json:"createdAt,omitempty"`
+	CreatedAt *int64 `json:"createdAt,omitempty"`
 
 	/* Output only. List of environments in the Apigee organization. */
 	// +optional
@@ -116,15 +116,15 @@ type ApigeeOrganizationStatus struct {
 
 	/* Output only. Time that the Apigee organization is scheduled for deletion. */
 	// +optional
-	ExpiresAt *int `json:"expiresAt,omitempty"`
+	ExpiresAt *int64 `json:"expiresAt,omitempty"`
 
 	/* Output only. Time that the Apigee organization was last modified in milliseconds since epoch. */
 	// +optional
-	LastModifiedAt *int `json:"lastModifiedAt,omitempty"`
+	LastModifiedAt *int64 `json:"lastModifiedAt,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Project ID associated with the Apigee organization. */
 	// +optional

--- a/pkg/clients/generated/apis/apigee/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/apigee/v1beta1/zz_generated.deepcopy.go
@@ -139,17 +139,17 @@ func (in *ApigeeEnvironmentStatus) DeepCopyInto(out *ApigeeEnvironmentStatus) {
 	}
 	if in.CreatedAt != nil {
 		in, out := &in.CreatedAt, &out.CreatedAt
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LastModifiedAt != nil {
 		in, out := &in.LastModifiedAt, &out.LastModifiedAt
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -305,7 +305,7 @@ func (in *ApigeeOrganizationStatus) DeepCopyInto(out *ApigeeOrganizationStatus) 
 	}
 	if in.CreatedAt != nil {
 		in, out := &in.CreatedAt, &out.CreatedAt
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Environments != nil {
@@ -315,17 +315,17 @@ func (in *ApigeeOrganizationStatus) DeepCopyInto(out *ApigeeOrganizationStatus) 
 	}
 	if in.ExpiresAt != nil {
 		in, out := &in.ExpiresAt, &out.ExpiresAt
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LastModifiedAt != nil {
 		in, out := &in.LastModifiedAt, &out.LastModifiedAt
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectId != nil {

--- a/pkg/clients/generated/apis/apikeys/v1alpha1/apikeyskey_types.go
+++ b/pkg/clients/generated/apis/apikeys/v1alpha1/apikeyskey_types.go
@@ -121,7 +121,7 @@ type APIKeysKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Unique id in UUID4 format. */
 	// +optional

--- a/pkg/clients/generated/apis/apikeys/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/apikeys/v1alpha1/zz_generated.deepcopy.go
@@ -137,7 +137,7 @@ func (in *APIKeysKeyStatus) DeepCopyInto(out *APIKeysKeyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Uid != nil {

--- a/pkg/clients/generated/apis/appengine/v1alpha1/appenginedomainmapping_types.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/appenginedomainmapping_types.go
@@ -101,7 +101,7 @@ type AppEngineDomainMappingStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The resource records required to configure this domain mapping. These records must be added to the domain's DNS
 	configuration in order to serve the application via this domain mapping. */

--- a/pkg/clients/generated/apis/appengine/v1alpha1/appenginefirewallrule_types.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/appenginefirewallrule_types.go
@@ -61,7 +61,7 @@ type AppEngineFirewallRuleStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/appengine/v1alpha1/appengineflexibleappversion_types.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/appengineflexibleappversion_types.go
@@ -74,11 +74,11 @@ type FlexibleappversionAutomaticScaling struct {
 
 	Defaults to a runtime-specific value. */
 	// +optional
-	MaxConcurrentRequests *int `json:"maxConcurrentRequests,omitempty"`
+	MaxConcurrentRequests *int64 `json:"maxConcurrentRequests,omitempty"`
 
 	/* Maximum number of idle instances that should be maintained for this version. */
 	// +optional
-	MaxIdleInstances *int `json:"maxIdleInstances,omitempty"`
+	MaxIdleInstances *int64 `json:"maxIdleInstances,omitempty"`
 
 	/* Maximum amount of time that a request should wait in the pending queue before starting a new instance to handle it. */
 	// +optional
@@ -86,11 +86,11 @@ type FlexibleappversionAutomaticScaling struct {
 
 	/* Maximum number of instances that should be started to handle requests for this version. Default: 20. */
 	// +optional
-	MaxTotalInstances *int `json:"maxTotalInstances,omitempty"`
+	MaxTotalInstances *int64 `json:"maxTotalInstances,omitempty"`
 
 	/* Minimum number of idle instances that should be maintained for this version. Only applicable for the default version of a service. */
 	// +optional
-	MinIdleInstances *int `json:"minIdleInstances,omitempty"`
+	MinIdleInstances *int64 `json:"minIdleInstances,omitempty"`
 
 	/* Minimum amount of time a request should wait in the pending queue before starting a new instance to handle it. */
 	// +optional
@@ -98,7 +98,7 @@ type FlexibleappversionAutomaticScaling struct {
 
 	/* Minimum number of running instances that should be maintained for this version. Default: 2. */
 	// +optional
-	MinTotalInstances *int `json:"minTotalInstances,omitempty"`
+	MinTotalInstances *int64 `json:"minTotalInstances,omitempty"`
 
 	/* Target scaling by network usage. */
 	// +optional
@@ -157,19 +157,19 @@ type FlexibleappversionDeployment struct {
 type FlexibleappversionDiskUtilization struct {
 	/* Target bytes read per second. */
 	// +optional
-	TargetReadBytesPerSecond *int `json:"targetReadBytesPerSecond,omitempty"`
+	TargetReadBytesPerSecond *int64 `json:"targetReadBytesPerSecond,omitempty"`
 
 	/* Target ops read per seconds. */
 	// +optional
-	TargetReadOpsPerSecond *int `json:"targetReadOpsPerSecond,omitempty"`
+	TargetReadOpsPerSecond *int64 `json:"targetReadOpsPerSecond,omitempty"`
 
 	/* Target bytes written per second. */
 	// +optional
-	TargetWriteBytesPerSecond *int `json:"targetWriteBytesPerSecond,omitempty"`
+	TargetWriteBytesPerSecond *int64 `json:"targetWriteBytesPerSecond,omitempty"`
 
 	/* Target ops written per second. */
 	// +optional
-	TargetWriteOpsPerSecond *int `json:"targetWriteOpsPerSecond,omitempty"`
+	TargetWriteOpsPerSecond *int64 `json:"targetWriteOpsPerSecond,omitempty"`
 }
 
 type FlexibleappversionEndpointsApiService struct {
@@ -280,7 +280,7 @@ type FlexibleappversionManualScaling struct {
 
 	**Note:** When managing the number of instances at runtime through the App Engine Admin API or the (now deprecated) Python 2
 	Modules API set_num_instances() you must use 'lifecycle.ignore_changes = ["manual_scaling"[0].instances]' to prevent drift detection. */
-	Instances int `json:"instances"`
+	Instances int64 `json:"instances"`
 }
 
 type FlexibleappversionNetwork struct {
@@ -312,19 +312,19 @@ type FlexibleappversionNetwork struct {
 type FlexibleappversionNetworkUtilization struct {
 	/* Target bytes received per second. */
 	// +optional
-	TargetReceivedBytesPerSecond *int `json:"targetReceivedBytesPerSecond,omitempty"`
+	TargetReceivedBytesPerSecond *int64 `json:"targetReceivedBytesPerSecond,omitempty"`
 
 	/* Target packets received per second. */
 	// +optional
-	TargetReceivedPacketsPerSecond *int `json:"targetReceivedPacketsPerSecond,omitempty"`
+	TargetReceivedPacketsPerSecond *int64 `json:"targetReceivedPacketsPerSecond,omitempty"`
 
 	/* Target bytes sent per second. */
 	// +optional
-	TargetSentBytesPerSecond *int `json:"targetSentBytesPerSecond,omitempty"`
+	TargetSentBytesPerSecond *int64 `json:"targetSentBytesPerSecond,omitempty"`
 
 	/* Target packets sent per second. */
 	// +optional
-	TargetSentPacketsPerSecond *int `json:"targetSentPacketsPerSecond,omitempty"`
+	TargetSentPacketsPerSecond *int64 `json:"targetSentPacketsPerSecond,omitempty"`
 }
 
 type FlexibleappversionReadinessCheck struct {
@@ -370,11 +370,11 @@ type FlexibleappversionRequestUtilization struct {
 type FlexibleappversionResources struct {
 	/* Number of CPU cores needed. */
 	// +optional
-	Cpu *int `json:"cpu,omitempty"`
+	Cpu *int64 `json:"cpu,omitempty"`
 
 	/* Disk size (GB) needed. */
 	// +optional
-	DiskGb *int `json:"diskGb,omitempty"`
+	DiskGb *int64 `json:"diskGb,omitempty"`
 
 	/* Memory (GB) needed. */
 	// +optional
@@ -432,7 +432,7 @@ type FlexibleappversionVolumes struct {
 	Name string `json:"name"`
 
 	/* Volume size in gigabytes. */
-	SizeGb int `json:"sizeGb"`
+	SizeGb int64 `json:"sizeGb"`
 
 	/* Underlying volume type, e.g. 'tmpfs'. */
 	VolumeType string `json:"volumeType"`
@@ -446,7 +446,7 @@ type FlexibleappversionVpcAccessConnector struct {
 type FlexibleappversionZip struct {
 	/* files count. */
 	// +optional
-	FilesCount *int `json:"filesCount,omitempty"`
+	FilesCount *int64 `json:"filesCount,omitempty"`
 
 	/* Source URL. */
 	SourceUrl string `json:"sourceUrl"`
@@ -582,7 +582,7 @@ type AppEngineFlexibleAppVersionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/appengine/v1alpha1/appengineservicesplittraffic_types.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/appengineservicesplittraffic_types.go
@@ -67,7 +67,7 @@ type AppEngineServiceSplitTrafficStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/appengine/v1alpha1/appenginestandardappversion_types.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/appenginestandardappversion_types.go
@@ -40,11 +40,11 @@ type StandardappversionAutomaticScaling struct {
 
 	Defaults to a runtime-specific value. */
 	// +optional
-	MaxConcurrentRequests *int `json:"maxConcurrentRequests,omitempty"`
+	MaxConcurrentRequests *int64 `json:"maxConcurrentRequests,omitempty"`
 
 	/* Maximum number of idle instances that should be maintained for this version. */
 	// +optional
-	MaxIdleInstances *int `json:"maxIdleInstances,omitempty"`
+	MaxIdleInstances *int64 `json:"maxIdleInstances,omitempty"`
 
 	/* Maximum amount of time that a request should wait in the pending queue before starting a new instance to handle it.
 	A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". */
@@ -53,7 +53,7 @@ type StandardappversionAutomaticScaling struct {
 
 	/* Minimum number of idle instances that should be maintained for this version. Only applicable for the default version of a service. */
 	// +optional
-	MinIdleInstances *int `json:"minIdleInstances,omitempty"`
+	MinIdleInstances *int64 `json:"minIdleInstances,omitempty"`
 
 	/* Minimum amount of time a request should wait in the pending queue before starting a new instance to handle it.
 	A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". */
@@ -72,7 +72,7 @@ type StandardappversionBasicScaling struct {
 	IdleTimeout *string `json:"idleTimeout,omitempty"`
 
 	/* Maximum number of instances to create for this version. Must be in the range [1.0, 200.0]. */
-	MaxInstances int `json:"maxInstances"`
+	MaxInstances int64 `json:"maxInstances"`
 }
 
 type StandardappversionDeployment struct {
@@ -149,7 +149,7 @@ type StandardappversionManualScaling struct {
 
 	**Note:** When managing the number of instances at runtime through the App Engine Admin API or the (now deprecated) Python 2
 	Modules API set_num_instances() you must use 'lifecycle.ignore_changes = ["manual_scaling"[0].instances]' to prevent drift detection. */
-	Instances int `json:"instances"`
+	Instances int64 `json:"instances"`
 }
 
 type StandardappversionScript struct {
@@ -160,11 +160,11 @@ type StandardappversionScript struct {
 type StandardappversionStandardSchedulerSettings struct {
 	/* Maximum number of instances to run for this version. Set to zero to disable maxInstances configuration. */
 	// +optional
-	MaxInstances *int `json:"maxInstances,omitempty"`
+	MaxInstances *int64 `json:"maxInstances,omitempty"`
 
 	/* Minimum number of instances to run for this version. Set to zero to disable minInstances configuration. */
 	// +optional
-	MinInstances *int `json:"minInstances,omitempty"`
+	MinInstances *int64 `json:"minInstances,omitempty"`
 
 	/* Target CPU utilization ratio to maintain when scaling. Should be a value in the range [0.50, 0.95], zero, or a negative value. */
 	// +optional
@@ -222,7 +222,7 @@ type StandardappversionVpcAccessConnector struct {
 type StandardappversionZip struct {
 	/* files count. */
 	// +optional
-	FilesCount *int `json:"filesCount,omitempty"`
+	FilesCount *int64 `json:"filesCount,omitempty"`
 
 	/* Source URL. */
 	SourceUrl string `json:"sourceUrl"`
@@ -325,7 +325,7 @@ type AppEngineStandardAppVersionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/appengine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/appengine/v1alpha1/zz_generated.deepcopy.go
@@ -141,7 +141,7 @@ func (in *AppEngineDomainMappingStatus) DeepCopyInto(out *AppEngineDomainMapping
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceRecords != nil {
@@ -266,7 +266,7 @@ func (in *AppEngineFirewallRuleStatus) DeepCopyInto(out *AppEngineFirewallRuleSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -508,7 +508,7 @@ func (in *AppEngineFlexibleAppVersionStatus) DeepCopyInto(out *AppEngineFlexible
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -627,7 +627,7 @@ func (in *AppEngineServiceSplitTrafficStatus) DeepCopyInto(out *AppEngineService
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -829,7 +829,7 @@ func (in *AppEngineStandardAppVersionStatus) DeepCopyInto(out *AppEngineStandard
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -954,12 +954,12 @@ func (in *FlexibleappversionAutomaticScaling) DeepCopyInto(out *Flexibleappversi
 	}
 	if in.MaxConcurrentRequests != nil {
 		in, out := &in.MaxConcurrentRequests, &out.MaxConcurrentRequests
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxIdleInstances != nil {
 		in, out := &in.MaxIdleInstances, &out.MaxIdleInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxPendingLatency != nil {
@@ -969,12 +969,12 @@ func (in *FlexibleappversionAutomaticScaling) DeepCopyInto(out *Flexibleappversi
 	}
 	if in.MaxTotalInstances != nil {
 		in, out := &in.MaxTotalInstances, &out.MaxTotalInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinIdleInstances != nil {
 		in, out := &in.MinIdleInstances, &out.MinIdleInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinPendingLatency != nil {
@@ -984,7 +984,7 @@ func (in *FlexibleappversionAutomaticScaling) DeepCopyInto(out *Flexibleappversi
 	}
 	if in.MinTotalInstances != nil {
 		in, out := &in.MinTotalInstances, &out.MinTotalInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NetworkUtilization != nil {
@@ -1111,22 +1111,22 @@ func (in *FlexibleappversionDiskUtilization) DeepCopyInto(out *Flexibleappversio
 	*out = *in
 	if in.TargetReadBytesPerSecond != nil {
 		in, out := &in.TargetReadBytesPerSecond, &out.TargetReadBytesPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetReadOpsPerSecond != nil {
 		in, out := &in.TargetReadOpsPerSecond, &out.TargetReadOpsPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetWriteBytesPerSecond != nil {
 		in, out := &in.TargetWriteBytesPerSecond, &out.TargetWriteBytesPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetWriteOpsPerSecond != nil {
 		in, out := &in.TargetWriteOpsPerSecond, &out.TargetWriteOpsPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1364,22 +1364,22 @@ func (in *FlexibleappversionNetworkUtilization) DeepCopyInto(out *Flexibleappver
 	*out = *in
 	if in.TargetReceivedBytesPerSecond != nil {
 		in, out := &in.TargetReceivedBytesPerSecond, &out.TargetReceivedBytesPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetReceivedPacketsPerSecond != nil {
 		in, out := &in.TargetReceivedPacketsPerSecond, &out.TargetReceivedPacketsPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetSentBytesPerSecond != nil {
 		in, out := &in.TargetSentBytesPerSecond, &out.TargetSentBytesPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetSentPacketsPerSecond != nil {
 		in, out := &in.TargetSentPacketsPerSecond, &out.TargetSentPacketsPerSecond
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1472,12 +1472,12 @@ func (in *FlexibleappversionResources) DeepCopyInto(out *FlexibleappversionResou
 	*out = *in
 	if in.Cpu != nil {
 		in, out := &in.Cpu, &out.Cpu
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskGb != nil {
 		in, out := &in.DiskGb, &out.DiskGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MemoryGb != nil {
@@ -1609,7 +1609,7 @@ func (in *FlexibleappversionZip) DeepCopyInto(out *FlexibleappversionZip) {
 	*out = *in
 	if in.FilesCount != nil {
 		in, out := &in.FilesCount, &out.FilesCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1658,12 +1658,12 @@ func (in *StandardappversionAutomaticScaling) DeepCopyInto(out *Standardappversi
 	*out = *in
 	if in.MaxConcurrentRequests != nil {
 		in, out := &in.MaxConcurrentRequests, &out.MaxConcurrentRequests
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxIdleInstances != nil {
 		in, out := &in.MaxIdleInstances, &out.MaxIdleInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxPendingLatency != nil {
@@ -1673,7 +1673,7 @@ func (in *StandardappversionAutomaticScaling) DeepCopyInto(out *Standardappversi
 	}
 	if in.MinIdleInstances != nil {
 		in, out := &in.MinIdleInstances, &out.MinIdleInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinPendingLatency != nil {
@@ -1899,12 +1899,12 @@ func (in *StandardappversionStandardSchedulerSettings) DeepCopyInto(out *Standar
 	*out = *in
 	if in.MaxInstances != nil {
 		in, out := &in.MaxInstances, &out.MaxInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinInstances != nil {
 		in, out := &in.MinInstances, &out.MinInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TargetCpuUtilization != nil {
@@ -2009,7 +2009,7 @@ func (in *StandardappversionZip) DeepCopyInto(out *StandardappversionZip) {
 	*out = *in
 	if in.FilesCount != nil {
 		in, out := &in.FilesCount, &out.FilesCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/artifactregistry/v1beta1/artifactregistryrepository_types.go
+++ b/pkg/clients/generated/apis/artifactregistry/v1beta1/artifactregistryrepository_types.go
@@ -110,7 +110,7 @@ type RepositoryMavenRepository struct {
 type RepositoryMostRecentVersions struct {
 	/* Minimum number of versions to keep. */
 	// +optional
-	KeepCount *int `json:"keepCount,omitempty"`
+	KeepCount *int64 `json:"keepCount,omitempty"`
 
 	/* Match versions by package prefix. Applied on any prefix match. */
 	// +optional
@@ -158,7 +158,7 @@ type RepositoryUpstreamPolicies struct {
 
 	/* Entries with a greater priority value take precedence in the pull order. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* A reference to the repository resource, for example:
 	"projects/p1/locations/us-central1/repositories/repo1". */
@@ -246,7 +246,7 @@ type ArtifactRegistryRepositoryStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the repository was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/artifactregistry/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/artifactregistry/v1beta1/zz_generated.deepcopy.go
@@ -178,7 +178,7 @@ func (in *ArtifactRegistryRepositoryStatus) DeepCopyInto(out *ArtifactRegistryRe
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -370,7 +370,7 @@ func (in *RepositoryMostRecentVersions) DeepCopyInto(out *RepositoryMostRecentVe
 	*out = *in
 	if in.KeepCount != nil {
 		in, out := &in.KeepCount, &out.KeepCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PackageNamePrefixes != nil {
@@ -484,7 +484,7 @@ func (in *RepositoryUpstreamPolicies) DeepCopyInto(out *RepositoryUpstreamPolici
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RepositoryRef != nil {

--- a/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappconnection_types.go
+++ b/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappconnection_types.go
@@ -40,7 +40,7 @@ type AppconnectionApplicationEndpoint struct {
 	Host string `json:"host"`
 
 	/* Port of the remote application endpoint. */
-	Port int `json:"port"`
+	Port int64 `json:"port"`
 }
 
 type AppconnectionGateway struct {
@@ -49,7 +49,7 @@ type AppconnectionGateway struct {
 
 	/* Ingress port reserved on the gateways for this AppConnection, if not specified or zero, the default port is 19443. */
 	// +optional
-	IngressPort *int `json:"ingressPort,omitempty"`
+	IngressPort *int64 `json:"ingressPort,omitempty"`
 
 	/* The type of hosting used by the gateway. Refer to
 	https://cloud.google.com/beyondcorp/docs/reference/rest/v1/projects.locations.appConnections#Type_1
@@ -101,7 +101,7 @@ type BeyondCorpAppConnectionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappconnector_types.go
+++ b/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappconnector_types.go
@@ -70,7 +70,7 @@ type BeyondCorpAppConnectorStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Represents the different states of a AppConnector. */
 	// +optional

--- a/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappgateway_types.go
+++ b/pkg/clients/generated/apis/beyondcorp/v1alpha1/beyondcorpappgateway_types.go
@@ -62,7 +62,7 @@ type BeyondCorpAppGatewaySpec struct {
 type AppgatewayAllocatedConnectionsStatus struct {
 	/* The ingress port of an allocated connection. */
 	// +optional
-	IngressPort *int `json:"ingressPort,omitempty"`
+	IngressPort *int64 `json:"ingressPort,omitempty"`
 
 	/* The PSC uri of an allocated connection. */
 	// +optional
@@ -79,7 +79,7 @@ type BeyondCorpAppGatewayStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Represents the different states of a AppGateway. */
 	// +optional

--- a/pkg/clients/generated/apis/beyondcorp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/beyondcorp/v1alpha1/zz_generated.deepcopy.go
@@ -50,7 +50,7 @@ func (in *AppconnectionGateway) DeepCopyInto(out *AppconnectionGateway) {
 	*out = *in
 	if in.IngressPort != nil {
 		in, out := &in.IngressPort, &out.IngressPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Type != nil {
@@ -114,7 +114,7 @@ func (in *AppgatewayAllocatedConnectionsStatus) DeepCopyInto(out *AppgatewayAllo
 	*out = *in
 	if in.IngressPort != nil {
 		in, out := &in.IngressPort, &out.IngressPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PscUri != nil {
@@ -249,7 +249,7 @@ func (in *BeyondCorpAppConnectionStatus) DeepCopyInto(out *BeyondCorpAppConnecti
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -364,7 +364,7 @@ func (in *BeyondCorpAppConnectorStatus) DeepCopyInto(out *BeyondCorpAppConnector
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -500,7 +500,7 @@ func (in *BeyondCorpAppGatewayStatus) DeepCopyInto(out *BeyondCorpAppGatewayStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/bigquery/v1alpha1/bigquerydatasetaccess_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1alpha1/bigquerydatasetaccess_types.go
@@ -136,7 +136,7 @@ type BigQueryDatasetAccessStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigquery/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigquery/v1alpha1/zz_generated.deepcopy.go
@@ -167,7 +167,7 @@ func (in *BigQueryDatasetAccessStatus) DeepCopyInto(out *BigQueryDatasetAccessSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigquery/v1beta1/bigquerydataset_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/bigquerydataset_types.go
@@ -181,7 +181,7 @@ type BigQueryDatasetSpec struct {
 	creating or updating a partitioned table, that value takes precedence
 	over the default partition expiration time indicated by this property. */
 	// +optional
-	DefaultPartitionExpirationMs *int `json:"defaultPartitionExpirationMs,omitempty"`
+	DefaultPartitionExpirationMs *int64 `json:"defaultPartitionExpirationMs,omitempty"`
 
 	/* The default lifetime of all tables in the dataset, in milliseconds.
 	The minimum value is 3600000 milliseconds (one hour).
@@ -197,7 +197,7 @@ type BigQueryDatasetSpec struct {
 	creating a table, that value takes precedence over the default
 	expiration time indicated by this property. */
 	// +optional
-	DefaultTableExpirationMs *int `json:"defaultTableExpirationMs,omitempty"`
+	DefaultTableExpirationMs *int64 `json:"defaultTableExpirationMs,omitempty"`
 
 	/* A user-friendly description of the dataset. */
 	// +optional
@@ -256,7 +256,7 @@ type BigQueryDatasetStatus struct {
 	/* The time when this dataset was created, in milliseconds since the
 	epoch. */
 	// +optional
-	CreationTime *int `json:"creationTime,omitempty"`
+	CreationTime *int64 `json:"creationTime,omitempty"`
 
 	/* A hash of the resource. */
 	// +optional
@@ -265,11 +265,11 @@ type BigQueryDatasetStatus struct {
 	/* The date when this dataset or any of its tables was last modified, in
 	milliseconds since the epoch. */
 	// +optional
-	LastModifiedTime *int `json:"lastModifiedTime,omitempty"`
+	LastModifiedTime *int64 `json:"lastModifiedTime,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/bigquery/v1beta1/bigqueryjob_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/bigqueryjob_types.go
@@ -180,7 +180,7 @@ type JobLoad struct {
 	/* Immutable. The maximum number of bad records that BigQuery can ignore when running the job. If the number of bad records exceeds this value,
 	an invalid error is returned in the job result. The default value is 0, which requires that all records are valid. */
 	// +optional
-	MaxBadRecords *int `json:"maxBadRecords,omitempty"`
+	MaxBadRecords *int64 `json:"maxBadRecords,omitempty"`
 
 	/* Immutable. Specifies a string that represents a null value in a CSV file. For example, if you specify "\N", BigQuery interprets "\N" as a null value
 	when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an
@@ -224,7 +224,7 @@ type JobLoad struct {
 	skipLeadingRows = N > 0 - Autodetect skips N-1 rows and tries to detect headers in row N. If headers are not detected,
 	row N is just skipped. Otherwise row N is used to extract column names for the detected schema. */
 	// +optional
-	SkipLeadingRows *int `json:"skipLeadingRows,omitempty"`
+	SkipLeadingRows *int64 `json:"skipLeadingRows,omitempty"`
 
 	/* Immutable. The format of the data files. For CSV files, specify "CSV". For datastore backups, specify "DATASTORE_BACKUP".
 	For newline-delimited JSON, specify "NEWLINE_DELIMITED_JSON". For Avro, specify "AVRO". For parquet, specify "PARQUET".
@@ -301,7 +301,7 @@ type JobQuery struct {
 	/* Immutable. Limits the billing tier for this job. Queries that have resource usage beyond this tier will fail (without incurring a charge).
 	If unspecified, this will be set to your project default. */
 	// +optional
-	MaximumBillingTier *int `json:"maximumBillingTier,omitempty"`
+	MaximumBillingTier *int64 `json:"maximumBillingTier,omitempty"`
 
 	/* Immutable. Limits the bytes billed for this job. Queries that will have bytes billed beyond this limit will fail (without incurring a charge).
 	If unspecified, this will be set to your project default. */
@@ -496,7 +496,7 @@ type BigQueryJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The status of this job. Examine this value when polling an asynchronous job to see if the job is complete. */
 	// +optional

--- a/pkg/clients/generated/apis/bigquery/v1beta1/bigqueryroutine_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/bigqueryroutine_types.go
@@ -127,16 +127,16 @@ type BigQueryRoutineStatus struct {
 	/* The time when this routine was created, in milliseconds since the
 	epoch. */
 	// +optional
-	CreationTime *int `json:"creationTime,omitempty"`
+	CreationTime *int64 `json:"creationTime,omitempty"`
 
 	/* The time when this routine was modified, in milliseconds since the
 	epoch. */
 	// +optional
-	LastModifiedTime *int `json:"lastModifiedTime,omitempty"`
+	LastModifiedTime *int64 `json:"lastModifiedTime,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigquery/v1beta1/bigquerytable_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/bigquerytable_types.go
@@ -69,7 +69,7 @@ type TableCsvOptions struct {
 
 	/* The number of rows at the top of a CSV file that BigQuery will skip when reading the data. */
 	// +optional
-	SkipLeadingRows *int `json:"skipLeadingRows,omitempty"`
+	SkipLeadingRows *int64 `json:"skipLeadingRows,omitempty"`
 }
 
 type TableEncryptionConfiguration struct {
@@ -122,7 +122,7 @@ type TableExternalDataConfiguration struct {
 
 	/* The maximum number of bad records that BigQuery can ignore when reading data. */
 	// +optional
-	MaxBadRecords *int `json:"maxBadRecords,omitempty"`
+	MaxBadRecords *int64 `json:"maxBadRecords,omitempty"`
 
 	/* Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source. */
 	// +optional
@@ -171,7 +171,7 @@ type TableGoogleSheetsOptions struct {
 
 	/* The number of rows at the top of the sheet that BigQuery will skip when reading the data. At least one of range or skip_leading_rows must be set. */
 	// +optional
-	SkipLeadingRows *int `json:"skipLeadingRows,omitempty"`
+	SkipLeadingRows *int64 `json:"skipLeadingRows,omitempty"`
 }
 
 type TableHivePartitioningOptions struct {
@@ -208,7 +208,7 @@ type TableMaterializedView struct {
 
 	/* Specifies maximum frequency at which this materialized view will be refreshed. The default is 1800000. */
 	// +optional
-	RefreshIntervalMs *int `json:"refreshIntervalMs,omitempty"`
+	RefreshIntervalMs *int64 `json:"refreshIntervalMs,omitempty"`
 }
 
 type TableParquetOptions struct {
@@ -228,13 +228,13 @@ type TablePrimaryKey struct {
 
 type TableRange struct {
 	/* End of the range partitioning, exclusive. */
-	End int `json:"end"`
+	End int64 `json:"end"`
 
 	/* The width of each range within the partition. */
-	Interval int `json:"interval"`
+	Interval int64 `json:"interval"`
 
 	/* Start of the range partitioning, inclusive. */
-	Start int `json:"start"`
+	Start int64 `json:"start"`
 }
 
 type TableRangePartitioning struct {
@@ -269,7 +269,7 @@ type TableTableConstraints struct {
 type TableTimePartitioning struct {
 	/* Number of milliseconds for which to keep the storage for a partition. */
 	// +optional
-	ExpirationMs *int `json:"expirationMs,omitempty"`
+	ExpirationMs *int64 `json:"expirationMs,omitempty"`
 
 	/* Immutable. The field used to determine how to create a time-based partition. If time-based partitioning is enabled without this value, the table is partitioned based on the load time. */
 	// +optional
@@ -309,7 +309,7 @@ type BigQueryTableSpec struct {
 
 	/* The time when this table expires, in milliseconds since the epoch. If not present, the table will persist indefinitely. Expired tables will be deleted and their storage reclaimed. */
 	// +optional
-	ExpirationTime *int `json:"expirationTime,omitempty"`
+	ExpirationTime *int64 `json:"expirationTime,omitempty"`
 
 	/* Describes the data format, location, and other properties of a table stored outside of BigQuery. By defining these properties, the data source can then be queried as if it were a standard BigQuery table. */
 	// +optional
@@ -358,7 +358,7 @@ type BigQueryTableStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* The time when this table was created, in milliseconds since the epoch. */
 	// +optional
-	CreationTime *int `json:"creationTime,omitempty"`
+	CreationTime *int64 `json:"creationTime,omitempty"`
 
 	/* A hash of the resource. */
 	// +optional
@@ -366,7 +366,7 @@ type BigQueryTableStatus struct {
 
 	/* The time when this table was last modified, in milliseconds since the epoch. */
 	// +optional
-	LastModifiedTime *int `json:"lastModifiedTime,omitempty"`
+	LastModifiedTime *int64 `json:"lastModifiedTime,omitempty"`
 
 	/* The geographic location where the table resides. This value is inherited from the dataset. */
 	// +optional
@@ -374,19 +374,19 @@ type BigQueryTableStatus struct {
 
 	/* The geographic location where the table resides. This value is inherited from the dataset. */
 	// +optional
-	NumBytes *int `json:"numBytes,omitempty"`
+	NumBytes *int64 `json:"numBytes,omitempty"`
 
 	/* The number of bytes in the table that are considered "long-term storage". */
 	// +optional
-	NumLongTermBytes *int `json:"numLongTermBytes,omitempty"`
+	NumLongTermBytes *int64 `json:"numLongTermBytes,omitempty"`
 
 	/* The number of rows of data in this table, excluding any data in the streaming buffer. */
 	// +optional
-	NumRows *int `json:"numRows,omitempty"`
+	NumRows *int64 `json:"numRows,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/bigquery/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/zz_generated.deepcopy.go
@@ -112,12 +112,12 @@ func (in *BigQueryDatasetSpec) DeepCopyInto(out *BigQueryDatasetSpec) {
 	}
 	if in.DefaultPartitionExpirationMs != nil {
 		in, out := &in.DefaultPartitionExpirationMs, &out.DefaultPartitionExpirationMs
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DefaultTableExpirationMs != nil {
 		in, out := &in.DefaultTableExpirationMs, &out.DefaultTableExpirationMs
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -183,7 +183,7 @@ func (in *BigQueryDatasetStatus) DeepCopyInto(out *BigQueryDatasetStatus) {
 	}
 	if in.CreationTime != nil {
 		in, out := &in.CreationTime, &out.CreationTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Etag != nil {
@@ -193,12 +193,12 @@ func (in *BigQueryDatasetStatus) DeepCopyInto(out *BigQueryDatasetStatus) {
 	}
 	if in.LastModifiedTime != nil {
 		in, out := &in.LastModifiedTime, &out.LastModifiedTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -346,7 +346,7 @@ func (in *BigQueryJobStatus) DeepCopyInto(out *BigQueryJobStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Status != nil {
@@ -510,17 +510,17 @@ func (in *BigQueryRoutineStatus) DeepCopyInto(out *BigQueryRoutineStatus) {
 	}
 	if in.CreationTime != nil {
 		in, out := &in.CreationTime, &out.CreationTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LastModifiedTime != nil {
 		in, out := &in.LastModifiedTime, &out.LastModifiedTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -618,7 +618,7 @@ func (in *BigQueryTableSpec) DeepCopyInto(out *BigQueryTableSpec) {
 	}
 	if in.ExpirationTime != nil {
 		in, out := &in.ExpirationTime, &out.ExpirationTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ExternalDataConfiguration != nil {
@@ -694,7 +694,7 @@ func (in *BigQueryTableStatus) DeepCopyInto(out *BigQueryTableStatus) {
 	}
 	if in.CreationTime != nil {
 		in, out := &in.CreationTime, &out.CreationTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Etag != nil {
@@ -704,7 +704,7 @@ func (in *BigQueryTableStatus) DeepCopyInto(out *BigQueryTableStatus) {
 	}
 	if in.LastModifiedTime != nil {
 		in, out := &in.LastModifiedTime, &out.LastModifiedTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Location != nil {
@@ -714,22 +714,22 @@ func (in *BigQueryTableStatus) DeepCopyInto(out *BigQueryTableStatus) {
 	}
 	if in.NumBytes != nil {
 		in, out := &in.NumBytes, &out.NumBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NumLongTermBytes != nil {
 		in, out := &in.NumLongTermBytes, &out.NumLongTermBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NumRows != nil {
 		in, out := &in.NumRows, &out.NumRows
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1142,7 +1142,7 @@ func (in *JobLoad) DeepCopyInto(out *JobLoad) {
 	}
 	if in.MaxBadRecords != nil {
 		in, out := &in.MaxBadRecords, &out.MaxBadRecords
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NullMarker != nil {
@@ -1172,7 +1172,7 @@ func (in *JobLoad) DeepCopyInto(out *JobLoad) {
 	}
 	if in.SkipLeadingRows != nil {
 		in, out := &in.SkipLeadingRows, &out.SkipLeadingRows
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SourceFormat != nil {
@@ -1269,7 +1269,7 @@ func (in *JobQuery) DeepCopyInto(out *JobQuery) {
 	}
 	if in.MaximumBillingTier != nil {
 		in, out := &in.MaximumBillingTier, &out.MaximumBillingTier
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaximumBytesBilled != nil {
@@ -1577,7 +1577,7 @@ func (in *TableCsvOptions) DeepCopyInto(out *TableCsvOptions) {
 	}
 	if in.SkipLeadingRows != nil {
 		in, out := &in.SkipLeadingRows, &out.SkipLeadingRows
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1665,7 +1665,7 @@ func (in *TableExternalDataConfiguration) DeepCopyInto(out *TableExternalDataCon
 	}
 	if in.MaxBadRecords != nil {
 		in, out := &in.MaxBadRecords, &out.MaxBadRecords
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MetadataCacheMode != nil {
@@ -1749,7 +1749,7 @@ func (in *TableGoogleSheetsOptions) DeepCopyInto(out *TableGoogleSheetsOptions) 
 	}
 	if in.SkipLeadingRows != nil {
 		in, out := &in.SkipLeadingRows, &out.SkipLeadingRows
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1832,7 +1832,7 @@ func (in *TableMaterializedView) DeepCopyInto(out *TableMaterializedView) {
 	}
 	if in.RefreshIntervalMs != nil {
 		in, out := &in.RefreshIntervalMs, &out.RefreshIntervalMs
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1977,7 +1977,7 @@ func (in *TableTimePartitioning) DeepCopyInto(out *TableTimePartitioning) {
 	*out = *in
 	if in.ExpirationMs != nil {
 		in, out := &in.ExpirationMs, &out.ExpirationMs
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Field != nil {

--- a/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange_types.go
+++ b/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange_types.go
@@ -72,7 +72,7 @@ type BigQueryAnalyticsHubDataExchangeStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* Number of listings contained in the data exchange. */
 	// +optional
-	ListingCount *int `json:"listingCount,omitempty"`
+	ListingCount *int64 `json:"listingCount,omitempty"`
 
 	/* The resource name of the data exchange, for example:
 	"projects/myproject/locations/US/dataExchanges/123". */
@@ -81,7 +81,7 @@ type BigQueryAnalyticsHubDataExchangeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshublisting_types.go
+++ b/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshublisting_types.go
@@ -121,7 +121,7 @@ type BigQueryAnalyticsHubListingStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigqueryanalyticshub/v1alpha1/zz_generated.deepcopy.go
@@ -142,7 +142,7 @@ func (in *BigQueryAnalyticsHubDataExchangeStatus) DeepCopyInto(out *BigQueryAnal
 	}
 	if in.ListingCount != nil {
 		in, out := &in.ListingCount, &out.ListingCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Name != nil {
@@ -152,7 +152,7 @@ func (in *BigQueryAnalyticsHubDataExchangeStatus) DeepCopyInto(out *BigQueryAnal
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -307,7 +307,7 @@ func (in *BigQueryAnalyticsHubListingStatus) DeepCopyInto(out *BigQueryAnalytics
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigqueryconnection/v1alpha1/bigqueryconnectionconnection_types.go
+++ b/pkg/clients/generated/apis/bigqueryconnection/v1alpha1/bigqueryconnectionconnection_types.go
@@ -200,7 +200,7 @@ type BigQueryConnectionConnectionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigqueryconnection/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigqueryconnection/v1alpha1/zz_generated.deepcopy.go
@@ -167,7 +167,7 @@ func (in *BigQueryConnectionConnectionStatus) DeepCopyInto(out *BigQueryConnecti
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigquerydatapolicy/v1alpha1/bigquerydatapolicydatapolicy_types.go
+++ b/pkg/clients/generated/apis/bigquerydatapolicy/v1alpha1/bigquerydatapolicydatapolicy_types.go
@@ -72,7 +72,7 @@ type BigQueryDataPolicyDataPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigquerydatapolicy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigquerydatapolicy/v1alpha1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *BigQueryDataPolicyDataPolicyStatus) DeepCopyInto(out *BigQueryDataPoli
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigquerydatatransfer/v1alpha1/bigquerydatatransferconfig_types.go
+++ b/pkg/clients/generated/apis/bigquerydatatransfer/v1alpha1/bigquerydatatransferconfig_types.go
@@ -93,7 +93,7 @@ type BigQueryDataTransferConfigSpec struct {
 	just [today-1]. Only valid if the data source supports the feature.
 	Set the value to 0 to use the default value. */
 	// +optional
-	DataRefreshWindowDays *int `json:"dataRefreshWindowDays,omitempty"`
+	DataRefreshWindowDays *int64 `json:"dataRefreshWindowDays,omitempty"`
 
 	/* Immutable. The data source id. Cannot be changed once the transfer config is created. */
 	DataSourceId string `json:"dataSourceId"`
@@ -179,7 +179,7 @@ type BigQueryDataTransferConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigquerydatatransfer/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigquerydatatransfer/v1alpha1/zz_generated.deepcopy.go
@@ -95,7 +95,7 @@ func (in *BigQueryDataTransferConfigSpec) DeepCopyInto(out *BigQueryDataTransfer
 	*out = *in
 	if in.DataRefreshWindowDays != nil {
 		in, out := &in.DataRefreshWindowDays, &out.DataRefreshWindowDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DestinationDatasetId != nil {
@@ -184,7 +184,7 @@ func (in *BigQueryDataTransferConfigStatus) DeepCopyInto(out *BigQueryDataTransf
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/bigqueryreservationcapacitycommitment_types.go
+++ b/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/bigqueryreservationcapacitycommitment_types.go
@@ -63,7 +63,7 @@ type BigQueryReservationCapacityCommitmentSpec struct {
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	/* Immutable. Number of slots in this commitment. */
-	SlotCount int `json:"slotCount"`
+	SlotCount int64 `json:"slotCount"`
 }
 
 type BigQueryReservationCapacityCommitmentStatus struct {
@@ -84,7 +84,7 @@ type BigQueryReservationCapacityCommitmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State of the commitment. */
 	// +optional

--- a/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/bigqueryreservationreservation_types.go
+++ b/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/bigqueryreservationreservation_types.go
@@ -38,11 +38,11 @@ import (
 type ReservationAutoscale struct {
 	/* The slot capacity added to this reservation when autoscale happens. Will be between [0, max_slots]. */
 	// +optional
-	CurrentSlots *int `json:"currentSlots,omitempty"`
+	CurrentSlots *int64 `json:"currentSlots,omitempty"`
 
 	/* Number of slots to be scaled when needed. */
 	// +optional
-	MaxSlots *int `json:"maxSlots,omitempty"`
+	MaxSlots *int64 `json:"maxSlots,omitempty"`
 }
 
 type BigQueryReservationReservationSpec struct {
@@ -52,7 +52,7 @@ type BigQueryReservationReservationSpec struct {
 
 	/* Maximum number of queries that are allowed to run concurrently in this reservation. This is a soft limit due to asynchronous nature of the system and various optimizations for small queries. Default value is 0 which means that concurrency will be automatically set based on the reservation size. */
 	// +optional
-	Concurrency *int `json:"concurrency,omitempty"`
+	Concurrency *int64 `json:"concurrency,omitempty"`
 
 	/* Immutable. The edition type. Valid values are STANDARD, ENTERPRISE, ENTERPRISE_PLUS. */
 	// +optional
@@ -82,7 +82,7 @@ type BigQueryReservationReservationSpec struct {
 
 	/* Minimum slots available to this reservation. A slot is a unit of computational power in BigQuery, and serves as the
 	unit of parallelism. Queries using this reservation might use more slots during runtime if ignoreIdleSlots is set to false. */
-	SlotCapacity int `json:"slotCapacity"`
+	SlotCapacity int64 `json:"slotCapacity"`
 }
 
 type BigQueryReservationReservationStatus struct {
@@ -91,7 +91,7 @@ type BigQueryReservationReservationStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigqueryreservation/v1alpha1/zz_generated.deepcopy.go
@@ -152,7 +152,7 @@ func (in *BigQueryReservationCapacityCommitmentStatus) DeepCopyInto(out *BigQuer
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -244,7 +244,7 @@ func (in *BigQueryReservationReservationSpec) DeepCopyInto(out *BigQueryReservat
 	}
 	if in.Concurrency != nil {
 		in, out := &in.Concurrency, &out.Concurrency
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Edition != nil {
@@ -291,7 +291,7 @@ func (in *BigQueryReservationReservationStatus) DeepCopyInto(out *BigQueryReserv
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -312,12 +312,12 @@ func (in *ReservationAutoscale) DeepCopyInto(out *ReservationAutoscale) {
 	*out = *in
 	if in.CurrentSlots != nil {
 		in, out := &in.CurrentSlots, &out.CurrentSlots
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxSlots != nil {
 		in, out := &in.MaxSlots, &out.MaxSlots
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/bigtable/v1beta1/bigtableappprofile_types.go
+++ b/pkg/clients/generated/apis/bigtable/v1beta1/bigtableappprofile_types.go
@@ -92,7 +92,7 @@ type BigtableAppProfileStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigtable/v1beta1/bigtablegcpolicy_types.go
+++ b/pkg/clients/generated/apis/bigtable/v1beta1/bigtablegcpolicy_types.go
@@ -38,7 +38,7 @@ import (
 type GcpolicyMaxAge struct {
 	/* DEPRECATED. Deprecated in favor of duration. Immutable. Number of days before applying GC policy. */
 	// +optional
-	Days *int `json:"days,omitempty"`
+	Days *int64 `json:"days,omitempty"`
 
 	/* Immutable. Duration before applying GC policy. */
 	// +optional
@@ -47,7 +47,7 @@ type GcpolicyMaxAge struct {
 
 type GcpolicyMaxVersion struct {
 	/* Immutable. Number of version before applying the GC policy. */
-	Number int `json:"number"`
+	Number int64 `json:"number"`
 }
 
 type BigtableGCPolicySpec struct {
@@ -89,7 +89,7 @@ type BigtableGCPolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigtable/v1beta1/bigtableinstance_types.go
+++ b/pkg/clients/generated/apis/bigtable/v1beta1/bigtableinstance_types.go
@@ -37,17 +37,17 @@ import (
 
 type InstanceAutoscalingConfig struct {
 	/* The target CPU utilization for autoscaling. Value must be between 10 and 80. */
-	CpuTarget int `json:"cpuTarget"`
+	CpuTarget int64 `json:"cpuTarget"`
 
 	/* The maximum number of nodes for autoscaling. */
-	MaxNodes int `json:"maxNodes"`
+	MaxNodes int64 `json:"maxNodes"`
 
 	/* The minimum number of nodes for autoscaling. */
-	MinNodes int `json:"minNodes"`
+	MinNodes int64 `json:"minNodes"`
 
 	/* The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters. */
 	// +optional
-	StorageTarget *int `json:"storageTarget,omitempty"`
+	StorageTarget *int64 `json:"storageTarget,omitempty"`
 }
 
 type InstanceCluster struct {
@@ -68,7 +68,7 @@ type InstanceCluster struct {
 
 	/* The number of nodes in the cluster. If no value is set, Cloud Bigtable automatically allocates nodes based on your data footprint and optimized for 50% storage utilization. */
 	// +optional
-	NumNodes *int `json:"numNodes,omitempty"`
+	NumNodes *int64 `json:"numNodes,omitempty"`
 
 	/* The storage type to use. One of "SSD" or "HDD". Defaults to "SSD". */
 	// +optional
@@ -106,7 +106,7 @@ type BigtableInstanceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigtable/v1beta1/bigtabletable_types.go
+++ b/pkg/clients/generated/apis/bigtable/v1beta1/bigtabletable_types.go
@@ -70,7 +70,7 @@ type BigtableTableStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/bigtable/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigtable/v1beta1/zz_generated.deepcopy.go
@@ -193,7 +193,7 @@ func (in *BigtableAppProfileStatus) DeepCopyInto(out *BigtableAppProfileStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -325,7 +325,7 @@ func (in *BigtableGCPolicyStatus) DeepCopyInto(out *BigtableGCPolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -455,7 +455,7 @@ func (in *BigtableInstanceStatus) DeepCopyInto(out *BigtableInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -584,7 +584,7 @@ func (in *BigtableTableStatus) DeepCopyInto(out *BigtableTableStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -605,7 +605,7 @@ func (in *GcpolicyMaxAge) DeepCopyInto(out *GcpolicyMaxAge) {
 	*out = *in
 	if in.Days != nil {
 		in, out := &in.Days, &out.Days
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Duration != nil {
@@ -647,7 +647,7 @@ func (in *InstanceAutoscalingConfig) DeepCopyInto(out *InstanceAutoscalingConfig
 	*out = *in
 	if in.StorageTarget != nil {
 		in, out := &in.StorageTarget, &out.StorageTarget
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -678,7 +678,7 @@ func (in *InstanceCluster) DeepCopyInto(out *InstanceCluster) {
 	}
 	if in.NumNodes != nil {
 		in, out := &in.NumNodes, &out.NumNodes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StorageType != nil {

--- a/pkg/clients/generated/apis/billingbudgets/v1beta1/billingbudgetsbudget_types.go
+++ b/pkg/clients/generated/apis/billingbudgets/v1beta1/billingbudgetsbudget_types.go
@@ -105,15 +105,15 @@ type BudgetCustomPeriod struct {
 type BudgetEndDate struct {
 	/* Immutable. Day of a month. Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant. */
 	// +optional
-	Day *int `json:"day,omitempty"`
+	Day *int64 `json:"day,omitempty"`
 
 	/* Immutable. Month of a year. Must be from 1 to 12, or 0 to specify a year without a month and day. */
 	// +optional
-	Month *int `json:"month,omitempty"`
+	Month *int64 `json:"month,omitempty"`
 
 	/* Immutable. Year of the date. Must be from 1 to 9999, or 0 to specify a date without a year. */
 	// +optional
-	Year *int `json:"year,omitempty"`
+	Year *int64 `json:"year,omitempty"`
 }
 
 type BudgetLabels struct {
@@ -132,25 +132,25 @@ type BudgetSpecifiedAmount struct {
 
 	/* Number of nano (10^-9) units of the amount. The value must be between -999,999,999 and +999,999,999 inclusive. If `units` is positive, `nanos` must be positive or zero. If `units` is zero, `nanos` can be positive, zero, or negative. If `units` is negative, `nanos` must be negative or zero. For example $-1.75 is represented as `units`=-1 and `nanos`=-750,000,000. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* The whole units of the amount. For example if `currencyCode` is `"USD"`, then 1 unit is one US dollar. */
 	// +optional
-	Units *int `json:"units,omitempty"`
+	Units *int64 `json:"units,omitempty"`
 }
 
 type BudgetStartDate struct {
 	/* Immutable. Day of a month. Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant. */
 	// +optional
-	Day *int `json:"day,omitempty"`
+	Day *int64 `json:"day,omitempty"`
 
 	/* Immutable. Month of a year. Must be from 1 to 12, or 0 to specify a year without a month and day. */
 	// +optional
-	Month *int `json:"month,omitempty"`
+	Month *int64 `json:"month,omitempty"`
 
 	/* Immutable. Year of the date. Must be from 1 to 9999, or 0 to specify a date without a year. */
 	// +optional
-	Year *int `json:"year,omitempty"`
+	Year *int64 `json:"year,omitempty"`
 }
 
 type BudgetThresholdRules struct {
@@ -200,7 +200,7 @@ type BillingBudgetsBudgetStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/billingbudgets/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/billingbudgets/v1beta1/zz_generated.deepcopy.go
@@ -150,7 +150,7 @@ func (in *BillingBudgetsBudgetStatus) DeepCopyInto(out *BillingBudgetsBudgetStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -313,17 +313,17 @@ func (in *BudgetEndDate) DeepCopyInto(out *BudgetEndDate) {
 	*out = *in
 	if in.Day != nil {
 		in, out := &in.Day, &out.Day
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Month != nil {
 		in, out := &in.Month, &out.Month
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Year != nil {
 		in, out := &in.Year, &out.Year
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -386,12 +386,12 @@ func (in *BudgetSpecifiedAmount) DeepCopyInto(out *BudgetSpecifiedAmount) {
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Units != nil {
 		in, out := &in.Units, &out.Units
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -412,17 +412,17 @@ func (in *BudgetStartDate) DeepCopyInto(out *BudgetStartDate) {
 	*out = *in
 	if in.Day != nil {
 		in, out := &in.Day, &out.Day
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Month != nil {
 		in, out := &in.Month, &out.Month
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Year != nil {
 		in, out := &in.Year, &out.Year
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/binaryauthorization/v1beta1/binaryauthorizationattestor_types.go
+++ b/pkg/clients/generated/apis/binaryauthorization/v1beta1/binaryauthorizationattestor_types.go
@@ -101,7 +101,7 @@ type BinaryAuthorizationAttestorStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Time when the attestor was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/binaryauthorization/v1beta1/binaryauthorizationpolicy_types.go
+++ b/pkg/clients/generated/apis/binaryauthorization/v1beta1/binaryauthorizationpolicy_types.go
@@ -138,7 +138,7 @@ type BinaryAuthorizationPolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The resource name, in the format `projects/* /policy`. There is at most one policy per project. */
 	// +optional

--- a/pkg/clients/generated/apis/binaryauthorization/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/binaryauthorization/v1beta1/zz_generated.deepcopy.go
@@ -239,7 +239,7 @@ func (in *BinaryAuthorizationAttestorStatus) DeepCopyInto(out *BinaryAuthorizati
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -399,7 +399,7 @@ func (in *BinaryAuthorizationPolicyStatus) DeepCopyInto(out *BinaryAuthorization
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificate_types.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificate_types.go
@@ -203,7 +203,7 @@ type CertificateManagerCertificateStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemap_types.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemap_types.go
@@ -73,7 +73,7 @@ type CertificatemapIpConfigsStatus struct {
 
 	/* A list of ports. */
 	// +optional
-	Ports []int `json:"ports,omitempty"`
+	Ports []int64 `json:"ports,omitempty"`
 }
 
 type CertificateManagerCertificateMapStatus struct {
@@ -92,7 +92,7 @@ type CertificateManagerCertificateMapStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Update timestamp of a Certificate Map. Timestamp is in RFC3339 UTC "Zulu" format,
 	accurate to nanoseconds with up to nine fractional digits.

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemapentry_types.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagercertificatemapentry_types.go
@@ -75,7 +75,7 @@ type CertificateManagerCertificateMapEntryStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* A serving state of this Certificate Map Entry. */
 	// +optional

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagerdnsauthorization_types.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/certificatemanagerdnsauthorization_types.go
@@ -80,7 +80,7 @@ type CertificateManagerDNSAuthorizationStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/certificatemanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/certificatemanager/v1beta1/zz_generated.deepcopy.go
@@ -349,7 +349,7 @@ func (in *CertificateManagerCertificateMapEntryStatus) DeepCopyInto(out *Certifi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -457,7 +457,7 @@ func (in *CertificateManagerCertificateMapStatus) DeepCopyInto(out *CertificateM
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -530,7 +530,7 @@ func (in *CertificateManagerCertificateStatus) DeepCopyInto(out *CertificateMana
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -651,7 +651,7 @@ func (in *CertificateManagerDNSAuthorizationStatus) DeepCopyInto(out *Certificat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -845,7 +845,7 @@ func (in *CertificatemapIpConfigsStatus) DeepCopyInto(out *CertificatemapIpConfi
 	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetfolderfeed_types.go
+++ b/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetfolderfeed_types.go
@@ -130,7 +130,7 @@ type CloudAssetFolderFeedStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetorganizationfeed_types.go
+++ b/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetorganizationfeed_types.go
@@ -122,7 +122,7 @@ type CloudAssetOrganizationFeedStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetprojectfeed_types.go
+++ b/pkg/clients/generated/apis/cloudasset/v1alpha1/cloudassetprojectfeed_types.go
@@ -124,7 +124,7 @@ type CloudAssetProjectFeedStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudasset/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudasset/v1alpha1/zz_generated.deepcopy.go
@@ -153,7 +153,7 @@ func (in *CloudAssetFolderFeedStatus) DeepCopyInto(out *CloudAssetFolderFeedStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -288,7 +288,7 @@ func (in *CloudAssetOrganizationFeedStatus) DeepCopyInto(out *CloudAssetOrganiza
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -428,7 +428,7 @@ func (in *CloudAssetProjectFeedStatus) DeepCopyInto(out *CloudAssetProjectFeedSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/cloudbuild/v1beta1/cloudbuildtrigger_types.go
+++ b/pkg/clients/generated/apis/cloudbuild/v1beta1/cloudbuildtrigger_types.go
@@ -247,7 +247,7 @@ type TriggerOptions struct {
 	the build may run with a larger disk than requested. At present, the maximum disk size
 	is 1000GB; builds that request more than the maximum are rejected with an error. */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* Option to specify whether or not to apply bash style string operations to the substitutions.
 
@@ -496,7 +496,7 @@ type TriggerStep struct {
 
 	If 'allowFailure' is also specified, this field will take precedence. */
 	// +optional
-	AllowExitCodes []int `json:"allowExitCodes,omitempty"`
+	AllowExitCodes []int64 `json:"allowExitCodes,omitempty"`
 
 	/* Allow this build step to fail without failing the entire build.
 	If false, the entire build will fail if this step fails. Otherwise, the
@@ -846,7 +846,7 @@ type CloudBuildTriggerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the trigger. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudbuild/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudbuild/v1beta1/zz_generated.deepcopy.go
@@ -228,7 +228,7 @@ func (in *CloudBuildTriggerStatus) DeepCopyInto(out *CloudBuildTriggerStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TriggerId != nil {
@@ -546,7 +546,7 @@ func (in *TriggerOptions) DeepCopyInto(out *TriggerOptions) {
 	*out = *in
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DynamicSubstitutions != nil {
@@ -904,7 +904,7 @@ func (in *TriggerStep) DeepCopyInto(out *TriggerStep) {
 	*out = *in
 	if in.AllowExitCodes != nil {
 		in, out := &in.AllowExitCodes, &out.AllowExitCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.AllowFailure != nil {

--- a/pkg/clients/generated/apis/cloudfunctions/v1beta1/cloudfunctionsfunction_types.go
+++ b/pkg/clients/generated/apis/cloudfunctions/v1beta1/cloudfunctionsfunction_types.go
@@ -94,7 +94,7 @@ type FunctionSourceRepository struct {
 type CloudFunctionsFunctionSpec struct {
 	/* Memory (in MB), available to the function. Default value is 256MB. Allowed values are: 128MB, 256MB, 512MB, 1024MB, and 2048MB. */
 	// +optional
-	AvailableMemoryMb *int `json:"availableMemoryMb,omitempty"`
+	AvailableMemoryMb *int64 `json:"availableMemoryMb,omitempty"`
 
 	/* User-provided description of a function. */
 	// +optional
@@ -129,7 +129,7 @@ type CloudFunctionsFunctionSpec struct {
 	/* The limit on the maximum number of function instances that may coexist at a
 	given time. */
 	// +optional
-	MaxInstances *int `json:"maxInstances,omitempty"`
+	MaxInstances *int64 `json:"maxInstances,omitempty"`
 
 	/* Immutable. The Project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -198,7 +198,7 @@ type CloudFunctionsFunctionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SourceRepository *FunctionSourceRepositoryStatus `json:"sourceRepository,omitempty"`
@@ -214,7 +214,7 @@ type CloudFunctionsFunctionStatus struct {
 	/* Output only. The version identifier of the Cloud Function. Each deployment attempt
 	results in a new version of a function being created. */
 	// +optional
-	VersionId *int `json:"versionId,omitempty"`
+	VersionId *int64 `json:"versionId,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudfunctions/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudfunctions/v1beta1/zz_generated.deepcopy.go
@@ -95,7 +95,7 @@ func (in *CloudFunctionsFunctionSpec) DeepCopyInto(out *CloudFunctionsFunctionSp
 	*out = *in
 	if in.AvailableMemoryMb != nil {
 		in, out := &in.AvailableMemoryMb, &out.AvailableMemoryMb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -132,7 +132,7 @@ func (in *CloudFunctionsFunctionSpec) DeepCopyInto(out *CloudFunctionsFunctionSp
 	}
 	if in.MaxInstances != nil {
 		in, out := &in.MaxInstances, &out.MaxInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -199,7 +199,7 @@ func (in *CloudFunctionsFunctionStatus) DeepCopyInto(out *CloudFunctionsFunction
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SourceRepository != nil {
@@ -219,7 +219,7 @@ func (in *CloudFunctionsFunctionStatus) DeepCopyInto(out *CloudFunctionsFunction
 	}
 	if in.VersionId != nil {
 		in, out := &in.VersionId, &out.VersionId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/cloudfunctions2/v1alpha1/cloudfunctions2function_types.go
+++ b/pkg/clients/generated/apis/cloudfunctions2/v1alpha1/cloudfunctions2function_types.go
@@ -216,16 +216,16 @@ type FunctionServiceConfig struct {
 	/* The limit on the maximum number of function instances that may coexist at a
 	given time. */
 	// +optional
-	MaxInstanceCount *int `json:"maxInstanceCount,omitempty"`
+	MaxInstanceCount *int64 `json:"maxInstanceCount,omitempty"`
 
 	/* Sets the maximum number of concurrent requests that each instance can receive. Defaults to 1. */
 	// +optional
-	MaxInstanceRequestConcurrency *int `json:"maxInstanceRequestConcurrency,omitempty"`
+	MaxInstanceRequestConcurrency *int64 `json:"maxInstanceRequestConcurrency,omitempty"`
 
 	/* The limit on the minimum number of function instances that may coexist at a
 	given time. */
 	// +optional
-	MinInstanceCount *int `json:"minInstanceCount,omitempty"`
+	MinInstanceCount *int64 `json:"minInstanceCount,omitempty"`
 
 	/* Secret environment variables configuration. */
 	// +optional
@@ -247,7 +247,7 @@ type FunctionServiceConfig struct {
 	can be terminated if the function is not completed at the end of the
 	timeout period. Defaults to 60 seconds. */
 	// +optional
-	TimeoutSeconds *int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 
 	/* URI of the Service deployed. */
 	// +optional
@@ -280,7 +280,7 @@ type FunctionStorageSource struct {
 	/* Google Cloud Storage generation for the object. If the generation
 	is omitted, the latest generation will be used. */
 	// +optional
-	Generation *int `json:"generation,omitempty"`
+	Generation *int64 `json:"generation,omitempty"`
 
 	/* Google Cloud Storage object containing the source. */
 	// +optional
@@ -340,7 +340,7 @@ type CloudFunctions2FunctionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Describes the current state of the function. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudfunctions2/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudfunctions2/v1alpha1/zz_generated.deepcopy.go
@@ -152,7 +152,7 @@ func (in *CloudFunctions2FunctionStatus) DeepCopyInto(out *CloudFunctions2Functi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -435,17 +435,17 @@ func (in *FunctionServiceConfig) DeepCopyInto(out *FunctionServiceConfig) {
 	}
 	if in.MaxInstanceCount != nil {
 		in, out := &in.MaxInstanceCount, &out.MaxInstanceCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxInstanceRequestConcurrency != nil {
 		in, out := &in.MaxInstanceRequestConcurrency, &out.MaxInstanceRequestConcurrency
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinInstanceCount != nil {
 		in, out := &in.MinInstanceCount, &out.MinInstanceCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SecretEnvironmentVariables != nil {
@@ -472,7 +472,7 @@ func (in *FunctionServiceConfig) DeepCopyInto(out *FunctionServiceConfig) {
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Uri != nil {
@@ -539,7 +539,7 @@ func (in *FunctionStorageSource) DeepCopyInto(out *FunctionStorageSource) {
 	}
 	if in.Generation != nil {
 		in, out := &in.Generation, &out.Generation
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Object != nil {

--- a/pkg/clients/generated/apis/cloudidentity/v1beta1/cloudidentitygroup_types.go
+++ b/pkg/clients/generated/apis/cloudidentity/v1beta1/cloudidentitygroup_types.go
@@ -118,7 +118,7 @@ type CloudIdentityGroupStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the Group was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudidentity/v1beta1/cloudidentitymembership_types.go
+++ b/pkg/clients/generated/apis/cloudidentity/v1beta1/cloudidentitymembership_types.go
@@ -135,7 +135,7 @@ type CloudIdentityMembershipStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The type of the membership. Possible values: OWNER_TYPE_UNSPECIFIED, OWNER_TYPE_CUSTOMER, OWNER_TYPE_PARTNER */
 	// +optional

--- a/pkg/clients/generated/apis/cloudidentity/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudidentity/v1beta1/zz_generated.deepcopy.go
@@ -154,7 +154,7 @@ func (in *CloudIdentityGroupStatus) DeepCopyInto(out *CloudIdentityGroupStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -296,7 +296,7 @@ func (in *CloudIdentityMembershipStatus) DeepCopyInto(out *CloudIdentityMembersh
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Type != nil {

--- a/pkg/clients/generated/apis/cloudids/v1alpha1/cloudidsendpoint_types.go
+++ b/pkg/clients/generated/apis/cloudids/v1alpha1/cloudidsendpoint_types.go
@@ -79,7 +79,7 @@ type CloudIDSEndpointStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Last update timestamp in RFC 3339 text format. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudids/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudids/v1alpha1/zz_generated.deepcopy.go
@@ -147,7 +147,7 @@ func (in *CloudIDSEndpointStatus) DeepCopyInto(out *CloudIDSEndpointStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/cloudiot/v1alpha1/cloudiotdevice_types.go
+++ b/pkg/clients/generated/apis/cloudiot/v1alpha1/cloudiotdevice_types.go
@@ -132,7 +132,7 @@ type DeviceLastErrorStatusStatus struct {
 
 	/* The status code, which should be an enum value of google.rpc.Code. */
 	// +optional
-	Number *int `json:"number,omitempty"`
+	Number *int64 `json:"number,omitempty"`
 }
 
 type DeviceStateStatus struct {
@@ -188,7 +188,7 @@ type CloudIOTDeviceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The state most recently received from the device. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudiot/v1alpha1/cloudiotdeviceregistry_types.go
+++ b/pkg/clients/generated/apis/cloudiot/v1alpha1/cloudiotdeviceregistry_types.go
@@ -114,7 +114,7 @@ type CloudIOTDeviceRegistryStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudiot/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudiot/v1alpha1/zz_generated.deepcopy.go
@@ -219,7 +219,7 @@ func (in *CloudIOTDeviceRegistryStatus) DeepCopyInto(out *CloudIOTDeviceRegistry
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -344,7 +344,7 @@ func (in *CloudIOTDeviceStatus) DeepCopyInto(out *CloudIOTDeviceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -492,7 +492,7 @@ func (in *DeviceLastErrorStatusStatus) DeepCopyInto(out *DeviceLastErrorStatusSt
 	}
 	if in.Number != nil {
 		in, out := &in.Number, &out.Number
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/cloudscheduler/v1beta1/cloudschedulerjob_types.go
+++ b/pkg/clients/generated/apis/cloudscheduler/v1beta1/cloudschedulerjob_types.go
@@ -133,7 +133,7 @@ type JobRetryConfig struct {
 
 	/* The time between retries will double `max_doublings` times. A job's retry interval starts at min_backoff_duration, then doubles `max_doublings` times, then increases linearly, and finally retries at intervals of max_backoff_duration up to retry_count times. For example, if min_backoff_duration is 10s, max_backoff_duration is 300s, and `max_doublings` is 3, then the a job will first be retried in 10s. The retry interval will double three times, and then increase linearly by 2^3 * 10s. Finally, the job will retry at intervals of max_backoff_duration until the job has been attempted retry_count times. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s, 240s, 300s, 300s, .... The default value of this field is 5. */
 	// +optional
-	MaxDoublings *int `json:"maxDoublings,omitempty"`
+	MaxDoublings *int64 `json:"maxDoublings,omitempty"`
 
 	/* The time limit for retrying a failed job, measured from time when an execution was first attempted. If specified with retry_count, the job will be retried until both limits are reached. The default value for max_retry_duration is zero, which means retry duration is unlimited. */
 	// +optional
@@ -145,7 +145,7 @@ type JobRetryConfig struct {
 
 	/* The number of attempts that the system will make to run a job using the exponential backoff procedure described by max_doublings. The default value of retry_count is zero. If retry_count is zero, a job attempt will *not* be retried if it fails. Instead the Cloud Scheduler system will wait for the next scheduled execution time. If retry_count is set to a non-zero number then Cloud Scheduler will retry failed attempts, using exponential backoff, retry_count times, or until the next scheduled execution time, whichever comes first. Values greater than 5 and negative values are not allowed. */
 	// +optional
-	RetryCount *int `json:"retryCount,omitempty"`
+	RetryCount *int64 `json:"retryCount,omitempty"`
 }
 
 type CloudSchedulerJobSpec struct {
@@ -213,7 +213,7 @@ type JobDetailsStatus struct {
 type JobStatusStatus struct {
 	/* The status code, which should be an enum value of google.rpc.Code. */
 	// +optional
-	Code *int `json:"code,omitempty"`
+	Code *int64 `json:"code,omitempty"`
 
 	/* A list of messages that carry the error details. There is a common set of message types for APIs to use. */
 	// +optional
@@ -237,7 +237,7 @@ type CloudSchedulerJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The next time the job is scheduled. Note that this may be a retry of a previously failed attempt or the next execution time according to the schedule. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudscheduler/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudscheduler/v1beta1/zz_generated.deepcopy.go
@@ -171,7 +171,7 @@ func (in *CloudSchedulerJobStatus) DeepCopyInto(out *CloudSchedulerJobStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ScheduleTime != nil {
@@ -483,7 +483,7 @@ func (in *JobRetryConfig) DeepCopyInto(out *JobRetryConfig) {
 	}
 	if in.MaxDoublings != nil {
 		in, out := &in.MaxDoublings, &out.MaxDoublings
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRetryDuration != nil {
@@ -498,7 +498,7 @@ func (in *JobRetryConfig) DeepCopyInto(out *JobRetryConfig) {
 	}
 	if in.RetryCount != nil {
 		in, out := &in.RetryCount, &out.RetryCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -519,7 +519,7 @@ func (in *JobStatusStatus) DeepCopyInto(out *JobStatusStatus) {
 	*out = *in
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Details != nil {

--- a/pkg/clients/generated/apis/cloudtasks/v1alpha1/cloudtasksqueue_types.go
+++ b/pkg/clients/generated/apis/cloudtasks/v1alpha1/cloudtasksqueue_types.go
@@ -67,14 +67,14 @@ type QueueRateLimits struct {
 	rate so processing starts shortly after a task is enqueued, but still limits
 	resource usage when many tasks are enqueued in a short period of time. */
 	// +optional
-	MaxBurstSize *int `json:"maxBurstSize,omitempty"`
+	MaxBurstSize *int64 `json:"maxBurstSize,omitempty"`
 
 	/* The maximum number of concurrent tasks that Cloud Tasks allows to
 	be dispatched for this queue. After this threshold has been
 	reached, Cloud Tasks stops dispatching tasks until the number of
 	concurrent requests decreases. */
 	// +optional
-	MaxConcurrentDispatches *int `json:"maxConcurrentDispatches,omitempty"`
+	MaxConcurrentDispatches *int64 `json:"maxConcurrentDispatches,omitempty"`
 
 	/* The maximum rate at which tasks are dispatched from this queue.
 
@@ -95,7 +95,7 @@ type QueueRetryConfig struct {
 
 	-1 indicates unlimited attempts. */
 	// +optional
-	MaxAttempts *int `json:"maxAttempts,omitempty"`
+	MaxAttempts *int64 `json:"maxAttempts,omitempty"`
 
 	/* A task will be scheduled for retry between minBackoff and
 	maxBackoff duration after it fails, if the queue's RetryConfig
@@ -109,7 +109,7 @@ type QueueRetryConfig struct {
 	then increases linearly, and finally retries retries at intervals of maxBackoff
 	up to maxAttempts times. */
 	// +optional
-	MaxDoublings *int `json:"maxDoublings,omitempty"`
+	MaxDoublings *int64 `json:"maxDoublings,omitempty"`
 
 	/* If positive, maxRetryDuration specifies the time limit for
 	retrying a failed task, measured from when the task was first
@@ -178,7 +178,7 @@ type CloudTasksQueueStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/cloudtasks/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudtasks/v1alpha1/zz_generated.deepcopy.go
@@ -142,7 +142,7 @@ func (in *CloudTasksQueueStatus) DeepCopyInto(out *CloudTasksQueueStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -199,12 +199,12 @@ func (in *QueueRateLimits) DeepCopyInto(out *QueueRateLimits) {
 	*out = *in
 	if in.MaxBurstSize != nil {
 		in, out := &in.MaxBurstSize, &out.MaxBurstSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxConcurrentDispatches != nil {
 		in, out := &in.MaxConcurrentDispatches, &out.MaxConcurrentDispatches
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxDispatchesPerSecond != nil {
@@ -230,7 +230,7 @@ func (in *QueueRetryConfig) DeepCopyInto(out *QueueRetryConfig) {
 	*out = *in
 	if in.MaxAttempts != nil {
 		in, out := &in.MaxAttempts, &out.MaxAttempts
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxBackoff != nil {
@@ -240,7 +240,7 @@ func (in *QueueRetryConfig) DeepCopyInto(out *QueueRetryConfig) {
 	}
 	if in.MaxDoublings != nil {
 		in, out := &in.MaxDoublings, &out.MaxDoublings
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRetryDuration != nil {

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeautoscaler_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeautoscaler_types.go
@@ -47,7 +47,7 @@ type AutoscalerAutoscalingPolicy struct {
 	instance may take to initialize. To do this, create an instance
 	and time the startup process. */
 	// +optional
-	CooldownPeriod *int `json:"cooldownPeriod,omitempty"`
+	CooldownPeriod *int64 `json:"cooldownPeriod,omitempty"`
 
 	/* Defines the CPU utilization policy that allows the autoscaler to
 	scale based on the average CPU utilization of a managed instance
@@ -63,7 +63,7 @@ type AutoscalerAutoscalingPolicy struct {
 	to. This is required when creating or updating an autoscaler. The
 	maximum number of replicas should not be lower than minimal number
 	of replicas. */
-	MaxReplicas int `json:"maxReplicas"`
+	MaxReplicas int64 `json:"maxReplicas"`
 
 	/* Configuration parameters of autoscaling based on a custom metric. */
 	// +optional
@@ -73,7 +73,7 @@ type AutoscalerAutoscalingPolicy struct {
 	to. This cannot be less than 0. If not provided, autoscaler will
 	choose a default value depending on maximum number of instances
 	allowed. */
-	MinReplicas int `json:"minReplicas"`
+	MinReplicas int64 `json:"minReplicas"`
 
 	/* Defines operating mode for this policy. */
 	// +optional
@@ -130,24 +130,24 @@ type AutoscalerMaxScaledDownReplicas struct {
 	/* Specifies a fixed number of VM instances. This must be a positive
 	integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive.
 	For example, specify 80 for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type AutoscalerMaxScaledInReplicas struct {
 	/* Specifies a fixed number of VM instances. This must be a positive
 	integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive.
 	For example, specify 80 for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type AutoscalerMetric struct {
@@ -237,7 +237,7 @@ type AutoscalerScaleDownControl struct {
 	/* How long back autoscaling should look when computing recommendations
 	to include directives regarding slower scale down, as described above. */
 	// +optional
-	TimeWindowSec *int `json:"timeWindowSec,omitempty"`
+	TimeWindowSec *int64 `json:"timeWindowSec,omitempty"`
 }
 
 type AutoscalerScaleInControl struct {
@@ -248,7 +248,7 @@ type AutoscalerScaleInControl struct {
 	/* How long back autoscaling should look when computing recommendations
 	to include directives regarding slower scale down, as described above. */
 	// +optional
-	TimeWindowSec *int `json:"timeWindowSec,omitempty"`
+	TimeWindowSec *int64 `json:"timeWindowSec,omitempty"`
 }
 
 type AutoscalerScalingSchedules struct {
@@ -261,10 +261,10 @@ type AutoscalerScalingSchedules struct {
 	Disabled *bool `json:"disabled,omitempty"`
 
 	/* The duration of time intervals (in seconds) for which this scaling schedule will be running. The minimum allowed value is 300. */
-	DurationSec int `json:"durationSec"`
+	DurationSec int64 `json:"durationSec"`
 
 	/* Minimum number of VM instances that autoscaler will recommend in time intervals starting according to schedule. */
-	MinRequiredReplicas int `json:"minRequiredReplicas"`
+	MinRequiredReplicas int64 `json:"minRequiredReplicas"`
 
 	Name string `json:"name"`
 
@@ -312,7 +312,7 @@ type ComputeAutoscalerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/computebackendbucketsignedurlkey_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computebackendbucketsignedurlkey_types.go
@@ -72,7 +72,7 @@ type ComputeBackendBucketSignedURLKeyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computebackendservicesignedurlkey_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computebackendservicesignedurlkey_types.go
@@ -72,7 +72,7 @@ type ComputeBackendServiceSignedURLKeyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computediskresourcepolicyattachment_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computediskresourcepolicyattachment_types.go
@@ -55,7 +55,7 @@ type ComputeDiskResourcePolicyAttachmentStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeglobalnetworkendpoint_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeglobalnetworkendpoint_types.go
@@ -62,7 +62,7 @@ type ComputeGlobalNetworkEndpointStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeglobalnetworkendpointgroup_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeglobalnetworkendpointgroup_types.go
@@ -39,7 +39,7 @@ type ComputeGlobalNetworkEndpointGroupSpec struct {
 	/* Immutable. The default port used if the port number is not specified in the
 	network endpoint. */
 	// +optional
-	DefaultPort *int `json:"defaultPort,omitempty"`
+	DefaultPort *int64 `json:"defaultPort,omitempty"`
 
 	/* Immutable. An optional description of this resource. Provide this property when
 	you create the resource. */
@@ -63,7 +63,7 @@ type ComputeGlobalNetworkEndpointGroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeinstancegroupnamedport_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeinstancegroupnamedport_types.go
@@ -39,7 +39,7 @@ type ComputeInstanceGroupNamedPortSpec struct {
 	GroupRef v1alpha1.ResourceRef `json:"groupRef"`
 
 	/* Immutable. The port number, which can be a value between 1 and 65535. */
-	Port int `json:"port"`
+	Port int64 `json:"port"`
 
 	/* The project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -58,7 +58,7 @@ type ComputeInstanceGroupNamedPortStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computemachineimage_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computemachineimage_types.go
@@ -90,7 +90,7 @@ type ComputeMachineImageStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/computemanagedsslcertificate_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computemanagedsslcertificate_types.go
@@ -70,7 +70,7 @@ type ComputeManagedSSLCertificateStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* The unique identifier for the resource. */
 	// +optional
-	CertificateId *int `json:"certificateId,omitempty"`
+	CertificateId *int64 `json:"certificateId,omitempty"`
 
 	/* Creation timestamp in RFC3339 text format. */
 	// +optional
@@ -82,7 +82,7 @@ type ComputeManagedSSLCertificateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/computenetworkendpoint_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computenetworkendpoint_types.go
@@ -63,7 +63,7 @@ type ComputeNetworkEndpointStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computenetworkpeeringroutesconfig_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computenetworkpeeringroutesconfig_types.go
@@ -58,7 +58,7 @@ type ComputeNetworkPeeringRoutesConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicy_types.go
@@ -69,7 +69,7 @@ type ComputeOrganizationSecurityPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the resource. This identifier is defined by the server. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicyassociation_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicyassociation_types.go
@@ -57,7 +57,7 @@ type ComputeOrganizationSecurityPolicyAssociationStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicyrule_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeorganizationsecuritypolicyrule_types.go
@@ -135,7 +135,7 @@ type ComputeOrganizationSecurityPolicyRuleStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeperinstanceconfig_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeperinstanceconfig_types.go
@@ -152,7 +152,7 @@ type ComputePerInstanceConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeregionautoscaler_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeregionautoscaler_types.go
@@ -47,7 +47,7 @@ type RegionautoscalerAutoscalingPolicy struct {
 	instance may take to initialize. To do this, create an instance
 	and time the startup process. */
 	// +optional
-	CooldownPeriod *int `json:"cooldownPeriod,omitempty"`
+	CooldownPeriod *int64 `json:"cooldownPeriod,omitempty"`
 
 	/* Defines the CPU utilization policy that allows the autoscaler to
 	scale based on the average CPU utilization of a managed instance
@@ -63,7 +63,7 @@ type RegionautoscalerAutoscalingPolicy struct {
 	to. This is required when creating or updating an autoscaler. The
 	maximum number of replicas should not be lower than minimal number
 	of replicas. */
-	MaxReplicas int `json:"maxReplicas"`
+	MaxReplicas int64 `json:"maxReplicas"`
 
 	/* Configuration parameters of autoscaling based on a custom metric. */
 	// +optional
@@ -73,7 +73,7 @@ type RegionautoscalerAutoscalingPolicy struct {
 	to. This cannot be less than 0. If not provided, autoscaler will
 	choose a default value depending on maximum number of instances
 	allowed. */
-	MinReplicas int `json:"minReplicas"`
+	MinReplicas int64 `json:"minReplicas"`
 
 	/* Defines operating mode for this policy. */
 	// +optional
@@ -130,24 +130,24 @@ type RegionautoscalerMaxScaledDownReplicas struct {
 	/* Specifies a fixed number of VM instances. This must be a positive
 	integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive.
 	For example, specify 80 for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type RegionautoscalerMaxScaledInReplicas struct {
 	/* Specifies a fixed number of VM instances. This must be a positive
 	integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive.
 	For example, specify 80 for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type RegionautoscalerMetric struct {
@@ -237,7 +237,7 @@ type RegionautoscalerScaleDownControl struct {
 	/* How long back autoscaling should look when computing recommendations
 	to include directives regarding slower scale down, as described above. */
 	// +optional
-	TimeWindowSec *int `json:"timeWindowSec,omitempty"`
+	TimeWindowSec *int64 `json:"timeWindowSec,omitempty"`
 }
 
 type RegionautoscalerScaleInControl struct {
@@ -248,7 +248,7 @@ type RegionautoscalerScaleInControl struct {
 	/* How long back autoscaling should look when computing recommendations
 	to include directives regarding slower scale down, as described above. */
 	// +optional
-	TimeWindowSec *int `json:"timeWindowSec,omitempty"`
+	TimeWindowSec *int64 `json:"timeWindowSec,omitempty"`
 }
 
 type RegionautoscalerScalingSchedules struct {
@@ -261,10 +261,10 @@ type RegionautoscalerScalingSchedules struct {
 	Disabled *bool `json:"disabled,omitempty"`
 
 	/* The duration of time intervals (in seconds) for which this scaling schedule will be running. The minimum allowed value is 300. */
-	DurationSec int `json:"durationSec"`
+	DurationSec int64 `json:"durationSec"`
 
 	/* Minimum number of VM instances that autoscaler will recommend in time intervals starting according to schedule. */
-	MinRequiredReplicas int `json:"minRequiredReplicas"`
+	MinRequiredReplicas int64 `json:"minRequiredReplicas"`
 
 	Name string `json:"name"`
 
@@ -313,7 +313,7 @@ type ComputeRegionAutoscalerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeregiondiskresourcepolicyattachment_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeregiondiskresourcepolicyattachment_types.go
@@ -55,7 +55,7 @@ type ComputeRegionDiskResourcePolicyAttachmentStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeregionperinstanceconfig_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeregionperinstanceconfig_types.go
@@ -152,7 +152,7 @@ type ComputeRegionPerInstanceConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1alpha1/computeregionsslpolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/computeregionsslpolicy_types.go
@@ -97,7 +97,7 @@ type ComputeRegionSSLPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -34,7 +34,7 @@ func (in *AutoscalerAutoscalingPolicy) DeepCopyInto(out *AutoscalerAutoscalingPo
 	*out = *in
 	if in.CooldownPeriod != nil {
 		in, out := &in.CooldownPeriod, &out.CooldownPeriod
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CpuUtilization != nil {
@@ -131,12 +131,12 @@ func (in *AutoscalerMaxScaledDownReplicas) DeepCopyInto(out *AutoscalerMaxScaled
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -157,12 +157,12 @@ func (in *AutoscalerMaxScaledInReplicas) DeepCopyInto(out *AutoscalerMaxScaledIn
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -224,7 +224,7 @@ func (in *AutoscalerScaleDownControl) DeepCopyInto(out *AutoscalerScaleDownContr
 	}
 	if in.TimeWindowSec != nil {
 		in, out := &in.TimeWindowSec, &out.TimeWindowSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -250,7 +250,7 @@ func (in *AutoscalerScaleInControl) DeepCopyInto(out *AutoscalerScaleInControl) 
 	}
 	if in.TimeWindowSec != nil {
 		in, out := &in.TimeWindowSec, &out.TimeWindowSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -496,7 +496,7 @@ func (in *ComputeAutoscalerStatus) DeepCopyInto(out *ComputeAutoscalerStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -612,7 +612,7 @@ func (in *ComputeBackendBucketSignedURLKeyStatus) DeepCopyInto(out *ComputeBacke
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -723,7 +723,7 @@ func (in *ComputeBackendServiceSignedURLKeyStatus) DeepCopyInto(out *ComputeBack
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -833,7 +833,7 @@ func (in *ComputeDiskResourcePolicyAttachmentStatus) DeepCopyInto(out *ComputeDi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -943,7 +943,7 @@ func (in *ComputeGlobalNetworkEndpointGroupSpec) DeepCopyInto(out *ComputeGlobal
 	*out = *in
 	if in.DefaultPort != nil {
 		in, out := &in.DefaultPort, &out.DefaultPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -980,7 +980,7 @@ func (in *ComputeGlobalNetworkEndpointGroupStatus) DeepCopyInto(out *ComputeGlob
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1076,7 +1076,7 @@ func (in *ComputeGlobalNetworkEndpointStatus) DeepCopyInto(out *ComputeGlobalNet
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1186,7 +1186,7 @@ func (in *ComputeInstanceGroupNamedPortStatus) DeepCopyInto(out *ComputeInstance
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1311,7 +1311,7 @@ func (in *ComputeMachineImageStatus) DeepCopyInto(out *ComputeMachineImageStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1445,7 +1445,7 @@ func (in *ComputeManagedSSLCertificateStatus) DeepCopyInto(out *ComputeManagedSS
 	}
 	if in.CertificateId != nil {
 		in, out := &in.CertificateId, &out.CertificateId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreationTimestamp != nil {
@@ -1460,7 +1460,7 @@ func (in *ComputeManagedSSLCertificateStatus) DeepCopyInto(out *ComputeManagedSS
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1585,7 +1585,7 @@ func (in *ComputeNetworkEndpointStatus) DeepCopyInto(out *ComputeNetworkEndpoint
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1695,7 +1695,7 @@ func (in *ComputeNetworkPeeringRoutesConfigStatus) DeepCopyInto(out *ComputeNetw
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1836,7 +1836,7 @@ func (in *ComputeOrganizationSecurityPolicyAssociationStatus) DeepCopyInto(out *
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2008,7 +2008,7 @@ func (in *ComputeOrganizationSecurityPolicyRuleStatus) DeepCopyInto(out *Compute
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2070,7 +2070,7 @@ func (in *ComputeOrganizationSecurityPolicyStatus) DeepCopyInto(out *ComputeOrga
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PolicyId != nil {
@@ -2205,7 +2205,7 @@ func (in *ComputePerInstanceConfigStatus) DeepCopyInto(out *ComputePerInstanceCo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2325,7 +2325,7 @@ func (in *ComputeRegionAutoscalerStatus) DeepCopyInto(out *ComputeRegionAutoscal
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2440,7 +2440,7 @@ func (in *ComputeRegionDiskResourcePolicyAttachmentStatus) DeepCopyInto(out *Com
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2570,7 +2570,7 @@ func (in *ComputeRegionPerInstanceConfigStatus) DeepCopyInto(out *ComputeRegionP
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2714,7 +2714,7 @@ func (in *ComputeRegionSSLPolicyStatus) DeepCopyInto(out *ComputeRegionSSLPolicy
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3021,7 +3021,7 @@ func (in *RegionautoscalerAutoscalingPolicy) DeepCopyInto(out *RegionautoscalerA
 	*out = *in
 	if in.CooldownPeriod != nil {
 		in, out := &in.CooldownPeriod, &out.CooldownPeriod
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CpuUtilization != nil {
@@ -3118,12 +3118,12 @@ func (in *RegionautoscalerMaxScaledDownReplicas) DeepCopyInto(out *Regionautosca
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3144,12 +3144,12 @@ func (in *RegionautoscalerMaxScaledInReplicas) DeepCopyInto(out *Regionautoscale
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3211,7 +3211,7 @@ func (in *RegionautoscalerScaleDownControl) DeepCopyInto(out *RegionautoscalerSc
 	}
 	if in.TimeWindowSec != nil {
 		in, out := &in.TimeWindowSec, &out.TimeWindowSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3237,7 +3237,7 @@ func (in *RegionautoscalerScaleInControl) DeepCopyInto(out *RegionautoscalerScal
 	}
 	if in.TimeWindowSec != nil {
 		in, out := &in.TimeWindowSec, &out.TimeWindowSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/compute/v1beta1/computeaddress_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeaddress_types.go
@@ -80,7 +80,7 @@ type ComputeAddressSpec struct {
 
 	/* Immutable. The prefix length if the resource represents an IP range. */
 	// +optional
-	PrefixLength *int `json:"prefixLength,omitempty"`
+	PrefixLength *int64 `json:"prefixLength,omitempty"`
 
 	/* Immutable. The purpose of this resource, which can be one of the following values.
 
@@ -140,7 +140,7 @@ type ComputeAddressStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computebackendbucket_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computebackendbucket_types.go
@@ -70,16 +70,16 @@ type BackendbucketCdnPolicy struct {
 
 	/* Specifies the maximum allowed TTL for cached content served by this origin. */
 	// +optional
-	ClientTtl *int `json:"clientTtl,omitempty"`
+	ClientTtl *int64 `json:"clientTtl,omitempty"`
 
 	/* Specifies the default TTL for cached content served by this origin for responses
 	that do not have an existing valid TTL (max-age or s-max-age). */
 	// +optional
-	DefaultTtl *int `json:"defaultTtl,omitempty"`
+	DefaultTtl *int64 `json:"defaultTtl,omitempty"`
 
 	/* Specifies the maximum allowed TTL for cached content served by this origin. */
 	// +optional
-	MaxTtl *int `json:"maxTtl,omitempty"`
+	MaxTtl *int64 `json:"maxTtl,omitempty"`
 
 	/* Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects. */
 	// +optional
@@ -96,7 +96,7 @@ type BackendbucketCdnPolicy struct {
 
 	/* Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache. */
 	// +optional
-	ServeWhileStale *int `json:"serveWhileStale,omitempty"`
+	ServeWhileStale *int64 `json:"serveWhileStale,omitempty"`
 
 	/* Maximum number of seconds the response to a signed URL request will
 	be considered fresh. After this time period,
@@ -107,19 +107,19 @@ type BackendbucketCdnPolicy struct {
 	max-age=[TTL]" header, regardless of any existing Cache-Control
 	header. The actual headers served in responses will not be altered. */
 	// +optional
-	SignedUrlCacheMaxAgeSec *int `json:"signedUrlCacheMaxAgeSec,omitempty"`
+	SignedUrlCacheMaxAgeSec *int64 `json:"signedUrlCacheMaxAgeSec,omitempty"`
 }
 
 type BackendbucketNegativeCachingPolicy struct {
 	/* The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
 	can be specified as values, and you cannot specify a status code more than once. */
 	// +optional
-	Code *int `json:"code,omitempty"`
+	Code *int64 `json:"code,omitempty"`
 
 	/* The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
 	(30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL. */
 	// +optional
-	Ttl *int `json:"ttl,omitempty"`
+	Ttl *int64 `json:"ttl,omitempty"`
 }
 
 type ComputeBackendBucketSpec struct {
@@ -166,7 +166,7 @@ type ComputeBackendBucketStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computebackendservice_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computebackendservice_types.go
@@ -92,7 +92,7 @@ type BackendserviceBackend struct {
 	of maxConnectionsPerInstance or maxConnectionsPerEndpoint,
 	as appropriate for group type, must be set. */
 	// +optional
-	MaxConnections *int `json:"maxConnections,omitempty"`
+	MaxConnections *int64 `json:"maxConnections,omitempty"`
 
 	/* The max number of simultaneous connections that a single backend
 	network endpoint can handle. This is used to calculate the
@@ -102,7 +102,7 @@ type BackendserviceBackend struct {
 	For CONNECTION mode, either
 	maxConnections or maxConnectionsPerEndpoint must be set. */
 	// +optional
-	MaxConnectionsPerEndpoint *int `json:"maxConnectionsPerEndpoint,omitempty"`
+	MaxConnectionsPerEndpoint *int64 `json:"maxConnectionsPerEndpoint,omitempty"`
 
 	/* The max number of simultaneous connections that a single
 	backend instance can handle. This is used to calculate the
@@ -112,7 +112,7 @@ type BackendserviceBackend struct {
 	For CONNECTION mode, either maxConnections or
 	maxConnectionsPerInstance must be set. */
 	// +optional
-	MaxConnectionsPerInstance *int `json:"maxConnectionsPerInstance,omitempty"`
+	MaxConnectionsPerInstance *int64 `json:"maxConnectionsPerInstance,omitempty"`
 
 	/* The max requests per second (RPS) of the group.
 
@@ -121,7 +121,7 @@ type BackendserviceBackend struct {
 	of maxRatePerInstance or maxRatePerEndpoint, as appropriate for
 	group type, must be set. */
 	// +optional
-	MaxRate *int `json:"maxRate,omitempty"`
+	MaxRate *int64 `json:"maxRate,omitempty"`
 
 	/* The max requests per second (RPS) that a single backend network
 	endpoint can handle. This is used to calculate the capacity of
@@ -148,11 +148,11 @@ type BackendserviceBaseEjectionTime struct {
 	less than one second are represented with a 0 'seconds' field and a positive
 	'nanos' field. Must be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
 	inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type BackendserviceBypassCacheOnRequestHeaders struct {
@@ -224,16 +224,16 @@ type BackendserviceCdnPolicy struct {
 
 	/* Specifies the maximum allowed TTL for cached content served by this origin. */
 	// +optional
-	ClientTtl *int `json:"clientTtl,omitempty"`
+	ClientTtl *int64 `json:"clientTtl,omitempty"`
 
 	/* Specifies the default TTL for cached content served by this origin for responses
 	that do not have an existing valid TTL (max-age or s-max-age). */
 	// +optional
-	DefaultTtl *int `json:"defaultTtl,omitempty"`
+	DefaultTtl *int64 `json:"defaultTtl,omitempty"`
 
 	/* Specifies the maximum allowed TTL for cached content served by this origin. */
 	// +optional
-	MaxTtl *int `json:"maxTtl,omitempty"`
+	MaxTtl *int64 `json:"maxTtl,omitempty"`
 
 	/* Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects. */
 	// +optional
@@ -246,7 +246,7 @@ type BackendserviceCdnPolicy struct {
 
 	/* Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache. */
 	// +optional
-	ServeWhileStale *int `json:"serveWhileStale,omitempty"`
+	ServeWhileStale *int64 `json:"serveWhileStale,omitempty"`
 
 	/* Maximum number of seconds the response to a signed URL request
 	will be considered fresh, defaults to 1hr (3600s). After this
@@ -259,7 +259,7 @@ type BackendserviceCdnPolicy struct {
 	existing Cache-Control header. The actual headers served in
 	responses will not be altered. */
 	// +optional
-	SignedUrlCacheMaxAgeSec *int `json:"signedUrlCacheMaxAgeSec,omitempty"`
+	SignedUrlCacheMaxAgeSec *int64 `json:"signedUrlCacheMaxAgeSec,omitempty"`
 }
 
 type BackendserviceCircuitBreakers struct {
@@ -270,29 +270,29 @@ type BackendserviceCircuitBreakers struct {
 	/* The maximum number of connections to the backend cluster.
 	Defaults to 1024. */
 	// +optional
-	MaxConnections *int `json:"maxConnections,omitempty"`
+	MaxConnections *int64 `json:"maxConnections,omitempty"`
 
 	/* The maximum number of pending requests to the backend cluster.
 	Defaults to 1024. */
 	// +optional
-	MaxPendingRequests *int `json:"maxPendingRequests,omitempty"`
+	MaxPendingRequests *int64 `json:"maxPendingRequests,omitempty"`
 
 	/* The maximum number of parallel requests to the backend cluster.
 	Defaults to 1024. */
 	// +optional
-	MaxRequests *int `json:"maxRequests,omitempty"`
+	MaxRequests *int64 `json:"maxRequests,omitempty"`
 
 	/* Maximum requests for a single backend connection. This parameter
 	is respected by both the HTTP/1.1 and HTTP/2 implementations. If
 	not specified, there is no limit. Setting this parameter to 1
 	will effectively disable keep alive. */
 	// +optional
-	MaxRequestsPerConnection *int `json:"maxRequestsPerConnection,omitempty"`
+	MaxRequestsPerConnection *int64 `json:"maxRequestsPerConnection,omitempty"`
 
 	/* The maximum number of parallel retries to the backend cluster.
 	Defaults to 3. */
 	// +optional
-	MaxRetries *int `json:"maxRetries,omitempty"`
+	MaxRetries *int64 `json:"maxRetries,omitempty"`
 }
 
 type BackendserviceConnectTimeout struct {
@@ -301,11 +301,11 @@ type BackendserviceConnectTimeout struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type BackendserviceConnectionTrackingPolicy struct {
@@ -339,7 +339,7 @@ type BackendserviceConnectionTrackingPolicy struct {
 
 	For NLB the minimum(default) is 60 seconds and the maximum is 16 hours. */
 	// +optional
-	IdleTimeoutSec *int `json:"idleTimeoutSec,omitempty"`
+	IdleTimeoutSec *int64 `json:"idleTimeoutSec,omitempty"`
 
 	/* Specifies the key used for connection tracking. There are two options:
 	'PER_CONNECTION': The Connection Tracking is performed as per the
@@ -371,7 +371,7 @@ type BackendserviceConsistentHash struct {
 	virtual node.
 	Defaults to 1024. */
 	// +optional
-	MinimumRingSize *int `json:"minimumRingSize,omitempty"`
+	MinimumRingSize *int64 `json:"minimumRingSize,omitempty"`
 }
 
 type BackendserviceCustomPolicy struct {
@@ -476,11 +476,11 @@ type BackendserviceInterval struct {
 	less than one second are represented with a 0 'seconds' field and a positive
 	'nanos' field. Must be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
 	inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type BackendserviceLocalityLbPolicies struct {
@@ -511,12 +511,12 @@ type BackendserviceNegativeCachingPolicy struct {
 	/* The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
 	can be specified as values, and you cannot specify a status code more than once. */
 	// +optional
-	Code *int `json:"code,omitempty"`
+	Code *int64 `json:"code,omitempty"`
 
 	/* The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
 	(30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL. */
 	// +optional
-	Ttl *int `json:"ttl,omitempty"`
+	Ttl *BackendserviceTtl `json:"ttl,omitempty"`
 }
 
 type BackendserviceOauth2ClientSecret struct {
@@ -540,31 +540,31 @@ type BackendserviceOutlierDetection struct {
 	backend host is accessed over HTTP, a 5xx return code qualifies as an error.
 	Defaults to 5. */
 	// +optional
-	ConsecutiveErrors *int `json:"consecutiveErrors,omitempty"`
+	ConsecutiveErrors *int64 `json:"consecutiveErrors,omitempty"`
 
 	/* The number of consecutive gateway failures (502, 503, 504 status or connection
 	errors that are mapped to one of those status codes) before a consecutive
 	gateway failure ejection occurs. Defaults to 5. */
 	// +optional
-	ConsecutiveGatewayFailure *int `json:"consecutiveGatewayFailure,omitempty"`
+	ConsecutiveGatewayFailure *int64 `json:"consecutiveGatewayFailure,omitempty"`
 
 	/* The percentage chance that a host will be actually ejected when an outlier
 	status is detected through consecutive 5xx. This setting can be used to disable
 	ejection or to ramp it up slowly. Defaults to 100. */
 	// +optional
-	EnforcingConsecutiveErrors *int `json:"enforcingConsecutiveErrors,omitempty"`
+	EnforcingConsecutiveErrors *int64 `json:"enforcingConsecutiveErrors,omitempty"`
 
 	/* The percentage chance that a host will be actually ejected when an outlier
 	status is detected through consecutive gateway failures. This setting can be
 	used to disable ejection or to ramp it up slowly. Defaults to 0. */
 	// +optional
-	EnforcingConsecutiveGatewayFailure *int `json:"enforcingConsecutiveGatewayFailure,omitempty"`
+	EnforcingConsecutiveGatewayFailure *int64 `json:"enforcingConsecutiveGatewayFailure,omitempty"`
 
 	/* The percentage chance that a host will be actually ejected when an outlier
 	status is detected through success rate statistics. This setting can be used to
 	disable ejection or to ramp it up slowly. Defaults to 100. */
 	// +optional
-	EnforcingSuccessRate *int `json:"enforcingSuccessRate,omitempty"`
+	EnforcingSuccessRate *int64 `json:"enforcingSuccessRate,omitempty"`
 
 	/* Time interval between ejection sweep analysis. This can result in both new
 	ejections as well as hosts being returned to service. Defaults to 10 seconds. */
@@ -574,14 +574,14 @@ type BackendserviceOutlierDetection struct {
 	/* Maximum percentage of hosts in the load balancing pool for the backend service
 	that can be ejected. Defaults to 10%. */
 	// +optional
-	MaxEjectionPercent *int `json:"maxEjectionPercent,omitempty"`
+	MaxEjectionPercent *int64 `json:"maxEjectionPercent,omitempty"`
 
 	/* The number of hosts in a cluster that must have enough request volume to detect
 	success rate outliers. If the number of hosts is less than this setting, outlier
 	detection via success rate statistics is not performed for any host in the
 	cluster. Defaults to 5. */
 	// +optional
-	SuccessRateMinimumHosts *int `json:"successRateMinimumHosts,omitempty"`
+	SuccessRateMinimumHosts *int64 `json:"successRateMinimumHosts,omitempty"`
 
 	/* The minimum number of total requests that must be collected in one interval (as
 	defined by the interval duration above) to include this host in success rate
@@ -589,7 +589,7 @@ type BackendserviceOutlierDetection struct {
 	detection via success rate statistics is not performed for that host. Defaults
 	to 100. */
 	// +optional
-	SuccessRateRequestVolume *int `json:"successRateRequestVolume,omitempty"`
+	SuccessRateRequestVolume *int64 `json:"successRateRequestVolume,omitempty"`
 
 	/* This factor is used to determine the ejection threshold for success rate outlier
 	ejection. The ejection threshold is the difference between the mean success
@@ -598,7 +598,7 @@ type BackendserviceOutlierDetection struct {
 	by a thousand to get a double. That is, if the desired factor is 1.9, the
 	runtime value should be 1900. Defaults to 1900. */
 	// +optional
-	SuccessRateStdevFactor *int `json:"successRateStdevFactor,omitempty"`
+	SuccessRateStdevFactor *int64 `json:"successRateStdevFactor,omitempty"`
 }
 
 type BackendservicePolicy struct {
@@ -664,11 +664,11 @@ type BackendserviceTtl struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type BackendserviceValueFrom struct {
@@ -685,7 +685,7 @@ type ComputeBackendServiceSpec struct {
 
 	When the load balancing scheme is INTERNAL, this field is not used. */
 	// +optional
-	AffinityCookieTtlSec *int `json:"affinityCookieTtlSec,omitempty"`
+	AffinityCookieTtlSec *int64 `json:"affinityCookieTtlSec,omitempty"`
 
 	/* The set of backends that serve this BackendService. */
 	// +optional
@@ -707,7 +707,7 @@ type ComputeBackendServiceSpec struct {
 	/* Time for which instance will be drained (not accept new
 	connections, but still work to finish started). */
 	// +optional
-	ConnectionDrainingTimeoutSec *int `json:"connectionDrainingTimeoutSec,omitempty"`
+	ConnectionDrainingTimeoutSec *int64 `json:"connectionDrainingTimeoutSec,omitempty"`
 
 	/* Connection Tracking configuration for this BackendService.
 	This is available only for Layer 4 Internal Load Balancing and
@@ -902,7 +902,7 @@ type ComputeBackendServiceSpec struct {
 	/* How many seconds to wait for the backend before considering it a
 	failed request. Default is 30 seconds. Valid range is [1, 86400]. */
 	// +optional
-	TimeoutSec *int `json:"timeoutSec,omitempty"`
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
 }
 
 type ComputeBackendServiceStatus struct {
@@ -920,11 +920,11 @@ type ComputeBackendServiceStatus struct {
 
 	/* The unique identifier for the resource. This identifier is defined by the server. */
 	// +optional
-	GeneratedId *int `json:"generatedId,omitempty"`
+	GeneratedId *int64 `json:"generatedId,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computedisk_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computedisk_types.go
@@ -215,7 +215,7 @@ type ComputeDiskSpec struct {
 	If an unsupported value is requested, the error message will list
 	the supported values for the caller's project. */
 	// +optional
-	PhysicalBlockSizeBytes *int `json:"physicalBlockSizeBytes,omitempty"`
+	PhysicalBlockSizeBytes *int64 `json:"physicalBlockSizeBytes,omitempty"`
 
 	/* The project that this resource belongs to. */
 	// +optional
@@ -225,13 +225,13 @@ type ComputeDiskSpec struct {
 	Note: Updating currently is only supported by hyperdisk skus without the need to delete and recreate the disk, hyperdisk
 	allows for an update of IOPS every 4 hours. To update your hyperdisk more frequently, you'll need to manually delete and recreate it. */
 	// +optional
-	ProvisionedIops *int `json:"provisionedIops,omitempty"`
+	ProvisionedIops *int64 `json:"provisionedIops,omitempty"`
 
 	/* Indicates how much Throughput must be provisioned for the disk.
 	Note: Updating currently is only supported by hyperdisk skus without the need to delete and recreate the disk, hyperdisk
 	allows for an update of Throughput every 4 hours. To update your hyperdisk more frequently, you'll need to manually delete and recreate it. */
 	// +optional
-	ProvisionedThroughput *int `json:"provisionedThroughput,omitempty"`
+	ProvisionedThroughput *int64 `json:"provisionedThroughput,omitempty"`
 
 	/* Immutable. URLs of the zones where the disk should be replicated to. */
 	// +optional
@@ -256,7 +256,7 @@ type ComputeDiskSpec struct {
 	Upsizing the disk is mutable, but downsizing the disk
 	requires re-creating the resource. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	/* The source snapshot used to create this disk. */
 	// +optional
@@ -306,7 +306,7 @@ type ComputeDiskStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeexternalvpngateway_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeexternalvpngateway_types.go
@@ -42,7 +42,7 @@ type ExternalvpngatewayInterface struct {
 	* '0, 1 - TWO_IPS_REDUNDANCY'
 	* '0, 1, 2, 3 - FOUR_IPS_REDUNDANCY'. */
 	// +optional
-	Id *int `json:"id,omitempty"`
+	Id *int64 `json:"id,omitempty"`
 
 	/* Immutable. IP address of the interface in the external VPN gateway.
 	Only IPv4 is supported. This IP address can be either from
@@ -81,7 +81,7 @@ type ComputeExternalVPNGatewayStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computefirewall_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computefirewall_types.go
@@ -131,7 +131,7 @@ type ComputeFirewallSpec struct {
 	higher precedence than a rule with priority 1). DENY rules take
 	precedence over ALLOW rules having equal priority. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
@@ -186,7 +186,7 @@ type ComputeFirewallStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicy_types.go
@@ -74,11 +74,11 @@ type ComputeFirewallPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Total count of all firewall policy rule tuples. A firewall policy can not exceed a set number of tuples. */
 	// +optional
-	RuleTupleCount *int `json:"ruleTupleCount,omitempty"`
+	RuleTupleCount *int64 `json:"ruleTupleCount,omitempty"`
 
 	/* Server-defined URL for the resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicyassociation_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicyassociation_types.go
@@ -53,7 +53,7 @@ type ComputeFirewallPolicyAssociationStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The short name of the firewall policy of the association. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicyrule_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computefirewallpolicyrule_types.go
@@ -115,7 +115,7 @@ type ComputeFirewallPolicyRuleSpec struct {
 	Match FirewallpolicyruleMatch `json:"match"`
 
 	/* Immutable. An integer indicating the priority of a rule in the list. The priority must be a positive value between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest prority. */
-	Priority int `json:"priority"`
+	Priority int64 `json:"priority"`
 
 	// +optional
 	TargetResources []v1alpha1.ResourceRef `json:"targetResources,omitempty"`
@@ -134,11 +134,11 @@ type ComputeFirewallPolicyRuleStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Calculation of the complexity of a single firewall policy rule. */
 	// +optional
-	RuleTupleCount *int `json:"ruleTupleCount,omitempty"`
+	RuleTupleCount *int64 `json:"ruleTupleCount,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computeforwardingrule_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeforwardingrule_types.go
@@ -372,7 +372,7 @@ type ComputeForwardingRuleStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The PSC connection id of the PSC Forwarding Rule. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computehealthcheck_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computehealthcheck_types.go
@@ -48,7 +48,7 @@ type HealthcheckGrpcHealthCheck struct {
 	Must be specified if portName and portSpecification are not set
 	or if port_specification is USE_FIXED_PORT. Valid values are 1 through 65535. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -83,7 +83,7 @@ type HealthcheckHttp2HealthCheck struct {
 	/* The TCP port number for the HTTP2 health check request.
 	The default value is 443. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -134,7 +134,7 @@ type HealthcheckHttpHealthCheck struct {
 	/* The TCP port number for the HTTP health check request.
 	The default value is 80. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -185,7 +185,7 @@ type HealthcheckHttpsHealthCheck struct {
 	/* The TCP port number for the HTTPS health check request.
 	The default value is 443. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -237,7 +237,7 @@ type HealthcheckSslHealthCheck struct {
 	/* The TCP port number for the SSL health check request.
 	The default value is 443. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -284,7 +284,7 @@ type HealthcheckTcpHealthCheck struct {
 	/* The TCP port number for the TCP health check request.
 	The default value is 443. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Port name as defined in InstanceGroup#NamedPort#name. If both port and
 	port_name are defined, port takes precedence. */
@@ -331,7 +331,7 @@ type ComputeHealthCheckSpec struct {
 	/* How often (in seconds) to send a health check. The default value is 5
 	seconds. */
 	// +optional
-	CheckIntervalSec *int `json:"checkIntervalSec,omitempty"`
+	CheckIntervalSec *int64 `json:"checkIntervalSec,omitempty"`
 
 	/* An optional description of this resource. Provide this property when
 	you create the resource. */
@@ -345,7 +345,7 @@ type ComputeHealthCheckSpec struct {
 	/* A so-far unhealthy instance will be marked healthy after this many
 	consecutive successes. The default value is 2. */
 	// +optional
-	HealthyThreshold *int `json:"healthyThreshold,omitempty"`
+	HealthyThreshold *int64 `json:"healthyThreshold,omitempty"`
 
 	/* A nested object resource. */
 	// +optional
@@ -382,12 +382,12 @@ type ComputeHealthCheckSpec struct {
 	The default value is 5 seconds.  It is invalid for timeoutSec to have
 	greater value than checkIntervalSec. */
 	// +optional
-	TimeoutSec *int `json:"timeoutSec,omitempty"`
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
 
 	/* A so-far healthy instance will be marked unhealthy after this many
 	consecutive failures. The default value is 2. */
 	// +optional
-	UnhealthyThreshold *int `json:"unhealthyThreshold,omitempty"`
+	UnhealthyThreshold *int64 `json:"unhealthyThreshold,omitempty"`
 }
 
 type ComputeHealthCheckStatus struct {
@@ -400,7 +400,7 @@ type ComputeHealthCheckStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computehttphealthcheck_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computehttphealthcheck_types.go
@@ -39,7 +39,7 @@ type ComputeHTTPHealthCheckSpec struct {
 	/* How often (in seconds) to send a health check. The default value is 5
 	seconds. */
 	// +optional
-	CheckIntervalSec *int `json:"checkIntervalSec,omitempty"`
+	CheckIntervalSec *int64 `json:"checkIntervalSec,omitempty"`
 
 	/* An optional description of this resource. Provide this property when
 	you create the resource. */
@@ -49,7 +49,7 @@ type ComputeHTTPHealthCheckSpec struct {
 	/* A so-far unhealthy instance will be marked healthy after this many
 	consecutive successes. The default value is 2. */
 	// +optional
-	HealthyThreshold *int `json:"healthyThreshold,omitempty"`
+	HealthyThreshold *int64 `json:"healthyThreshold,omitempty"`
 
 	/* The value of the host header in the HTTP health check request. If
 	left empty (default value), the public IP on behalf of which this
@@ -60,7 +60,7 @@ type ComputeHTTPHealthCheckSpec struct {
 	/* The TCP port number for the HTTP health check request.
 	The default value is 80. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* The request path of the HTTP health check request.
 	The default value is /. */
@@ -75,12 +75,12 @@ type ComputeHTTPHealthCheckSpec struct {
 	The default value is 5 seconds.  It is invalid for timeoutSec to have
 	greater value than checkIntervalSec. */
 	// +optional
-	TimeoutSec *int `json:"timeoutSec,omitempty"`
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
 
 	/* A so-far healthy instance will be marked unhealthy after this many
 	consecutive failures. The default value is 2. */
 	// +optional
-	UnhealthyThreshold *int `json:"unhealthyThreshold,omitempty"`
+	UnhealthyThreshold *int64 `json:"unhealthyThreshold,omitempty"`
 }
 
 type ComputeHTTPHealthCheckStatus struct {
@@ -93,7 +93,7 @@ type ComputeHTTPHealthCheckStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computehttpshealthcheck_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computehttpshealthcheck_types.go
@@ -39,7 +39,7 @@ type ComputeHTTPSHealthCheckSpec struct {
 	/* How often (in seconds) to send a health check. The default value is 5
 	seconds. */
 	// +optional
-	CheckIntervalSec *int `json:"checkIntervalSec,omitempty"`
+	CheckIntervalSec *int64 `json:"checkIntervalSec,omitempty"`
 
 	/* An optional description of this resource. Provide this property when
 	you create the resource. */
@@ -49,7 +49,7 @@ type ComputeHTTPSHealthCheckSpec struct {
 	/* A so-far unhealthy instance will be marked healthy after this many
 	consecutive successes. The default value is 2. */
 	// +optional
-	HealthyThreshold *int `json:"healthyThreshold,omitempty"`
+	HealthyThreshold *int64 `json:"healthyThreshold,omitempty"`
 
 	/* The value of the host header in the HTTPS health check request. If
 	left empty (default value), the public IP on behalf of which this
@@ -60,7 +60,7 @@ type ComputeHTTPSHealthCheckSpec struct {
 	/* The TCP port number for the HTTPS health check request.
 	The default value is 443. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* The request path of the HTTPS health check request.
 	The default value is /. */
@@ -75,12 +75,12 @@ type ComputeHTTPSHealthCheckSpec struct {
 	The default value is 5 seconds.  It is invalid for timeoutSec to have
 	greater value than checkIntervalSec. */
 	// +optional
-	TimeoutSec *int `json:"timeoutSec,omitempty"`
+	TimeoutSec *int64 `json:"timeoutSec,omitempty"`
 
 	/* A so-far healthy instance will be marked unhealthy after this many
 	consecutive failures. The default value is 2. */
 	// +optional
-	UnhealthyThreshold *int `json:"unhealthyThreshold,omitempty"`
+	UnhealthyThreshold *int64 `json:"unhealthyThreshold,omitempty"`
 }
 
 type ComputeHTTPSHealthCheckStatus struct {
@@ -93,7 +93,7 @@ type ComputeHTTPSHealthCheckStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeimage_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeimage_types.go
@@ -86,7 +86,7 @@ type ComputeImageSpec struct {
 
 	/* Immutable. Size of the image when restored onto a persistent disk (in GB). */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* Immutable. The name of the image family to which this image belongs. You can
 	create disks by specifying an image family instead of a specific
@@ -143,7 +143,7 @@ type ComputeImageStatus struct {
 	/* Size of the image tar.gz archive stored in Google Cloud Storage (in
 	bytes). */
 	// +optional
-	ArchiveSizeBytes *int `json:"archiveSizeBytes,omitempty"`
+	ArchiveSizeBytes *int64 `json:"archiveSizeBytes,omitempty"`
 
 	/* Creation timestamp in RFC3339 text format. */
 	// +optional
@@ -156,7 +156,7 @@ type ComputeImageStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinstance_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinstance_types.go
@@ -55,11 +55,11 @@ type InstanceAdvancedMachineFeatures struct {
 
 	/* The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed. */
 	// +optional
-	ThreadsPerCore *int `json:"threadsPerCore,omitempty"`
+	ThreadsPerCore *int64 `json:"threadsPerCore,omitempty"`
 
 	/* The number of physical cores to expose to an instance. Multiply by the number of threads per core to compute the total number of virtual CPUs to expose to the instance. If unset, the number of cores is inferred from the instance\'s nominal CPU count and the underlying platform\'s SMT width. */
 	// +optional
-	VisibleCoreCount *int `json:"visibleCoreCount,omitempty"`
+	VisibleCoreCount *int64 `json:"visibleCoreCount,omitempty"`
 }
 
 type InstanceAliasIpRange struct {
@@ -144,7 +144,7 @@ type InstanceDiskEncryptionKeyRaw struct {
 
 type InstanceGuestAccelerator struct {
 	/* Immutable. The number of the guest accelerator cards exposed to this instance. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Immutable. The accelerator type resource exposed to this instance. E.g. nvidia-tesla-k80. */
 	Type string `json:"type"`
@@ -161,7 +161,7 @@ type InstanceInitializeParams struct {
 
 	/* Immutable. The size of the image in gigabytes. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	/* Immutable. The image from which to initialize this disk. */
 	// +optional
@@ -202,11 +202,11 @@ type InstanceLocalSsdRecoveryTimeout struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Immutable. Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type InstanceMaxRunDuration struct {
@@ -215,11 +215,11 @@ type InstanceMaxRunDuration struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Immutable. Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type InstanceMetadata struct {
@@ -239,7 +239,7 @@ type InstanceNetworkInterface struct {
 
 	/* The prefix length of the primary internal IPv6 range. */
 	// +optional
-	InternalIpv6PrefixLength *int `json:"internalIpv6PrefixLength,omitempty"`
+	InternalIpv6PrefixLength *int64 `json:"internalIpv6PrefixLength,omitempty"`
 
 	/* An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access. */
 	// +optional
@@ -273,7 +273,7 @@ type InstanceNetworkInterface struct {
 
 	/* Immutable. The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It will be empty if not specified. */
 	// +optional
-	QueueCount *int `json:"queueCount,omitempty"`
+	QueueCount *int64 `json:"queueCount,omitempty"`
 
 	/* The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. */
 	// +optional
@@ -340,7 +340,7 @@ type InstanceScheduling struct {
 	MaxRunDuration *InstanceMaxRunDuration `json:"maxRunDuration,omitempty"`
 
 	// +optional
-	MinNodeCpus *int `json:"minNodeCpus,omitempty"`
+	MinNodeCpus *int64 `json:"minNodeCpus,omitempty"`
 
 	// +optional
 	NodeAffinities []InstanceNodeAffinities `json:"nodeAffinities,omitempty"`
@@ -364,7 +364,7 @@ type InstanceScratchDisk struct {
 
 	/* Immutable. The size of the disk in gigabytes. One of 375 or 3000. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 }
 
 type InstanceServiceAccount struct {
@@ -545,7 +545,7 @@ type ComputeInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinstancegroup_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinstancegroup_types.go
@@ -40,7 +40,7 @@ type InstancegroupNamedPort struct {
 	Name string `json:"name"`
 
 	/* The port number to map the name to. */
-	Port int `json:"port"`
+	Port int64 `json:"port"`
 }
 
 type ComputeInstanceGroupSpec struct {
@@ -72,7 +72,7 @@ type ComputeInstanceGroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional
@@ -80,7 +80,7 @@ type ComputeInstanceGroupStatus struct {
 
 	/* The number of instances in the group. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinstancegroupmanager_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinstancegroupmanager_types.go
@@ -41,7 +41,7 @@ type InstancegroupmanagerAutoHealingPolicies struct {
 
 	/* The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances. This initial delay allows instances to initialize and run their startup scripts before the instance group determines that they are UNHEALTHY. This prevents the managed instance group from recreating its instances prematurely. This value must be from range [0, 3600]. */
 	// +optional
-	InitialDelaySec *int `json:"initialDelaySec,omitempty"`
+	InitialDelaySec *int64 `json:"initialDelaySec,omitempty"`
 }
 
 type InstancegroupmanagerDisks struct {
@@ -75,21 +75,21 @@ type InstancegroupmanagerInternalIps struct {
 type InstancegroupmanagerMaxSurge struct {
 	/* Specifies a fixed number of VM instances. This must be a positive integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive. For example, specify `80` for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type InstancegroupmanagerMaxUnavailable struct {
 	/* Specifies a fixed number of VM instances. This must be a positive integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive. For example, specify `80` for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type InstancegroupmanagerNamedPorts struct {
@@ -99,7 +99,7 @@ type InstancegroupmanagerNamedPorts struct {
 
 	/* Immutable. The port number, which can be a value between 1 and 65535. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 }
 
 type InstancegroupmanagerPreservedState struct {
@@ -124,15 +124,15 @@ type InstancegroupmanagerStatefulPolicy struct {
 type InstancegroupmanagerTargetSize struct {
 	/* [Output Only] Absolute value of VM instances calculated based on the specific mode. - If the value is `fixed`, then the `calculated` value is equal to the `fixed` value. - If the value is a `percent`, then the `calculated` value is `percent`/100 * `targetSize`. For example, the `calculated` value of a 80% of a managed instance group with 150 instances would be (80/100 * 150) = 120 VM instances. If there is a remainder, the number is rounded. */
 	// +optional
-	Calculated *int `json:"calculated,omitempty"`
+	Calculated *int64 `json:"calculated,omitempty"`
 
 	/* Specifies a fixed number of VM instances. This must be a positive integer. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies a percentage of instances between 0 to 100%, inclusive. For example, specify `80` for 80%. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type InstancegroupmanagerUpdatePolicy struct {
@@ -150,7 +150,7 @@ type InstancegroupmanagerUpdatePolicy struct {
 
 	/* Minimum number of seconds to wait for after a newly created instance becomes available. This value must be from range [0, 3600]. */
 	// +optional
-	MinReadySec *int `json:"minReadySec,omitempty"`
+	MinReadySec *int64 `json:"minReadySec,omitempty"`
 
 	/* Minimal action to be taken on an instance. You can specify either `RESTART` to restart existing instances or `REPLACE` to delete and create new instances from the target template. If you specify a `RESTART`, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action. */
 	// +optional
@@ -238,7 +238,7 @@ type ComputeInstanceGroupManagerSpec struct {
 	TargetPools []v1alpha1.ResourceRef `json:"targetPools,omitempty"`
 
 	/* The target number of running instances for this managed instance group. You can reduce this number by using the instanceGroupManager deleteInstances or abandonInstances methods. Resizing the group also changes this number. */
-	TargetSize int `json:"targetSize"`
+	TargetSize InstancegroupmanagerTargetSize `json:"targetSize"`
 
 	/* The update policy for this managed instance group. */
 	// +optional
@@ -252,51 +252,51 @@ type ComputeInstanceGroupManagerSpec struct {
 type InstancegroupmanagerCurrentActionsStatus struct {
 	/* [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it. */
 	// +optional
-	Abandoning *int `json:"abandoning,omitempty"`
+	Abandoning *int64 `json:"abandoning,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the `creatingWithoutRetries` field will be populated. */
 	// +optional
-	Creating *int `json:"creating,omitempty"`
+	Creating *int64 `json:"creating,omitempty"`
 
 	/* [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's `targetSize` value accordingly. */
 	// +optional
-	CreatingWithoutRetries *int `json:"creatingWithoutRetries,omitempty"`
+	CreatingWithoutRetries *int64 `json:"creatingWithoutRetries,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted. */
 	// +optional
-	Deleting *int `json:"deleting,omitempty"`
+	Deleting *int64 `json:"deleting,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions. */
 	// +optional
-	None *int `json:"none,omitempty"`
+	None *int64 `json:"none,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template. */
 	// +optional
-	Recreating *int `json:"recreating,omitempty"`
+	Recreating *int64 `json:"recreating,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance. */
 	// +optional
-	Refreshing *int `json:"refreshing,omitempty"`
+	Refreshing *int64 `json:"refreshing,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted. */
 	// +optional
-	Restarting *int `json:"restarting,omitempty"`
+	Restarting *int64 `json:"restarting,omitempty"`
 
 	/* [Output Only] The number of instances in the managed instance group that are being verified. See the `managedInstances[].currentAction` property in the `listManagedInstances` method documentation. */
 	// +optional
-	Verifying *int `json:"verifying,omitempty"`
+	Verifying *int64 `json:"verifying,omitempty"`
 }
 
 type InstancegroupmanagerMaxSurgeStatus struct {
 	/* [Output Only] Absolute value of VM instances calculated based on the specific mode. - If the value is `fixed`, then the `calculated` value is equal to the `fixed` value. - If the value is a `percent`, then the `calculated` value is `percent`/100 * `targetSize`. For example, the `calculated` value of a 80% of a managed instance group with 150 instances would be (80/100 * 150) = 120 VM instances. If there is a remainder, the number is rounded. */
 	// +optional
-	Calculated *int `json:"calculated,omitempty"`
+	Calculated *int64 `json:"calculated,omitempty"`
 }
 
 type InstancegroupmanagerMaxUnavailableStatus struct {
 	/* [Output Only] Absolute value of VM instances calculated based on the specific mode. - If the value is `fixed`, then the `calculated` value is equal to the `fixed` value. - If the value is a `percent`, then the `calculated` value is `percent`/100 * `targetSize`. For example, the `calculated` value of a 80% of a managed instance group with 150 instances would be (80/100 * 150) = 120 VM instances. If there is a remainder, the number is rounded. */
 	// +optional
-	Calculated *int `json:"calculated,omitempty"`
+	Calculated *int64 `json:"calculated,omitempty"`
 }
 
 type InstancegroupmanagerPerInstanceConfigsStatus struct {
@@ -369,7 +369,7 @@ type ComputeInstanceGroupManagerStatus struct {
 
 	/* [Output Only] A unique identifier for this resource type. The server generates this identifier. */
 	// +optional
-	Id *int `json:"id,omitempty"`
+	Id *int64 `json:"id,omitempty"`
 
 	/* [Output Only] The URL of the Instance Group resource. */
 	// +optional
@@ -377,7 +377,7 @@ type ComputeInstanceGroupManagerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* [Output Only] The URL of the [region](/compute/docs/regions-zones/#available) where the managed instance group resides (for regional resources). */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinstancetemplate_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinstancetemplate_types.go
@@ -55,11 +55,11 @@ type InstancetemplateAdvancedMachineFeatures struct {
 
 	/* Immutable. The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed. */
 	// +optional
-	ThreadsPerCore *int `json:"threadsPerCore,omitempty"`
+	ThreadsPerCore *int64 `json:"threadsPerCore,omitempty"`
 
 	/* Immutable. The number of physical cores to expose to an instance. Multiply by the number of threads per core to compute the total number of virtual CPUs to expose to the instance. If unset, the number of cores is inferred from the instance\'s nominal CPU count and the underlying platform\'s SMT width. */
 	// +optional
-	VisibleCoreCount *int `json:"visibleCoreCount,omitempty"`
+	VisibleCoreCount *int64 `json:"visibleCoreCount,omitempty"`
 }
 
 type InstancetemplateAliasIpRange struct {
@@ -99,7 +99,7 @@ type InstancetemplateDisk struct {
 
 	/* Immutable. The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375 or 3000 GB, with a default of 375 GB. */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* Immutable. The Google Compute Engine disk type. Such as "pd-ssd", "local-ssd", "pd-balanced" or "pd-standard". */
 	// +optional
@@ -119,7 +119,7 @@ type InstancetemplateDisk struct {
 
 	/* Immutable. Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk). */
 	// +optional
-	ProvisionedIops *int `json:"provisionedIops,omitempty"`
+	ProvisionedIops *int64 `json:"provisionedIops,omitempty"`
 
 	// +optional
 	ResourcePolicies []v1alpha1.ResourceRef `json:"resourcePolicies,omitempty"`
@@ -163,7 +163,7 @@ type InstancetemplateDiskEncryptionKey struct {
 
 type InstancetemplateGuestAccelerator struct {
 	/* Immutable. The number of the guest accelerator cards exposed to this instance. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Immutable. The accelerator type resource to expose to this instance. E.g. nvidia-tesla-k80. */
 	Type string `json:"type"`
@@ -196,11 +196,11 @@ type InstancetemplateLocalSsdRecoveryTimeout struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Immutable. Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type InstancetemplateMaxRunDuration struct {
@@ -209,11 +209,11 @@ type InstancetemplateMaxRunDuration struct {
 	with a 0 seconds field and a positive nanos field. Must
 	be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Immutable. Span of time at a resolution of a second.
 	Must be from 0 to 315,576,000,000 inclusive. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type InstancetemplateMetadata struct {
@@ -232,7 +232,7 @@ type InstancetemplateNetworkInterface struct {
 
 	/* The prefix length of the primary internal IPv6 range. */
 	// +optional
-	InternalIpv6PrefixLength *int `json:"internalIpv6PrefixLength,omitempty"`
+	InternalIpv6PrefixLength *int64 `json:"internalIpv6PrefixLength,omitempty"`
 
 	/* An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access. */
 	// +optional
@@ -267,7 +267,7 @@ type InstancetemplateNetworkInterface struct {
 
 	/* Immutable. The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It will be empty if not specified. */
 	// +optional
-	QueueCount *int `json:"queueCount,omitempty"`
+	QueueCount *int64 `json:"queueCount,omitempty"`
 
 	/* The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used. */
 	// +optional
@@ -326,7 +326,7 @@ type InstancetemplateScheduling struct {
 
 	/* Minimum number of cpus for the instance. */
 	// +optional
-	MinNodeCpus *int `json:"minNodeCpus,omitempty"`
+	MinNodeCpus *int64 `json:"minNodeCpus,omitempty"`
 
 	// +optional
 	NodeAffinities []InstancetemplateNodeAffinities `json:"nodeAffinities,omitempty"`
@@ -501,7 +501,7 @@ type ComputeInstanceTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinterconnectattachment_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinterconnectattachment_types.go
@@ -124,14 +124,14 @@ type ComputeInterconnectAttachmentSpec struct {
 	/* Immutable. The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. When
 	using PARTNER type this will be managed upstream. */
 	// +optional
-	VlanTag8021q *int `json:"vlanTag8021q,omitempty"`
+	VlanTag8021q *int64 `json:"vlanTag8021q,omitempty"`
 }
 
 type InterconnectattachmentPrivateInterconnectInfoStatus struct {
 	/* 802.1q encapsulation tag to be used for traffic between
 	Google and the customer, going to and from this network and region. */
 	// +optional
-	Tag8021q *int `json:"tag8021q,omitempty"`
+	Tag8021q *int64 `json:"tag8021q,omitempty"`
 }
 
 type ComputeInterconnectAttachmentStatus struct {
@@ -159,7 +159,7 @@ type ComputeInterconnectAttachmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* [Output only for type PARTNER. Not present for DEDICATED]. The opaque
 	identifier of an PARTNER attachment used to initiate provisioning with

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetwork_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetwork_types.go
@@ -74,7 +74,7 @@ type ComputeNetworkSpec struct {
 	with an ICMP 'Fragmentation-Needed' message if the packets are routed to the Internet or other VPCs
 	with varying MTUs. */
 	// +optional
-	Mtu *int `json:"mtu,omitempty"`
+	Mtu *int64 `json:"mtu,omitempty"`
 
 	/* Set the order that Firewall Rules and Firewall Policies are evaluated. Default value: "AFTER_CLASSIC_FIREWALL" Possible values: ["BEFORE_CLASSIC_FIREWALL", "AFTER_CLASSIC_FIREWALL"]. */
 	// +optional
@@ -104,7 +104,7 @@ type ComputeNetworkStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetworkendpointgroup_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetworkendpointgroup_types.go
@@ -39,7 +39,7 @@ type ComputeNetworkEndpointGroupSpec struct {
 	/* Immutable. The default port used if the port number is not specified in the
 	network endpoint. */
 	// +optional
-	DefaultPort *int `json:"defaultPort,omitempty"`
+	DefaultPort *int64 `json:"defaultPort,omitempty"`
 
 	/* Immutable. An optional description of this resource. Provide this property when
 	you create the resource. */
@@ -80,14 +80,14 @@ type ComputeNetworkEndpointGroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`
 
 	/* Number of network endpoints in the network endpoint group. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetworkfirewallpolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetworkfirewallpolicy_types.go
@@ -66,11 +66,11 @@ type ComputeNetworkFirewallPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Total count of all firewall policy rule tuples. A firewall policy can not exceed a set number of tuples. */
 	// +optional
-	RuleTupleCount *int `json:"ruleTupleCount,omitempty"`
+	RuleTupleCount *int64 `json:"ruleTupleCount,omitempty"`
 
 	/* Server-defined URL for the resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetworkfirewallpolicyassociation_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetworkfirewallpolicyassociation_types.go
@@ -56,7 +56,7 @@ type ComputeNetworkFirewallPolicyAssociationStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The short name of the firewall policy of the association. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computenetworkpeering_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenetworkpeering_types.go
@@ -71,7 +71,7 @@ type ComputeNetworkPeeringStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State for the peering, either ACTIVE or INACTIVE. The peering is ACTIVE when there's a matching configuration in the peer network. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computenodegroup_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenodegroup_types.go
@@ -39,12 +39,12 @@ type NodegroupAutoscalingPolicy struct {
 	/* Immutable. Maximum size of the node group. Set to a value less than or equal
 	to 100 and greater than or equal to min-nodes. */
 	// +optional
-	MaxNodes *int `json:"maxNodes,omitempty"`
+	MaxNodes *int64 `json:"maxNodes,omitempty"`
 
 	/* Immutable. Minimum size of the node group. Must be less
 	than or equal to max-nodes. The default value is 0. */
 	// +optional
-	MinNodes *int `json:"minNodes,omitempty"`
+	MinNodes *int64 `json:"minNodes,omitempty"`
 
 	/* Immutable. The autoscaling mode. Set to one of the following:
 	- OFF: Disables the autoscaler.
@@ -91,7 +91,7 @@ type ComputeNodeGroupSpec struct {
 
 	/* Immutable. The initial number of nodes in the node group. One of 'initial_size' or 'size' must be specified. */
 	// +optional
-	InitialSize *int `json:"initialSize,omitempty"`
+	InitialSize *int64 `json:"initialSize,omitempty"`
 
 	/* Immutable. Specifies how to handle instances when a node in the group undergoes maintenance. Set to one of: DEFAULT, RESTART_IN_PLACE, or MIGRATE_WITHIN_NODE_GROUP. The default value is DEFAULT. */
 	// +optional
@@ -114,7 +114,7 @@ type ComputeNodeGroupSpec struct {
 
 	/* Immutable. The total number of nodes in the node group. One of 'initial_size' or 'size' must be specified. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	/* Immutable. Zone where this node group is located. */
 	Zone string `json:"zone"`
@@ -130,7 +130,7 @@ type ComputeNodeGroupStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computenodetemplate_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computenodetemplate_types.go
@@ -110,7 +110,7 @@ type ComputeNodeTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computepacketmirroring_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computepacketmirroring_types.go
@@ -118,7 +118,7 @@ type ComputePacketMirroringSpec struct {
 
 	/* The priority of applying this configuration. Priority is used to break ties in cases where there is more than one matching rule. In the case of two rules that apply for a given Instance, the one with the lowest-numbered priority value wins. Default value is 1000. Valid range is 0 through 65535. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* Immutable. The Project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -149,14 +149,14 @@ type ComputePacketMirroringStatus struct {
 
 	/* Output only. The unique identifier for the resource. This identifier is defined by the server. */
 	// +optional
-	Id *int `json:"id,omitempty"`
+	Id *int64 `json:"id,omitempty"`
 
 	// +optional
 	Network *PacketmirroringNetworkStatus `json:"network,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* URI of the region where the packetMirroring resides. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computeprojectmetadata_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeprojectmetadata_types.go
@@ -46,7 +46,7 @@ type ComputeProjectMetadataStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computeregionnetworkendpointgroup_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeregionnetworkendpointgroup_types.go
@@ -129,7 +129,7 @@ type ComputeRegionNetworkEndpointGroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computereservation_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computereservation_types.go
@@ -38,7 +38,7 @@ import (
 type ReservationGuestAccelerators struct {
 	/* Immutable. The number of the guest accelerator cards exposed to
 	this instance. */
-	AcceleratorCount int `json:"acceleratorCount"`
+	AcceleratorCount int64 `json:"acceleratorCount"`
 
 	/* Immutable. The full or partial URL of the accelerator type to
 	attach to this instance. For example:
@@ -71,7 +71,7 @@ type ReservationInstanceProperties struct {
 
 type ReservationLocalSsds struct {
 	/* Immutable. The size of the disk in base-2 GB. */
-	DiskSizeGb int `json:"diskSizeGb"`
+	DiskSizeGb int64 `json:"diskSizeGb"`
 
 	/* Immutable. The disk interface to use for attaching this disk. Default value: "SCSI" Possible values: ["SCSI", "NVME"]. */
 	// +optional
@@ -80,11 +80,11 @@ type ReservationLocalSsds struct {
 
 type ReservationSpecificReservation struct {
 	/* The number of resources that are allocated. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* How many instances are in use. */
 	// +optional
-	InUseCount *int `json:"inUseCount,omitempty"`
+	InUseCount *int64 `json:"inUseCount,omitempty"`
 
 	/* Immutable. The instance properties for the reservation. */
 	InstanceProperties ReservationInstanceProperties `json:"instanceProperties"`
@@ -127,7 +127,7 @@ type ComputeReservationStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeresourcepolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeresourcepolicy_types.go
@@ -37,7 +37,7 @@ import (
 
 type ResourcepolicyDailySchedule struct {
 	/* Immutable. Defines a schedule with units measured in days. The value determines how many days pass between the start of each cycle. Days in cycle for snapshot schedule policy must be 1. */
-	DaysInCycle int `json:"daysInCycle"`
+	DaysInCycle int64 `json:"daysInCycle"`
 
 	/* Immutable. This must be in UTC format that resolves to one of
 	00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example,
@@ -63,7 +63,7 @@ type ResourcepolicyGroupPlacementPolicy struct {
 	/* Immutable. The number of availability domains instances will be spread across. If two instances are in different
 	availability domain, they will not be put in the same low latency network. */
 	// +optional
-	AvailabilityDomainCount *int `json:"availabilityDomainCount,omitempty"`
+	AvailabilityDomainCount *int64 `json:"availabilityDomainCount,omitempty"`
 
 	/* Immutable. Collocation specifies whether to place VMs inside the same availability domain on the same low-latency network.
 	Specify 'COLLOCATED' to enable collocation. Can only be specified with 'vm_count'. If compute instances are created
@@ -74,18 +74,18 @@ type ResourcepolicyGroupPlacementPolicy struct {
 
 	/* Immutable. Specifies the number of max logical switches. */
 	// +optional
-	MaxDistance *int `json:"maxDistance,omitempty"`
+	MaxDistance *int64 `json:"maxDistance,omitempty"`
 
 	/* Immutable. Number of VMs in this placement group. Google does not recommend that you use this field
 	unless you use a compact policy and you want your policy to work only if it contains this
 	exact number of VMs. */
 	// +optional
-	VmCount *int `json:"vmCount,omitempty"`
+	VmCount *int64 `json:"vmCount,omitempty"`
 }
 
 type ResourcepolicyHourlySchedule struct {
 	/* Immutable. The number of hours between snapshots. */
-	HoursInCycle int `json:"hoursInCycle"`
+	HoursInCycle int64 `json:"hoursInCycle"`
 
 	/* Immutable. Time within the window to start the operations.
 	It must be in an hourly format "HH:MM",
@@ -118,7 +118,7 @@ type ResourcepolicyInstanceSchedulePolicy struct {
 
 type ResourcepolicyRetentionPolicy struct {
 	/* Immutable. Maximum age of the snapshot that is allowed to be kept. */
-	MaxRetentionDays int `json:"maxRetentionDays"`
+	MaxRetentionDays int64 `json:"maxRetentionDays"`
 
 	/* Immutable. Specifies the behavior to apply to scheduled snapshots when
 	the source disk is deleted. Default value: "KEEP_AUTO_SNAPSHOTS" Possible values: ["KEEP_AUTO_SNAPSHOTS", "APPLY_RETENTION_POLICY"]. */
@@ -224,7 +224,7 @@ type ComputeResourcePolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeroute_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeroute_types.go
@@ -84,7 +84,7 @@ type ComputeRouteSpec struct {
 
 	Default value is 1000. Valid range is 0 through 65535. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
@@ -105,7 +105,7 @@ type ComputeRouteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computerouter_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computerouter_types.go
@@ -72,7 +72,7 @@ type RouterBgp struct {
 	private ASN, either 16-bit or 32-bit. The value will be fixed for
 	this router resource. All VPN tunnels that link to this router
 	will have the same local ASN. */
-	Asn int `json:"asn"`
+	Asn int64 `json:"asn"`
 
 	/* The interval in seconds between BGP keepalive messages that are sent
 	to the peer. Hold time is three times the interval at which keepalive
@@ -85,7 +85,7 @@ type RouterBgp struct {
 	between the two peers. If set, this value must be between 20 and 60.
 	The default is 20. */
 	// +optional
-	KeepaliveInterval *int `json:"keepaliveInterval,omitempty"`
+	KeepaliveInterval *int64 `json:"keepaliveInterval,omitempty"`
 }
 
 type ComputeRouterSpec struct {
@@ -123,7 +123,7 @@ type ComputeRouterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computerouterinterface_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computerouterinterface_types.go
@@ -72,7 +72,7 @@ type ComputeRouterInterfaceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computerouternat_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computerouternat_types.go
@@ -76,7 +76,7 @@ type RouternatRules struct {
 
 	/* An integer uniquely identifying a rule in the list.
 	The rule number must be a positive value between 0 and 65000, and must be unique among rules within a NAT. */
-	RuleNumber int `json:"ruleNumber"`
+	RuleNumber int64 `json:"ruleNumber"`
 }
 
 type RouternatSubnetwork struct {
@@ -118,7 +118,7 @@ type ComputeRouterNATSpec struct {
 
 	/* Timeout (in seconds) for ICMP connections. Defaults to 30s if not set. */
 	// +optional
-	IcmpIdleTimeoutSec *int `json:"icmpIdleTimeoutSec,omitempty"`
+	IcmpIdleTimeoutSec *int64 `json:"icmpIdleTimeoutSec,omitempty"`
 
 	/* Configuration for logging on NAT. */
 	// +optional
@@ -127,11 +127,11 @@ type ComputeRouterNATSpec struct {
 	/* Maximum number of ports allocated to a VM from this NAT.
 	This field can only be set when enableDynamicPortAllocation is enabled. */
 	// +optional
-	MaxPortsPerVm *int `json:"maxPortsPerVm,omitempty"`
+	MaxPortsPerVm *int64 `json:"maxPortsPerVm,omitempty"`
 
 	/* Minimum number of ports allocated to a VM from this NAT. */
 	// +optional
-	MinPortsPerVm *int `json:"minPortsPerVm,omitempty"`
+	MinPortsPerVm *int64 `json:"minPortsPerVm,omitempty"`
 
 	/* How external IPs should be allocated for this NAT. Valid values are
 	'AUTO_ONLY' for only allowing NAT IPs allocated by Google Cloud
@@ -175,21 +175,21 @@ type ComputeRouterNATSpec struct {
 	/* Timeout (in seconds) for TCP established connections.
 	Defaults to 1200s if not set. */
 	// +optional
-	TcpEstablishedIdleTimeoutSec *int `json:"tcpEstablishedIdleTimeoutSec,omitempty"`
+	TcpEstablishedIdleTimeoutSec *int64 `json:"tcpEstablishedIdleTimeoutSec,omitempty"`
 
 	/* Timeout (in seconds) for TCP connections that are in TIME_WAIT state.
 	Defaults to 120s if not set. */
 	// +optional
-	TcpTimeWaitTimeoutSec *int `json:"tcpTimeWaitTimeoutSec,omitempty"`
+	TcpTimeWaitTimeoutSec *int64 `json:"tcpTimeWaitTimeoutSec,omitempty"`
 
 	/* Timeout (in seconds) for TCP transitory connections.
 	Defaults to 30s if not set. */
 	// +optional
-	TcpTransitoryIdleTimeoutSec *int `json:"tcpTransitoryIdleTimeoutSec,omitempty"`
+	TcpTransitoryIdleTimeoutSec *int64 `json:"tcpTransitoryIdleTimeoutSec,omitempty"`
 
 	/* Timeout (in seconds) for UDP connections. Defaults to 30s if not set. */
 	// +optional
-	UdpIdleTimeoutSec *int `json:"udpIdleTimeoutSec,omitempty"`
+	UdpIdleTimeoutSec *int64 `json:"udpIdleTimeoutSec,omitempty"`
 }
 
 type ComputeRouterNATStatus struct {
@@ -198,7 +198,7 @@ type ComputeRouterNATStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computerouterpeer_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computerouterpeer_types.go
@@ -52,7 +52,7 @@ type RouterpeerBfd struct {
 	and the transmit interval of the other router. If set, this value
 	must be between 1000 and 30000. */
 	// +optional
-	MinReceiveInterval *int `json:"minReceiveInterval,omitempty"`
+	MinReceiveInterval *int64 `json:"minReceiveInterval,omitempty"`
 
 	/* The minimum interval, in milliseconds, between BFD control packets
 	transmitted to the peer router. The actual value is negotiated
@@ -60,13 +60,13 @@ type RouterpeerBfd struct {
 	and the corresponding receive interval of the other router. If set,
 	this value must be between 1000 and 30000. */
 	// +optional
-	MinTransmitInterval *int `json:"minTransmitInterval,omitempty"`
+	MinTransmitInterval *int64 `json:"minTransmitInterval,omitempty"`
 
 	/* The number of consecutive BFD packets that must be missed before
 	BFD declares that a peer is unavailable. If set, the value must
 	be a value between 5 and 16. */
 	// +optional
-	Multiplier *int `json:"multiplier,omitempty"`
+	Multiplier *int64 `json:"multiplier,omitempty"`
 
 	/* The BFD session initialization mode for this BGP peer.
 	If set to 'ACTIVE', the Cloud Router will initiate the BFD session
@@ -114,7 +114,7 @@ type ComputeRouterPeerSpec struct {
 	Where there is more than one matching route of maximum
 	length, the routes with the lowest priority value win. */
 	// +optional
-	AdvertisedRoutePriority *int `json:"advertisedRoutePriority,omitempty"`
+	AdvertisedRoutePriority *int64 `json:"advertisedRoutePriority,omitempty"`
 
 	/* BFD configuration for the BGP peering. */
 	// +optional
@@ -145,7 +145,7 @@ type ComputeRouterPeerSpec struct {
 
 	/* Peer BGP Autonomous System Number (ASN).
 	Each BGP interface may use a different value. */
-	PeerAsn int `json:"peerAsn"`
+	PeerAsn int64 `json:"peerAsn"`
 
 	/* IP address of the BGP interface outside Google Cloud Platform.
 	Only IPv4 is supported. Required if 'ip_address' is set. */
@@ -201,7 +201,7 @@ type ComputeRouterPeerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computesecuritypolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesecuritypolicy_types.go
@@ -70,7 +70,7 @@ type SecuritypolicyAutoDeployConfig struct {
 
 	/* Google Cloud Armor stops applying the action in the automatically deployed rule to an identified attacker after this duration. The rule continues to operate against new requests. */
 	// +optional
-	ExpirationSec *int `json:"expirationSec,omitempty"`
+	ExpirationSec *int64 `json:"expirationSec,omitempty"`
 
 	/* Rules are only automatically deployed when the estimated impact to baseline traffic from the suggested mitigation is below this threshold. */
 	// +optional
@@ -83,10 +83,10 @@ type SecuritypolicyAutoDeployConfig struct {
 
 type SecuritypolicyBanThreshold struct {
 	/* Number of HTTP(S) requests for calculating the threshold. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Interval over which the threshold is computed. */
-	IntervalSec int `json:"intervalSec"`
+	IntervalSec int64 `json:"intervalSec"`
 }
 
 type SecuritypolicyConfig struct {
@@ -186,7 +186,7 @@ type SecuritypolicyPreconfiguredWafConfig struct {
 type SecuritypolicyRateLimitOptions struct {
 	/* Can only be specified if the action for the rule is "rate_based_ban". If specified, determines the time (in seconds) the traffic will continue to be banned by the rate limit after the rate falls below the threshold. */
 	// +optional
-	BanDurationSec *int `json:"banDurationSec,omitempty"`
+	BanDurationSec *int64 `json:"banDurationSec,omitempty"`
 
 	/* Can only be specified if the action for the rule is "rate_based_ban". If specified, the key will be banned for the configured 'banDurationSec' when the number of requests that exceed the 'rateLimitThreshold' also exceed this 'banThreshold'. */
 	// +optional
@@ -220,10 +220,10 @@ type SecuritypolicyRateLimitOptions struct {
 
 type SecuritypolicyRateLimitThreshold struct {
 	/* Number of HTTP(S) requests for calculating the threshold. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Interval over which the threshold is computed. */
-	IntervalSec int `json:"intervalSec"`
+	IntervalSec int64 `json:"intervalSec"`
 }
 
 type SecuritypolicyRecaptchaOptionsConfig struct {
@@ -314,7 +314,7 @@ type SecuritypolicyRule struct {
 	Preview *bool `json:"preview,omitempty"`
 
 	/* An unique positive integer indicating the priority of evaluation for a rule. Rules are evaluated from highest priority (lowest numerically) to lowest priority (highest numerically) in order. */
-	Priority int `json:"priority"`
+	Priority int64 `json:"priority"`
 
 	/* Rate limit threshold for this security policy. Must be specified if the action is "rate_based_ban" or "throttle". Cannot be specified for any other actions. */
 	// +optional
@@ -365,7 +365,7 @@ type ComputeSecurityPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computeserviceattachment_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeserviceattachment_types.go
@@ -38,7 +38,7 @@ import (
 type ServiceattachmentConsumerAcceptLists struct {
 	/* The value of the limit to set. */
 	// +optional
-	ConnectionLimit *int `json:"connectionLimit,omitempty"`
+	ConnectionLimit *int64 `json:"connectionLimit,omitempty"`
 
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
 }
@@ -85,7 +85,7 @@ type ServiceattachmentConnectedEndpointsStatus struct {
 
 	/* The PSC connection id of the connected endpoint. */
 	// +optional
-	PscConnectionId *int `json:"pscConnectionId,omitempty"`
+	PscConnectionId *int64 `json:"pscConnectionId,omitempty"`
 
 	/* The status of a connected endpoint to this service attachment. Possible values: PENDING, RUNNING, DONE */
 	// +optional
@@ -94,10 +94,10 @@ type ServiceattachmentConnectedEndpointsStatus struct {
 
 type ServiceattachmentPscServiceAttachmentIdStatus struct {
 	// +optional
-	High *int `json:"high,omitempty"`
+	High *int64 `json:"high,omitempty"`
 
 	// +optional
-	Low *int `json:"low,omitempty"`
+	Low *int64 `json:"low,omitempty"`
 }
 
 type ComputeServiceAttachmentStatus struct {
@@ -114,11 +114,11 @@ type ComputeServiceAttachmentStatus struct {
 
 	/* The unique identifier for the resource type. The server generates this identifier. */
 	// +optional
-	Id *int `json:"id,omitempty"`
+	Id *int64 `json:"id,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* An 128-bit global unique ID of the PSC service attachment. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computesharedvpchostproject_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesharedvpchostproject_types.go
@@ -44,7 +44,7 @@ type ComputeSharedVPCHostProjectStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computesharedvpcserviceproject_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesharedvpcserviceproject_types.go
@@ -50,7 +50,7 @@ type ComputeSharedVPCServiceProjectStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computesnapshot_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesnapshot_types.go
@@ -146,7 +146,7 @@ type ComputeSnapshotStatus struct {
 
 	/* Size of the snapshot, specified in GB. */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* The fingerprint used for optimistic locking of this resource. Used
 	internally during updates. */
@@ -162,20 +162,20 @@ type ComputeSnapshotStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`
 
 	/* The unique identifier for the resource. */
 	// +optional
-	SnapshotId *int `json:"snapshotId,omitempty"`
+	SnapshotId *int64 `json:"snapshotId,omitempty"`
 
 	/* A size of the storage used by the snapshot. As snapshots share
 	storage, this number is expected to change with snapshot
 	creation/deletion. */
 	// +optional
-	StorageBytes *int `json:"storageBytes,omitempty"`
+	StorageBytes *int64 `json:"storageBytes,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/computesslcertificate_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesslcertificate_types.go
@@ -88,7 +88,7 @@ type ComputeSSLCertificateStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* The unique identifier for the resource. */
 	// +optional
-	CertificateId *int `json:"certificateId,omitempty"`
+	CertificateId *int64 `json:"certificateId,omitempty"`
 
 	/* Creation timestamp in RFC3339 text format. */
 	// +optional
@@ -100,7 +100,7 @@ type ComputeSSLCertificateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computesslpolicy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesslpolicy_types.go
@@ -93,7 +93,7 @@ type ComputeSSLPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computesubnetwork_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computesubnetwork_types.go
@@ -186,7 +186,7 @@ type ComputeSubnetworkStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargetgrpcproxy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargetgrpcproxy_types.go
@@ -83,7 +83,7 @@ type ComputeTargetGRPCProxyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargethttpproxy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargethttpproxy_types.go
@@ -47,7 +47,7 @@ type ComputeTargetHTTPProxySpec struct {
 	the maximum allowed value is 1200 seconds. For Global external HTTP(S)
 	load balancer (classic), this option is not available publicly. */
 	// +optional
-	HttpKeepAliveTimeoutSec *int `json:"httpKeepAliveTimeoutSec,omitempty"`
+	HttpKeepAliveTimeoutSec *int64 `json:"httpKeepAliveTimeoutSec,omitempty"`
 
 	/* Location represents the geographical location of the ComputeTargetHTTPProxy. Specify a region name or "global" for global resources. Reference: GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/) */
 	Location string `json:"location"`
@@ -76,11 +76,11 @@ type ComputeTargetHTTPProxyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the resource. */
 	// +optional
-	ProxyId *int `json:"proxyId,omitempty"`
+	ProxyId *int64 `json:"proxyId,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargethttpsproxy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargethttpsproxy_types.go
@@ -56,7 +56,7 @@ type ComputeTargetHTTPSProxySpec struct {
 	the maximum allowed value is 1200 seconds. For Global external HTTP(S)
 	load balancer (classic), this option is not available publicly. */
 	// +optional
-	HttpKeepAliveTimeoutSec *int `json:"httpKeepAliveTimeoutSec,omitempty"`
+	HttpKeepAliveTimeoutSec *int64 `json:"httpKeepAliveTimeoutSec,omitempty"`
 
 	/* Location represents the geographical location of the ComputeTargetHTTPSProxy. Specify a region name or "global" for global resources. Reference: GCP definition of regions/zones (https://cloud.google.com/compute/docs/regions-zones/) */
 	Location string `json:"location"`
@@ -114,11 +114,11 @@ type ComputeTargetHTTPSProxyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the resource. */
 	// +optional
-	ProxyId *int `json:"proxyId,omitempty"`
+	ProxyId *int64 `json:"proxyId,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargetinstance_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargetinstance_types.go
@@ -76,7 +76,7 @@ type ComputeTargetInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargetpool_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargetpool_types.go
@@ -80,7 +80,7 @@ type ComputeTargetPoolStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargetsslproxy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargetsslproxy_types.go
@@ -80,11 +80,11 @@ type ComputeTargetSSLProxyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the resource. */
 	// +optional
-	ProxyId *int `json:"proxyId,omitempty"`
+	ProxyId *int64 `json:"proxyId,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargettcpproxy_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargettcpproxy_types.go
@@ -68,11 +68,11 @@ type ComputeTargetTCPProxyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier for the resource. */
 	// +optional
-	ProxyId *int `json:"proxyId,omitempty"`
+	ProxyId *int64 `json:"proxyId,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computetargetvpngateway_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computetargetvpngateway_types.go
@@ -61,11 +61,11 @@ type ComputeTargetVPNGatewayStatus struct {
 
 	/* The unique identifier for the resource. */
 	// +optional
-	GatewayId *int `json:"gatewayId,omitempty"`
+	GatewayId *int64 `json:"gatewayId,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computeurlmap_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeurlmap_types.go
@@ -39,7 +39,7 @@ type UrlmapAbort struct {
 	/* The HTTP status code used to abort the request. The value must be between 200
 	and 599 inclusive. */
 	// +optional
-	HttpStatus *int `json:"httpStatus,omitempty"`
+	HttpStatus *int64 `json:"httpStatus,omitempty"`
 
 	/* The percentage of traffic (connections/operations/requests) which will be
 	aborted as part of fault injection. The value must be between 0.0 and 100.0
@@ -86,7 +86,7 @@ type UrlmapCorsPolicy struct {
 	/* Specifies how long the results of a preflight request can be cached. This
 	translates to the content for the Access-Control-Max-Age header. */
 	// +optional
-	MaxAge *int `json:"maxAge,omitempty"`
+	MaxAge *int64 `json:"maxAge,omitempty"`
 }
 
 type UrlmapDefaultRouteAction struct {
@@ -236,7 +236,7 @@ type UrlmapFixedDelay struct {
 	less than one second are represented with a 0 'seconds' field and a positive
 	'nanos' field. Must be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
 	inclusive. */
@@ -524,7 +524,7 @@ type UrlmapPerTryTimeout struct {
 	less than one second are represented with a 0 'seconds' field and a positive
 	'nanos' field. Must be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
 	inclusive. */
@@ -558,10 +558,10 @@ type UrlmapQueryParameterMatches struct {
 
 type UrlmapRangeMatch struct {
 	/* The end of the range (exclusive). */
-	RangeEnd int `json:"rangeEnd"`
+	RangeEnd int64 `json:"rangeEnd"`
 
 	/* The start of the range (inclusive). */
-	RangeStart int `json:"rangeStart"`
+	RangeStart int64 `json:"rangeStart"`
 }
 
 type UrlmapRequestHeadersToAdd struct {
@@ -597,7 +597,7 @@ type UrlmapResponseHeadersToAdd struct {
 
 type UrlmapRetryPolicy struct {
 	/* Specifies the allowed number retries. This number must be > 0. */
-	NumRetries int `json:"numRetries"`
+	NumRetries int64 `json:"numRetries"`
 
 	/* Specifies a non-zero timeout per retry attempt. */
 	// +optional
@@ -707,7 +707,7 @@ type UrlmapRouteRules struct {
 	1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which
 	you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the
 	future without any impact on existing rules. */
-	Priority int `json:"priority"`
+	Priority int64 `json:"priority"`
 
 	/* In response to a matching matchRule, the load balancer performs advanced routing
 	actions like URL rewrites, header transformations, etc. prior to forwarding the
@@ -767,7 +767,7 @@ type UrlmapTimeout struct {
 	less than one second are represented with a 0 'seconds' field and a positive
 	'nanos' field. Must be from 0 to 999,999,999 inclusive. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
 	inclusive. */
@@ -878,7 +878,7 @@ type UrlmapWeightedBackendServices struct {
 	been directed to a backendService, subsequent requests will be sent to the same
 	backendService as determined by the BackendService's session affinity policy.
 	The value must be between 0 and 1000. */
-	Weight int `json:"weight"`
+	Weight int64 `json:"weight"`
 }
 
 type ComputeURLMapSpec struct {
@@ -959,11 +959,11 @@ type ComputeURLMapStatus struct {
 
 	/* The unique identifier for the resource. */
 	// +optional
-	MapId *int `json:"mapId,omitempty"`
+	MapId *int64 `json:"mapId,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computevpngateway_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computevpngateway_types.go
@@ -38,7 +38,7 @@ import (
 type VpngatewayVpnInterfaces struct {
 	/* Immutable. The numeric ID of this VPN gateway interface. */
 	// +optional
-	Id *int `json:"id,omitempty"`
+	Id *int64 `json:"id,omitempty"`
 
 	/* Immutable. When this value is present, the VPN Gateway will be used
 	for IPsec-encrypted Cloud Interconnect; all Egress or Ingress
@@ -83,7 +83,7 @@ type ComputeVPNGatewayStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/computevpntunnel_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computevpntunnel_types.go
@@ -60,7 +60,7 @@ type ComputeVPNTunnelSpec struct {
 	peer VPN gateway.
 	Acceptable IKE versions are 1 or 2. Default version is 2. */
 	// +optional
-	IkeVersion *int `json:"ikeVersion,omitempty"`
+	IkeVersion *int64 `json:"ikeVersion,omitempty"`
 
 	/* Immutable. Local traffic selector to use when establishing the VPN tunnel with
 	peer VPN gateway. The value should be a CIDR formatted string,
@@ -71,7 +71,7 @@ type ComputeVPNTunnelSpec struct {
 
 	/* Immutable. The interface ID of the external VPN gateway to which this VPN tunnel is connected. */
 	// +optional
-	PeerExternalGatewayInterface *int `json:"peerExternalGatewayInterface,omitempty"`
+	PeerExternalGatewayInterface *int64 `json:"peerExternalGatewayInterface,omitempty"`
 
 	/* The peer side external VPN gateway to which this VPN tunnel
 	is connected. */
@@ -117,7 +117,7 @@ type ComputeVPNTunnelSpec struct {
 
 	/* Immutable. The interface ID of the VPN gateway with which this VPN tunnel is associated. */
 	// +optional
-	VpnGatewayInterface *int `json:"vpnGatewayInterface,omitempty"`
+	VpnGatewayInterface *int64 `json:"vpnGatewayInterface,omitempty"`
 
 	/* The ComputeVPNGateway with which this VPN tunnel is associated.
 	This must be used if a High Availability VPN gateway resource is
@@ -145,7 +145,7 @@ type ComputeVPNTunnelStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/compute/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/zz_generated.deepcopy.go
@@ -119,17 +119,17 @@ func (in *BackendbucketCdnPolicy) DeepCopyInto(out *BackendbucketCdnPolicy) {
 	}
 	if in.ClientTtl != nil {
 		in, out := &in.ClientTtl, &out.ClientTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DefaultTtl != nil {
 		in, out := &in.DefaultTtl, &out.DefaultTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxTtl != nil {
 		in, out := &in.MaxTtl, &out.MaxTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NegativeCaching != nil {
@@ -151,12 +151,12 @@ func (in *BackendbucketCdnPolicy) DeepCopyInto(out *BackendbucketCdnPolicy) {
 	}
 	if in.ServeWhileStale != nil {
 		in, out := &in.ServeWhileStale, &out.ServeWhileStale
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SignedUrlCacheMaxAgeSec != nil {
 		in, out := &in.SignedUrlCacheMaxAgeSec, &out.SignedUrlCacheMaxAgeSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -177,12 +177,12 @@ func (in *BackendbucketNegativeCachingPolicy) DeepCopyInto(out *BackendbucketNeg
 	*out = *in
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Ttl != nil {
 		in, out := &in.Ttl, &out.Ttl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -224,22 +224,22 @@ func (in *BackendserviceBackend) DeepCopyInto(out *BackendserviceBackend) {
 	in.Group.DeepCopyInto(&out.Group)
 	if in.MaxConnections != nil {
 		in, out := &in.MaxConnections, &out.MaxConnections
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxConnectionsPerEndpoint != nil {
 		in, out := &in.MaxConnectionsPerEndpoint, &out.MaxConnectionsPerEndpoint
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxConnectionsPerInstance != nil {
 		in, out := &in.MaxConnectionsPerInstance, &out.MaxConnectionsPerInstance
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRate != nil {
 		in, out := &in.MaxRate, &out.MaxRate
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRatePerEndpoint != nil {
@@ -275,7 +275,7 @@ func (in *BackendserviceBaseEjectionTime) DeepCopyInto(out *BackendserviceBaseEj
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -378,17 +378,17 @@ func (in *BackendserviceCdnPolicy) DeepCopyInto(out *BackendserviceCdnPolicy) {
 	}
 	if in.ClientTtl != nil {
 		in, out := &in.ClientTtl, &out.ClientTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DefaultTtl != nil {
 		in, out := &in.DefaultTtl, &out.DefaultTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxTtl != nil {
 		in, out := &in.MaxTtl, &out.MaxTtl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NegativeCaching != nil {
@@ -405,12 +405,12 @@ func (in *BackendserviceCdnPolicy) DeepCopyInto(out *BackendserviceCdnPolicy) {
 	}
 	if in.ServeWhileStale != nil {
 		in, out := &in.ServeWhileStale, &out.ServeWhileStale
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SignedUrlCacheMaxAgeSec != nil {
 		in, out := &in.SignedUrlCacheMaxAgeSec, &out.SignedUrlCacheMaxAgeSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -436,27 +436,27 @@ func (in *BackendserviceCircuitBreakers) DeepCopyInto(out *BackendserviceCircuit
 	}
 	if in.MaxConnections != nil {
 		in, out := &in.MaxConnections, &out.MaxConnections
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxPendingRequests != nil {
 		in, out := &in.MaxPendingRequests, &out.MaxPendingRequests
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRequests != nil {
 		in, out := &in.MaxRequests, &out.MaxRequests
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRequestsPerConnection != nil {
 		in, out := &in.MaxRequestsPerConnection, &out.MaxRequestsPerConnection
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxRetries != nil {
 		in, out := &in.MaxRetries, &out.MaxRetries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -477,7 +477,7 @@ func (in *BackendserviceConnectTimeout) DeepCopyInto(out *BackendserviceConnectT
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -508,7 +508,7 @@ func (in *BackendserviceConnectionTrackingPolicy) DeepCopyInto(out *Backendservi
 	}
 	if in.IdleTimeoutSec != nil {
 		in, out := &in.IdleTimeoutSec, &out.IdleTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TrackingMode != nil {
@@ -544,7 +544,7 @@ func (in *BackendserviceConsistentHash) DeepCopyInto(out *BackendserviceConsiste
 	}
 	if in.MinimumRingSize != nil {
 		in, out := &in.MinimumRingSize, &out.MinimumRingSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -736,7 +736,7 @@ func (in *BackendserviceInterval) DeepCopyInto(out *BackendserviceInterval) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -809,13 +809,13 @@ func (in *BackendserviceNegativeCachingPolicy) DeepCopyInto(out *BackendserviceN
 	*out = *in
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Ttl != nil {
 		in, out := &in.Ttl, &out.Ttl
-		*out = new(int)
-		**out = **in
+		*out = new(BackendserviceTtl)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -866,27 +866,27 @@ func (in *BackendserviceOutlierDetection) DeepCopyInto(out *BackendserviceOutlie
 	}
 	if in.ConsecutiveErrors != nil {
 		in, out := &in.ConsecutiveErrors, &out.ConsecutiveErrors
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ConsecutiveGatewayFailure != nil {
 		in, out := &in.ConsecutiveGatewayFailure, &out.ConsecutiveGatewayFailure
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcingConsecutiveErrors != nil {
 		in, out := &in.EnforcingConsecutiveErrors, &out.EnforcingConsecutiveErrors
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcingConsecutiveGatewayFailure != nil {
 		in, out := &in.EnforcingConsecutiveGatewayFailure, &out.EnforcingConsecutiveGatewayFailure
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnforcingSuccessRate != nil {
 		in, out := &in.EnforcingSuccessRate, &out.EnforcingSuccessRate
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Interval != nil {
@@ -896,22 +896,22 @@ func (in *BackendserviceOutlierDetection) DeepCopyInto(out *BackendserviceOutlie
 	}
 	if in.MaxEjectionPercent != nil {
 		in, out := &in.MaxEjectionPercent, &out.MaxEjectionPercent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SuccessRateMinimumHosts != nil {
 		in, out := &in.SuccessRateMinimumHosts, &out.SuccessRateMinimumHosts
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SuccessRateRequestVolume != nil {
 		in, out := &in.SuccessRateRequestVolume, &out.SuccessRateRequestVolume
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SuccessRateStdevFactor != nil {
 		in, out := &in.SuccessRateStdevFactor, &out.SuccessRateStdevFactor
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -986,7 +986,7 @@ func (in *BackendserviceTtl) DeepCopyInto(out *BackendserviceTtl) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1124,7 +1124,7 @@ func (in *ComputeAddressSpec) DeepCopyInto(out *ComputeAddressSpec) {
 	}
 	if in.PrefixLength != nil {
 		in, out := &in.PrefixLength, &out.PrefixLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Purpose != nil {
@@ -1175,7 +1175,7 @@ func (in *ComputeAddressStatus) DeepCopyInto(out *ComputeAddressStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -1334,7 +1334,7 @@ func (in *ComputeBackendBucketStatus) DeepCopyInto(out *ComputeBackendBucketStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1421,7 +1421,7 @@ func (in *ComputeBackendServiceSpec) DeepCopyInto(out *ComputeBackendServiceSpec
 	*out = *in
 	if in.AffinityCookieTtlSec != nil {
 		in, out := &in.AffinityCookieTtlSec, &out.AffinityCookieTtlSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Backend != nil {
@@ -1448,7 +1448,7 @@ func (in *ComputeBackendServiceSpec) DeepCopyInto(out *ComputeBackendServiceSpec
 	}
 	if in.ConnectionDrainingTimeoutSec != nil {
 		in, out := &in.ConnectionDrainingTimeoutSec, &out.ConnectionDrainingTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ConnectionTrackingPolicy != nil {
@@ -1577,7 +1577,7 @@ func (in *ComputeBackendServiceSpec) DeepCopyInto(out *ComputeBackendServiceSpec
 	}
 	if in.TimeoutSec != nil {
 		in, out := &in.TimeoutSec, &out.TimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1613,12 +1613,12 @@ func (in *ComputeBackendServiceStatus) DeepCopyInto(out *ComputeBackendServiceSt
 	}
 	if in.GeneratedId != nil {
 		in, out := &in.GeneratedId, &out.GeneratedId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1750,7 +1750,7 @@ func (in *ComputeDiskSpec) DeepCopyInto(out *ComputeDiskSpec) {
 	}
 	if in.PhysicalBlockSizeBytes != nil {
 		in, out := &in.PhysicalBlockSizeBytes, &out.PhysicalBlockSizeBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectRef != nil {
@@ -1760,12 +1760,12 @@ func (in *ComputeDiskSpec) DeepCopyInto(out *ComputeDiskSpec) {
 	}
 	if in.ProvisionedIops != nil {
 		in, out := &in.ProvisionedIops, &out.ProvisionedIops
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProvisionedThroughput != nil {
 		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ReplicaZones != nil {
@@ -1785,7 +1785,7 @@ func (in *ComputeDiskSpec) DeepCopyInto(out *ComputeDiskSpec) {
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SnapshotRef != nil {
@@ -1856,7 +1856,7 @@ func (in *ComputeDiskStatus) DeepCopyInto(out *ComputeDiskStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2011,7 +2011,7 @@ func (in *ComputeExternalVPNGatewayStatus) DeepCopyInto(out *ComputeExternalVPNG
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2215,7 +2215,7 @@ func (in *ComputeFirewallPolicyAssociationStatus) DeepCopyInto(out *ComputeFirew
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ShortName != nil {
@@ -2388,12 +2388,12 @@ func (in *ComputeFirewallPolicyRuleStatus) DeepCopyInto(out *ComputeFirewallPoli
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RuleTupleCount != nil {
 		in, out := &in.RuleTupleCount, &out.RuleTupleCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2470,12 +2470,12 @@ func (in *ComputeFirewallPolicyStatus) DeepCopyInto(out *ComputeFirewallPolicySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RuleTupleCount != nil {
 		in, out := &in.RuleTupleCount, &out.RuleTupleCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2551,7 +2551,7 @@ func (in *ComputeFirewallSpec) DeepCopyInto(out *ComputeFirewallSpec) {
 	out.NetworkRef = in.NetworkRef
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -2612,7 +2612,7 @@ func (in *ComputeFirewallStatus) DeepCopyInto(out *ComputeFirewallStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2849,7 +2849,7 @@ func (in *ComputeForwardingRuleStatus) DeepCopyInto(out *ComputeForwardingRuleSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PscConnectionId != nil {
@@ -2951,7 +2951,7 @@ func (in *ComputeHTTPHealthCheckSpec) DeepCopyInto(out *ComputeHTTPHealthCheckSp
 	*out = *in
 	if in.CheckIntervalSec != nil {
 		in, out := &in.CheckIntervalSec, &out.CheckIntervalSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -2961,7 +2961,7 @@ func (in *ComputeHTTPHealthCheckSpec) DeepCopyInto(out *ComputeHTTPHealthCheckSp
 	}
 	if in.HealthyThreshold != nil {
 		in, out := &in.HealthyThreshold, &out.HealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Host != nil {
@@ -2971,7 +2971,7 @@ func (in *ComputeHTTPHealthCheckSpec) DeepCopyInto(out *ComputeHTTPHealthCheckSp
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RequestPath != nil {
@@ -2986,12 +2986,12 @@ func (in *ComputeHTTPHealthCheckSpec) DeepCopyInto(out *ComputeHTTPHealthCheckSp
 	}
 	if in.TimeoutSec != nil {
 		in, out := &in.TimeoutSec, &out.TimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UnhealthyThreshold != nil {
 		in, out := &in.UnhealthyThreshold, &out.UnhealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3022,7 +3022,7 @@ func (in *ComputeHTTPHealthCheckStatus) DeepCopyInto(out *ComputeHTTPHealthCheck
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3109,7 +3109,7 @@ func (in *ComputeHTTPSHealthCheckSpec) DeepCopyInto(out *ComputeHTTPSHealthCheck
 	*out = *in
 	if in.CheckIntervalSec != nil {
 		in, out := &in.CheckIntervalSec, &out.CheckIntervalSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -3119,7 +3119,7 @@ func (in *ComputeHTTPSHealthCheckSpec) DeepCopyInto(out *ComputeHTTPSHealthCheck
 	}
 	if in.HealthyThreshold != nil {
 		in, out := &in.HealthyThreshold, &out.HealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Host != nil {
@@ -3129,7 +3129,7 @@ func (in *ComputeHTTPSHealthCheckSpec) DeepCopyInto(out *ComputeHTTPSHealthCheck
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RequestPath != nil {
@@ -3144,12 +3144,12 @@ func (in *ComputeHTTPSHealthCheckSpec) DeepCopyInto(out *ComputeHTTPSHealthCheck
 	}
 	if in.TimeoutSec != nil {
 		in, out := &in.TimeoutSec, &out.TimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UnhealthyThreshold != nil {
 		in, out := &in.UnhealthyThreshold, &out.UnhealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3180,7 +3180,7 @@ func (in *ComputeHTTPSHealthCheckStatus) DeepCopyInto(out *ComputeHTTPSHealthChe
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3267,7 +3267,7 @@ func (in *ComputeHealthCheckSpec) DeepCopyInto(out *ComputeHealthCheckSpec) {
 	*out = *in
 	if in.CheckIntervalSec != nil {
 		in, out := &in.CheckIntervalSec, &out.CheckIntervalSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -3282,7 +3282,7 @@ func (in *ComputeHealthCheckSpec) DeepCopyInto(out *ComputeHealthCheckSpec) {
 	}
 	if in.HealthyThreshold != nil {
 		in, out := &in.HealthyThreshold, &out.HealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Http2HealthCheck != nil {
@@ -3322,12 +3322,12 @@ func (in *ComputeHealthCheckSpec) DeepCopyInto(out *ComputeHealthCheckSpec) {
 	}
 	if in.TimeoutSec != nil {
 		in, out := &in.TimeoutSec, &out.TimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UnhealthyThreshold != nil {
 		in, out := &in.UnhealthyThreshold, &out.UnhealthyThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3358,7 +3358,7 @@ func (in *ComputeHealthCheckStatus) DeepCopyInto(out *ComputeHealthCheckStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3460,7 +3460,7 @@ func (in *ComputeImageSpec) DeepCopyInto(out *ComputeImageSpec) {
 	}
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Family != nil {
@@ -3531,7 +3531,7 @@ func (in *ComputeImageStatus) DeepCopyInto(out *ComputeImageStatus) {
 	}
 	if in.ArchiveSizeBytes != nil {
 		in, out := &in.ArchiveSizeBytes, &out.ArchiveSizeBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreationTimestamp != nil {
@@ -3546,7 +3546,7 @@ func (in *ComputeImageStatus) DeepCopyInto(out *ComputeImageStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3785,6 +3785,7 @@ func (in *ComputeInstanceGroupManagerSpec) DeepCopyInto(out *ComputeInstanceGrou
 		*out = make([]v1alpha1.ResourceRef, len(*in))
 		copy(*out, *in)
 	}
+	in.TargetSize.DeepCopyInto(&out.TargetSize)
 	if in.UpdatePolicy != nil {
 		in, out := &in.UpdatePolicy, &out.UpdatePolicy
 		*out = new(InstancegroupmanagerUpdatePolicy)
@@ -3835,7 +3836,7 @@ func (in *ComputeInstanceGroupManagerStatus) DeepCopyInto(out *ComputeInstanceGr
 	}
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.InstanceGroup != nil {
@@ -3845,7 +3846,7 @@ func (in *ComputeInstanceGroupManagerStatus) DeepCopyInto(out *ComputeInstanceGr
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Region != nil {
@@ -3937,7 +3938,7 @@ func (in *ComputeInstanceGroupStatus) DeepCopyInto(out *ComputeInstanceGroupStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -3947,7 +3948,7 @@ func (in *ComputeInstanceGroupStatus) DeepCopyInto(out *ComputeInstanceGroupStat
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -4193,7 +4194,7 @@ func (in *ComputeInstanceStatus) DeepCopyInto(out *ComputeInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -4425,7 +4426,7 @@ func (in *ComputeInstanceTemplateStatus) DeepCopyInto(out *ComputeInstanceTempla
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -4578,7 +4579,7 @@ func (in *ComputeInterconnectAttachmentSpec) DeepCopyInto(out *ComputeInterconne
 	}
 	if in.VlanTag8021q != nil {
 		in, out := &in.VlanTag8021q, &out.VlanTag8021q
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -4624,7 +4625,7 @@ func (in *ComputeInterconnectAttachmentStatus) DeepCopyInto(out *ComputeIntercon
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PairingKey != nil {
@@ -4759,7 +4760,7 @@ func (in *ComputeNetworkEndpointGroupSpec) DeepCopyInto(out *ComputeNetworkEndpo
 	*out = *in
 	if in.DefaultPort != nil {
 		in, out := &in.DefaultPort, &out.DefaultPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Description != nil {
@@ -4806,7 +4807,7 @@ func (in *ComputeNetworkEndpointGroupStatus) DeepCopyInto(out *ComputeNetworkEnd
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -4816,7 +4817,7 @@ func (in *ComputeNetworkEndpointGroupStatus) DeepCopyInto(out *ComputeNetworkEnd
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -4955,7 +4956,7 @@ func (in *ComputeNetworkFirewallPolicyAssociationStatus) DeepCopyInto(out *Compu
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ShortName != nil {
@@ -5061,12 +5062,12 @@ func (in *ComputeNetworkFirewallPolicyStatus) DeepCopyInto(out *ComputeNetworkFi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RuleTupleCount != nil {
 		in, out := &in.RuleTupleCount, &out.RuleTupleCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -5244,7 +5245,7 @@ func (in *ComputeNetworkPeeringStatus) DeepCopyInto(out *ComputeNetworkPeeringSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -5300,7 +5301,7 @@ func (in *ComputeNetworkSpec) DeepCopyInto(out *ComputeNetworkSpec) {
 	}
 	if in.Mtu != nil {
 		in, out := &in.Mtu, &out.Mtu
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NetworkFirewallPolicyEnforcementOrder != nil {
@@ -5346,7 +5347,7 @@ func (in *ComputeNetworkStatus) DeepCopyInto(out *ComputeNetworkStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -5443,7 +5444,7 @@ func (in *ComputeNodeGroupSpec) DeepCopyInto(out *ComputeNodeGroupSpec) {
 	}
 	if in.InitialSize != nil {
 		in, out := &in.InitialSize, &out.InitialSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaintenancePolicy != nil {
@@ -5469,7 +5470,7 @@ func (in *ComputeNodeGroupSpec) DeepCopyInto(out *ComputeNodeGroupSpec) {
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -5500,7 +5501,7 @@ func (in *ComputeNodeGroupStatus) DeepCopyInto(out *ComputeNodeGroupStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -5643,7 +5644,7 @@ func (in *ComputeNodeTemplateStatus) DeepCopyInto(out *ComputeNodeTemplateStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -5748,7 +5749,7 @@ func (in *ComputePacketMirroringSpec) DeepCopyInto(out *ComputePacketMirroringSp
 	out.Network = in.Network
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -5785,7 +5786,7 @@ func (in *ComputePacketMirroringStatus) DeepCopyInto(out *ComputePacketMirroring
 	}
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Network != nil {
@@ -5795,7 +5796,7 @@ func (in *ComputePacketMirroringStatus) DeepCopyInto(out *ComputePacketMirroring
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Region != nil {
@@ -5915,7 +5916,7 @@ func (in *ComputeProjectMetadataStatus) DeepCopyInto(out *ComputeProjectMetadata
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -6058,7 +6059,7 @@ func (in *ComputeRegionNetworkEndpointGroupStatus) DeepCopyInto(out *ComputeRegi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -6192,7 +6193,7 @@ func (in *ComputeReservationStatus) DeepCopyInto(out *ComputeReservationStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -6335,7 +6336,7 @@ func (in *ComputeResourcePolicyStatus) DeepCopyInto(out *ComputeResourcePolicySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -6453,7 +6454,7 @@ func (in *ComputeRouteSpec) DeepCopyInto(out *ComputeRouteSpec) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -6494,7 +6495,7 @@ func (in *ComputeRouteStatus) DeepCopyInto(out *ComputeRouteStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -6666,7 +6667,7 @@ func (in *ComputeRouterInterfaceStatus) DeepCopyInto(out *ComputeRouterInterface
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -6796,7 +6797,7 @@ func (in *ComputeRouterNATSpec) DeepCopyInto(out *ComputeRouterNATSpec) {
 	}
 	if in.IcmpIdleTimeoutSec != nil {
 		in, out := &in.IcmpIdleTimeoutSec, &out.IcmpIdleTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LogConfig != nil {
@@ -6806,12 +6807,12 @@ func (in *ComputeRouterNATSpec) DeepCopyInto(out *ComputeRouterNATSpec) {
 	}
 	if in.MaxPortsPerVm != nil {
 		in, out := &in.MaxPortsPerVm, &out.MaxPortsPerVm
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinPortsPerVm != nil {
 		in, out := &in.MinPortsPerVm, &out.MinPortsPerVm
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NatIps != nil {
@@ -6841,22 +6842,22 @@ func (in *ComputeRouterNATSpec) DeepCopyInto(out *ComputeRouterNATSpec) {
 	}
 	if in.TcpEstablishedIdleTimeoutSec != nil {
 		in, out := &in.TcpEstablishedIdleTimeoutSec, &out.TcpEstablishedIdleTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TcpTimeWaitTimeoutSec != nil {
 		in, out := &in.TcpTimeWaitTimeoutSec, &out.TcpTimeWaitTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TcpTransitoryIdleTimeoutSec != nil {
 		in, out := &in.TcpTransitoryIdleTimeoutSec, &out.TcpTransitoryIdleTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UdpIdleTimeoutSec != nil {
 		in, out := &in.UdpIdleTimeoutSec, &out.UdpIdleTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -6882,7 +6883,7 @@ func (in *ComputeRouterNATStatus) DeepCopyInto(out *ComputeRouterNATStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -6981,7 +6982,7 @@ func (in *ComputeRouterPeerSpec) DeepCopyInto(out *ComputeRouterPeerSpec) {
 	}
 	if in.AdvertisedRoutePriority != nil {
 		in, out := &in.AdvertisedRoutePriority, &out.AdvertisedRoutePriority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Bfd != nil {
@@ -7059,7 +7060,7 @@ func (in *ComputeRouterPeerStatus) DeepCopyInto(out *ComputeRouterPeerStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -7127,7 +7128,7 @@ func (in *ComputeRouterStatus) DeepCopyInto(out *ComputeRouterStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -7247,7 +7248,7 @@ func (in *ComputeSSLCertificateStatus) DeepCopyInto(out *ComputeSSLCertificateSt
 	}
 	if in.CertificateId != nil {
 		in, out := &in.CertificateId, &out.CertificateId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreationTimestamp != nil {
@@ -7262,7 +7263,7 @@ func (in *ComputeSSLCertificateStatus) DeepCopyInto(out *ComputeSSLCertificateSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -7410,7 +7411,7 @@ func (in *ComputeSSLPolicyStatus) DeepCopyInto(out *ComputeSSLPolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -7560,7 +7561,7 @@ func (in *ComputeSecurityPolicyStatus) DeepCopyInto(out *ComputeSecurityPolicySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -7714,12 +7715,12 @@ func (in *ComputeServiceAttachmentStatus) DeepCopyInto(out *ComputeServiceAttach
 	}
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PscServiceAttachmentId != nil {
@@ -7837,7 +7838,7 @@ func (in *ComputeSharedVPCHostProjectStatus) DeepCopyInto(out *ComputeSharedVPCH
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -7946,7 +7947,7 @@ func (in *ComputeSharedVPCServiceProjectStatus) DeepCopyInto(out *ComputeSharedV
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -8090,7 +8091,7 @@ func (in *ComputeSnapshotStatus) DeepCopyInto(out *ComputeSnapshotStatus) {
 	}
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LabelFingerprint != nil {
@@ -8105,7 +8106,7 @@ func (in *ComputeSnapshotStatus) DeepCopyInto(out *ComputeSnapshotStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -8115,12 +8116,12 @@ func (in *ComputeSnapshotStatus) DeepCopyInto(out *ComputeSnapshotStatus) {
 	}
 	if in.SnapshotId != nil {
 		in, out := &in.SnapshotId, &out.SnapshotId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StorageBytes != nil {
 		in, out := &in.StorageBytes, &out.StorageBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -8304,7 +8305,7 @@ func (in *ComputeSubnetworkStatus) DeepCopyInto(out *ComputeSubnetworkStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -8442,7 +8443,7 @@ func (in *ComputeTargetGRPCProxyStatus) DeepCopyInto(out *ComputeTargetGRPCProxy
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -8539,7 +8540,7 @@ func (in *ComputeTargetHTTPProxySpec) DeepCopyInto(out *ComputeTargetHTTPProxySp
 	}
 	if in.HttpKeepAliveTimeoutSec != nil {
 		in, out := &in.HttpKeepAliveTimeoutSec, &out.HttpKeepAliveTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyBind != nil {
@@ -8581,12 +8582,12 @@ func (in *ComputeTargetHTTPProxyStatus) DeepCopyInto(out *ComputeTargetHTTPProxy
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyId != nil {
 		in, out := &in.ProxyId, &out.ProxyId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -8688,7 +8689,7 @@ func (in *ComputeTargetHTTPSProxySpec) DeepCopyInto(out *ComputeTargetHTTPSProxy
 	}
 	if in.HttpKeepAliveTimeoutSec != nil {
 		in, out := &in.HttpKeepAliveTimeoutSec, &out.HttpKeepAliveTimeoutSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyBind != nil {
@@ -8750,12 +8751,12 @@ func (in *ComputeTargetHTTPSProxyStatus) DeepCopyInto(out *ComputeTargetHTTPSPro
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyId != nil {
 		in, out := &in.ProxyId, &out.ProxyId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -8894,7 +8895,7 @@ func (in *ComputeTargetInstanceStatus) DeepCopyInto(out *ComputeTargetInstanceSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9044,7 +9045,7 @@ func (in *ComputeTargetPoolStatus) DeepCopyInto(out *ComputeTargetPoolStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9188,12 +9189,12 @@ func (in *ComputeTargetSSLProxyStatus) DeepCopyInto(out *ComputeTargetSSLProxySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyId != nil {
 		in, out := &in.ProxyId, &out.ProxyId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9327,12 +9328,12 @@ func (in *ComputeTargetTCPProxyStatus) DeepCopyInto(out *ComputeTargetTCPProxySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProxyId != nil {
 		in, out := &in.ProxyId, &out.ProxyId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9456,12 +9457,12 @@ func (in *ComputeTargetVPNGatewayStatus) DeepCopyInto(out *ComputeTargetVPNGatew
 	}
 	if in.GatewayId != nil {
 		in, out := &in.GatewayId, &out.GatewayId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9630,12 +9631,12 @@ func (in *ComputeURLMapStatus) DeepCopyInto(out *ComputeURLMapStatus) {
 	}
 	if in.MapId != nil {
 		in, out := &in.MapId, &out.MapId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9766,7 +9767,7 @@ func (in *ComputeVPNGatewayStatus) DeepCopyInto(out *ComputeVPNGatewayStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -9858,7 +9859,7 @@ func (in *ComputeVPNTunnelSpec) DeepCopyInto(out *ComputeVPNTunnelSpec) {
 	}
 	if in.IkeVersion != nil {
 		in, out := &in.IkeVersion, &out.IkeVersion
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LocalTrafficSelector != nil {
@@ -9868,7 +9869,7 @@ func (in *ComputeVPNTunnelSpec) DeepCopyInto(out *ComputeVPNTunnelSpec) {
 	}
 	if in.PeerExternalGatewayInterface != nil {
 		in, out := &in.PeerExternalGatewayInterface, &out.PeerExternalGatewayInterface
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PeerExternalGatewayRef != nil {
@@ -9909,7 +9910,7 @@ func (in *ComputeVPNTunnelSpec) DeepCopyInto(out *ComputeVPNTunnelSpec) {
 	}
 	if in.VpnGatewayInterface != nil {
 		in, out := &in.VpnGatewayInterface, &out.VpnGatewayInterface
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VpnGatewayRef != nil {
@@ -9955,7 +9956,7 @@ func (in *ComputeVPNTunnelStatus) DeepCopyInto(out *ComputeVPNTunnelStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -10210,7 +10211,7 @@ func (in *ExternalvpngatewayInterface) DeepCopyInto(out *ExternalvpngatewayInter
 	*out = *in
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.IpAddress != nil {
@@ -10528,7 +10529,7 @@ func (in *HealthcheckGrpcHealthCheck) DeepCopyInto(out *HealthcheckGrpcHealthChe
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10564,7 +10565,7 @@ func (in *HealthcheckHttp2HealthCheck) DeepCopyInto(out *HealthcheckHttp2HealthC
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10615,7 +10616,7 @@ func (in *HealthcheckHttpHealthCheck) DeepCopyInto(out *HealthcheckHttpHealthChe
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10666,7 +10667,7 @@ func (in *HealthcheckHttpsHealthCheck) DeepCopyInto(out *HealthcheckHttpsHealthC
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10733,7 +10734,7 @@ func (in *HealthcheckSslHealthCheck) DeepCopyInto(out *HealthcheckSslHealthCheck
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10779,7 +10780,7 @@ func (in *HealthcheckTcpHealthCheck) DeepCopyInto(out *HealthcheckTcpHealthCheck
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PortName != nil {
@@ -10929,12 +10930,12 @@ func (in *InstanceAdvancedMachineFeatures) DeepCopyInto(out *InstanceAdvancedMac
 	}
 	if in.ThreadsPerCore != nil {
 		in, out := &in.ThreadsPerCore, &out.ThreadsPerCore
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VisibleCoreCount != nil {
 		in, out := &in.VisibleCoreCount, &out.VisibleCoreCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11142,7 +11143,7 @@ func (in *InstanceInitializeParams) DeepCopyInto(out *InstanceInitializeParams) 
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SourceImageRef != nil {
@@ -11225,7 +11226,7 @@ func (in *InstanceLocalSsdRecoveryTimeout) DeepCopyInto(out *InstanceLocalSsdRec
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11246,7 +11247,7 @@ func (in *InstanceMaxRunDuration) DeepCopyInto(out *InstanceMaxRunDuration) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11297,7 +11298,7 @@ func (in *InstanceNetworkInterface) DeepCopyInto(out *InstanceNetworkInterface) 
 	}
 	if in.InternalIpv6PrefixLength != nil {
 		in, out := &in.InternalIpv6PrefixLength, &out.InternalIpv6PrefixLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Ipv6AccessConfig != nil {
@@ -11344,7 +11345,7 @@ func (in *InstanceNetworkInterface) DeepCopyInto(out *InstanceNetworkInterface) 
 	}
 	if in.QueueCount != nil {
 		in, out := &in.QueueCount, &out.QueueCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StackType != nil {
@@ -11500,7 +11501,7 @@ func (in *InstanceScheduling) DeepCopyInto(out *InstanceScheduling) {
 	}
 	if in.MinNodeCpus != nil {
 		in, out := &in.MinNodeCpus, &out.MinNodeCpus
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeAffinities != nil {
@@ -11543,7 +11544,7 @@ func (in *InstanceScratchDisk) DeepCopyInto(out *InstanceScratchDisk) {
 	*out = *in
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11700,7 +11701,7 @@ func (in *InstancegroupmanagerAutoHealingPolicies) DeepCopyInto(out *Instancegro
 	}
 	if in.InitialDelaySec != nil {
 		in, out := &in.InitialDelaySec, &out.InitialDelaySec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11721,47 +11722,47 @@ func (in *InstancegroupmanagerCurrentActionsStatus) DeepCopyInto(out *Instancegr
 	*out = *in
 	if in.Abandoning != nil {
 		in, out := &in.Abandoning, &out.Abandoning
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Creating != nil {
 		in, out := &in.Creating, &out.Creating
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreatingWithoutRetries != nil {
 		in, out := &in.CreatingWithoutRetries, &out.CreatingWithoutRetries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Deleting != nil {
 		in, out := &in.Deleting, &out.Deleting
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.None != nil {
 		in, out := &in.None, &out.None
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Recreating != nil {
 		in, out := &in.Recreating, &out.Recreating
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Refreshing != nil {
 		in, out := &in.Refreshing, &out.Refreshing
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Restarting != nil {
 		in, out := &in.Restarting, &out.Restarting
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Verifying != nil {
 		in, out := &in.Verifying, &out.Verifying
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11873,12 +11874,12 @@ func (in *InstancegroupmanagerMaxSurge) DeepCopyInto(out *InstancegroupmanagerMa
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11899,7 +11900,7 @@ func (in *InstancegroupmanagerMaxSurgeStatus) DeepCopyInto(out *Instancegroupman
 	*out = *in
 	if in.Calculated != nil {
 		in, out := &in.Calculated, &out.Calculated
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11920,12 +11921,12 @@ func (in *InstancegroupmanagerMaxUnavailable) DeepCopyInto(out *Instancegroupman
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11946,7 +11947,7 @@ func (in *InstancegroupmanagerMaxUnavailableStatus) DeepCopyInto(out *Instancegr
 	*out = *in
 	if in.Calculated != nil {
 		in, out := &in.Calculated, &out.Calculated
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -11972,7 +11973,7 @@ func (in *InstancegroupmanagerNamedPorts) DeepCopyInto(out *Instancegroupmanager
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -12139,17 +12140,17 @@ func (in *InstancegroupmanagerTargetSize) DeepCopyInto(out *Instancegroupmanager
 	*out = *in
 	if in.Calculated != nil {
 		in, out := &in.Calculated, &out.Calculated
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -12185,7 +12186,7 @@ func (in *InstancegroupmanagerUpdatePolicy) DeepCopyInto(out *Instancegroupmanag
 	}
 	if in.MinReadySec != nil {
 		in, out := &in.MinReadySec, &out.MinReadySec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinimalAction != nil {
@@ -12361,12 +12362,12 @@ func (in *InstancetemplateAdvancedMachineFeatures) DeepCopyInto(out *Instancetem
 	}
 	if in.ThreadsPerCore != nil {
 		in, out := &in.ThreadsPerCore, &out.ThreadsPerCore
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VisibleCoreCount != nil {
 		in, out := &in.VisibleCoreCount, &out.VisibleCoreCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -12449,7 +12450,7 @@ func (in *InstancetemplateDisk) DeepCopyInto(out *InstancetemplateDisk) {
 	}
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskType != nil {
@@ -12476,7 +12477,7 @@ func (in *InstancetemplateDisk) DeepCopyInto(out *InstancetemplateDisk) {
 	}
 	if in.ProvisionedIops != nil {
 		in, out := &in.ProvisionedIops, &out.ProvisionedIops
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourcePolicies != nil {
@@ -12601,7 +12602,7 @@ func (in *InstancetemplateLocalSsdRecoveryTimeout) DeepCopyInto(out *Instancetem
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -12622,7 +12623,7 @@ func (in *InstancetemplateMaxRunDuration) DeepCopyInto(out *InstancetemplateMaxR
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -12673,7 +12674,7 @@ func (in *InstancetemplateNetworkInterface) DeepCopyInto(out *InstancetemplateNe
 	}
 	if in.InternalIpv6PrefixLength != nil {
 		in, out := &in.InternalIpv6PrefixLength, &out.InternalIpv6PrefixLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Ipv6AccessConfig != nil {
@@ -12720,7 +12721,7 @@ func (in *InstancetemplateNetworkInterface) DeepCopyInto(out *InstancetemplateNe
 	}
 	if in.QueueCount != nil {
 		in, out := &in.QueueCount, &out.QueueCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StackType != nil {
@@ -12841,7 +12842,7 @@ func (in *InstancetemplateScheduling) DeepCopyInto(out *InstancetemplateScheduli
 	}
 	if in.MinNodeCpus != nil {
 		in, out := &in.MinNodeCpus, &out.MinNodeCpus
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeAffinities != nil {
@@ -13022,7 +13023,7 @@ func (in *InterconnectattachmentPrivateInterconnectInfoStatus) DeepCopyInto(out 
 	*out = *in
 	if in.Tag8021q != nil {
 		in, out := &in.Tag8021q, &out.Tag8021q
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -13043,12 +13044,12 @@ func (in *NodegroupAutoscalingPolicy) DeepCopyInto(out *NodegroupAutoscalingPoli
 	*out = *in
 	if in.MaxNodes != nil {
 		in, out := &in.MaxNodes, &out.MaxNodes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinNodes != nil {
 		in, out := &in.MinNodes, &out.MinNodes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Mode != nil {
@@ -13497,7 +13498,7 @@ func (in *ReservationSpecificReservation) DeepCopyInto(out *ReservationSpecificR
 	*out = *in
 	if in.InUseCount != nil {
 		in, out := &in.InUseCount, &out.InUseCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	in.InstanceProperties.DeepCopyInto(&out.InstanceProperties)
@@ -13567,7 +13568,7 @@ func (in *ResourcepolicyGroupPlacementPolicy) DeepCopyInto(out *ResourcepolicyGr
 	*out = *in
 	if in.AvailabilityDomainCount != nil {
 		in, out := &in.AvailabilityDomainCount, &out.AvailabilityDomainCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Collocation != nil {
@@ -13577,12 +13578,12 @@ func (in *ResourcepolicyGroupPlacementPolicy) DeepCopyInto(out *ResourcepolicyGr
 	}
 	if in.MaxDistance != nil {
 		in, out := &in.MaxDistance, &out.MaxDistance
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VmCount != nil {
 		in, out := &in.VmCount, &out.VmCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -13863,7 +13864,7 @@ func (in *RouterBgp) DeepCopyInto(out *RouterBgp) {
 	}
 	if in.KeepaliveInterval != nil {
 		in, out := &in.KeepaliveInterval, &out.KeepaliveInterval
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -14000,17 +14001,17 @@ func (in *RouterpeerBfd) DeepCopyInto(out *RouterpeerBfd) {
 	*out = *in
 	if in.MinReceiveInterval != nil {
 		in, out := &in.MinReceiveInterval, &out.MinReceiveInterval
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinTransmitInterval != nil {
 		in, out := &in.MinTransmitInterval, &out.MinTransmitInterval
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Multiplier != nil {
 		in, out := &in.Multiplier, &out.Multiplier
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -14119,7 +14120,7 @@ func (in *SecuritypolicyAutoDeployConfig) DeepCopyInto(out *SecuritypolicyAutoDe
 	}
 	if in.ExpirationSec != nil {
 		in, out := &in.ExpirationSec, &out.ExpirationSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ImpactedBaselineThreshold != nil {
@@ -14423,7 +14424,7 @@ func (in *SecuritypolicyRateLimitOptions) DeepCopyInto(out *SecuritypolicyRateLi
 	*out = *in
 	if in.BanDurationSec != nil {
 		in, out := &in.BanDurationSec, &out.BanDurationSec
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BanThreshold != nil {
@@ -14683,7 +14684,7 @@ func (in *ServiceattachmentConnectedEndpointsStatus) DeepCopyInto(out *Serviceat
 	}
 	if in.PscConnectionId != nil {
 		in, out := &in.PscConnectionId, &out.PscConnectionId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Status != nil {
@@ -14709,7 +14710,7 @@ func (in *ServiceattachmentConsumerAcceptLists) DeepCopyInto(out *Serviceattachm
 	*out = *in
 	if in.ConnectionLimit != nil {
 		in, out := &in.ConnectionLimit, &out.ConnectionLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -14731,12 +14732,12 @@ func (in *ServiceattachmentPscServiceAttachmentIdStatus) DeepCopyInto(out *Servi
 	*out = *in
 	if in.High != nil {
 		in, out := &in.High, &out.High
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Low != nil {
 		in, out := &in.Low, &out.Low
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -15017,7 +15018,7 @@ func (in *UrlmapAbort) DeepCopyInto(out *UrlmapAbort) {
 	*out = *in
 	if in.HttpStatus != nil {
 		in, out := &in.HttpStatus, &out.HttpStatus
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percentage != nil {
@@ -15078,7 +15079,7 @@ func (in *UrlmapCorsPolicy) DeepCopyInto(out *UrlmapCorsPolicy) {
 	}
 	if in.MaxAge != nil {
 		in, out := &in.MaxAge, &out.MaxAge
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -15287,7 +15288,7 @@ func (in *UrlmapFixedDelay) DeepCopyInto(out *UrlmapFixedDelay) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -15595,7 +15596,7 @@ func (in *UrlmapPerTryTimeout) DeepCopyInto(out *UrlmapPerTryTimeout) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -15882,7 +15883,7 @@ func (in *UrlmapTimeout) DeepCopyInto(out *UrlmapTimeout) {
 	*out = *in
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -16002,7 +16003,7 @@ func (in *VpngatewayVpnInterfaces) DeepCopyInto(out *VpngatewayVpnInterfaces) {
 	*out = *in
 	if in.Id != nil {
 		in, out := &in.Id, &out.Id
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.InterconnectAttachmentRef != nil {

--- a/pkg/clients/generated/apis/configcontroller/v1beta1/configcontrollerinstance_types.go
+++ b/pkg/clients/generated/apis/configcontroller/v1beta1/configcontrollerinstance_types.go
@@ -133,7 +133,7 @@ type ConfigControllerInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The current state of the internal state machine for the KrmApiHost. Possible values: STATE_UNSPECIFIED, CREATING, RUNNING, DELETING, SUSPENDED, READ_ONLY */
 	// +optional

--- a/pkg/clients/generated/apis/configcontroller/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/configcontroller/v1beta1/zz_generated.deepcopy.go
@@ -133,7 +133,7 @@ func (in *ConfigControllerInstanceStatus) DeepCopyInto(out *ConfigControllerInst
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
+++ b/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
@@ -101,7 +101,7 @@ type ClusterAdvancedDatapathObservabilityConfig struct {
 
 type ClusterAdvancedMachineFeatures struct {
 	/* Immutable. The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed. */
-	ThreadsPerCore int `json:"threadsPerCore"`
+	ThreadsPerCore int64 `json:"threadsPerCore"`
 }
 
 type ClusterAuthenticatorGroupsConfig struct {
@@ -117,7 +117,7 @@ type ClusterAutoProvisioningDefaults struct {
 
 	/* Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. */
 	// +optional
-	DiskSize *int `json:"diskSize,omitempty"`
+	DiskSize *int64 `json:"diskSize,omitempty"`
 
 	/* The default image type used by NAP once a new node pool is being created. */
 	// +optional
@@ -278,12 +278,12 @@ type ClusterEnableK8sBetaApis struct {
 
 type ClusterEphemeralStorageConfig struct {
 	/* Immutable. Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD must be 375 or 3000 GB in size, and all local SSDs must share the same size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type ClusterEphemeralStorageLocalSsdConfig struct {
 	/* Immutable. Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD must be 375 or 3000 GB in size, and all local SSDs must share the same size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type ClusterExclusionOptions struct {
@@ -337,12 +337,12 @@ type ClusterGpuSharingConfig struct {
 	GpuSharingStrategy string `json:"gpuSharingStrategy"`
 
 	/* Immutable. The maximum number of containers that can share a GPU. */
-	MaxSharedClientsPerGpu int `json:"maxSharedClientsPerGpu"`
+	MaxSharedClientsPerGpu int64 `json:"maxSharedClientsPerGpu"`
 }
 
 type ClusterGuestAccelerator struct {
 	/* Immutable. The number of the accelerator cards exposed to an instance. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Immutable. Configuration for auto installation of GPU driver. */
 	// +optional
@@ -441,7 +441,7 @@ type ClusterKubeletConfig struct {
 
 	/* Controls the maximum number of processes allowed to run in a pod. */
 	// +optional
-	PodPidsLimit *int `json:"podPidsLimit,omitempty"`
+	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
 }
 
 type ClusterLinuxNodeConfig struct {
@@ -456,7 +456,7 @@ type ClusterLinuxNodeConfig struct {
 
 type ClusterLocalNvmeSsdBlockConfig struct {
 	/* Immutable. Number of raw-block local NVMe SSD disks to be attached to the node. Each local SSD is 375 GB in size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type ClusterLoggingConfig struct {
@@ -613,7 +613,7 @@ type ClusterNodeConfig struct {
 
 	/* Immutable. Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* Immutable. Type of the disk attached to each node. Such as pd-standard, pd-balanced or pd-ssd. */
 	// +optional
@@ -669,7 +669,7 @@ type ClusterNodeConfig struct {
 
 	/* Immutable. The number of local SSD disks to be attached to the node. */
 	// +optional
-	LocalSsdCount *int `json:"localSsdCount,omitempty"`
+	LocalSsdCount *int64 `json:"localSsdCount,omitempty"`
 
 	/* Type of logging agent that is used as the default value for node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. */
 	// +optional
@@ -878,11 +878,11 @@ type ClusterReservationAffinity struct {
 type ClusterResourceLimits struct {
 	/* Maximum amount of the resource in the cluster. */
 	// +optional
-	Maximum *int `json:"maximum,omitempty"`
+	Maximum *int64 `json:"maximum,omitempty"`
 
 	/* Minimum amount of the resource in the cluster. */
 	// +optional
-	Minimum *int `json:"minimum,omitempty"`
+	Minimum *int64 `json:"minimum,omitempty"`
 
 	/* The type of the resource. For example, cpu and memory. See the guide to using Node Auto-Provisioning for a list of types. */
 	ResourceType string `json:"resourceType"`
@@ -939,7 +939,7 @@ type ClusterSoleTenantConfig struct {
 type ClusterStandardRolloutPolicy struct {
 	/* Number of blue nodes to drain in a batch. */
 	// +optional
-	BatchNodeCount *int `json:"batchNodeCount,omitempty"`
+	BatchNodeCount *int64 `json:"batchNodeCount,omitempty"`
 
 	/* Percentage of the bool pool nodes to drain in a batch. The range of this field should be (0.0, 1.0]. */
 	// +optional
@@ -980,11 +980,11 @@ type ClusterUpgradeSettings struct {
 
 	/* The maximum number of nodes that can be created beyond the current size of the node pool during the upgrade process. */
 	// +optional
-	MaxSurge *int `json:"maxSurge,omitempty"`
+	MaxSurge *int64 `json:"maxSurge,omitempty"`
 
 	/* The maximum number of nodes that can be simultaneously unavailable during the upgrade process. */
 	// +optional
-	MaxUnavailable *int `json:"maxUnavailable,omitempty"`
+	MaxUnavailable *int64 `json:"maxUnavailable,omitempty"`
 
 	/* Update strategy of the node pool. */
 	// +optional
@@ -1075,7 +1075,7 @@ type ContainerClusterSpec struct {
 
 	/* Immutable. The default maximum number of pods per node in this cluster. This doesn't work on "routes-based" clusters, clusters that don't have IP Aliasing enabled. */
 	// +optional
-	DefaultMaxPodsPerNode *int `json:"defaultMaxPodsPerNode,omitempty"`
+	DefaultMaxPodsPerNode *int64 `json:"defaultMaxPodsPerNode,omitempty"`
 
 	/* Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled. */
 	// +optional
@@ -1143,7 +1143,7 @@ type ContainerClusterSpec struct {
 
 	/* Immutable. The number of nodes to create in this cluster's default node pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Must be set if node_pool is not set. If you're using google_container_node_pool objects with no default node pool, you'll need to set this to a value of at least 1, alongside setting remove_default_node_pool to true. */
 	// +optional
-	InitialNodeCount *int `json:"initialNodeCount,omitempty"`
+	InitialNodeCount *int64 `json:"initialNodeCount,omitempty"`
 
 	/* Immutable. Configuration of cluster IP allocation for VPC-native clusters. Adding this block enables IP aliasing, making the cluster VPC-native instead of routes-based. */
 	// +optional
@@ -1300,7 +1300,7 @@ type ContainerClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/container/v1beta1/containernodepool_types.go
+++ b/pkg/clients/generated/apis/container/v1beta1/containernodepool_types.go
@@ -48,7 +48,7 @@ type NodepoolAdditionalNodeNetworkConfigs struct {
 type NodepoolAdditionalPodNetworkConfigs struct {
 	/* Immutable. The maximum number of pods per node which use this pod network. */
 	// +optional
-	MaxPodsPerNode *int `json:"maxPodsPerNode,omitempty"`
+	MaxPodsPerNode *int64 `json:"maxPodsPerNode,omitempty"`
 
 	/* Immutable. The name of the secondary range on the subnet which provides IP address for this pod range. */
 	// +optional
@@ -61,7 +61,7 @@ type NodepoolAdditionalPodNetworkConfigs struct {
 
 type NodepoolAdvancedMachineFeatures struct {
 	/* Immutable. The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed. */
-	ThreadsPerCore int `json:"threadsPerCore"`
+	ThreadsPerCore int64 `json:"threadsPerCore"`
 }
 
 type NodepoolAutoscaling struct {
@@ -71,19 +71,19 @@ type NodepoolAutoscaling struct {
 
 	/* Maximum number of nodes per zone in the node pool. Must be >= min_node_count. Cannot be used with total limits. */
 	// +optional
-	MaxNodeCount *int `json:"maxNodeCount,omitempty"`
+	MaxNodeCount *int64 `json:"maxNodeCount,omitempty"`
 
 	/* Minimum number of nodes per zone in the node pool. Must be >=0 and <= max_node_count. Cannot be used with total limits. */
 	// +optional
-	MinNodeCount *int `json:"minNodeCount,omitempty"`
+	MinNodeCount *int64 `json:"minNodeCount,omitempty"`
 
 	/* Maximum number of all nodes in the node pool. Must be >= total_min_node_count. Cannot be used with per zone limits. */
 	// +optional
-	TotalMaxNodeCount *int `json:"totalMaxNodeCount,omitempty"`
+	TotalMaxNodeCount *int64 `json:"totalMaxNodeCount,omitempty"`
 
 	/* Minimum number of all nodes in the node pool. Must be >=0 and <= total_max_node_count. Cannot be used with per zone limits. */
 	// +optional
-	TotalMinNodeCount *int `json:"totalMinNodeCount,omitempty"`
+	TotalMinNodeCount *int64 `json:"totalMinNodeCount,omitempty"`
 }
 
 type NodepoolBlueGreenSettings struct {
@@ -102,12 +102,12 @@ type NodepoolConfidentialNodes struct {
 
 type NodepoolEphemeralStorageConfig struct {
 	/* Immutable. Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD must be 375 or 3000 GB in size, and all local SSDs must share the same size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type NodepoolEphemeralStorageLocalSsdConfig struct {
 	/* Immutable. Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD must be 375 or 3000 GB in size, and all local SSDs must share the same size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type NodepoolFastSocket struct {
@@ -130,12 +130,12 @@ type NodepoolGpuSharingConfig struct {
 	GpuSharingStrategy string `json:"gpuSharingStrategy"`
 
 	/* Immutable. The maximum number of containers that can share a GPU. */
-	MaxSharedClientsPerGpu int `json:"maxSharedClientsPerGpu"`
+	MaxSharedClientsPerGpu int64 `json:"maxSharedClientsPerGpu"`
 }
 
 type NodepoolGuestAccelerator struct {
 	/* Immutable. The number of the accelerator cards exposed to an instance. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 
 	/* Immutable. Configuration for auto installation of GPU driver. */
 	// +optional
@@ -177,7 +177,7 @@ type NodepoolKubeletConfig struct {
 
 	/* Controls the maximum number of processes allowed to run in a pod. */
 	// +optional
-	PodPidsLimit *int `json:"podPidsLimit,omitempty"`
+	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
 }
 
 type NodepoolLinuxNodeConfig struct {
@@ -192,7 +192,7 @@ type NodepoolLinuxNodeConfig struct {
 
 type NodepoolLocalNvmeSsdBlockConfig struct {
 	/* Immutable. Number of raw-block local NVMe SSD disks to be attached to the node. Each local SSD is 375 GB in size. */
-	LocalSsdCount int `json:"localSsdCount"`
+	LocalSsdCount int64 `json:"localSsdCount"`
 }
 
 type NodepoolManagement struct {
@@ -260,7 +260,7 @@ type NodepoolNodeConfig struct {
 
 	/* Immutable. Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. */
 	// +optional
-	DiskSizeGb *int `json:"diskSizeGb,omitempty"`
+	DiskSizeGb *int64 `json:"diskSizeGb,omitempty"`
 
 	/* Immutable. Type of the disk attached to each node. Such as pd-standard, pd-balanced or pd-ssd. */
 	// +optional
@@ -316,7 +316,7 @@ type NodepoolNodeConfig struct {
 
 	/* Immutable. The number of local SSD disks to be attached to the node. */
 	// +optional
-	LocalSsdCount *int `json:"localSsdCount,omitempty"`
+	LocalSsdCount *int64 `json:"localSsdCount,omitempty"`
 
 	/* Type of logging agent that is used as the default value for node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. */
 	// +optional
@@ -441,7 +441,7 @@ type NodepoolSoleTenantConfig struct {
 type NodepoolStandardRolloutPolicy struct {
 	/* Number of blue nodes to drain in a batch. */
 	// +optional
-	BatchNodeCount *int `json:"batchNodeCount,omitempty"`
+	BatchNodeCount *int64 `json:"batchNodeCount,omitempty"`
 
 	/* Percentage of the blue pool nodes to drain in a batch. */
 	// +optional
@@ -470,11 +470,11 @@ type NodepoolUpgradeSettings struct {
 
 	/* The number of additional nodes that can be added to the node pool during an upgrade. Increasing max_surge raises the number of nodes that can be upgraded simultaneously. Can be set to 0 or greater. */
 	// +optional
-	MaxSurge *int `json:"maxSurge,omitempty"`
+	MaxSurge *int64 `json:"maxSurge,omitempty"`
 
 	/* The number of nodes that can be simultaneously unavailable during an upgrade. Increasing max_unavailable raises the number of nodes that can be upgraded in parallel. Can be set to 0 or greater. */
 	// +optional
-	MaxUnavailable *int `json:"maxUnavailable,omitempty"`
+	MaxUnavailable *int64 `json:"maxUnavailable,omitempty"`
 
 	/* Update strategy for the given nodepool. */
 	// +optional
@@ -500,7 +500,7 @@ type ContainerNodePoolSpec struct {
 
 	/* Immutable. The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. */
 	// +optional
-	InitialNodeCount *int `json:"initialNodeCount,omitempty"`
+	InitialNodeCount *int64 `json:"initialNodeCount,omitempty"`
 
 	/* Immutable. The location (region or zone) of the cluster. */
 	Location string `json:"location"`
@@ -511,7 +511,7 @@ type ContainerNodePoolSpec struct {
 
 	/* Immutable. The maximum number of pods per node in this node pool. Note that this does not work on node pools which are "route-based" - that is, node pools belonging to clusters that do not have IP Aliasing enabled. */
 	// +optional
-	MaxPodsPerNode *int `json:"maxPodsPerNode,omitempty"`
+	MaxPodsPerNode *int64 `json:"maxPodsPerNode,omitempty"`
 
 	/* Immutable. Creates a unique name for the node pool beginning with the specified prefix. Conflicts with name. */
 	// +optional
@@ -527,7 +527,7 @@ type ContainerNodePoolSpec struct {
 
 	/* The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling. */
 	// +optional
-	NodeCount *int `json:"nodeCount,omitempty"`
+	NodeCount *int64 `json:"nodeCount,omitempty"`
 
 	/* The list of zones in which the node pool's nodes should be located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. If unspecified, the cluster-level node_locations will be used. */
 	// +optional
@@ -568,7 +568,7 @@ type ContainerNodePoolStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/container/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/container/v1beta1/zz_generated.deepcopy.go
@@ -189,7 +189,7 @@ func (in *ClusterAutoProvisioningDefaults) DeepCopyInto(out *ClusterAutoProvisio
 	}
 	if in.DiskSize != nil {
 		in, out := &in.DiskSize, &out.DiskSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ImageType != nil {
@@ -1026,7 +1026,7 @@ func (in *ClusterKubeletConfig) DeepCopyInto(out *ClusterKubeletConfig) {
 	}
 	if in.PodPidsLimit != nil {
 		in, out := &in.PodPidsLimit, &out.PodPidsLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1469,7 +1469,7 @@ func (in *ClusterNodeConfig) DeepCopyInto(out *ClusterNodeConfig) {
 	}
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskType != nil {
@@ -1543,7 +1543,7 @@ func (in *ClusterNodeConfig) DeepCopyInto(out *ClusterNodeConfig) {
 	}
 	if in.LocalSsdCount != nil {
 		in, out := &in.LocalSsdCount, &out.LocalSsdCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LoggingVariant != nil {
@@ -1983,12 +1983,12 @@ func (in *ClusterResourceLimits) DeepCopyInto(out *ClusterResourceLimits) {
 	*out = *in
 	if in.Maximum != nil {
 		in, out := &in.Maximum, &out.Maximum
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minimum != nil {
 		in, out := &in.Minimum, &out.Minimum
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2143,7 +2143,7 @@ func (in *ClusterStandardRolloutPolicy) DeepCopyInto(out *ClusterStandardRollout
 	*out = *in
 	if in.BatchNodeCount != nil {
 		in, out := &in.BatchNodeCount, &out.BatchNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BatchPercentage != nil {
@@ -2221,12 +2221,12 @@ func (in *ClusterUpgradeSettings) DeepCopyInto(out *ClusterUpgradeSettings) {
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Strategy != nil {
@@ -2473,7 +2473,7 @@ func (in *ContainerClusterSpec) DeepCopyInto(out *ContainerClusterSpec) {
 	}
 	if in.DefaultMaxPodsPerNode != nil {
 		in, out := &in.DefaultMaxPodsPerNode, &out.DefaultMaxPodsPerNode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DefaultSnatStatus != nil {
@@ -2558,7 +2558,7 @@ func (in *ContainerClusterSpec) DeepCopyInto(out *ContainerClusterSpec) {
 	}
 	if in.InitialNodeCount != nil {
 		in, out := &in.InitialNodeCount, &out.InitialNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.IpAllocationPolicy != nil {
@@ -2754,7 +2754,7 @@ func (in *ContainerClusterStatus) DeepCopyInto(out *ContainerClusterStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -2867,7 +2867,7 @@ func (in *ContainerNodePoolSpec) DeepCopyInto(out *ContainerNodePoolSpec) {
 	out.ClusterRef = in.ClusterRef
 	if in.InitialNodeCount != nil {
 		in, out := &in.InitialNodeCount, &out.InitialNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Management != nil {
@@ -2877,7 +2877,7 @@ func (in *ContainerNodePoolSpec) DeepCopyInto(out *ContainerNodePoolSpec) {
 	}
 	if in.MaxPodsPerNode != nil {
 		in, out := &in.MaxPodsPerNode, &out.MaxPodsPerNode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NamePrefix != nil {
@@ -2897,7 +2897,7 @@ func (in *ContainerNodePoolSpec) DeepCopyInto(out *ContainerNodePoolSpec) {
 	}
 	if in.NodeCount != nil {
 		in, out := &in.NodeCount, &out.NodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeLocations != nil {
@@ -2958,7 +2958,7 @@ func (in *ContainerNodePoolStatus) DeepCopyInto(out *ContainerNodePoolStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -3015,7 +3015,7 @@ func (in *NodepoolAdditionalPodNetworkConfigs) DeepCopyInto(out *NodepoolAdditio
 	*out = *in
 	if in.MaxPodsPerNode != nil {
 		in, out := &in.MaxPodsPerNode, &out.MaxPodsPerNode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SecondaryPodRange != nil {
@@ -3067,22 +3067,22 @@ func (in *NodepoolAutoscaling) DeepCopyInto(out *NodepoolAutoscaling) {
 	}
 	if in.MaxNodeCount != nil {
 		in, out := &in.MaxNodeCount, &out.MaxNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinNodeCount != nil {
 		in, out := &in.MinNodeCount, &out.MinNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TotalMaxNodeCount != nil {
 		in, out := &in.TotalMaxNodeCount, &out.TotalMaxNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TotalMinNodeCount != nil {
 		in, out := &in.TotalMinNodeCount, &out.TotalMinNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3310,7 +3310,7 @@ func (in *NodepoolKubeletConfig) DeepCopyInto(out *NodepoolKubeletConfig) {
 	}
 	if in.PodPidsLimit != nil {
 		in, out := &in.PodPidsLimit, &out.PodPidsLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3492,7 +3492,7 @@ func (in *NodepoolNodeConfig) DeepCopyInto(out *NodepoolNodeConfig) {
 	}
 	if in.DiskSizeGb != nil {
 		in, out := &in.DiskSizeGb, &out.DiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskType != nil {
@@ -3566,7 +3566,7 @@ func (in *NodepoolNodeConfig) DeepCopyInto(out *NodepoolNodeConfig) {
 	}
 	if in.LocalSsdCount != nil {
 		in, out := &in.LocalSsdCount, &out.LocalSsdCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LoggingVariant != nil {
@@ -3830,7 +3830,7 @@ func (in *NodepoolStandardRolloutPolicy) DeepCopyInto(out *NodepoolStandardRollo
 	*out = *in
 	if in.BatchNodeCount != nil {
 		in, out := &in.BatchNodeCount, &out.BatchNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BatchPercentage != nil {
@@ -3882,12 +3882,12 @@ func (in *NodepoolUpgradeSettings) DeepCopyInto(out *NodepoolUpgradeSettings) {
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Strategy != nil {

--- a/pkg/clients/generated/apis/containeranalysis/v1alpha1/containeranalysisoccurrence_types.go
+++ b/pkg/clients/generated/apis/containeranalysis/v1alpha1/containeranalysisoccurrence_types.go
@@ -126,7 +126,7 @@ type ContainerAnalysisOccurrenceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the repository was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/containeranalysis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/containeranalysis/v1alpha1/zz_generated.deepcopy.go
@@ -143,7 +143,7 @@ func (in *ContainerAnalysisOccurrenceStatus) DeepCopyInto(out *ContainerAnalysis
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/containeranalysis/v1beta1/containeranalysisnote_types.go
+++ b/pkg/clients/generated/apis/containeranalysis/v1beta1/containeranalysisnote_types.go
@@ -38,7 +38,7 @@ import (
 type NoteAffectedVersionEnd struct {
 	/* Used to correct mistakes in the version numbering scheme. */
 	// +optional
-	Epoch *int `json:"epoch,omitempty"`
+	Epoch *int64 `json:"epoch,omitempty"`
 
 	/* Human readable version string. This string is of the form :- and is only set when kind is NORMAL. */
 	// +optional
@@ -59,7 +59,7 @@ type NoteAffectedVersionEnd struct {
 type NoteAffectedVersionStart struct {
 	/* Used to correct mistakes in the version numbering scheme. */
 	// +optional
-	Epoch *int `json:"epoch,omitempty"`
+	Epoch *int64 `json:"epoch,omitempty"`
 
 	/* Human readable version string. This string is of the form :- and is only set when kind is NORMAL. */
 	// +optional
@@ -226,7 +226,7 @@ type NoteFingerprint struct {
 type NoteFixedVersion struct {
 	/* Used to correct mistakes in the version numbering scheme. */
 	// +optional
-	Epoch *int `json:"epoch,omitempty"`
+	Epoch *int64 `json:"epoch,omitempty"`
 
 	/* Human readable version string. This string is of the form :- and is only set when kind is NORMAL. */
 	// +optional
@@ -270,7 +270,7 @@ type NoteImage struct {
 type NoteLatestVersion struct {
 	/* Used to correct mistakes in the version numbering scheme. */
 	// +optional
-	Epoch *int `json:"epoch,omitempty"`
+	Epoch *int64 `json:"epoch,omitempty"`
 
 	/* Human readable version string. This string is of the form :- and is only set when kind is NORMAL. */
 	// +optional
@@ -425,7 +425,7 @@ type ContainerAnalysisNoteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The time this note was last updated. This field can be used as a filter in list requests. */
 	// +optional

--- a/pkg/clients/generated/apis/containeranalysis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/containeranalysis/v1beta1/zz_generated.deepcopy.go
@@ -193,7 +193,7 @@ func (in *ContainerAnalysisNoteStatus) DeepCopyInto(out *ContainerAnalysisNoteSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -219,7 +219,7 @@ func (in *NoteAffectedVersionEnd) DeepCopyInto(out *NoteAffectedVersionEnd) {
 	*out = *in
 	if in.Epoch != nil {
 		in, out := &in.Epoch, &out.Epoch
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.FullName != nil {
@@ -255,7 +255,7 @@ func (in *NoteAffectedVersionStart) DeepCopyInto(out *NoteAffectedVersionStart) 
 	*out = *in
 	if in.Epoch != nil {
 		in, out := &in.Epoch, &out.Epoch
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.FullName != nil {
@@ -585,7 +585,7 @@ func (in *NoteFixedVersion) DeepCopyInto(out *NoteFixedVersion) {
 	*out = *in
 	if in.Epoch != nil {
 		in, out := &in.Epoch, &out.Epoch
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.FullName != nil {
@@ -701,7 +701,7 @@ func (in *NoteLatestVersion) DeepCopyInto(out *NoteLatestVersion) {
 	*out = *in
 	if in.Epoch != nil {
 		in, out := &in.Epoch, &out.Epoch
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.FullName != nil {

--- a/pkg/clients/generated/apis/containerattached/v1beta1/containerattachedcluster_types.go
+++ b/pkg/clients/generated/apis/containerattached/v1beta1/containerattachedcluster_types.go
@@ -211,7 +211,7 @@ type ContainerAttachedClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* If set, there are currently changes in flight to the cluster. */
 	// +optional

--- a/pkg/clients/generated/apis/containerattached/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/containerattached/v1beta1/zz_generated.deepcopy.go
@@ -404,7 +404,7 @@ func (in *ContainerAttachedClusterStatus) DeepCopyInto(out *ContainerAttachedClu
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {

--- a/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogentry_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogentry_types.go
@@ -62,7 +62,7 @@ type EntrySampleGcsFileSpecs struct {
 
 	/* The size of the file, in bytes. */
 	// +optional
-	SizeBytes *int `json:"sizeBytes,omitempty"`
+	SizeBytes *int64 `json:"sizeBytes,omitempty"`
 }
 
 type DataCatalogEntrySpec struct {
@@ -133,7 +133,7 @@ type EntryBigqueryDateShardedSpecStatus struct {
 
 	/* Total number of shards. */
 	// +optional
-	ShardCount *int `json:"shardCount,omitempty"`
+	ShardCount *int64 `json:"shardCount,omitempty"`
 
 	/* The table name prefix of the shards. The name of any given shard is [tablePrefix]YYYYMMDD,
 	for example, for shard MyTable20180101, the tablePrefix is MyTable. */
@@ -195,7 +195,7 @@ type DataCatalogEntryStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogentrygroup_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogentrygroup_types.go
@@ -70,7 +70,7 @@ type DataCatalogEntryGroupStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogtag_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogtag_types.go
@@ -58,7 +58,7 @@ type TagFields struct {
 	a more important field. The value can be negative. Multiple fields can have the same order, and field orders
 	within a tag do not have to be sequential. */
 	// +optional
-	Order *int `json:"order,omitempty"`
+	Order *int64 `json:"order,omitempty"`
 
 	/* Holds the value for a tag field with string type. */
 	// +optional
@@ -110,7 +110,7 @@ type DataCatalogTagStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The display name of the tag template. */
 	// +optional

--- a/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogtagtemplate_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1alpha1/datacatalogtagtemplate_types.go
@@ -72,7 +72,7 @@ type TagtemplateFields struct {
 	A higher value indicates a more important field. The value can be negative.
 	Multiple fields can have the same order, and field orders within a tag do not have to be sequential. */
 	// +optional
-	Order *int `json:"order,omitempty"`
+	Order *int64 `json:"order,omitempty"`
 
 	/* The type of value this tag field can contain. */
 	Type TagtemplateType `json:"type"`
@@ -127,7 +127,7 @@ type DataCatalogTagTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datacatalog/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/datacatalog/v1alpha1/zz_generated.deepcopy.go
@@ -170,7 +170,7 @@ func (in *DataCatalogEntryGroupStatus) DeepCopyInto(out *DataCatalogEntryGroupSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -314,7 +314,7 @@ func (in *DataCatalogEntryStatus) DeepCopyInto(out *DataCatalogEntryStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -444,7 +444,7 @@ func (in *DataCatalogTagStatus) DeepCopyInto(out *DataCatalogTagStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TemplateDisplayname != nil {
@@ -585,7 +585,7 @@ func (in *DataCatalogTagTemplateStatus) DeepCopyInto(out *DataCatalogTagTemplate
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -611,7 +611,7 @@ func (in *EntryBigqueryDateShardedSpecStatus) DeepCopyInto(out *EntryBigqueryDat
 	}
 	if in.ShardCount != nil {
 		in, out := &in.ShardCount, &out.ShardCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TablePrefix != nil {
@@ -705,7 +705,7 @@ func (in *EntrySampleGcsFileSpecs) DeepCopyInto(out *EntrySampleGcsFileSpecs) {
 	}
 	if in.SizeBytes != nil {
 		in, out := &in.SizeBytes, &out.SizeBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -788,7 +788,7 @@ func (in *TagFields) DeepCopyInto(out *TagFields) {
 	}
 	if in.Order != nil {
 		in, out := &in.Order, &out.Order
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -876,7 +876,7 @@ func (in *TagtemplateFields) DeepCopyInto(out *TagtemplateFields) {
 	}
 	if in.Order != nil {
 		in, out := &in.Order, &out.Order
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	in.Type.DeepCopyInto(&out.Type)

--- a/pkg/clients/generated/apis/datacatalog/v1beta1/datacatalogpolicytag_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1beta1/datacatalogpolicytag_types.go
@@ -73,7 +73,7 @@ type DataCatalogPolicyTagStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datacatalog/v1beta1/datacatalogtaxonomy_types.go
+++ b/pkg/clients/generated/apis/datacatalog/v1beta1/datacatalogtaxonomy_types.go
@@ -76,7 +76,7 @@ type DataCatalogTaxonomyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datacatalog/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/datacatalog/v1beta1/zz_generated.deepcopy.go
@@ -142,7 +142,7 @@ func (in *DataCatalogPolicyTagStatus) DeepCopyInto(out *DataCatalogPolicyTagStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -271,7 +271,7 @@ func (in *DataCatalogTaxonomyStatus) DeepCopyInto(out *DataCatalogTaxonomyStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/dataflow/v1beta1/dataflowflextemplatejob_types.go
+++ b/pkg/clients/generated/apis/dataflow/v1beta1/dataflowflextemplatejob_types.go
@@ -74,14 +74,14 @@ type DataflowFlexTemplateJobSpec struct {
 
 	/* Immutable. The maximum number of Google Compute Engine instances to be made available to your pipeline during execution, from 1 to 1000. */
 	// +optional
-	MaxWorkers *int `json:"maxWorkers,omitempty"`
+	MaxWorkers *int64 `json:"maxWorkers,omitempty"`
 
 	// +optional
 	NetworkRef *v1alpha1.ResourceRef `json:"networkRef,omitempty"`
 
 	/* Immutable. The initial number of Google Compute Engine instances for the job. */
 	// +optional
-	NumWorkers *int `json:"numWorkers,omitempty"`
+	NumWorkers *int64 `json:"numWorkers,omitempty"`
 
 	// +optional
 	Parameters *FlextemplatejobParameters `json:"parameters,omitempty"`
@@ -122,7 +122,7 @@ type DataflowFlexTemplateJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	State *string `json:"state,omitempty"`

--- a/pkg/clients/generated/apis/dataflow/v1beta1/dataflowjob_types.go
+++ b/pkg/clients/generated/apis/dataflow/v1beta1/dataflowjob_types.go
@@ -64,7 +64,7 @@ type DataflowJobSpec struct {
 
 	/* Immutable. The number of workers permitted to work on the job. More workers may improve processing speed at additional cost. */
 	// +optional
-	MaxWorkers *int `json:"maxWorkers,omitempty"`
+	MaxWorkers *int64 `json:"maxWorkers,omitempty"`
 
 	// +optional
 	NetworkRef *v1alpha1.ResourceRef `json:"networkRef,omitempty"`
@@ -112,7 +112,7 @@ type DataflowJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The current state of the resource, selected from the JobState enum. */
 	// +optional

--- a/pkg/clients/generated/apis/dataflow/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dataflow/v1beta1/zz_generated.deepcopy.go
@@ -130,7 +130,7 @@ func (in *DataflowFlexTemplateJobSpec) DeepCopyInto(out *DataflowFlexTemplateJob
 	}
 	if in.MaxWorkers != nil {
 		in, out := &in.MaxWorkers, &out.MaxWorkers
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NetworkRef != nil {
@@ -140,7 +140,7 @@ func (in *DataflowFlexTemplateJobSpec) DeepCopyInto(out *DataflowFlexTemplateJob
 	}
 	if in.NumWorkers != nil {
 		in, out := &in.NumWorkers, &out.NumWorkers
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Parameters != nil {
@@ -211,7 +211,7 @@ func (in *DataflowFlexTemplateJobStatus) DeepCopyInto(out *DataflowFlexTemplateJ
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -328,7 +328,7 @@ func (in *DataflowJobSpec) DeepCopyInto(out *DataflowJobSpec) {
 	}
 	if in.MaxWorkers != nil {
 		in, out := &in.MaxWorkers, &out.MaxWorkers
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NetworkRef != nil {
@@ -399,7 +399,7 @@ func (in *DataflowJobStatus) DeepCopyInto(out *DataflowJobStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/dataform/v1alpha1/dataformrepository_types.go
+++ b/pkg/clients/generated/apis/dataform/v1alpha1/dataformrepository_types.go
@@ -90,7 +90,7 @@ type DataformRepositoryStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dataform/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dataform/v1alpha1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *DataformRepositoryStatus) DeepCopyInto(out *DataformRepositoryStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/datafusion/v1beta1/datafusioninstance_types.go
+++ b/pkg/clients/generated/apis/datafusion/v1beta1/datafusioninstance_types.go
@@ -132,7 +132,7 @@ type DataFusionInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. P4 service account for the customer project. */
 	// +optional

--- a/pkg/clients/generated/apis/datafusion/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/datafusion/v1beta1/zz_generated.deepcopy.go
@@ -195,7 +195,7 @@ func (in *DataFusionInstanceStatus) DeepCopyInto(out *DataFusionInstanceStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.P4ServiceAccount != nil {

--- a/pkg/clients/generated/apis/dataproc/v1beta1/dataprocautoscalingpolicy_types.go
+++ b/pkg/clients/generated/apis/dataproc/v1beta1/dataprocautoscalingpolicy_types.go
@@ -47,28 +47,28 @@ type AutoscalingpolicyBasicAlgorithm struct {
 type AutoscalingpolicySecondaryWorkerConfig struct {
 	/* Optional. Maximum number of instances for this group. Note that by default, clusters will not use secondary workers. Required for secondary workers if the minimum secondary instances is set. Primary workers - Bounds: [min_instances, ). Secondary workers - Bounds: [min_instances, ). Default: 0. */
 	// +optional
-	MaxInstances *int `json:"maxInstances,omitempty"`
+	MaxInstances *int64 `json:"maxInstances,omitempty"`
 
 	/* Optional. Minimum number of instances for this group. Primary workers - Bounds: . Default: 0. */
 	// +optional
-	MinInstances *int `json:"minInstances,omitempty"`
+	MinInstances *int64 `json:"minInstances,omitempty"`
 
 	/* Optional. Weight for the instance group, which is used to determine the fraction of total workers in the cluster from this instance group. For example, if primary workers have weight 2, and secondary workers have weight 1, the cluster will have approximately 2 primary workers for each secondary worker. The cluster may not reach the specified balance if constrained by min/max bounds or other autoscaling settings. For example, if `max_instances` for secondary workers is 0, then only primary workers will be added. The cluster can also be out of balance when created. If weight is not set on any instance group, the cluster will default to equal weight for all groups: the cluster will attempt to maintain an equal number of workers in each group within the configured size bounds for each group. If weight is set for one group only, the cluster will default to zero weight on the unset group. For example if weight is set only on primary workers, the cluster will use primary workers only and no secondary workers. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type AutoscalingpolicyWorkerConfig struct {
 	/* Required. Maximum number of instances for this group. Required for primary workers. Note that by default, clusters will not use secondary workers. Required for secondary workers if the minimum secondary instances is set. Primary workers - Bounds: [min_instances, ). Secondary workers - Bounds: [min_instances, ). Default: 0. */
-	MaxInstances int `json:"maxInstances"`
+	MaxInstances int64 `json:"maxInstances"`
 
 	/* Optional. Minimum number of instances for this group. Primary workers - Bounds: . Default: 0. */
 	// +optional
-	MinInstances *int `json:"minInstances,omitempty"`
+	MinInstances *int64 `json:"minInstances,omitempty"`
 
 	/* Optional. Weight for the instance group, which is used to determine the fraction of total workers in the cluster from this instance group. For example, if primary workers have weight 2, and secondary workers have weight 1, the cluster will have approximately 2 primary workers for each secondary worker. The cluster may not reach the specified balance if constrained by min/max bounds or other autoscaling settings. For example, if `max_instances` for secondary workers is 0, then only primary workers will be added. The cluster can also be out of balance when created. If weight is not set on any instance group, the cluster will default to equal weight for all groups: the cluster will attempt to maintain an equal number of workers in each group within the configured size bounds for each group. If weight is set for one group only, the cluster will default to zero weight on the unset group. For example if weight is set only on primary workers, the cluster will use primary workers only and no secondary workers. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type AutoscalingpolicyYarnConfig struct {
@@ -118,7 +118,7 @@ type DataprocAutoscalingPolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dataproc/v1beta1/dataproccluster_types.go
+++ b/pkg/clients/generated/apis/dataproc/v1beta1/dataproccluster_types.go
@@ -38,7 +38,7 @@ import (
 type ClusterAccelerators struct {
 	/* Immutable. The number of accelerator cards exposed to an instance. */
 	// +optional
-	AcceleratorCount *int `json:"acceleratorCount,omitempty"`
+	AcceleratorCount *int64 `json:"acceleratorCount,omitempty"`
 
 	/* Immutable. The accelerator type resource namename (see GPUs on Compute Engine). */
 	// +optional
@@ -52,11 +52,11 @@ type ClusterAccelerators struct {
 type ClusterAutoscaling struct {
 	/* Immutable. The maximum number of nodes in the node pool. Must be >= min_node_count, and must be > 0. **Note:** Quota must be sufficient to scale up the cluster. */
 	// +optional
-	MaxNodeCount *int `json:"maxNodeCount,omitempty"`
+	MaxNodeCount *int64 `json:"maxNodeCount,omitempty"`
 
 	/* Immutable. The minimum number of nodes in the node pool. Must be >= 0 and <= max_node_count. */
 	// +optional
-	MinNodeCount *int `json:"minNodeCount,omitempty"`
+	MinNodeCount *int64 `json:"minNodeCount,omitempty"`
 }
 
 type ClusterAutoscalingConfig struct {
@@ -96,7 +96,7 @@ type ClusterConfig struct {
 
 	/* Immutable. Optional. The number of local SSD disks to attach to the node, which is limited by the maximum number of disks allowable per zone (see [Adding Local SSDs](https://cloud.google.com/compute/docs/disks/local-ssd)). */
 	// +optional
-	LocalSsdCount *int `json:"localSsdCount,omitempty"`
+	LocalSsdCount *int64 `json:"localSsdCount,omitempty"`
 
 	/* Immutable. Optional. The name of a Compute Engine [machine type](https://cloud.google.com/compute/docs/machine-types). */
 	// +optional
@@ -123,7 +123,7 @@ type ClusterDataprocMetricConfig struct {
 type ClusterDiskConfig struct {
 	/* Immutable. Optional. Size in GB of the boot disk (default is 500GB). */
 	// +optional
-	BootDiskSizeGb *int `json:"bootDiskSizeGb,omitempty"`
+	BootDiskSizeGb *int64 `json:"bootDiskSizeGb,omitempty"`
 
 	/* Immutable. Optional. Type of the boot disk (default is "pd-standard"). Valid values: "pd-balanced" (Persistent Disk Balanced Solid State Drive), "pd-ssd" (Persistent Disk Solid State Drive), or "pd-standard" (Persistent Disk Hard Disk Drive). See [Disk types](https://cloud.google.com/compute/docs/disks#disk-types). */
 	// +optional
@@ -135,7 +135,7 @@ type ClusterDiskConfig struct {
 
 	/* Immutable. Optional. Number of attached SSDs, from 0 to 4 (default is 0). If SSDs are not attached, the boot disk is used to store runtime logs and [HDFS](https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html) data. If one or more SSDs are attached, this runtime bulk data is spread across them, and the boot disk contains only basic config and installed binaries. */
 	// +optional
-	NumLocalSsds *int `json:"numLocalSsds,omitempty"`
+	NumLocalSsds *int64 `json:"numLocalSsds,omitempty"`
 }
 
 type ClusterEncryptionConfig struct {
@@ -153,7 +153,7 @@ type ClusterEndpointConfig struct {
 type ClusterEphemeralStorageConfig struct {
 	/* Immutable. Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage. */
 	// +optional
-	LocalSsdCount *int `json:"localSsdCount,omitempty"`
+	LocalSsdCount *int64 `json:"localSsdCount,omitempty"`
 }
 
 type ClusterGceClusterConfig struct {
@@ -285,7 +285,7 @@ type ClusterKerberosConfig struct {
 
 	/* Immutable. Optional. The lifetime of the ticket granting ticket, in hours. If not specified, or user specifies 0, then default value 10 will be used. */
 	// +optional
-	TgtLifetimeHours *int `json:"tgtLifetimeHours,omitempty"`
+	TgtLifetimeHours *int64 `json:"tgtLifetimeHours,omitempty"`
 
 	/* Immutable. Optional. The Cloud Storage URI of the truststore file used for SSL encryption. If not provided, Dataproc will provide a self-signed certificate. */
 	// +optional
@@ -356,7 +356,7 @@ type ClusterMasterConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -445,7 +445,7 @@ type ClusterSecondaryWorkerConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -532,7 +532,7 @@ type ClusterWorkerConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -734,7 +734,7 @@ type DataprocClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Cluster status. */
 	// +optional

--- a/pkg/clients/generated/apis/dataproc/v1beta1/dataprocworkflowtemplate_types.go
+++ b/pkg/clients/generated/apis/dataproc/v1beta1/dataprocworkflowtemplate_types.go
@@ -38,7 +38,7 @@ import (
 type WorkflowtemplateAccelerators struct {
 	/* Immutable. The number of the accelerator cards of this type exposed to this instance. */
 	// +optional
-	AcceleratorCount *int `json:"acceleratorCount,omitempty"`
+	AcceleratorCount *int64 `json:"acceleratorCount,omitempty"`
 
 	/* Immutable. Full URL, partial URI, or short name of the accelerator type resource to expose to this instance. See [Compute Engine AcceleratorTypes](https://cloud.google.com/compute/docs/reference/beta/acceleratorTypes). Examples: * `https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80` * `projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80` * `nvidia-tesla-k80` **Auto Zone Exception**: If you are using the Dataproc [Auto Zone Placement](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone#using_auto_zone_placement) feature, you must use the short name of the accelerator type resource, for example, `nvidia-tesla-k80`. */
 	// +optional
@@ -117,7 +117,7 @@ type WorkflowtemplateConfig struct {
 type WorkflowtemplateDiskConfig struct {
 	/* Immutable. Optional. Size in GB of the boot disk (default is 500GB). */
 	// +optional
-	BootDiskSizeGb *int `json:"bootDiskSizeGb,omitempty"`
+	BootDiskSizeGb *int64 `json:"bootDiskSizeGb,omitempty"`
 
 	/* Immutable. Optional. Type of the boot disk (default is "pd-standard"). Valid values: "pd-balanced" (Persistent Disk Balanced Solid State Drive), "pd-ssd" (Persistent Disk Solid State Drive), or "pd-standard" (Persistent Disk Hard Disk Drive). See [Disk types](https://cloud.google.com/compute/docs/disks#disk-types). */
 	// +optional
@@ -125,7 +125,7 @@ type WorkflowtemplateDiskConfig struct {
 
 	/* Immutable. Optional. Number of attached SSDs, from 0 to 4 (default is 0). If SSDs are not attached, the boot disk is used to store runtime logs and [HDFS](https://hadoop.apache.org/docs/r1.2.1/hdfs_user_guide.html) data. If one or more SSDs are attached, this runtime bulk data is spread across them, and the boot disk contains only basic config and installed binaries. */
 	// +optional
-	NumLocalSsds *int `json:"numLocalSsds,omitempty"`
+	NumLocalSsds *int64 `json:"numLocalSsds,omitempty"`
 }
 
 type WorkflowtemplateEncryptionConfig struct {
@@ -360,7 +360,7 @@ type WorkflowtemplateKerberosConfig struct {
 
 	/* Immutable. Optional. The lifetime of the ticket granting ticket, in hours. If not specified, or user specifies 0, then default value 10 will be used. */
 	// +optional
-	TgtLifetimeHours *int `json:"tgtLifetimeHours,omitempty"`
+	TgtLifetimeHours *int64 `json:"tgtLifetimeHours,omitempty"`
 
 	/* Immutable. Optional. The Cloud Storage URI of the truststore file used for SSL encryption. If not provided, Dataproc will provide a self-signed certificate. */
 	// +optional
@@ -426,7 +426,7 @@ type WorkflowtemplateMasterConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -584,11 +584,11 @@ type WorkflowtemplateReservationAffinity struct {
 type WorkflowtemplateScheduling struct {
 	/* Immutable. Optional. Maximum number of times per hour a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed. A job may be reported as thrashing if driver exits with non-zero code 4 times within 10 minute window. Maximum value is 10. */
 	// +optional
-	MaxFailuresPerHour *int `json:"maxFailuresPerHour,omitempty"`
+	MaxFailuresPerHour *int64 `json:"maxFailuresPerHour,omitempty"`
 
 	/* Immutable. Optional. Maximum number of times in total a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed. Maximum value is 240. */
 	// +optional
-	MaxFailuresTotal *int `json:"maxFailuresTotal,omitempty"`
+	MaxFailuresTotal *int64 `json:"maxFailuresTotal,omitempty"`
 }
 
 type WorkflowtemplateSecondaryWorkerConfig struct {
@@ -614,7 +614,7 @@ type WorkflowtemplateSecondaryWorkerConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -778,7 +778,7 @@ type WorkflowtemplateWorkerConfig struct {
 
 	/* Immutable. Optional. The number of VM instances in the instance group. For [HA cluster](/dataproc/docs/concepts/configuring-clusters/high-availability) [master_config](#FIELDS.master_config) groups, **must be set to 3**. For standard cluster [master_config](#FIELDS.master_config) groups, **must be set to 1**. */
 	// +optional
-	NumInstances *int `json:"numInstances,omitempty"`
+	NumInstances *int64 `json:"numInstances,omitempty"`
 
 	/* Immutable. Optional. Specifies the preemptibility of the instance group. The default value for master and worker groups is `NON_PREEMPTIBLE`. This default cannot be changed. The default value for secondary instances is `PREEMPTIBLE`. Possible values: PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE */
 	// +optional
@@ -913,7 +913,7 @@ type DataprocWorkflowTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	Placement *WorkflowtemplatePlacementStatus `json:"placement,omitempty"`
@@ -924,7 +924,7 @@ type DataprocWorkflowTemplateStatus struct {
 
 	/* Output only. The current version of this workflow template. */
 	// +optional
-	Version *int `json:"version,omitempty"`
+	Version *int64 `json:"version,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dataproc/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dataproc/v1beta1/zz_generated.deepcopy.go
@@ -56,17 +56,17 @@ func (in *AutoscalingpolicySecondaryWorkerConfig) DeepCopyInto(out *Autoscalingp
 	*out = *in
 	if in.MaxInstances != nil {
 		in, out := &in.MaxInstances, &out.MaxInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinInstances != nil {
 		in, out := &in.MinInstances, &out.MinInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -87,12 +87,12 @@ func (in *AutoscalingpolicyWorkerConfig) DeepCopyInto(out *AutoscalingpolicyWork
 	*out = *in
 	if in.MinInstances != nil {
 		in, out := &in.MinInstances, &out.MinInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -139,7 +139,7 @@ func (in *ClusterAccelerators) DeepCopyInto(out *ClusterAccelerators) {
 	*out = *in
 	if in.AcceleratorCount != nil {
 		in, out := &in.AcceleratorCount, &out.AcceleratorCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.AcceleratorType != nil {
@@ -170,12 +170,12 @@ func (in *ClusterAutoscaling) DeepCopyInto(out *ClusterAutoscaling) {
 	*out = *in
 	if in.MaxNodeCount != nil {
 		in, out := &in.MaxNodeCount, &out.MaxNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinNodeCount != nil {
 		in, out := &in.MinNodeCount, &out.MinNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -281,7 +281,7 @@ func (in *ClusterConfig) DeepCopyInto(out *ClusterConfig) {
 	}
 	if in.LocalSsdCount != nil {
 		in, out := &in.LocalSsdCount, &out.LocalSsdCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MachineType != nil {
@@ -386,7 +386,7 @@ func (in *ClusterDiskConfig) DeepCopyInto(out *ClusterDiskConfig) {
 	*out = *in
 	if in.BootDiskSizeGb != nil {
 		in, out := &in.BootDiskSizeGb, &out.BootDiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BootDiskType != nil {
@@ -401,7 +401,7 @@ func (in *ClusterDiskConfig) DeepCopyInto(out *ClusterDiskConfig) {
 	}
 	if in.NumLocalSsds != nil {
 		in, out := &in.NumLocalSsds, &out.NumLocalSsds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -487,7 +487,7 @@ func (in *ClusterEphemeralStorageConfig) DeepCopyInto(out *ClusterEphemeralStora
 	*out = *in
 	if in.LocalSsdCount != nil {
 		in, out := &in.LocalSsdCount, &out.LocalSsdCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -759,7 +759,7 @@ func (in *ClusterKerberosConfig) DeepCopyInto(out *ClusterKerberosConfig) {
 	}
 	if in.TgtLifetimeHours != nil {
 		in, out := &in.TgtLifetimeHours, &out.TgtLifetimeHours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Truststore != nil {
@@ -952,7 +952,7 @@ func (in *ClusterMasterConfig) DeepCopyInto(out *ClusterMasterConfig) {
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {
@@ -1217,7 +1217,7 @@ func (in *ClusterSecondaryWorkerConfig) DeepCopyInto(out *ClusterSecondaryWorker
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {
@@ -1518,7 +1518,7 @@ func (in *ClusterWorkerConfig) DeepCopyInto(out *ClusterWorkerConfig) {
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {
@@ -1681,7 +1681,7 @@ func (in *DataprocAutoscalingPolicyStatus) DeepCopyInto(out *DataprocAutoscaling
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1819,7 +1819,7 @@ func (in *DataprocClusterStatus) DeepCopyInto(out *DataprocClusterStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Status != nil {
@@ -1969,7 +1969,7 @@ func (in *DataprocWorkflowTemplateStatus) DeepCopyInto(out *DataprocWorkflowTemp
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Placement != nil {
@@ -1984,7 +1984,7 @@ func (in *DataprocWorkflowTemplateStatus) DeepCopyInto(out *DataprocWorkflowTemp
 	}
 	if in.Version != nil {
 		in, out := &in.Version, &out.Version
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2005,7 +2005,7 @@ func (in *WorkflowtemplateAccelerators) DeepCopyInto(out *WorkflowtemplateAccele
 	*out = *in
 	if in.AcceleratorCount != nil {
 		in, out := &in.AcceleratorCount, &out.AcceleratorCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.AcceleratorType != nil {
@@ -2204,7 +2204,7 @@ func (in *WorkflowtemplateDiskConfig) DeepCopyInto(out *WorkflowtemplateDiskConf
 	*out = *in
 	if in.BootDiskSizeGb != nil {
 		in, out := &in.BootDiskSizeGb, &out.BootDiskSizeGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BootDiskType != nil {
@@ -2214,7 +2214,7 @@ func (in *WorkflowtemplateDiskConfig) DeepCopyInto(out *WorkflowtemplateDiskConf
 	}
 	if in.NumLocalSsds != nil {
 		in, out := &in.NumLocalSsds, &out.NumLocalSsds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2645,7 +2645,7 @@ func (in *WorkflowtemplateKerberosConfig) DeepCopyInto(out *WorkflowtemplateKerb
 	}
 	if in.TgtLifetimeHours != nil {
 		in, out := &in.TgtLifetimeHours, &out.TgtLifetimeHours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Truststore != nil {
@@ -2849,7 +2849,7 @@ func (in *WorkflowtemplateMasterConfig) DeepCopyInto(out *WorkflowtemplateMaster
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {
@@ -3237,12 +3237,12 @@ func (in *WorkflowtemplateScheduling) DeepCopyInto(out *WorkflowtemplateScheduli
 	*out = *in
 	if in.MaxFailuresPerHour != nil {
 		in, out := &in.MaxFailuresPerHour, &out.MaxFailuresPerHour
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxFailuresTotal != nil {
 		in, out := &in.MaxFailuresTotal, &out.MaxFailuresTotal
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3290,7 +3290,7 @@ func (in *WorkflowtemplateSecondaryWorkerConfig) DeepCopyInto(out *Workflowtempl
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {
@@ -3659,7 +3659,7 @@ func (in *WorkflowtemplateWorkerConfig) DeepCopyInto(out *WorkflowtemplateWorker
 	}
 	if in.NumInstances != nil {
 		in, out := &in.NumInstances, &out.NumInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Preemptibility != nil {

--- a/pkg/clients/generated/apis/datastore/v1alpha1/datastoreindex_types.go
+++ b/pkg/clients/generated/apis/datastore/v1alpha1/datastoreindex_types.go
@@ -73,7 +73,7 @@ type DatastoreIndexStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datastore/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/datastore/v1alpha1/zz_generated.deepcopy.go
@@ -137,7 +137,7 @@ func (in *DatastoreIndexStatus) DeepCopyInto(out *DatastoreIndexStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/datastream/v1alpha1/datastreamconnectionprofile_types.go
+++ b/pkg/clients/generated/apis/datastream/v1alpha1/datastreamconnectionprofile_types.go
@@ -78,7 +78,7 @@ type ConnectionprofileForwardSshConnectivity struct {
 
 	/* Port for the SSH tunnel. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Immutable. SSH private key. */
 	// +optional
@@ -106,7 +106,7 @@ type ConnectionprofileMysqlProfile struct {
 
 	/* Port for the MySQL connection. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* SSL configuration for the MySQL connection. */
 	// +optional
@@ -132,7 +132,7 @@ type ConnectionprofileOracleProfile struct {
 
 	/* Port for the Oracle connection. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Username for the Oracle connection. */
 	Username string `json:"username"`
@@ -160,7 +160,7 @@ type ConnectionprofilePostgresqlProfile struct {
 
 	/* Port for the PostgreSQL connection. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Username for the PostgreSQL connection. */
 	Username string `json:"username"`
@@ -272,7 +272,7 @@ type DatastreamConnectionProfileStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/datastream/v1alpha1/datastreamprivateconnection_types.go
+++ b/pkg/clients/generated/apis/datastream/v1alpha1/datastreamprivateconnection_types.go
@@ -87,7 +87,7 @@ type DatastreamPrivateConnectionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State of the PrivateConnection. */
 	// +optional

--- a/pkg/clients/generated/apis/datastream/v1alpha1/datastreamstream_types.go
+++ b/pkg/clients/generated/apis/datastream/v1alpha1/datastreamstream_types.go
@@ -123,7 +123,7 @@ type StreamGcsDestinationConfig struct {
 
 	/* The maximum file size to be saved in the bucket. */
 	// +optional
-	FileRotationMb *int `json:"fileRotationMb,omitempty"`
+	FileRotationMb *int64 `json:"fileRotationMb,omitempty"`
 
 	/* JSON file format configuration. */
 	// +optional
@@ -165,7 +165,7 @@ type StreamMysqlColumns struct {
 
 	/* Column length. */
 	// +optional
-	Length *int `json:"length,omitempty"`
+	Length *int64 `json:"length,omitempty"`
 
 	/* Whether or not the column can accept a null value. */
 	// +optional
@@ -173,7 +173,7 @@ type StreamMysqlColumns struct {
 
 	/* The ordinal position of the column in the table. */
 	// +optional
-	OrdinalPosition *int `json:"ordinalPosition,omitempty"`
+	OrdinalPosition *int64 `json:"ordinalPosition,omitempty"`
 
 	/* Whether or not the column represents a primary key. */
 	// +optional
@@ -206,12 +206,12 @@ type StreamMysqlSourceConfig struct {
 	/* Maximum number of concurrent backfill tasks. The number should be non negative.
 	If not set (or set to 0), the system's default value will be used. */
 	// +optional
-	MaxConcurrentBackfillTasks *int `json:"maxConcurrentBackfillTasks,omitempty"`
+	MaxConcurrentBackfillTasks *int64 `json:"maxConcurrentBackfillTasks,omitempty"`
 
 	/* Maximum number of concurrent CDC tasks. The number should be non negative.
 	If not set (or set to 0), the system's default value will be used. */
 	// +optional
-	MaxConcurrentCdcTasks *int `json:"maxConcurrentCdcTasks,omitempty"`
+	MaxConcurrentCdcTasks *int64 `json:"maxConcurrentCdcTasks,omitempty"`
 }
 
 type StreamMysqlTables struct {
@@ -239,7 +239,7 @@ type StreamOracleColumns struct {
 
 	/* Column length. */
 	// +optional
-	Length *int `json:"length,omitempty"`
+	Length *int64 `json:"length,omitempty"`
 
 	/* Whether or not the column can accept a null value. */
 	// +optional
@@ -247,11 +247,11 @@ type StreamOracleColumns struct {
 
 	/* The ordinal position of the column in the table. */
 	// +optional
-	OrdinalPosition *int `json:"ordinalPosition,omitempty"`
+	OrdinalPosition *int64 `json:"ordinalPosition,omitempty"`
 
 	/* Column precision. */
 	// +optional
-	Precision *int `json:"precision,omitempty"`
+	Precision *int64 `json:"precision,omitempty"`
 
 	/* Whether or not the column represents a primary key. */
 	// +optional
@@ -259,7 +259,7 @@ type StreamOracleColumns struct {
 
 	/* Column scale. */
 	// +optional
-	Scale *int `json:"scale,omitempty"`
+	Scale *int64 `json:"scale,omitempty"`
 }
 
 type StreamOracleExcludedObjects struct {
@@ -292,12 +292,12 @@ type StreamOracleSourceConfig struct {
 	/* Maximum number of concurrent backfill tasks. The number should be non negative.
 	If not set (or set to 0), the system's default value will be used. */
 	// +optional
-	MaxConcurrentBackfillTasks *int `json:"maxConcurrentBackfillTasks,omitempty"`
+	MaxConcurrentBackfillTasks *int64 `json:"maxConcurrentBackfillTasks,omitempty"`
 
 	/* Maximum number of concurrent CDC tasks. The number should be non negative.
 	If not set (or set to 0), the system's default value will be used. */
 	// +optional
-	MaxConcurrentCdcTasks *int `json:"maxConcurrentCdcTasks,omitempty"`
+	MaxConcurrentCdcTasks *int64 `json:"maxConcurrentCdcTasks,omitempty"`
 
 	/* Configuration to drop large object values. */
 	// +optional
@@ -325,7 +325,7 @@ type StreamPostgresqlColumns struct {
 
 	/* Column length. */
 	// +optional
-	Length *int `json:"length,omitempty"`
+	Length *int64 `json:"length,omitempty"`
 
 	/* Whether or not the column can accept a null value. */
 	// +optional
@@ -333,11 +333,11 @@ type StreamPostgresqlColumns struct {
 
 	/* The ordinal position of the column in the table. */
 	// +optional
-	OrdinalPosition *int `json:"ordinalPosition,omitempty"`
+	OrdinalPosition *int64 `json:"ordinalPosition,omitempty"`
 
 	/* Column precision. */
 	// +optional
-	Precision *int `json:"precision,omitempty"`
+	Precision *int64 `json:"precision,omitempty"`
 
 	/* Whether or not the column represents a primary key. */
 	// +optional
@@ -345,7 +345,7 @@ type StreamPostgresqlColumns struct {
 
 	/* Column scale. */
 	// +optional
-	Scale *int `json:"scale,omitempty"`
+	Scale *int64 `json:"scale,omitempty"`
 }
 
 type StreamPostgresqlExcludedObjects struct {
@@ -374,7 +374,7 @@ type StreamPostgresqlSourceConfig struct {
 	/* Maximum number of concurrent backfill tasks. The number should be non
 	negative. If not set (or set to 0), the system's default value will be used. */
 	// +optional
-	MaxConcurrentBackfillTasks *int `json:"maxConcurrentBackfillTasks,omitempty"`
+	MaxConcurrentBackfillTasks *int64 `json:"maxConcurrentBackfillTasks,omitempty"`
 
 	/* The name of the publication that includes the set of all tables
 	that are defined in the stream's include_objects. */
@@ -473,7 +473,7 @@ type DatastreamStreamStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The state of the stream. */
 	// +optional

--- a/pkg/clients/generated/apis/datastream/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/datastream/v1alpha1/zz_generated.deepcopy.go
@@ -133,7 +133,7 @@ func (in *ConnectionprofileForwardSshConnectivity) DeepCopyInto(out *Connectionp
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrivateKey != nil {
@@ -181,7 +181,7 @@ func (in *ConnectionprofileMysqlProfile) DeepCopyInto(out *ConnectionprofileMysq
 	in.Password.DeepCopyInto(&out.Password)
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SslConfig != nil {
@@ -215,7 +215,7 @@ func (in *ConnectionprofileOracleProfile) DeepCopyInto(out *ConnectionprofileOra
 	in.Password.DeepCopyInto(&out.Password)
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -263,7 +263,7 @@ func (in *ConnectionprofilePostgresqlProfile) DeepCopyInto(out *Connectionprofil
 	in.Password.DeepCopyInto(&out.Password)
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -521,7 +521,7 @@ func (in *DatastreamConnectionProfileStatus) DeepCopyInto(out *DatastreamConnect
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -643,7 +643,7 @@ func (in *DatastreamPrivateConnectionStatus) DeepCopyInto(out *DatastreamPrivate
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -784,7 +784,7 @@ func (in *DatastreamStreamStatus) DeepCopyInto(out *DatastreamStreamStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -1049,7 +1049,7 @@ func (in *StreamGcsDestinationConfig) DeepCopyInto(out *StreamGcsDestinationConf
 	}
 	if in.FileRotationMb != nil {
 		in, out := &in.FileRotationMb, &out.FileRotationMb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.JsonFileFormat != nil {
@@ -1144,7 +1144,7 @@ func (in *StreamMysqlColumns) DeepCopyInto(out *StreamMysqlColumns) {
 	}
 	if in.Length != nil {
 		in, out := &in.Length, &out.Length
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nullable != nil {
@@ -1154,7 +1154,7 @@ func (in *StreamMysqlColumns) DeepCopyInto(out *StreamMysqlColumns) {
 	}
 	if in.OrdinalPosition != nil {
 		in, out := &in.OrdinalPosition, &out.OrdinalPosition
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrimaryKey != nil {
@@ -1236,12 +1236,12 @@ func (in *StreamMysqlSourceConfig) DeepCopyInto(out *StreamMysqlSourceConfig) {
 	}
 	if in.MaxConcurrentBackfillTasks != nil {
 		in, out := &in.MaxConcurrentBackfillTasks, &out.MaxConcurrentBackfillTasks
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxConcurrentCdcTasks != nil {
 		in, out := &in.MaxConcurrentCdcTasks, &out.MaxConcurrentCdcTasks
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1300,7 +1300,7 @@ func (in *StreamOracleColumns) DeepCopyInto(out *StreamOracleColumns) {
 	}
 	if in.Length != nil {
 		in, out := &in.Length, &out.Length
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nullable != nil {
@@ -1310,12 +1310,12 @@ func (in *StreamOracleColumns) DeepCopyInto(out *StreamOracleColumns) {
 	}
 	if in.OrdinalPosition != nil {
 		in, out := &in.OrdinalPosition, &out.OrdinalPosition
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Precision != nil {
 		in, out := &in.Precision, &out.Precision
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrimaryKey != nil {
@@ -1325,7 +1325,7 @@ func (in *StreamOracleColumns) DeepCopyInto(out *StreamOracleColumns) {
 	}
 	if in.Scale != nil {
 		in, out := &in.Scale, &out.Scale
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1407,12 +1407,12 @@ func (in *StreamOracleSourceConfig) DeepCopyInto(out *StreamOracleSourceConfig) 
 	}
 	if in.MaxConcurrentBackfillTasks != nil {
 		in, out := &in.MaxConcurrentBackfillTasks, &out.MaxConcurrentBackfillTasks
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxConcurrentCdcTasks != nil {
 		in, out := &in.MaxConcurrentCdcTasks, &out.MaxConcurrentCdcTasks
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StreamLargeObjects != nil {
@@ -1471,7 +1471,7 @@ func (in *StreamPostgresqlColumns) DeepCopyInto(out *StreamPostgresqlColumns) {
 	}
 	if in.Length != nil {
 		in, out := &in.Length, &out.Length
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nullable != nil {
@@ -1481,12 +1481,12 @@ func (in *StreamPostgresqlColumns) DeepCopyInto(out *StreamPostgresqlColumns) {
 	}
 	if in.OrdinalPosition != nil {
 		in, out := &in.OrdinalPosition, &out.OrdinalPosition
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Precision != nil {
 		in, out := &in.Precision, &out.Precision
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrimaryKey != nil {
@@ -1496,7 +1496,7 @@ func (in *StreamPostgresqlColumns) DeepCopyInto(out *StreamPostgresqlColumns) {
 	}
 	if in.Scale != nil {
 		in, out := &in.Scale, &out.Scale
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1573,7 +1573,7 @@ func (in *StreamPostgresqlSourceConfig) DeepCopyInto(out *StreamPostgresqlSource
 	}
 	if in.MaxConcurrentBackfillTasks != nil {
 		in, out := &in.MaxConcurrentBackfillTasks, &out.MaxConcurrentBackfillTasks
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/deploymentmanager/v1alpha1/deploymentmanagerdeployment_types.go
+++ b/pkg/clients/generated/apis/deploymentmanager/v1alpha1/deploymentmanagerdeployment_types.go
@@ -114,7 +114,7 @@ type DeploymentManagerDeploymentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server defined URL for the resource. */
 	// +optional

--- a/pkg/clients/generated/apis/deploymentmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/deploymentmanager/v1alpha1/zz_generated.deepcopy.go
@@ -195,7 +195,7 @@ func (in *DeploymentManagerDeploymentStatus) DeepCopyInto(out *DeploymentManager
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowagent_types.go
+++ b/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowagent_types.go
@@ -109,7 +109,7 @@ type DialogflowAgentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowentitytype_types.go
+++ b/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowentitytype_types.go
@@ -89,7 +89,7 @@ type DialogflowEntityTypeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowfulfillment_types.go
+++ b/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowfulfillment_types.go
@@ -93,7 +93,7 @@ type DialogflowFulfillmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowintent_types.go
+++ b/pkg/clients/generated/apis/dialogflow/v1alpha1/dialogflowintent_types.go
@@ -80,7 +80,7 @@ type DialogflowIntentSpec struct {
 	to the Normal priority in the console.
 	- If the supplied value is negative, the intent is ignored in runtime detect intent requests. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* The project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -129,7 +129,7 @@ type DialogflowIntentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique identifier of the root intent in the chain of followup intents. It identifies the correct followup
 	intents chain for this intent.

--- a/pkg/clients/generated/apis/dialogflow/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dialogflow/v1alpha1/zz_generated.deepcopy.go
@@ -166,7 +166,7 @@ func (in *DialogflowAgentStatus) DeepCopyInto(out *DialogflowAgentStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -292,7 +292,7 @@ func (in *DialogflowEntityTypeStatus) DeepCopyInto(out *DialogflowEntityTypeStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -421,7 +421,7 @@ func (in *DialogflowFulfillmentStatus) DeepCopyInto(out *DialogflowFulfillmentSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -538,7 +538,7 @@ func (in *DialogflowIntentSpec) DeepCopyInto(out *DialogflowIntentSpec) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -592,7 +592,7 @@ func (in *DialogflowIntentStatus) DeepCopyInto(out *DialogflowIntentStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RootFollowupIntentName != nil {

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxagent_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxagent_types.go
@@ -106,7 +106,7 @@ type DialogflowCXAgentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Name of the start flow in this agent. A start flow will be automatically created when the agent is created, and can only be deleted by deleting the agent. Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>. */
 	// +optional

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxentitytype_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxentitytype_types.go
@@ -115,7 +115,7 @@ type DialogflowCXEntityTypeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxflow_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxflow_types.go
@@ -310,7 +310,7 @@ type DialogflowCXFlowStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxintent_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxintent_types.go
@@ -78,7 +78,7 @@ type IntentTrainingPhrases struct {
 
 	/* Indicates how many times this example was added to the intent. */
 	// +optional
-	RepeatCount *int `json:"repeatCount,omitempty"`
+	RepeatCount *int64 `json:"repeatCount,omitempty"`
 }
 
 type DialogflowCXIntentSpec struct {
@@ -113,7 +113,7 @@ type DialogflowCXIntentSpec struct {
 	If the supplied value is unspecified or 0, the service translates the value to 500,000, which corresponds to the Normal priority in the console.
 	If the supplied value is negative, the intent is ignored in runtime detect intent requests. */
 	// +optional
-	Priority *int `json:"priority,omitempty"`
+	Priority *int64 `json:"priority,omitempty"`
 
 	/* Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource. */
 	// +optional
@@ -135,7 +135,7 @@ type DialogflowCXIntentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxpage_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxpage_types.go
@@ -430,7 +430,7 @@ type DialogflowCXPageStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxwebhook_types.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/dialogflowcxwebhook_types.go
@@ -109,7 +109,7 @@ type DialogflowCXWebhookStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Name of the start flow in this agent. A start flow will be automatically created when the agent is created, and can only be deleted by deleting the agent. Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>. */
 	// +optional

--- a/pkg/clients/generated/apis/dialogflowcx/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dialogflowcx/v1alpha1/zz_generated.deepcopy.go
@@ -183,7 +183,7 @@ func (in *DialogflowCXAgentStatus) DeepCopyInto(out *DialogflowCXAgentStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StartFlow != nil {
@@ -340,7 +340,7 @@ func (in *DialogflowCXEntityTypeStatus) DeepCopyInto(out *DialogflowCXEntityType
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -492,7 +492,7 @@ func (in *DialogflowCXFlowStatus) DeepCopyInto(out *DialogflowCXFlowStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -601,7 +601,7 @@ func (in *DialogflowCXIntentSpec) DeepCopyInto(out *DialogflowCXIntentSpec) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -644,7 +644,7 @@ func (in *DialogflowCXIntentStatus) DeepCopyInto(out *DialogflowCXIntentStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -796,7 +796,7 @@ func (in *DialogflowCXPageStatus) DeepCopyInto(out *DialogflowCXPageStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -949,7 +949,7 @@ func (in *DialogflowCXWebhookStatus) DeepCopyInto(out *DialogflowCXWebhookStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StartFlow != nil {
@@ -1492,7 +1492,7 @@ func (in *IntentTrainingPhrases) DeepCopyInto(out *IntentTrainingPhrases) {
 	}
 	if in.RepeatCount != nil {
 		in, out := &in.RepeatCount, &out.RepeatCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/dlp/v1beta1/dlpdeidentifytemplate_types.go
+++ b/pkg/clients/generated/apis/dlp/v1beta1/dlpdeidentifytemplate_types.go
@@ -65,7 +65,7 @@ type DeidentifytemplateCharacterMaskConfig struct {
 
 	/* Number of characters to mask. If not set, all matching chars will be masked. Skipped characters do not count towards this tally. */
 	// +optional
-	NumberToMask *int `json:"numberToMask,omitempty"`
+	NumberToMask *int64 `json:"numberToMask,omitempty"`
 
 	/* Mask characters in reverse order. For example, if `masking_character` is `0`, `number_to_mask` is `14`, and `reverse_order` is `false`, then the input string `1234-5678-9012-3456` is masked as `00000000000000-3456`. If `masking_character` is `*`, `number_to_mask` is `3`, and `reverse_order` is `true`, then the string `12345` is masked as `12***`. */
 	// +optional
@@ -158,7 +158,7 @@ type DeidentifytemplateCryptoReplaceFfxFpeConfig struct {
 
 	/* The native way to select the alphabet. Must be in the range [2, 95]. */
 	// +optional
-	Radix *int `json:"radix,omitempty"`
+	Radix *int64 `json:"radix,omitempty"`
 
 	/* The custom infoType to annotate the surrogate with. This annotation will be applied to the surrogate by prefixing it with the name of the custom infoType followed by the number of characters comprising the surrogate. The following scheme defines the format: info_type_name(surrogate_character_count):surrogate For example, if the name of custom infoType is 'MY_TOKEN_INFO_TYPE' and the surrogate is 'abc', the full replacement value will be: 'MY_TOKEN_INFO_TYPE(3):abc' This annotation identifies the surrogate when inspecting content using the custom infoType [`SurrogateType`](https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#surrogatetype). This facilitates reversal of the surrogate when it occurs in free text. In order for inspection to work properly, the name of this infoType must not occur naturally anywhere in your data; otherwise, inspection may find a surrogate that does not correspond to an actual identifier. Therefore, choose your custom infoType name carefully after considering what your data looks like. One way to select a name that has a high chance of yielding reliable detection is to include one or more unicode characters that are highly improbable to exist in your data. For example, assuming your data is entered from a regular ASCII keyboard, the symbol with the hex code point 29DD might be used like so: ⧝MY_TOKEN_TYPE */
 	// +optional
@@ -175,24 +175,24 @@ type DeidentifytemplateDateShiftConfig struct {
 	CryptoKey *DeidentifytemplateCryptoKey `json:"cryptoKey,omitempty"`
 
 	/* Required. For example, -5 means shift date to at most 5 days back in the past. */
-	LowerBoundDays int `json:"lowerBoundDays"`
+	LowerBoundDays int64 `json:"lowerBoundDays"`
 
 	/* Required. Range of shift in days. Actual shift will be selected at random within this range (inclusive ends). Negative means shift to earlier in time. Must not be more than 365250 days (1000 years) each direction. For example, 3 means shift date to at most 3 days into the future. */
-	UpperBoundDays int `json:"upperBoundDays"`
+	UpperBoundDays int64 `json:"upperBoundDays"`
 }
 
 type DeidentifytemplateDateValue struct {
 	/* Day of a month. Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant. */
 	// +optional
-	Day *int `json:"day,omitempty"`
+	Day *int64 `json:"day,omitempty"`
 
 	/* Month of a year. Must be from 1 to 12, or 0 to specify a year without a month and day. */
 	// +optional
-	Month *int `json:"month,omitempty"`
+	Month *int64 `json:"month,omitempty"`
 
 	/* Year of the date. Must be from 1 to 9999, or 0 to specify a date without a year. */
 	// +optional
-	Year *int `json:"year,omitempty"`
+	Year *int64 `json:"year,omitempty"`
 }
 
 type DeidentifytemplateDeidentifyConfig struct {
@@ -299,7 +299,7 @@ type DeidentifytemplateLowerBound struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -333,7 +333,7 @@ type DeidentifytemplateMax struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -367,7 +367,7 @@ type DeidentifytemplateMin struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -401,7 +401,7 @@ type DeidentifytemplateNewValue struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -509,7 +509,7 @@ type DeidentifytemplateReplacementValue struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -542,19 +542,19 @@ type DeidentifytemplateTimePartConfig struct {
 type DeidentifytemplateTimeValue struct {
 	/* Hours of day in 24 hour format. Should be from 0 to 23. An API may choose to allow the value "24:00:00" for scenarios like business closing time. */
 	// +optional
-	Hours *int `json:"hours,omitempty"`
+	Hours *int64 `json:"hours,omitempty"`
 
 	/* Minutes of hour of day. Must be from 0 to 59. */
 	// +optional
-	Minutes *int `json:"minutes,omitempty"`
+	Minutes *int64 `json:"minutes,omitempty"`
 
 	/* Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Seconds of minutes of the time. Must normally be from 0 to 59. An API may allow the value 60 if it allows leap-seconds. */
 	// +optional
-	Seconds *int `json:"seconds,omitempty"`
+	Seconds *int64 `json:"seconds,omitempty"`
 }
 
 type DeidentifytemplateTransformationErrorHandling struct {
@@ -605,7 +605,7 @@ type DeidentifytemplateUpperBound struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -639,7 +639,7 @@ type DeidentifytemplateValue struct {
 
 	/* integer */
 	// +optional
-	IntegerValue *int `json:"integerValue,omitempty"`
+	IntegerValue *int64 `json:"integerValue,omitempty"`
 
 	/* string */
 	// +optional
@@ -698,7 +698,7 @@ type DLPDeidentifyTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of an inspectTemplate. */
 	// +optional

--- a/pkg/clients/generated/apis/dlp/v1beta1/dlpinspecttemplate_types.go
+++ b/pkg/clients/generated/apis/dlp/v1beta1/dlpinspecttemplate_types.go
@@ -108,7 +108,7 @@ type InspecttemplateExclusionRule struct {
 type InspecttemplateHotwordRegex struct {
 	/* The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included. */
 	// +optional
-	GroupIndexes []int `json:"groupIndexes,omitempty"`
+	GroupIndexes []int64 `json:"groupIndexes,omitempty"`
 
 	/* Pattern defining the regular expression. Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub. */
 	// +optional
@@ -182,7 +182,7 @@ type InspecttemplateLikelihoodAdjustment struct {
 
 	/* Increase or decrease the likelihood by the specified number of levels. For example, if a finding would be `POSSIBLE` without the detection rule and `relative_likelihood` is 1, then it is upgraded to `LIKELY`, while a value of -1 would downgrade it to `UNLIKELY`. Likelihood may never drop below `VERY_UNLIKELY` or exceed `VERY_LIKELY`, so applying an adjustment of 1 followed by an adjustment of -1 when base likelihood is `VERY_LIKELY` will result in a final likelihood of `LIKELY`. */
 	// +optional
-	RelativeLikelihood *int `json:"relativeLikelihood,omitempty"`
+	RelativeLikelihood *int64 `json:"relativeLikelihood,omitempty"`
 }
 
 type InspecttemplateLimits struct {
@@ -192,11 +192,11 @@ type InspecttemplateLimits struct {
 
 	/* Max number of findings that will be returned for each item scanned. When set within `InspectJobConfig`, the maximum returned is 2000 regardless if this is set higher. When set within `InspectContentRequest`, this field is ignored. */
 	// +optional
-	MaxFindingsPerItem *int `json:"maxFindingsPerItem,omitempty"`
+	MaxFindingsPerItem *int64 `json:"maxFindingsPerItem,omitempty"`
 
 	/* Max number of findings that will be returned per request/job. When set within `InspectContentRequest`, the maximum returned is 2000 regardless if this is set higher. */
 	// +optional
-	MaxFindingsPerRequest *int `json:"maxFindingsPerRequest,omitempty"`
+	MaxFindingsPerRequest *int64 `json:"maxFindingsPerRequest,omitempty"`
 }
 
 type InspecttemplateMaxFindingsPerInfoType struct {
@@ -206,23 +206,23 @@ type InspecttemplateMaxFindingsPerInfoType struct {
 
 	/* Max findings limit for the given infoType. */
 	// +optional
-	MaxFindings *int `json:"maxFindings,omitempty"`
+	MaxFindings *int64 `json:"maxFindings,omitempty"`
 }
 
 type InspecttemplateProximity struct {
 	/* Number of characters after the finding to consider. */
 	// +optional
-	WindowAfter *int `json:"windowAfter,omitempty"`
+	WindowAfter *int64 `json:"windowAfter,omitempty"`
 
 	/* Number of characters before the finding to consider. */
 	// +optional
-	WindowBefore *int `json:"windowBefore,omitempty"`
+	WindowBefore *int64 `json:"windowBefore,omitempty"`
 }
 
 type InspecttemplateRegex struct {
 	/* The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included. */
 	// +optional
-	GroupIndexes []int `json:"groupIndexes,omitempty"`
+	GroupIndexes []int64 `json:"groupIndexes,omitempty"`
 
 	/* Pattern defining the regular expression. Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub. */
 	// +optional
@@ -310,7 +310,7 @@ type DLPInspectTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of an inspectTemplate. */
 	// +optional

--- a/pkg/clients/generated/apis/dlp/v1beta1/dlpjobtrigger_types.go
+++ b/pkg/clients/generated/apis/dlp/v1beta1/dlpjobtrigger_types.go
@@ -76,11 +76,11 @@ type JobtriggerBigQueryOptions struct {
 
 	/* Max number of rows to scan. If the table has more rows than this value, the rest of the rows are omitted. If not set, or if set to 0, all rows will be scanned. Only one of rows_limit and rows_limit_percent can be specified. Cannot be used in conjunction with TimespanConfig. */
 	// +optional
-	RowsLimit *int `json:"rowsLimit,omitempty"`
+	RowsLimit *int64 `json:"rowsLimit,omitempty"`
 
 	/* Max percentage of rows to scan. The rest are omitted. The number of rows scanned is rounded down. Must be between 0 and 100, inclusively. Both 0 and 100 means no limit. Defaults to 0. Only one of rows_limit and rows_limit_percent can be specified. Cannot be used in conjunction with TimespanConfig. */
 	// +optional
-	RowsLimitPercent *int `json:"rowsLimitPercent,omitempty"`
+	RowsLimitPercent *int64 `json:"rowsLimitPercent,omitempty"`
 
 	/* Possible values: SAMPLE_METHOD_UNSPECIFIED, TOP, RANDOM_START */
 	// +optional
@@ -93,11 +93,11 @@ type JobtriggerBigQueryOptions struct {
 type JobtriggerCloudStorageOptions struct {
 	/* Max number of bytes to scan from a file. If a scanned file's size is bigger than this value then the rest of the bytes are omitted. Only one of bytes_limit_per_file and bytes_limit_per_file_percent can be specified. Cannot be set if de-identification is requested. */
 	// +optional
-	BytesLimitPerFile *int `json:"bytesLimitPerFile,omitempty"`
+	BytesLimitPerFile *int64 `json:"bytesLimitPerFile,omitempty"`
 
 	/* Max percentage of bytes to scan from a file. The rest are omitted. The number of bytes scanned is rounded down. Must be between 0 and 100, inclusively. Both 0 and 100 means no limit. Defaults to 0. Only one of bytes_limit_per_file and bytes_limit_per_file_percent can be specified. Cannot be set if de-identification is requested. */
 	// +optional
-	BytesLimitPerFilePercent *int `json:"bytesLimitPerFilePercent,omitempty"`
+	BytesLimitPerFilePercent *int64 `json:"bytesLimitPerFilePercent,omitempty"`
 
 	/* The set of one or more files to scan. */
 	// +optional
@@ -109,7 +109,7 @@ type JobtriggerCloudStorageOptions struct {
 
 	/* Limits the number of files to scan to this percentage of the input FileSet. Number of files scanned is rounded down. Must be between 0 and 100, inclusively. Both 0 and 100 means no limit. Defaults to 0. */
 	// +optional
-	FilesLimitPercent *int `json:"filesLimitPercent,omitempty"`
+	FilesLimitPercent *int64 `json:"filesLimitPercent,omitempty"`
 
 	/* Possible values: SAMPLE_METHOD_UNSPECIFIED, TOP, RANDOM_START */
 	// +optional
@@ -228,7 +228,7 @@ type JobtriggerFileSet struct {
 type JobtriggerHotwordRegex struct {
 	/* The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included. */
 	// +optional
-	GroupIndexes []int `json:"groupIndexes,omitempty"`
+	GroupIndexes []int64 `json:"groupIndexes,omitempty"`
 
 	/* Pattern defining the regular expression. Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub. */
 	// +optional
@@ -361,7 +361,7 @@ type JobtriggerLikelihoodAdjustment struct {
 
 	/* Increase or decrease the likelihood by the specified number of levels. For example, if a finding would be `POSSIBLE` without the detection rule and `relative_likelihood` is 1, then it is upgraded to `LIKELY`, while a value of -1 would downgrade it to `UNLIKELY`. Likelihood may never drop below `VERY_UNLIKELY` or exceed `VERY_LIKELY`, so applying an adjustment of 1 followed by an adjustment of -1 when base likelihood is `VERY_LIKELY` will result in a final likelihood of `LIKELY`. */
 	// +optional
-	RelativeLikelihood *int `json:"relativeLikelihood,omitempty"`
+	RelativeLikelihood *int64 `json:"relativeLikelihood,omitempty"`
 }
 
 type JobtriggerLimits struct {
@@ -371,11 +371,11 @@ type JobtriggerLimits struct {
 
 	/* Max number of findings that will be returned for each item scanned. When set within `InspectJobConfig`, the maximum returned is 2000 regardless if this is set higher. When set within `InspectContentRequest`, this field is ignored. */
 	// +optional
-	MaxFindingsPerItem *int `json:"maxFindingsPerItem,omitempty"`
+	MaxFindingsPerItem *int64 `json:"maxFindingsPerItem,omitempty"`
 
 	/* Max number of findings that will be returned per request/job. When set within `InspectContentRequest`, the maximum returned is 2000 regardless if this is set higher. */
 	// +optional
-	MaxFindingsPerRequest *int `json:"maxFindingsPerRequest,omitempty"`
+	MaxFindingsPerRequest *int64 `json:"maxFindingsPerRequest,omitempty"`
 }
 
 type JobtriggerManual struct {
@@ -388,7 +388,7 @@ type JobtriggerMaxFindingsPerInfoType struct {
 
 	/* Max findings limit for the given infoType. */
 	// +optional
-	MaxFindings *int `json:"maxFindings,omitempty"`
+	MaxFindings *int64 `json:"maxFindings,omitempty"`
 }
 
 type JobtriggerOutputConfig struct {
@@ -417,11 +417,11 @@ type JobtriggerPartitionId struct {
 type JobtriggerProximity struct {
 	/* Number of characters after the finding to consider. */
 	// +optional
-	WindowAfter *int `json:"windowAfter,omitempty"`
+	WindowAfter *int64 `json:"windowAfter,omitempty"`
 
 	/* Number of characters before the finding to consider. */
 	// +optional
-	WindowBefore *int `json:"windowBefore,omitempty"`
+	WindowBefore *int64 `json:"windowBefore,omitempty"`
 }
 
 type JobtriggerPubSub struct {
@@ -441,7 +441,7 @@ type JobtriggerPublishToStackdriver struct {
 type JobtriggerRegex struct {
 	/* The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included. */
 	// +optional
-	GroupIndexes []int `json:"groupIndexes,omitempty"`
+	GroupIndexes []int64 `json:"groupIndexes,omitempty"`
 
 	/* Pattern defining the regular expression. Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub. */
 	// +optional
@@ -664,7 +664,7 @@ type DLPJobTriggerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of a triggeredJob. */
 	// +optional

--- a/pkg/clients/generated/apis/dlp/v1beta1/dlpstoredinfotype_types.go
+++ b/pkg/clients/generated/apis/dlp/v1beta1/dlpstoredinfotype_types.go
@@ -93,7 +93,7 @@ type StoredinfotypeOutputPath struct {
 type StoredinfotypeRegex struct {
 	/* The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included. */
 	// +optional
-	GroupIndexes []int `json:"groupIndexes,omitempty"`
+	GroupIndexes []int64 `json:"groupIndexes,omitempty"`
 
 	/* Pattern defining the regular expression. Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub. */
 	Pattern string `json:"pattern"`
@@ -159,7 +159,7 @@ type DLPStoredInfoTypeStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dlp/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dlp/v1beta1/zz_generated.deepcopy.go
@@ -161,7 +161,7 @@ func (in *DLPDeidentifyTemplateStatus) DeepCopyInto(out *DLPDeidentifyTemplateSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -314,7 +314,7 @@ func (in *DLPInspectTemplateStatus) DeepCopyInto(out *DLPInspectTemplateStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -473,7 +473,7 @@ func (in *DLPJobTriggerStatus) DeepCopyInto(out *DLPJobTriggerStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -626,7 +626,7 @@ func (in *DLPStoredInfoTypeStatus) DeepCopyInto(out *DLPStoredInfoTypeStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -709,7 +709,7 @@ func (in *DeidentifytemplateCharacterMaskConfig) DeepCopyInto(out *Deidentifytem
 	}
 	if in.NumberToMask != nil {
 		in, out := &in.NumberToMask, &out.NumberToMask
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ReverseOrder != nil {
@@ -924,7 +924,7 @@ func (in *DeidentifytemplateCryptoReplaceFfxFpeConfig) DeepCopyInto(out *Deident
 	}
 	if in.Radix != nil {
 		in, out := &in.Radix, &out.Radix
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SurrogateInfoType != nil {
@@ -976,17 +976,17 @@ func (in *DeidentifytemplateDateValue) DeepCopyInto(out *DeidentifytemplateDateV
 	*out = *in
 	if in.Day != nil {
 		in, out := &in.Day, &out.Day
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Month != nil {
 		in, out := &in.Month, &out.Month
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Year != nil {
 		in, out := &in.Year, &out.Year
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1259,7 +1259,7 @@ func (in *DeidentifytemplateLowerBound) DeepCopyInto(out *DeidentifytemplateLowe
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1315,7 +1315,7 @@ func (in *DeidentifytemplateMax) DeepCopyInto(out *DeidentifytemplateMax) {
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1371,7 +1371,7 @@ func (in *DeidentifytemplateMin) DeepCopyInto(out *DeidentifytemplateMin) {
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1427,7 +1427,7 @@ func (in *DeidentifytemplateNewValue) DeepCopyInto(out *DeidentifytemplateNewVal
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1658,7 +1658,7 @@ func (in *DeidentifytemplateReplacementValue) DeepCopyInto(out *Deidentifytempla
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1752,22 +1752,22 @@ func (in *DeidentifytemplateTimeValue) DeepCopyInto(out *DeidentifytemplateTimeV
 	*out = *in
 	if in.Hours != nil {
 		in, out := &in.Hours, &out.Hours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minutes != nil {
 		in, out := &in.Minutes, &out.Minutes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Seconds != nil {
 		in, out := &in.Seconds, &out.Seconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1890,7 +1890,7 @@ func (in *DeidentifytemplateUpperBound) DeepCopyInto(out *DeidentifytemplateUppe
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -1946,7 +1946,7 @@ func (in *DeidentifytemplateValue) DeepCopyInto(out *DeidentifytemplateValue) {
 	}
 	if in.IntegerValue != nil {
 		in, out := &in.IntegerValue, &out.IntegerValue
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StringValue != nil {
@@ -2139,7 +2139,7 @@ func (in *InspecttemplateHotwordRegex) DeepCopyInto(out *InspecttemplateHotwordR
 	*out = *in
 	if in.GroupIndexes != nil {
 		in, out := &in.GroupIndexes, &out.GroupIndexes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Pattern != nil {
@@ -2305,7 +2305,7 @@ func (in *InspecttemplateLikelihoodAdjustment) DeepCopyInto(out *Inspecttemplate
 	}
 	if in.RelativeLikelihood != nil {
 		in, out := &in.RelativeLikelihood, &out.RelativeLikelihood
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2333,12 +2333,12 @@ func (in *InspecttemplateLimits) DeepCopyInto(out *InspecttemplateLimits) {
 	}
 	if in.MaxFindingsPerItem != nil {
 		in, out := &in.MaxFindingsPerItem, &out.MaxFindingsPerItem
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxFindingsPerRequest != nil {
 		in, out := &in.MaxFindingsPerRequest, &out.MaxFindingsPerRequest
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2364,7 +2364,7 @@ func (in *InspecttemplateMaxFindingsPerInfoType) DeepCopyInto(out *Inspecttempla
 	}
 	if in.MaxFindings != nil {
 		in, out := &in.MaxFindings, &out.MaxFindings
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2385,12 +2385,12 @@ func (in *InspecttemplateProximity) DeepCopyInto(out *InspecttemplateProximity) 
 	*out = *in
 	if in.WindowAfter != nil {
 		in, out := &in.WindowAfter, &out.WindowAfter
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.WindowBefore != nil {
 		in, out := &in.WindowBefore, &out.WindowBefore
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2411,7 +2411,7 @@ func (in *InspecttemplateRegex) DeepCopyInto(out *InspecttemplateRegex) {
 	*out = *in
 	if in.GroupIndexes != nil {
 		in, out := &in.GroupIndexes, &out.GroupIndexes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Pattern != nil {
@@ -2623,12 +2623,12 @@ func (in *JobtriggerBigQueryOptions) DeepCopyInto(out *JobtriggerBigQueryOptions
 	}
 	if in.RowsLimit != nil {
 		in, out := &in.RowsLimit, &out.RowsLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RowsLimitPercent != nil {
 		in, out := &in.RowsLimitPercent, &out.RowsLimitPercent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SampleMethod != nil {
@@ -2655,12 +2655,12 @@ func (in *JobtriggerCloudStorageOptions) DeepCopyInto(out *JobtriggerCloudStorag
 	*out = *in
 	if in.BytesLimitPerFile != nil {
 		in, out := &in.BytesLimitPerFile, &out.BytesLimitPerFile
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BytesLimitPerFilePercent != nil {
 		in, out := &in.BytesLimitPerFilePercent, &out.BytesLimitPerFilePercent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.FileSet != nil {
@@ -2675,7 +2675,7 @@ func (in *JobtriggerCloudStorageOptions) DeepCopyInto(out *JobtriggerCloudStorag
 	}
 	if in.FilesLimitPercent != nil {
 		in, out := &in.FilesLimitPercent, &out.FilesLimitPercent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SampleMethod != nil {
@@ -3027,7 +3027,7 @@ func (in *JobtriggerHotwordRegex) DeepCopyInto(out *JobtriggerHotwordRegex) {
 	*out = *in
 	if in.GroupIndexes != nil {
 		in, out := &in.GroupIndexes, &out.GroupIndexes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Pattern != nil {
@@ -3349,7 +3349,7 @@ func (in *JobtriggerLikelihoodAdjustment) DeepCopyInto(out *JobtriggerLikelihood
 	}
 	if in.RelativeLikelihood != nil {
 		in, out := &in.RelativeLikelihood, &out.RelativeLikelihood
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3377,12 +3377,12 @@ func (in *JobtriggerLimits) DeepCopyInto(out *JobtriggerLimits) {
 	}
 	if in.MaxFindingsPerItem != nil {
 		in, out := &in.MaxFindingsPerItem, &out.MaxFindingsPerItem
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxFindingsPerRequest != nil {
 		in, out := &in.MaxFindingsPerRequest, &out.MaxFindingsPerRequest
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3424,7 +3424,7 @@ func (in *JobtriggerMaxFindingsPerInfoType) DeepCopyInto(out *JobtriggerMaxFindi
 	}
 	if in.MaxFindings != nil {
 		in, out := &in.MaxFindings, &out.MaxFindings
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3502,12 +3502,12 @@ func (in *JobtriggerProximity) DeepCopyInto(out *JobtriggerProximity) {
 	*out = *in
 	if in.WindowAfter != nil {
 		in, out := &in.WindowAfter, &out.WindowAfter
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.WindowBefore != nil {
 		in, out := &in.WindowBefore, &out.WindowBefore
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3597,7 +3597,7 @@ func (in *JobtriggerRegex) DeepCopyInto(out *JobtriggerRegex) {
 	*out = *in
 	if in.GroupIndexes != nil {
 		in, out := &in.GroupIndexes, &out.GroupIndexes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Pattern != nil {
@@ -4172,7 +4172,7 @@ func (in *StoredinfotypeRegex) DeepCopyInto(out *StoredinfotypeRegex) {
 	*out = *in
 	if in.GroupIndexes != nil {
 		in, out := &in.GroupIndexes, &out.GroupIndexes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/pkg/clients/generated/apis/dns/v1alpha1/dnsresponsepolicy_types.go
+++ b/pkg/clients/generated/apis/dns/v1alpha1/dnsresponsepolicy_types.go
@@ -76,7 +76,7 @@ type DNSResponsePolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dns/v1alpha1/dnsresponsepolicyrule_types.go
+++ b/pkg/clients/generated/apis/dns/v1alpha1/dnsresponsepolicyrule_types.go
@@ -51,7 +51,7 @@ type ResponsepolicyruleLocalDatas struct {
 	/* Number of seconds that this ResourceRecordSet can be cached by
 	resolvers. */
 	// +optional
-	Ttl *int `json:"ttl,omitempty"`
+	Ttl *int64 `json:"ttl,omitempty"`
 
 	/* One of valid DNS resource types. Possible values: ["A", "AAAA", "CAA", "CNAME", "DNSKEY", "DS", "HTTPS", "IPSECVPNKEY", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV", "SSHFP", "SVCB", "TLSA", "TXT"]. */
 	Type string `json:"type"`
@@ -87,7 +87,7 @@ type DNSResponsePolicyRuleStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dns/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dns/v1alpha1/zz_generated.deepcopy.go
@@ -193,7 +193,7 @@ func (in *DNSResponsePolicyRuleStatus) DeepCopyInto(out *DNSResponsePolicyRuleSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -256,7 +256,7 @@ func (in *DNSResponsePolicyStatus) DeepCopyInto(out *DNSResponsePolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -337,7 +337,7 @@ func (in *ResponsepolicyruleLocalDatas) DeepCopyInto(out *ResponsepolicyruleLoca
 	}
 	if in.Ttl != nil {
 		in, out := &in.Ttl, &out.Ttl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/dns/v1beta1/dnsmanagedzone_types.go
+++ b/pkg/clients/generated/apis/dns/v1beta1/dnsmanagedzone_types.go
@@ -47,7 +47,7 @@ type ManagedzoneDefaultKeySpecs struct {
 
 	/* Length of the keys in bits. */
 	// +optional
-	KeyLength *int `json:"keyLength,omitempty"`
+	KeyLength *int64 `json:"keyLength,omitempty"`
 
 	/* Specifies whether this is a key signing key (KSK) or a zone
 	signing key (ZSK). Key signing keys have the Secure Entry
@@ -211,7 +211,7 @@ type DNSManagedZoneStatus struct {
 
 	/* Unique identifier for the resource; defined by the server. */
 	// +optional
-	ManagedZoneId *int `json:"managedZoneId,omitempty"`
+	ManagedZoneId *int64 `json:"managedZoneId,omitempty"`
 
 	/* Delegate your managed_zone to these virtual name servers;
 	defined by the server. */
@@ -220,7 +220,7 @@ type DNSManagedZoneStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dns/v1beta1/dnspolicy_types.go
+++ b/pkg/clients/generated/apis/dns/v1beta1/dnspolicy_types.go
@@ -96,7 +96,7 @@ type DNSPolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dns/v1beta1/dnsrecordset_types.go
+++ b/pkg/clients/generated/apis/dns/v1beta1/dnsrecordset_types.go
@@ -172,7 +172,7 @@ type DNSRecordSetSpec struct {
 
 	/* The time-to-live of this record set (seconds). */
 	// +optional
-	Ttl *int `json:"ttl,omitempty"`
+	Ttl *int64 `json:"ttl,omitempty"`
 
 	/* The DNS record set type. */
 	Type string `json:"type"`
@@ -184,7 +184,7 @@ type DNSRecordSetStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/dns/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/dns/v1beta1/zz_generated.deepcopy.go
@@ -171,7 +171,7 @@ func (in *DNSManagedZoneStatus) DeepCopyInto(out *DNSManagedZoneStatus) {
 	}
 	if in.ManagedZoneId != nil {
 		in, out := &in.ManagedZoneId, &out.ManagedZoneId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NameServers != nil {
@@ -181,7 +181,7 @@ func (in *DNSManagedZoneStatus) DeepCopyInto(out *DNSManagedZoneStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -314,7 +314,7 @@ func (in *DNSPolicyStatus) DeepCopyInto(out *DNSPolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -414,7 +414,7 @@ func (in *DNSRecordSetSpec) DeepCopyInto(out *DNSRecordSetSpec) {
 	}
 	if in.Ttl != nil {
 		in, out := &in.Ttl, &out.Ttl
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -440,7 +440,7 @@ func (in *DNSRecordSetStatus) DeepCopyInto(out *DNSRecordSetStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -482,7 +482,7 @@ func (in *ManagedzoneDefaultKeySpecs) DeepCopyInto(out *ManagedzoneDefaultKeySpe
 	}
 	if in.KeyLength != nil {
 		in, out := &in.KeyLength, &out.KeyLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.KeyType != nil {

--- a/pkg/clients/generated/apis/documentai/v1alpha1/documentaiprocessor_types.go
+++ b/pkg/clients/generated/apis/documentai/v1alpha1/documentaiprocessor_types.go
@@ -67,7 +67,7 @@ type DocumentAIProcessorStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/documentai/v1alpha1/documentaiprocessordefaultversion_types.go
+++ b/pkg/clients/generated/apis/documentai/v1alpha1/documentaiprocessordefaultversion_types.go
@@ -51,7 +51,7 @@ type DocumentAIProcessorDefaultVersionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/documentai/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/documentai/v1alpha1/zz_generated.deepcopy.go
@@ -149,7 +149,7 @@ func (in *DocumentAIProcessorDefaultVersionStatus) DeepCopyInto(out *DocumentAIP
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -240,7 +240,7 @@ func (in *DocumentAIProcessorStatus) DeepCopyInto(out *DocumentAIProcessorStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainercluster_types.go
+++ b/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainercluster_types.go
@@ -103,7 +103,7 @@ type ClusterIngress struct {
 type ClusterKmsStatus struct {
 	/* The status code, which should be an enum value of google.rpc.Code. */
 	// +optional
-	Code *int `json:"code,omitempty"`
+	Code *int64 `json:"code,omitempty"`
 
 	/* A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client. */
 	// +optional
@@ -120,7 +120,7 @@ type ClusterLocal struct {
 	/* The number of nodes to serve as replicas of the Control Plane.
 	Only 1 and 3 are supported. */
 	// +optional
-	NodeCount *int `json:"nodeCount,omitempty"`
+	NodeCount *int64 `json:"nodeCount,omitempty"`
 
 	/* Immutable. Name of the Google Distributed Cloud Edge zones where this node pool
 	will be created. For example: 'us-central1-edge-customer-a'. */
@@ -222,7 +222,7 @@ type EdgeContainerClusterSpec struct {
 	specified explicitly for a node pool in this cluster. If unspecified, the
 	Kubernetes default value will be used. */
 	// +optional
-	DefaultMaxPodsPerNode *int `json:"defaultMaxPodsPerNode,omitempty"`
+	DefaultMaxPodsPerNode *int64 `json:"defaultMaxPodsPerNode,omitempty"`
 
 	/* Address pools for cluster data plane external load balancing. */
 	// +optional
@@ -346,11 +346,11 @@ type EdgeContainerClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The port number of the Kubernetes API server. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Indicates the status of the cluster. */
 	// +optional

--- a/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainernodepool_types.go
+++ b/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainernodepool_types.go
@@ -76,7 +76,7 @@ type EdgeContainerNodePoolSpec struct {
 	NodeConfig *NodepoolNodeConfig `json:"nodeConfig,omitempty"`
 
 	/* The number of nodes in the pool. */
-	NodeCount int `json:"nodeCount"`
+	NodeCount int64 `json:"nodeCount"`
 
 	/* Immutable. Name of the Google Distributed Cloud Edge zone where this node pool will be created. For example: 'us-central1-edge-customer-a'. */
 	NodeLocation string `json:"nodeLocation"`
@@ -103,7 +103,7 @@ type EdgeContainerNodePoolStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the node pool was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainervpnconnection_types.go
+++ b/pkg/clients/generated/apis/edgecontainer/v1beta1/edgecontainervpnconnection_types.go
@@ -120,7 +120,7 @@ type EdgeContainerVpnConnectionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the VPN connection was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/edgecontainer/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/edgecontainer/v1beta1/zz_generated.deepcopy.go
@@ -180,7 +180,7 @@ func (in *ClusterKmsStatus) DeepCopyInto(out *ClusterKmsStatus) {
 	*out = *in
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Message != nil {
@@ -211,7 +211,7 @@ func (in *ClusterLocal) DeepCopyInto(out *ClusterLocal) {
 	}
 	if in.NodeCount != nil {
 		in, out := &in.NodeCount, &out.NodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeLocation != nil {
@@ -532,7 +532,7 @@ func (in *EdgeContainerClusterSpec) DeepCopyInto(out *EdgeContainerClusterSpec) 
 	}
 	if in.DefaultMaxPodsPerNode != nil {
 		in, out := &in.DefaultMaxPodsPerNode, &out.DefaultMaxPodsPerNode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ExternalLoadBalancerIpv4AddressPools != nil {
@@ -623,12 +623,12 @@ func (in *EdgeContainerClusterStatus) DeepCopyInto(out *EdgeContainerClusterStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Status != nil {
@@ -773,7 +773,7 @@ func (in *EdgeContainerNodePoolStatus) DeepCopyInto(out *EdgeContainerNodePoolSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -925,7 +925,7 @@ func (in *EdgeContainerVpnConnectionStatus) DeepCopyInto(out *EdgeContainerVpnCo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/edgenetwork/v1beta1/edgenetworknetwork_types.go
+++ b/pkg/clients/generated/apis/edgenetwork/v1beta1/edgenetworknetwork_types.go
@@ -45,7 +45,7 @@ type EdgeNetworkNetworkSpec struct {
 
 	/* Immutable. IP (L3) MTU value of the network. Default value is '1500'. Possible values are: '1500', '9000'. */
 	// +optional
-	Mtu *int `json:"mtu,omitempty"`
+	Mtu *int64 `json:"mtu,omitempty"`
 
 	/* The project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -75,7 +75,7 @@ type EdgeNetworkNetworkStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The time when the subnet was last updated.
 	A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine

--- a/pkg/clients/generated/apis/edgenetwork/v1beta1/edgenetworksubnet_types.go
+++ b/pkg/clients/generated/apis/edgenetwork/v1beta1/edgenetworksubnet_types.go
@@ -62,7 +62,7 @@ type EdgeNetworkSubnetSpec struct {
 
 	/* Immutable. VLAN ID for this subnetwork. If not specified, one is assigned automatically. */
 	// +optional
-	VlanId *int `json:"vlanId,omitempty"`
+	VlanId *int64 `json:"vlanId,omitempty"`
 
 	/* Immutable. The name of the target Distributed Cloud Edge zone. */
 	Zone string `json:"zone"`
@@ -85,7 +85,7 @@ type EdgeNetworkSubnetStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Current stage of the resource to the device by config push. */
 	// +optional

--- a/pkg/clients/generated/apis/edgenetwork/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/edgenetwork/v1beta1/zz_generated.deepcopy.go
@@ -100,7 +100,7 @@ func (in *EdgeNetworkNetworkSpec) DeepCopyInto(out *EdgeNetworkNetworkSpec) {
 	}
 	if in.Mtu != nil {
 		in, out := &in.Mtu, &out.Mtu
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -142,7 +142,7 @@ func (in *EdgeNetworkNetworkStatus) DeepCopyInto(out *EdgeNetworkNetworkStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -251,7 +251,7 @@ func (in *EdgeNetworkSubnetSpec) DeepCopyInto(out *EdgeNetworkSubnetSpec) {
 	}
 	if in.VlanId != nil {
 		in, out := &in.VlanId, &out.VlanId
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -287,7 +287,7 @@ func (in *EdgeNetworkSubnetStatus) DeepCopyInto(out *EdgeNetworkSubnetStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/essentialcontacts/v1alpha1/essentialcontactscontact_types.go
+++ b/pkg/clients/generated/apis/essentialcontacts/v1alpha1/essentialcontactscontact_types.go
@@ -63,7 +63,7 @@ type EssentialContactsContactStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/essentialcontacts/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/essentialcontacts/v1alpha1/zz_generated.deepcopy.go
@@ -131,7 +131,7 @@ func (in *EssentialContactsContactStatus) DeepCopyInto(out *EssentialContactsCon
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/eventarc/v1beta1/eventarctrigger_types.go
+++ b/pkg/clients/generated/apis/eventarc/v1beta1/eventarctrigger_types.go
@@ -178,7 +178,7 @@ type EventarcTriggerStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The reason(s) why a trigger is in FAILED state. */
 	// +optional

--- a/pkg/clients/generated/apis/eventarc/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/eventarc/v1beta1/zz_generated.deepcopy.go
@@ -160,7 +160,7 @@ func (in *EventarcTriggerStatus) DeepCopyInto(out *EventarcTriggerStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceConditions != nil {

--- a/pkg/clients/generated/apis/filestore/v1alpha1/filestoresnapshot_types.go
+++ b/pkg/clients/generated/apis/filestore/v1alpha1/filestoresnapshot_types.go
@@ -68,7 +68,7 @@ type FilestoreSnapshotStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The snapshot state. */
 	// +optional

--- a/pkg/clients/generated/apis/filestore/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/filestore/v1alpha1/zz_generated.deepcopy.go
@@ -137,7 +137,7 @@ func (in *FilestoreSnapshotStatus) DeepCopyInto(out *FilestoreSnapshotStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/filestore/v1beta1/filestorebackup_types.go
+++ b/pkg/clients/generated/apis/filestore/v1beta1/filestorebackup_types.go
@@ -63,7 +63,7 @@ type FilestoreBackupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* Output only. Capacity of the source file share when the backup was created. */
 	// +optional
-	CapacityGb *int `json:"capacityGb,omitempty"`
+	CapacityGb *int64 `json:"capacityGb,omitempty"`
 
 	/* Output only. The time when the backup was created. */
 	// +optional
@@ -71,11 +71,11 @@ type FilestoreBackupStatus struct {
 
 	/* Output only. Amount of bytes that will be downloaded if the backup is restored. This may be different than storage bytes, since sequential backups of the same disk will share storage. */
 	// +optional
-	DownloadBytes *int `json:"downloadBytes,omitempty"`
+	DownloadBytes *int64 `json:"downloadBytes,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The service tier of the source Cloud Filestore instance that this backup is created from. Possible values: TIER_UNSPECIFIED, STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, HIGH_SCALE_SSD */
 	// +optional
@@ -87,7 +87,7 @@ type FilestoreBackupStatus struct {
 
 	/* Output only. The size of the storage used by the backup. As backups share storage, this number is expected to change with backup creation/deletion. */
 	// +optional
-	StorageBytes *int `json:"storageBytes,omitempty"`
+	StorageBytes *int64 `json:"storageBytes,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/filestore/v1beta1/filestoreinstance_types.go
+++ b/pkg/clients/generated/apis/filestore/v1beta1/filestoreinstance_types.go
@@ -38,7 +38,7 @@ import (
 type InstanceFileShares struct {
 	/* File share capacity in gigabytes (GB). Cloud Filestore defines 1 GB as 1024^3 bytes. */
 	// +optional
-	CapacityGb *int `json:"capacityGb,omitempty"`
+	CapacityGb *int64 `json:"capacityGb,omitempty"`
 
 	/* The name of the file share (must be 16 characters or less). */
 	// +optional
@@ -77,11 +77,11 @@ type InstanceNfsExportOptions struct {
 
 	/* An integer representing the anonymous group id with a default value of 65534. Anon_gid may only be set with squash_mode of ROOT_SQUASH. An error will be returned if this field is specified for other squash_mode settings. */
 	// +optional
-	AnonGid *int `json:"anonGid,omitempty"`
+	AnonGid *int64 `json:"anonGid,omitempty"`
 
 	/* An integer representing the anonymous user id with a default value of 65534. Anon_uid may only be set with squash_mode of ROOT_SQUASH. An error will be returned if this field is specified for other squash_mode settings. */
 	// +optional
-	AnonUid *int `json:"anonUid,omitempty"`
+	AnonUid *int64 `json:"anonUid,omitempty"`
 
 	/* List of either an IPv4 addresses in the format `{octet1}.{octet2}.{octet3}.{octet4}` or CIDR ranges in the format `{octet1}.{octet2}.{octet3}.{octet4}/{mask size}` which may mount the file share. Overlapping IP ranges are not allowed, both within and across NfsExportOptions. An error will be returned. The limit is 64 IP ranges/addresses for each FileShareConfig among all NfsExportOptions. */
 	// +optional
@@ -134,7 +134,7 @@ type FilestoreInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The instance state. Possible values: STATE_UNSPECIFIED, CREATING, READY, REPAIRING, DELETING, ERROR */
 	// +optional

--- a/pkg/clients/generated/apis/filestore/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/filestore/v1beta1/zz_generated.deepcopy.go
@@ -128,7 +128,7 @@ func (in *FilestoreBackupStatus) DeepCopyInto(out *FilestoreBackupStatus) {
 	}
 	if in.CapacityGb != nil {
 		in, out := &in.CapacityGb, &out.CapacityGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreateTime != nil {
@@ -138,12 +138,12 @@ func (in *FilestoreBackupStatus) DeepCopyInto(out *FilestoreBackupStatus) {
 	}
 	if in.DownloadBytes != nil {
 		in, out := &in.DownloadBytes, &out.DownloadBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SourceInstanceTier != nil {
@@ -158,7 +158,7 @@ func (in *FilestoreBackupStatus) DeepCopyInto(out *FilestoreBackupStatus) {
 	}
 	if in.StorageBytes != nil {
 		in, out := &in.StorageBytes, &out.StorageBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -301,7 +301,7 @@ func (in *FilestoreInstanceStatus) DeepCopyInto(out *FilestoreInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -332,7 +332,7 @@ func (in *InstanceFileShares) DeepCopyInto(out *InstanceFileShares) {
 	*out = *in
 	if in.CapacityGb != nil {
 		in, out := &in.CapacityGb, &out.CapacityGb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Name != nil {
@@ -411,12 +411,12 @@ func (in *InstanceNfsExportOptions) DeepCopyInto(out *InstanceNfsExportOptions) 
 	}
 	if in.AnonGid != nil {
 		in, out := &in.AnonGid, &out.AnonGid
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.AnonUid != nil {
 		in, out := &in.AnonUid, &out.AnonUid
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.IpRanges != nil {

--- a/pkg/clients/generated/apis/firebase/v1alpha1/firebaseandroidapp_types.go
+++ b/pkg/clients/generated/apis/firebase/v1alpha1/firebaseandroidapp_types.go
@@ -90,7 +90,7 @@ type FirebaseAndroidAppStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firebase/v1alpha1/firebaseproject_types.go
+++ b/pkg/clients/generated/apis/firebase/v1alpha1/firebaseproject_types.go
@@ -54,7 +54,7 @@ type FirebaseProjectStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The number of the google project that firebase is enabled on. */
 	// +optional

--- a/pkg/clients/generated/apis/firebase/v1alpha1/firebasewebapp_types.go
+++ b/pkg/clients/generated/apis/firebase/v1alpha1/firebasewebapp_types.go
@@ -77,7 +77,7 @@ type FirebaseWebAppStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firebase/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/firebase/v1alpha1/zz_generated.deepcopy.go
@@ -162,7 +162,7 @@ func (in *FirebaseAndroidAppStatus) DeepCopyInto(out *FirebaseAndroidAppStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -276,7 +276,7 @@ func (in *FirebaseProjectStatus) DeepCopyInto(out *FirebaseProjectStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectNumber != nil {
@@ -419,7 +419,7 @@ func (in *FirebaseWebAppStatus) DeepCopyInto(out *FirebaseWebAppStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/firebasedatabase/v1alpha1/firebasedatabaseinstance_types.go
+++ b/pkg/clients/generated/apis/firebasedatabase/v1alpha1/firebasedatabaseinstance_types.go
@@ -77,7 +77,7 @@ type FirebaseDatabaseInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The current database state. Set desired_state to :DISABLED to disable the database and :ACTIVE to reenable the database. */
 	// +optional

--- a/pkg/clients/generated/apis/firebasedatabase/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/firebasedatabase/v1alpha1/zz_generated.deepcopy.go
@@ -142,7 +142,7 @@ func (in *FirebaseDatabaseInstanceStatus) DeepCopyInto(out *FirebaseDatabaseInst
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/firebasehosting/v1alpha1/firebasehostingchannel_types.go
+++ b/pkg/clients/generated/apis/firebasehosting/v1alpha1/firebasehostingchannel_types.go
@@ -49,7 +49,7 @@ type FirebaseHostingChannelSpec struct {
 	/* The number of previous releases to retain on the channel for rollback or other
 	purposes. Must be a number between 1-100. Defaults to 10 for new channels. */
 	// +optional
-	RetainedReleaseCount *int `json:"retainedReleaseCount,omitempty"`
+	RetainedReleaseCount *int64 `json:"retainedReleaseCount,omitempty"`
 
 	/* Immutable. Required. The ID of the site in which to create this channel. */
 	SiteId string `json:"siteId"`
@@ -72,7 +72,7 @@ type FirebaseHostingChannelStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firebasehosting/v1alpha1/firebasehostingsite_types.go
+++ b/pkg/clients/generated/apis/firebasehosting/v1alpha1/firebasehostingsite_types.go
@@ -69,7 +69,7 @@ type FirebaseHostingSiteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firebasehosting/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/firebasehosting/v1alpha1/zz_generated.deepcopy.go
@@ -105,7 +105,7 @@ func (in *FirebaseHostingChannelSpec) DeepCopyInto(out *FirebaseHostingChannelSp
 	}
 	if in.RetainedReleaseCount != nil {
 		in, out := &in.RetainedReleaseCount, &out.RetainedReleaseCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Ttl != nil {
@@ -141,7 +141,7 @@ func (in *FirebaseHostingChannelStatus) DeepCopyInto(out *FirebaseHostingChannel
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -265,7 +265,7 @@ func (in *FirebaseHostingSiteStatus) DeepCopyInto(out *FirebaseHostingSiteStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/firebasestorage/v1alpha1/firebasestoragebucket_types.go
+++ b/pkg/clients/generated/apis/firebasestorage/v1alpha1/firebasestoragebucket_types.go
@@ -54,7 +54,7 @@ type FirebaseStorageBucketStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firebasestorage/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/firebasestorage/v1alpha1/zz_generated.deepcopy.go
@@ -127,7 +127,7 @@ func (in *FirebaseStorageBucketStatus) DeepCopyInto(out *FirebaseStorageBucketSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/firestore/v1beta1/firestoreindex_types.go
+++ b/pkg/clients/generated/apis/firestore/v1beta1/firestoreindex_types.go
@@ -83,7 +83,7 @@ type FirestoreIndexStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/firestore/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/firestore/v1beta1/zz_generated.deepcopy.go
@@ -138,7 +138,7 @@ func (in *FirestoreIndexStatus) DeepCopyInto(out *FirestoreIndexStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/gkebackup/v1alpha1/gkebackupbackupplan_types.go
+++ b/pkg/clients/generated/apis/gkebackup/v1alpha1/gkebackupbackupplan_types.go
@@ -97,7 +97,7 @@ type BackupplanRetentionPolicy struct {
 	Updating this field of a BackupPlan does not affect existing Backups.
 	Backups created after a successful update will inherit this new value. */
 	// +optional
-	BackupDeleteLockDays *int `json:"backupDeleteLockDays,omitempty"`
+	BackupDeleteLockDays *int64 `json:"backupDeleteLockDays,omitempty"`
 
 	/* The default maximum age of a Backup created via this BackupPlan.
 	This field MUST be an integer value >= 0 and <= 365. If specified,
@@ -110,7 +110,7 @@ type BackupplanRetentionPolicy struct {
 	NOTE: backupRetainDays must be >= backupDeleteLockDays.
 	If cronSchedule is defined, then this must be <= 360 * the creation interval.]. */
 	// +optional
-	BackupRetainDays *int `json:"backupRetainDays,omitempty"`
+	BackupRetainDays *int64 `json:"backupRetainDays,omitempty"`
 
 	/* This flag denotes whether the retention policy of this BackupPlan is locked.
 	If set to True, no further update is allowed on this policy, including
@@ -182,11 +182,11 @@ type GKEBackupBackupPlanStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The number of Kubernetes Pods backed up in the last successful Backup created via this BackupPlan. */
 	// +optional
-	ProtectedPodCount *int `json:"protectedPodCount,omitempty"`
+	ProtectedPodCount *int64 `json:"protectedPodCount,omitempty"`
 
 	/* The State of the BackupPlan. */
 	// +optional

--- a/pkg/clients/generated/apis/gkebackup/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/gkebackup/v1alpha1/zz_generated.deepcopy.go
@@ -138,12 +138,12 @@ func (in *BackupplanRetentionPolicy) DeepCopyInto(out *BackupplanRetentionPolicy
 	*out = *in
 	if in.BackupDeleteLockDays != nil {
 		in, out := &in.BackupDeleteLockDays, &out.BackupDeleteLockDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BackupRetainDays != nil {
 		in, out := &in.BackupRetainDays, &out.BackupRetainDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Locked != nil {
@@ -329,12 +329,12 @@ func (in *GKEBackupBackupPlanStatus) DeepCopyInto(out *GKEBackupBackupPlanStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProtectedPodCount != nil {
 		in, out := &in.ProtectedPodCount, &out.ProtectedPodCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeature_types.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeature_types.go
@@ -131,7 +131,7 @@ type GKEHubFeatureStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State of the Feature resource itself. */
 	// +optional

--- a/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
@@ -209,11 +209,11 @@ type FeaturemembershipPolicyController struct {
 type FeaturemembershipPolicyControllerHubConfig struct {
 	/* Sets the interval for Policy Controller Audit Scans (in seconds). When set to 0, this disables audit functionality altogether. */
 	// +optional
-	AuditIntervalSeconds *int `json:"auditIntervalSeconds,omitempty"`
+	AuditIntervalSeconds *int64 `json:"auditIntervalSeconds,omitempty"`
 
 	/* The maximum number of audit violations to be stored in a constraint. If not set, the internal default of 20 will be used. */
 	// +optional
-	ConstraintViolationLimit *int `json:"constraintViolationLimit,omitempty"`
+	ConstraintViolationLimit *int64 `json:"constraintViolationLimit,omitempty"`
 
 	/* The set of namespaces that are excluded from Policy Controller checks. Namespaces do not need to currently exist on the cluster. */
 	// +optional
@@ -295,7 +295,7 @@ type GKEHubFeatureMembershipStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/gkehub/v1beta1/gkehubmembership_types.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/gkehubmembership_types.go
@@ -141,11 +141,11 @@ type MembershipKubernetesMetadataStatus struct {
 
 	/* Output only. The total memory capacity as reported by the sum of all Kubernetes nodes resources, defined in MB. */
 	// +optional
-	MemoryMb *int `json:"memoryMb,omitempty"`
+	MemoryMb *int64 `json:"memoryMb,omitempty"`
 
 	/* Output only. Node count as reported by Kubernetes nodes resources. */
 	// +optional
-	NodeCount *int `json:"nodeCount,omitempty"`
+	NodeCount *int64 `json:"nodeCount,omitempty"`
 
 	/* Output only. Node providerID as reported by the first node in the list of nodes on the Kubernetes endpoint. On Kubernetes platforms that support zero-node clusters (like GKE-on-GCP), the node_count will be zero and the node_provider_id will be empty. */
 	// +optional
@@ -157,7 +157,7 @@ type MembershipKubernetesMetadataStatus struct {
 
 	/* Output only. vCPU count as reported by Kubernetes nodes resources. */
 	// +optional
-	VcpuCount *int `json:"vcpuCount,omitempty"`
+	VcpuCount *int64 `json:"vcpuCount,omitempty"`
 }
 
 type MembershipKubernetesResourceStatus struct {
@@ -210,7 +210,7 @@ type GKEHubMembershipStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. State of the Membership resource. */
 	// +optional

--- a/pkg/clients/generated/apis/gkehub/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/zz_generated.deepcopy.go
@@ -578,12 +578,12 @@ func (in *FeaturemembershipPolicyControllerHubConfig) DeepCopyInto(out *Featurem
 	*out = *in
 	if in.AuditIntervalSeconds != nil {
 		in, out := &in.AuditIntervalSeconds, &out.AuditIntervalSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ConstraintViolationLimit != nil {
 		in, out := &in.ConstraintViolationLimit, &out.ConstraintViolationLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ExemptableNamespaces != nil {
@@ -848,7 +848,7 @@ func (in *GKEHubFeatureMembershipStatus) DeepCopyInto(out *GKEHubFeatureMembersh
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -911,7 +911,7 @@ func (in *GKEHubFeatureStatus) DeepCopyInto(out *GKEHubFeatureStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceState != nil {
@@ -1084,7 +1084,7 @@ func (in *GKEHubMembershipStatus) DeepCopyInto(out *GKEHubMembershipStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -1271,12 +1271,12 @@ func (in *MembershipKubernetesMetadataStatus) DeepCopyInto(out *MembershipKubern
 	}
 	if in.MemoryMb != nil {
 		in, out := &in.MemoryMb, &out.MemoryMb
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeCount != nil {
 		in, out := &in.NodeCount, &out.NodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NodeProviderId != nil {
@@ -1291,7 +1291,7 @@ func (in *MembershipKubernetesMetadataStatus) DeepCopyInto(out *MembershipKubern
 	}
 	if in.VcpuCount != nil {
 		in, out := &in.VcpuCount, &out.VcpuCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/healthcareconsentstore_types.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/healthcareconsentstore_types.go
@@ -61,7 +61,7 @@ type HealthcareConsentStoreStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/healthcaredataset_types.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/healthcaredataset_types.go
@@ -59,7 +59,7 @@ type HealthcareDatasetStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The fully qualified name of this dataset. */
 	// +optional

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/healthcaredicomstore_types.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/healthcaredicomstore_types.go
@@ -80,7 +80,7 @@ type HealthcareDICOMStoreStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The fully qualified name of this dataset. */
 	// +optional

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/healthcarefhirstore_types.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/healthcarefhirstore_types.go
@@ -97,7 +97,7 @@ type FhirstoreSchemaConfig struct {
 	resource is a recursive structure; when the depth is 2, the CodeSystem table will have a column called
 	concept.concept but not concept.concept.concept. If not specified or set to 0, the server will use the default
 	value 2. The maximum depth allowed is 5. */
-	RecursiveStructureDepth int `json:"recursiveStructureDepth"`
+	RecursiveStructureDepth int64 `json:"recursiveStructureDepth"`
 
 	/* Specifies the output schema type.
 	* ANALYTICS: Analytics schema defined by the FHIR community.
@@ -210,7 +210,7 @@ type HealthcareFHIRStoreStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The fully qualified name of this dataset. */
 	// +optional

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/healthcarehl7v2store_types.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/healthcarehl7v2store_types.go
@@ -122,7 +122,7 @@ type HealthcareHL7V2StoreStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The fully qualified name of this dataset. */
 	// +optional

--- a/pkg/clients/generated/apis/healthcare/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/healthcare/v1alpha1/zz_generated.deepcopy.go
@@ -308,7 +308,7 @@ func (in *HealthcareConsentStoreStatus) DeepCopyInto(out *HealthcareConsentStore
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -426,7 +426,7 @@ func (in *HealthcareDICOMStoreStatus) DeepCopyInto(out *HealthcareDICOMStoreStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -545,7 +545,7 @@ func (in *HealthcareDatasetStatus) DeepCopyInto(out *HealthcareDatasetStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -712,7 +712,7 @@ func (in *HealthcareFHIRStoreStatus) DeepCopyInto(out *HealthcareFHIRStoreStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -842,7 +842,7 @@ func (in *HealthcareHL7V2StoreStatus) DeepCopyInto(out *HealthcareHL7V2StoreStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/iam/v1beta1/iamaccessboundarypolicy_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamaccessboundarypolicy_types.go
@@ -104,7 +104,7 @@ type IAMAccessBoundaryPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iamauditconfig_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamauditconfig_types.go
@@ -61,7 +61,7 @@ type IAMAuditConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iamcustomrole_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamcustomrole_types.go
@@ -69,7 +69,7 @@ type IAMCustomRoleStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iampartialpolicy_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iampartialpolicy_types.go
@@ -143,7 +143,7 @@ type IAMPartialPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iampolicy_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iampolicy_types.go
@@ -93,7 +93,7 @@ type IAMPolicyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iampolicymember_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iampolicymember_types.go
@@ -88,7 +88,7 @@ type IAMPolicyMemberStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/iam/v1beta1/iamserviceaccount_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamserviceaccount_types.go
@@ -71,7 +71,7 @@ type IAMServiceAccountStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The unique id of the service account. */
 	// +optional

--- a/pkg/clients/generated/apis/iam/v1beta1/iamserviceaccountkey_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamserviceaccountkey_types.go
@@ -65,7 +65,7 @@ type IAMServiceAccountKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The private key in JSON format, base64 encoded. This is what you normally get as a file when creating service account keys through the CLI or web console. This is only populated when creating a new key. */
 	// +optional

--- a/pkg/clients/generated/apis/iam/v1beta1/iamworkforcepool_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamworkforcepool_types.go
@@ -69,7 +69,7 @@ type IAMWorkforcePoolStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The resource name of the pool. Format: `locations/{location}/workforcePools/{workforce_pool_id}` */
 	// +optional

--- a/pkg/clients/generated/apis/iam/v1beta1/iamworkforcepoolprovider_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamworkforcepoolprovider_types.go
@@ -160,7 +160,7 @@ type IAMWorkforcePoolProviderStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	Oidc *WorkforcepoolproviderOidcStatus `json:"oidc,omitempty"`

--- a/pkg/clients/generated/apis/iam/v1beta1/iamworkloadidentitypool_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamworkloadidentitypool_types.go
@@ -65,7 +65,7 @@ type IAMWorkloadIdentityPoolStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The state of the pool. Possible values: STATE_UNSPECIFIED, ACTIVE, DELETED */
 	// +optional

--- a/pkg/clients/generated/apis/iam/v1beta1/iamworkloadidentitypoolprovider_types.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/iamworkloadidentitypoolprovider_types.go
@@ -102,7 +102,7 @@ type IAMWorkloadIdentityPoolProviderStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The state of the provider. Possible values: STATE_UNSPECIFIED, ACTIVE, DELETED */
 	// +optional

--- a/pkg/clients/generated/apis/iam/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/iam/v1beta1/zz_generated.deepcopy.go
@@ -248,7 +248,7 @@ func (in *IAMAccessBoundaryPolicyStatus) DeepCopyInto(out *IAMAccessBoundaryPoli
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -359,7 +359,7 @@ func (in *IAMAuditConfigStatus) DeepCopyInto(out *IAMAuditConfigStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -492,7 +492,7 @@ func (in *IAMCustomRoleStatus) DeepCopyInto(out *IAMCustomRoleStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -617,7 +617,7 @@ func (in *IAMPartialPolicyStatus) DeepCopyInto(out *IAMPartialPolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -797,7 +797,7 @@ func (in *IAMPolicyMemberStatus) DeepCopyInto(out *IAMPolicyMemberStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -854,7 +854,7 @@ func (in *IAMPolicyStatus) DeepCopyInto(out *IAMPolicyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1011,7 +1011,7 @@ func (in *IAMServiceAccountKeyStatus) DeepCopyInto(out *IAMServiceAccountKeyStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrivateKey != nil {
@@ -1141,7 +1141,7 @@ func (in *IAMServiceAccountStatus) DeepCopyInto(out *IAMServiceAccountStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UniqueId != nil {
@@ -1353,7 +1353,7 @@ func (in *IAMWorkforcePoolProviderStatus) DeepCopyInto(out *IAMWorkforcePoolProv
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Oidc != nil {
@@ -1431,7 +1431,7 @@ func (in *IAMWorkforcePoolStatus) DeepCopyInto(out *IAMWorkforcePoolStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1649,7 +1649,7 @@ func (in *IAMWorkloadIdentityPoolProviderStatus) DeepCopyInto(out *IAMWorkloadId
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -1717,7 +1717,7 @@ func (in *IAMWorkloadIdentityPoolStatus) DeepCopyInto(out *IAMWorkloadIdentityPo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/iap/v1beta1/iapbrand_types.go
+++ b/pkg/clients/generated/apis/iap/v1beta1/iapbrand_types.go
@@ -55,7 +55,7 @@ type IAPBrandStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Whether the brand is only intended for usage inside the G Suite organization only. */
 	// +optional

--- a/pkg/clients/generated/apis/iap/v1beta1/iapidentityawareproxyclient_types.go
+++ b/pkg/clients/generated/apis/iap/v1beta1/iapidentityawareproxyclient_types.go
@@ -54,7 +54,7 @@ type IAPIdentityAwareProxyClientStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Client secret of the OAuth client. */
 	// +optional

--- a/pkg/clients/generated/apis/iap/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/iap/v1beta1/zz_generated.deepcopy.go
@@ -131,7 +131,7 @@ func (in *IAPBrandStatus) DeepCopyInto(out *IAPBrandStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.OrgInternalOnly != nil {
@@ -250,7 +250,7 @@ func (in *IAPIdentityAwareProxyClientStatus) DeepCopyInto(out *IAPIdentityAwareP
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Secret != nil {

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformdefaultsupportedidpconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformdefaultsupportedidpconfig_types.go
@@ -64,7 +64,7 @@ type IdentityPlatformDefaultSupportedIDPConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatforminboundsamlconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatforminboundsamlconfig_types.go
@@ -105,7 +105,7 @@ type IdentityPlatformInboundSAMLConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformprojectdefaultconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformprojectdefaultconfig_types.go
@@ -59,11 +59,11 @@ type ProjectdefaultconfigHashConfig struct {
 
 	/* Memory cost for hash calculation. Used by scrypt and other similar password derivation algorithms. See https://tools.ietf.org/html/rfc7914 for explanation of field. */
 	// +optional
-	MemoryCost *int `json:"memoryCost,omitempty"`
+	MemoryCost *int64 `json:"memoryCost,omitempty"`
 
 	/* How many rounds for hash calculation. Used by scrypt and other similar password derivation algorithms. */
 	// +optional
-	Rounds *int `json:"rounds,omitempty"`
+	Rounds *int64 `json:"rounds,omitempty"`
 
 	/* Non-printable character to be inserted between the salt and plain text password in base64. */
 	// +optional
@@ -129,7 +129,7 @@ type IdentityPlatformProjectDefaultConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformtenantdefaultsupportedidpconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformtenantdefaultsupportedidpconfig_types.go
@@ -67,7 +67,7 @@ type IdentityPlatformTenantDefaultSupportedIDPConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformtenantinboundsamlconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/identityplatformtenantinboundsamlconfig_types.go
@@ -106,7 +106,7 @@ type IdentityPlatformTenantInboundSAMLConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/identityplatform/v1alpha1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *IdentityPlatformDefaultSupportedIDPConfigStatus) DeepCopyInto(out *Ide
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -248,7 +248,7 @@ func (in *IdentityPlatformInboundSAMLConfigStatus) DeepCopyInto(out *IdentityPla
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -367,7 +367,7 @@ func (in *IdentityPlatformProjectDefaultConfigStatus) DeepCopyInto(out *Identity
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -486,7 +486,7 @@ func (in *IdentityPlatformTenantDefaultSupportedIDPConfigStatus) DeepCopyInto(ou
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -602,7 +602,7 @@ func (in *IdentityPlatformTenantInboundSAMLConfigStatus) DeepCopyInto(out *Ident
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -773,12 +773,12 @@ func (in *ProjectdefaultconfigHashConfig) DeepCopyInto(out *Projectdefaultconfig
 	}
 	if in.MemoryCost != nil {
 		in, out := &in.MemoryCost, &out.MemoryCost
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Rounds != nil {
 		in, out := &in.Rounds, &out.Rounds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SaltSeparator != nil {

--- a/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformconfig_types.go
@@ -285,7 +285,7 @@ type ConfigSignIn struct {
 type ConfigSignUpQuotaConfig struct {
 	/* Corresponds to the 'refill_token_count' field in QuotaServer config */
 	// +optional
-	Quota *int `json:"quota,omitempty"`
+	Quota *ConfigQuota `json:"quota,omitempty"`
 
 	/* How long this quota will be active for */
 	// +optional
@@ -307,7 +307,7 @@ type ConfigSmtp struct {
 
 	/* SMTP relay port */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* SMTP security mode. Possible values: SECURITY_MODE_UNSPECIFIED, SSL, START_TLS */
 	// +optional
@@ -451,11 +451,11 @@ type ConfigHashConfigStatus struct {
 
 	/* Output only. Memory cost for hash calculation. Used by scrypt and other similar password derivation algorithms. See https://tools.ietf.org/html/rfc7914 for explanation of field. */
 	// +optional
-	MemoryCost *int `json:"memoryCost,omitempty"`
+	MemoryCost *int64 `json:"memoryCost,omitempty"`
 
 	/* Output only. How many rounds for hash calculation. Used by scrypt and other similar password derivation algorithms. */
 	// +optional
-	Rounds *int `json:"rounds,omitempty"`
+	Rounds *int64 `json:"rounds,omitempty"`
 
 	/* Output only. Non-printable character to be inserted between the salt and plain text password in base64. */
 	// +optional
@@ -542,7 +542,7 @@ type IdentityPlatformConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SignIn *ConfigSignInStatus `json:"signIn,omitempty"`

--- a/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformoauthidpconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformoauthidpconfig_types.go
@@ -101,7 +101,7 @@ type IdentityPlatformOAuthIDPConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformtenant_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformtenant_types.go
@@ -85,7 +85,7 @@ type IdentityPlatformTenantStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformtenantoauthidpconfig_types.go
+++ b/pkg/clients/generated/apis/identityplatform/v1beta1/identityplatformtenantoauthidpconfig_types.go
@@ -104,7 +104,7 @@ type IdentityPlatformTenantOAuthIDPConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/identityplatform/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/identityplatform/v1beta1/zz_generated.deepcopy.go
@@ -301,12 +301,12 @@ func (in *ConfigHashConfigStatus) DeepCopyInto(out *ConfigHashConfigStatus) {
 	}
 	if in.MemoryCost != nil {
 		in, out := &in.MemoryCost, &out.MemoryCost
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Rounds != nil {
 		in, out := &in.Rounds, &out.Rounds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SaltSeparator != nil {
@@ -919,8 +919,8 @@ func (in *ConfigSignUpQuotaConfig) DeepCopyInto(out *ConfigSignUpQuotaConfig) {
 	*out = *in
 	if in.Quota != nil {
 		in, out := &in.Quota, &out.Quota
-		*out = new(int)
-		**out = **in
+		*out = new(ConfigQuota)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.QuotaDuration != nil {
 		in, out := &in.QuotaDuration, &out.QuotaDuration
@@ -981,7 +981,7 @@ func (in *ConfigSmtp) DeepCopyInto(out *ConfigSmtp) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SecurityMode != nil {
@@ -1269,7 +1269,7 @@ func (in *IdentityPlatformConfigStatus) DeepCopyInto(out *IdentityPlatformConfig
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SignIn != nil {
@@ -1417,7 +1417,7 @@ func (in *IdentityPlatformOAuthIDPConfigStatus) DeepCopyInto(out *IdentityPlatfo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1617,7 +1617,7 @@ func (in *IdentityPlatformTenantOAuthIDPConfigStatus) DeepCopyInto(out *Identity
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1701,7 +1701,7 @@ func (in *IdentityPlatformTenantStatus) DeepCopyInto(out *IdentityPlatformTenant
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/kms/v1alpha1/kmscryptokeyversion_types.go
+++ b/pkg/clients/generated/apis/kms/v1alpha1/kmscryptokeyversion_types.go
@@ -114,7 +114,7 @@ type KMSCryptoKeyVersionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The ProtectionLevel describing how crypto operations are performed with this CryptoKeyVersion. */
 	// +optional

--- a/pkg/clients/generated/apis/kms/v1alpha1/kmskeyringimportjob_types.go
+++ b/pkg/clients/generated/apis/kms/v1alpha1/kmskeyringimportjob_types.go
@@ -94,7 +94,7 @@ type KMSKeyRingImportJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The public key with which to wrap key material prior to import. Only returned if state is 'ACTIVE'. */
 	// +optional

--- a/pkg/clients/generated/apis/kms/v1alpha1/kmssecretciphertext_types.go
+++ b/pkg/clients/generated/apis/kms/v1alpha1/kmssecretciphertext_types.go
@@ -88,7 +88,7 @@ type KMSSecretCiphertextStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/kms/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/kms/v1alpha1/zz_generated.deepcopy.go
@@ -241,7 +241,7 @@ func (in *KMSCryptoKeyVersionStatus) DeepCopyInto(out *KMSCryptoKeyVersionStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProtectionLevel != nil {
@@ -371,7 +371,7 @@ func (in *KMSKeyRingImportJobStatus) DeepCopyInto(out *KMSKeyRingImportJobStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PublicKey != nil {
@@ -502,7 +502,7 @@ func (in *KMSSecretCiphertextStatus) DeepCopyInto(out *KMSSecretCiphertextStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/kms/v1beta1/kmscryptokey_types.go
+++ b/pkg/clients/generated/apis/kms/v1beta1/kmscryptokey_types.go
@@ -92,7 +92,7 @@ type KMSCryptoKeyStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The self link of the created key in the format projects/{project}/locations/{location}/keyRings/{keyRingName}/cryptoKeys/{name}. */
 	// +optional

--- a/pkg/clients/generated/apis/kms/v1beta1/kmskeyring_types.go
+++ b/pkg/clients/generated/apis/kms/v1beta1/kmskeyring_types.go
@@ -51,7 +51,7 @@ type KMSKeyRingStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The self link of the created KeyRing in the format projects/{project}/locations/{location}/keyRings/{name}. */
 	// +optional

--- a/pkg/clients/generated/apis/kms/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/kms/v1beta1/zz_generated.deepcopy.go
@@ -173,7 +173,7 @@ func (in *KMSCryptoKeyStatus) DeepCopyInto(out *KMSCryptoKeyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -286,7 +286,7 @@ func (in *KMSKeyRingStatus) DeepCopyInto(out *KMSKeyRingStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogbucket_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogbucket_types.go
@@ -73,7 +73,7 @@ type LoggingLogBucketSpec struct {
 
 	/* Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. */
 	// +optional
-	RetentionDays *int `json:"retentionDays,omitempty"`
+	RetentionDays *int64 `json:"retentionDays,omitempty"`
 }
 
 type LoggingLogBucketStatus struct {
@@ -90,7 +90,7 @@ type LoggingLogBucketStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of the bucket. */
 	// +optional

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogexclusion_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogexclusion_types.go
@@ -78,7 +78,7 @@ type LoggingLogExclusionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of the exclusion. This field may not be present for older exclusions. */
 	// +optional

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
@@ -62,7 +62,7 @@ type LogmetricExponentialBuckets struct {
 
 	/* Must be greater than 0. */
 	// +optional
-	NumFiniteBuckets *int `json:"numFiniteBuckets,omitempty"`
+	NumFiniteBuckets *int64 `json:"numFiniteBuckets,omitempty"`
 
 	/* Must be greater than 0. */
 	// +optional
@@ -86,7 +86,7 @@ type LogmetricLabels struct {
 type LogmetricLinearBuckets struct {
 	/* Must be greater than 0. */
 	// +optional
-	NumFiniteBuckets *int `json:"numFiniteBuckets,omitempty"`
+	NumFiniteBuckets *int64 `json:"numFiniteBuckets,omitempty"`
 
 	/* Lower bound of the first bucket. */
 	// +optional
@@ -204,7 +204,7 @@ type LoggingLogMetricStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of the metric. This field may not be present for older metrics. */
 	// +optional

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogsink_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogsink_types.go
@@ -128,7 +128,7 @@ type LoggingLogSinkStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The identity associated with this sink. This identity must be granted write access to the configured destination. */
 	// +optional

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogview_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogview_types.go
@@ -82,7 +82,7 @@ type LoggingLogViewStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The last update timestamp of the view. */
 	// +optional

--- a/pkg/clients/generated/apis/logging/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/zz_generated.deepcopy.go
@@ -135,7 +135,7 @@ func (in *LoggingLogBucketSpec) DeepCopyInto(out *LoggingLogBucketSpec) {
 	}
 	if in.RetentionDays != nil {
 		in, out := &in.RetentionDays, &out.RetentionDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -171,7 +171,7 @@ func (in *LoggingLogBucketStatus) DeepCopyInto(out *LoggingLogBucketStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -319,7 +319,7 @@ func (in *LoggingLogExclusionStatus) DeepCopyInto(out *LoggingLogExclusionStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -475,7 +475,7 @@ func (in *LoggingLogMetricStatus) DeepCopyInto(out *LoggingLogMetricStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -641,7 +641,7 @@ func (in *LoggingLogSinkStatus) DeepCopyInto(out *LoggingLogSinkStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.WriterIdentity != nil {
@@ -795,7 +795,7 @@ func (in *LoggingLogViewStatus) DeepCopyInto(out *LoggingLogViewStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -878,7 +878,7 @@ func (in *LogmetricExponentialBuckets) DeepCopyInto(out *LogmetricExponentialBuc
 	}
 	if in.NumFiniteBuckets != nil {
 		in, out := &in.NumFiniteBuckets, &out.NumFiniteBuckets
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Scale != nil {
@@ -935,7 +935,7 @@ func (in *LogmetricLinearBuckets) DeepCopyInto(out *LogmetricLinearBuckets) {
 	*out = *in
 	if in.NumFiniteBuckets != nil {
 		in, out := &in.NumFiniteBuckets, &out.NumFiniteBuckets
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Offset != nil {

--- a/pkg/clients/generated/apis/memcache/v1beta1/memcacheinstance_types.go
+++ b/pkg/clients/generated/apis/memcache/v1beta1/memcacheinstance_types.go
@@ -72,30 +72,30 @@ type InstanceMemcacheParameters struct {
 
 type InstanceNodeConfig struct {
 	/* Number of CPUs per node. */
-	CpuCount int `json:"cpuCount"`
+	CpuCount int64 `json:"cpuCount"`
 
 	/* Memory size in Mebibytes for each memcache node. */
-	MemorySizeMb int `json:"memorySizeMb"`
+	MemorySizeMb int64 `json:"memorySizeMb"`
 }
 
 type InstanceStartTime struct {
 	/* Hours of day in 24 hour format. Should be from 0 to 23.
 	An API may choose to allow the value "24:00:00" for scenarios like business closing time. */
 	// +optional
-	Hours *int `json:"hours,omitempty"`
+	Hours *int64 `json:"hours,omitempty"`
 
 	/* Minutes of hour of day. Must be from 0 to 59. */
 	// +optional
-	Minutes *int `json:"minutes,omitempty"`
+	Minutes *int64 `json:"minutes,omitempty"`
 
 	/* Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Seconds of minutes of the time. Must normally be from 0 to 59.
 	An API may allow the value 60 if it allows leap-seconds. */
 	// +optional
-	Seconds *int `json:"seconds,omitempty"`
+	Seconds *int64 `json:"seconds,omitempty"`
 }
 
 type InstanceWeeklyMaintenanceWindow struct {
@@ -146,7 +146,7 @@ type MemcacheInstanceSpec struct {
 	NodeConfig InstanceNodeConfig `json:"nodeConfig"`
 
 	/* Number of nodes in the memcache instance. */
-	NodeCount int `json:"nodeCount"`
+	NodeCount int64 `json:"nodeCount"`
 
 	/* Immutable. The region of the Memcache instance. If it is not provided, the provider region is used. */
 	Region string `json:"region"`
@@ -193,7 +193,7 @@ type InstanceMemcacheNodesStatus struct {
 
 	/* The port number of the Memcached server on this node. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Current state of the Memcached node. */
 	// +optional
@@ -230,7 +230,7 @@ type MemcacheInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/memcache/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/memcache/v1beta1/zz_generated.deepcopy.go
@@ -113,7 +113,7 @@ func (in *InstanceMemcacheNodesStatus) DeepCopyInto(out *InstanceMemcacheNodesSt
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -188,22 +188,22 @@ func (in *InstanceStartTime) DeepCopyInto(out *InstanceStartTime) {
 	*out = *in
 	if in.Hours != nil {
 		in, out := &in.Hours, &out.Hours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minutes != nil {
 		in, out := &in.Minutes, &out.Minutes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Seconds != nil {
 		in, out := &in.Seconds, &out.Seconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -388,7 +388,7 @@ func (in *MemcacheInstanceStatus) DeepCopyInto(out *MemcacheInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/mlengine/v1alpha1/mlenginemodel_types.go
+++ b/pkg/clients/generated/apis/mlengine/v1alpha1/mlenginemodel_types.go
@@ -77,7 +77,7 @@ type MLEngineModelStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/mlengine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/mlengine/v1alpha1/zz_generated.deepcopy.go
@@ -147,7 +147,7 @@ func (in *MLEngineModelStatus) DeepCopyInto(out *MLEngineModelStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringalertpolicy_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringalertpolicy_types.go
@@ -607,7 +607,7 @@ type AlertpolicyTrigger struct {
 	that must fail the predicate for the
 	condition to be triggered. */
 	// +optional
-	Count *int `json:"count,omitempty"`
+	Count *int64 `json:"count,omitempty"`
 
 	/* The percentage of time series that
 	must fail the predicate for the
@@ -684,7 +684,7 @@ type MonitoringAlertPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringdashboard_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringdashboard_types.go
@@ -71,7 +71,7 @@ type DashboardColumnLayout struct {
 type DashboardColumns struct {
 	/* The relative weight of this column. The column weight is used to adjust the width of columns on the screen (relative to peers). Greater the weight, greater the width of the column on the screen. If omitted, a value of 1 is used while rendering. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 
 	/* The display widgets arranged vertically in this column. */
 	// +optional
@@ -117,7 +117,7 @@ type DashboardGaugeView struct {
 type DashboardGridLayout struct {
 	/* The number of columns into which the view's width is divided. If omitted or set to zero, a system default will be used while rendering. */
 	// +optional
-	Columns *int `json:"columns,omitempty"`
+	Columns *DashboardColumns `json:"columns,omitempty"`
 
 	/* The informational elements that are arranged into the columns row-first. */
 	// +optional
@@ -136,7 +136,7 @@ type DashboardLogsPanel struct {
 type DashboardMosaicLayout struct {
 	/* The number of columns in the mosaic grid. */
 	// +optional
-	Columns *int `json:"columns,omitempty"`
+	Columns *DashboardColumns `json:"columns,omitempty"`
 
 	/* The tiles to display. */
 	// +optional
@@ -159,7 +159,7 @@ type DashboardPickTimeSeriesFilter struct {
 
 	/* How many time series to allow to pass through the filter. */
 	// +optional
-	NumTimeSeries *int `json:"numTimeSeries,omitempty"`
+	NumTimeSeries *int64 `json:"numTimeSeries,omitempty"`
 
 	/* `ranking_method` is applied to each time series independently to produce the value which will be used to compare the time series to other time series. Possible values: METHOD_UNSPECIFIED, METHOD_MEAN, METHOD_MAX, METHOD_MIN, METHOD_SUM, METHOD_LATEST */
 	// +optional
@@ -175,7 +175,7 @@ type DashboardRowLayout struct {
 type DashboardRows struct {
 	/* The relative weight of this row. The row weight is used to adjust the height of rows on the screen (relative to peers). Greater the weight, greater the height of the row on the screen. If omitted, a value of 1 is used while rendering. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 
 	/* The display widgets arranged horizontally in this row. */
 	// +optional
@@ -257,7 +257,7 @@ type DashboardThresholds struct {
 type DashboardTiles struct {
 	/* The height of the tile, measured in grid squares. */
 	// +optional
-	Height *int `json:"height,omitempty"`
+	Height *int64 `json:"height,omitempty"`
 
 	/* The informational widget contained in the tile. */
 	// +optional
@@ -265,15 +265,15 @@ type DashboardTiles struct {
 
 	/* The width of the tile, measured in grid squares. */
 	// +optional
-	Width *int `json:"width,omitempty"`
+	Width *int64 `json:"width,omitempty"`
 
 	/* The zero-indexed position of the tile in grid squares relative to the left edge of the grid. */
 	// +optional
-	XPos *int `json:"xPos,omitempty"`
+	XPos *int64 `json:"xPos,omitempty"`
 
 	/* The zero-indexed position of the tile in grid squares relative to the top edge of the grid. */
 	// +optional
-	YPos *int `json:"yPos,omitempty"`
+	YPos *int64 `json:"yPos,omitempty"`
 }
 
 type DashboardTimeSeriesFilter struct {
@@ -462,7 +462,7 @@ type MonitoringDashboardStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringgroup_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringgroup_types.go
@@ -64,7 +64,7 @@ type MonitoringGroupStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringmetricdescriptor_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringmetricdescriptor_types.go
@@ -111,7 +111,7 @@ type MonitoringMetricDescriptorStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The resource name of the metric descriptor. */
 	// +optional

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringmonitoredproject_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringmonitoredproject_types.go
@@ -54,7 +54,7 @@ type MonitoringMonitoredProjectStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringnotificationchannel_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringnotificationchannel_types.go
@@ -135,7 +135,7 @@ type MonitoringNotificationChannelStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Indicates whether this channel has been verified or not. On a ListNotificationChannels or GetNotificationChannel operation, this field is expected to be populated.If the value is UNVERIFIED, then it indicates that the channel is non-functioning (it both requires verification and lacks verification); otherwise, it is assumed that the channel works.If the channel is neither VERIFIED nor UNVERIFIED, it implies that the channel is of a type that does not require verification or that this specific channel has been exempted from verification because it was created prior to verification being required for channels of this type.This field cannot be modified using a standard UpdateNotificationChannel operation. To change the value of this field, you must call VerifyNotificationChannel. */
 	// +optional

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringservice_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringservice_types.go
@@ -64,7 +64,7 @@ type MonitoringServiceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringservicelevelobjective_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringservicelevelobjective_types.go
@@ -290,7 +290,7 @@ type MonitoringServiceLevelObjectiveStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. If set, this SLO is managed at the [Service Management](https://cloud.google.com/service-management/overview) level. Therefore the service yaml file is the source of truth for this SLO, and API `Update` and `Delete` operations are forbidden. */
 	// +optional

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringuptimecheckconfig_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringuptimecheckconfig_types.go
@@ -76,7 +76,7 @@ type UptimecheckconfigHttpCheck struct {
 
 	/* Optional (defaults to 80 when `use_ssl` is `false`, and 443 when `use_ssl` is `true`). The TCP port on the HTTP server against which to run the check. Will be combined with host (specified within the `monitored_resource`) and `path` to construct the full URL. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Immutable. The HTTP request method to use for the check. If set to `METHOD_UNSPECIFIED` then `request_method` defaults to `GET`. */
 	// +optional
@@ -121,7 +121,7 @@ type UptimecheckconfigResourceGroup struct {
 
 type UptimecheckconfigTcpCheck struct {
 	/* The TCP port on the server against which to run the check. Will be combined with host (specified within the `monitored_resource`) to construct the full URL. Required. */
-	Port int `json:"port"`
+	Port int64 `json:"port"`
 }
 
 type UptimecheckconfigValueFrom struct {
@@ -179,7 +179,7 @@ type MonitoringUptimeCheckConfigStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/monitoring/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/zz_generated.deepcopy.go
@@ -485,7 +485,7 @@ func (in *AlertpolicyTrigger) DeepCopyInto(out *AlertpolicyTrigger) {
 	*out = *in
 	if in.Count != nil {
 		in, out := &in.Count, &out.Count
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
@@ -607,7 +607,7 @@ func (in *DashboardColumns) DeepCopyInto(out *DashboardColumns) {
 	*out = *in
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Widgets != nil {
@@ -714,8 +714,8 @@ func (in *DashboardGridLayout) DeepCopyInto(out *DashboardGridLayout) {
 	*out = *in
 	if in.Columns != nil {
 		in, out := &in.Columns, &out.Columns
-		*out = new(int)
-		**out = **in
+		*out = new(DashboardColumns)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Widgets != nil {
 		in, out := &in.Widgets, &out.Widgets
@@ -768,8 +768,8 @@ func (in *DashboardMosaicLayout) DeepCopyInto(out *DashboardMosaicLayout) {
 	*out = *in
 	if in.Columns != nil {
 		in, out := &in.Columns, &out.Columns
-		*out = new(int)
-		**out = **in
+		*out = new(DashboardColumns)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tiles != nil {
 		in, out := &in.Tiles, &out.Tiles
@@ -822,7 +822,7 @@ func (in *DashboardPickTimeSeriesFilter) DeepCopyInto(out *DashboardPickTimeSeri
 	}
 	if in.NumTimeSeries != nil {
 		in, out := &in.NumTimeSeries, &out.NumTimeSeries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RankingMethod != nil {
@@ -871,7 +871,7 @@ func (in *DashboardRows) DeepCopyInto(out *DashboardRows) {
 	*out = *in
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Widgets != nil {
@@ -1052,7 +1052,7 @@ func (in *DashboardTiles) DeepCopyInto(out *DashboardTiles) {
 	*out = *in
 	if in.Height != nil {
 		in, out := &in.Height, &out.Height
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Widget != nil {
@@ -1062,17 +1062,17 @@ func (in *DashboardTiles) DeepCopyInto(out *DashboardTiles) {
 	}
 	if in.Width != nil {
 		in, out := &in.Width, &out.Width
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.XPos != nil {
 		in, out := &in.XPos, &out.XPos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.YPos != nil {
 		in, out := &in.YPos, &out.YPos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1578,7 +1578,7 @@ func (in *MonitoringAlertPolicyStatus) DeepCopyInto(out *MonitoringAlertPolicySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1712,7 +1712,7 @@ func (in *MonitoringDashboardStatus) DeepCopyInto(out *MonitoringDashboardStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1835,7 +1835,7 @@ func (in *MonitoringGroupStatus) DeepCopyInto(out *MonitoringGroupStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1976,7 +1976,7 @@ func (in *MonitoringMetricDescriptorStatus) DeepCopyInto(out *MonitoringMetricDe
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2094,7 +2094,7 @@ func (in *MonitoringMonitoredProjectStatus) DeepCopyInto(out *MonitoringMonitore
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2234,7 +2234,7 @@ func (in *MonitoringNotificationChannelStatus) DeepCopyInto(out *MonitoringNotif
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VerificationStatus != nil {
@@ -2407,7 +2407,7 @@ func (in *MonitoringServiceLevelObjectiveStatus) DeepCopyInto(out *MonitoringSer
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServiceManagementOwned != nil {
@@ -2503,7 +2503,7 @@ func (in *MonitoringServiceStatus) DeepCopyInto(out *MonitoringServiceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2649,7 +2649,7 @@ func (in *MonitoringUptimeCheckConfigStatus) DeepCopyInto(out *MonitoringUptimeC
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3367,7 +3367,7 @@ func (in *UptimecheckconfigHttpCheck) DeepCopyInto(out *UptimecheckconfigHttpChe
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RequestMethod != nil {

--- a/pkg/clients/generated/apis/networkconnectivity/v1beta1/networkconnectivityhub_types.go
+++ b/pkg/clients/generated/apis/networkconnectivity/v1beta1/networkconnectivityhub_types.go
@@ -64,7 +64,7 @@ type NetworkConnectivityHubStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The VPC network associated with this hub's spokes. All of the VPN tunnels, VLAN attachments, and router appliance instances referenced by this hub's spokes must belong to this VPC network. This field is read-only. Network Connectivity Center automatically populates it based on the set of spokes attached to the hub. */
 	// +optional

--- a/pkg/clients/generated/apis/networkconnectivity/v1beta1/networkconnectivityspoke_types.go
+++ b/pkg/clients/generated/apis/networkconnectivity/v1beta1/networkconnectivityspoke_types.go
@@ -123,7 +123,7 @@ type NetworkConnectivitySpokeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The current lifecycle state of this spoke. Possible values: STATE_UNSPECIFIED, CREATING, ACTIVE, DELETING */
 	// +optional

--- a/pkg/clients/generated/apis/networkconnectivity/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/networkconnectivity/v1beta1/zz_generated.deepcopy.go
@@ -153,7 +153,7 @@ func (in *NetworkConnectivityHubStatus) DeepCopyInto(out *NetworkConnectivityHub
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RoutingVpcs != nil {
@@ -315,7 +315,7 @@ func (in *NetworkConnectivitySpokeStatus) DeepCopyInto(out *NetworkConnectivityS
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/networkmanagement/v1alpha1/networkmanagementconnectivitytest_types.go
+++ b/pkg/clients/generated/apis/networkmanagement/v1alpha1/networkmanagementconnectivitytest_types.go
@@ -53,7 +53,7 @@ type ConnectivitytestDestination struct {
 	/* The IP protocol port of the endpoint. Only applicable when
 	protocol is TCP or UDP. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Project ID where the endpoint is located. The Project ID can be
 	derived from the URI if you provide a VM instance or network URI.
@@ -89,7 +89,7 @@ type ConnectivitytestSource struct {
 	/* The IP protocol port of the endpoint. Only applicable when
 	protocol is TCP or UDP. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Project ID where the endpoint is located. The Project ID can be
 	derived from the URI if you provide a VM instance or network URI.
@@ -180,7 +180,7 @@ type NetworkManagementConnectivityTestStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/networkmanagement/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/networkmanagement/v1alpha1/zz_generated.deepcopy.go
@@ -49,7 +49,7 @@ func (in *ConnectivitytestDestination) DeepCopyInto(out *ConnectivitytestDestina
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectId != nil {
@@ -95,7 +95,7 @@ func (in *ConnectivitytestSource) DeepCopyInto(out *ConnectivitytestSource) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectId != nil {
@@ -226,7 +226,7 @@ func (in *NetworkManagementConnectivityTestStatus) DeepCopyInto(out *NetworkMana
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityauthorizationpolicy_types.go
+++ b/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityauthorizationpolicy_types.go
@@ -48,7 +48,7 @@ type AuthorizationpolicyDestinations struct {
 	Methods []string `json:"methods,omitempty"`
 
 	/* Required. List of destination ports to match. */
-	Ports []int `json:"ports"`
+	Ports []int64 `json:"ports"`
 }
 
 type AuthorizationpolicyHttpHeaderMatch struct {
@@ -112,7 +112,7 @@ type NetworkSecurityAuthorizationPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The timestamp when the resource was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityclienttlspolicy_types.go
+++ b/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityclienttlspolicy_types.go
@@ -104,7 +104,7 @@ type NetworkSecurityClientTLSPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The timestamp when the resource was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityservertlspolicy_types.go
+++ b/pkg/clients/generated/apis/networksecurity/v1beta1/networksecurityservertlspolicy_types.go
@@ -109,7 +109,7 @@ type NetworkSecurityServerTLSPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The timestamp when the resource was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/networksecurity/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/networksecurity/v1beta1/zz_generated.deepcopy.go
@@ -49,7 +49,7 @@ func (in *AuthorizationpolicyDestinations) DeepCopyInto(out *Authorizationpolicy
 	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -331,7 +331,7 @@ func (in *NetworkSecurityAuthorizationPolicyStatus) DeepCopyInto(out *NetworkSec
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -476,7 +476,7 @@ func (in *NetworkSecurityClientTLSPolicyStatus) DeepCopyInto(out *NetworkSecurit
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -619,7 +619,7 @@ func (in *NetworkSecurityServerTLSPolicyStatus) DeepCopyInto(out *NetworkSecurit
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecachekeyset_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecachekeyset_types.go
@@ -114,7 +114,7 @@ type NetworkServicesEdgeCacheKeysetStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecacheorigin_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecacheorigin_types.go
@@ -176,7 +176,7 @@ type NetworkServicesEdgeCacheOriginSpec struct {
 
 	Defaults to 1. Must be a value greater than 0 and less than 4. */
 	// +optional
-	MaxAttempts *int `json:"maxAttempts,omitempty"`
+	MaxAttempts *int64 `json:"maxAttempts,omitempty"`
 
 	/* A fully qualified domain name (FQDN) or IP address reachable over the public Internet, or the address of a Google Cloud Storage bucket.
 
@@ -198,7 +198,7 @@ type NetworkServicesEdgeCacheOriginSpec struct {
 	/* The port to connect to the origin on.
 	Defaults to port 443 for HTTP2 and HTTPS protocols, and port 80 for HTTP. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* The project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -245,7 +245,7 @@ type NetworkServicesEdgeCacheOriginStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecacheservice_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1alpha1/networkservicesedgecacheservice_types.go
@@ -703,7 +703,7 @@ type NetworkServicesEdgeCacheServiceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/networkservices/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/networkservices/v1alpha1/zz_generated.deepcopy.go
@@ -1131,7 +1131,7 @@ func (in *NetworkServicesEdgeCacheKeysetStatus) DeepCopyInto(out *NetworkService
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1228,7 +1228,7 @@ func (in *NetworkServicesEdgeCacheOriginSpec) DeepCopyInto(out *NetworkServicesE
 	}
 	if in.MaxAttempts != nil {
 		in, out := &in.MaxAttempts, &out.MaxAttempts
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.OriginOverrideAction != nil {
@@ -1243,7 +1243,7 @@ func (in *NetworkServicesEdgeCacheOriginSpec) DeepCopyInto(out *NetworkServicesE
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -1290,7 +1290,7 @@ func (in *NetworkServicesEdgeCacheOriginStatus) DeepCopyInto(out *NetworkService
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1450,7 +1450,7 @@ func (in *NetworkServicesEdgeCacheServiceStatus) DeepCopyInto(out *NetworkServic
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesendpointpolicy_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesendpointpolicy_types.go
@@ -110,7 +110,7 @@ type NetworkServicesEndpointPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The timestamp when the resource was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesgateway_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesgateway_types.go
@@ -48,7 +48,7 @@ type NetworkServicesGatewaySpec struct {
 	Location string `json:"location"`
 
 	/* Required. One or more ports that the Gateway must receive traffic on. The proxy binds to the ports specified. Gateway listen on 0.0.0.0 on the ports specified below. */
-	Ports []int `json:"ports"`
+	Ports []int64 `json:"ports"`
 
 	/* Immutable. The Project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -78,7 +78,7 @@ type NetworkServicesGatewayStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesgrpcroute_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesgrpcroute_types.go
@@ -38,11 +38,11 @@ import (
 type GrpcrouteAbort struct {
 	/* The HTTP status code used to abort the request. The value must be between 200 and 599 inclusive. */
 	// +optional
-	HttpStatus *int `json:"httpStatus,omitempty"`
+	HttpStatus *int64 `json:"httpStatus,omitempty"`
 
 	/* The percentage of traffic which will be aborted. The value must be between [0, 100] */
 	// +optional
-	Percentage *int `json:"percentage,omitempty"`
+	Percentage *int64 `json:"percentage,omitempty"`
 }
 
 type GrpcrouteAction struct {
@@ -70,7 +70,7 @@ type GrpcrouteDelay struct {
 
 	/* The percentage of traffic on which delay will be injected. The value must be between [0, 100] */
 	// +optional
-	Percentage *int `json:"percentage,omitempty"`
+	Percentage *int64 `json:"percentage,omitempty"`
 }
 
 type GrpcrouteDestinations struct {
@@ -78,7 +78,7 @@ type GrpcrouteDestinations struct {
 
 	/* Optional. Specifies the proportion of requests forwarded to the backend referenced by the serviceName field. This is computed as: weight/Sum(weights in this destination list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. If only one serviceName is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weights are specified for any one service name, they need to be specified for all of them. If weights are unspecified for all services, then, traffic is distributed in equal proportions to all of them. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type GrpcrouteFaultInjectionPolicy struct {
@@ -132,7 +132,7 @@ type GrpcrouteMethod struct {
 type GrpcrouteRetryPolicy struct {
 	/* Specifies the allowed number of retries. This number must be > 0. If not specpfied, default to 1. */
 	// +optional
-	NumRetries *int `json:"numRetries,omitempty"`
+	NumRetries *int64 `json:"numRetries,omitempty"`
 
 	/* - connect-failure: Router will retry on failures connecting to Backend Services, for example due to connection timeouts. - refused-stream: Router will retry if the backend service resets the stream with a REFUSED_STREAM error code. This reset type indicates that it is safe to retry. - cancelled: Router will retry if the gRPC status code in the response header is set to cancelled - deadline-exceeded: Router will retry if the gRPC status code in the response header is set to deadline-exceeded - resource-exhausted: Router will retry if the gRPC status code in the response header is set to resource-exhausted - unavailable: Router will retry if the gRPC status code in the response header is set to unavailable */
 	// +optional
@@ -186,7 +186,7 @@ type NetworkServicesGRPCRouteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkserviceshttproute_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkserviceshttproute_types.go
@@ -38,11 +38,11 @@ import (
 type HttprouteAbort struct {
 	/* The HTTP status code used to abort the request. The value must be between 200 and 599 inclusive. */
 	// +optional
-	HttpStatus *int `json:"httpStatus,omitempty"`
+	HttpStatus *int64 `json:"httpStatus,omitempty"`
 
 	/* The percentage of traffic which will be aborted. The value must be between [0, 100] */
 	// +optional
-	Percentage *int `json:"percentage,omitempty"`
+	Percentage *int64 `json:"percentage,omitempty"`
 }
 
 type HttprouteAction struct {
@@ -128,7 +128,7 @@ type HttprouteDelay struct {
 
 	/* The percentage of traffic on which delay will be injected. The value must be between [0, 100] */
 	// +optional
-	Percentage *int `json:"percentage,omitempty"`
+	Percentage *int64 `json:"percentage,omitempty"`
 }
 
 type HttprouteDestination struct {
@@ -137,7 +137,7 @@ type HttprouteDestination struct {
 
 	/* Specifies the proportion of requests forwarded to the backend referenced by the serviceName field. This is computed as: weight/Sum(weights in this destination list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. If only one serviceName is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weights are specified for any one service name, they need to be specified for all of them. If weights are unspecified for all services, then, traffic is distributed in equal proportions to all of them. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type HttprouteDestinations struct {
@@ -146,7 +146,7 @@ type HttprouteDestinations struct {
 
 	/* Specifies the proportion of requests forwarded to the backend referenced by the serviceName field. This is computed as: weight/Sum(weights in this destination list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. If only one serviceName is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weights are specified for any one service name, they need to be specified for all of them. If weights are unspecified for all services, then, traffic is distributed in equal proportions to all of them. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type HttprouteFaultInjectionPolicy struct {
@@ -240,11 +240,11 @@ type HttprouteQueryParameters struct {
 type HttprouteRangeMatch struct {
 	/* End of the range (exclusive) */
 	// +optional
-	End *int `json:"end,omitempty"`
+	End *int64 `json:"end,omitempty"`
 
 	/* Start of the range (inclusive) */
 	// +optional
-	Start *int `json:"start,omitempty"`
+	Start *int64 `json:"start,omitempty"`
 }
 
 type HttprouteRedirect struct {
@@ -262,7 +262,7 @@ type HttprouteRedirect struct {
 
 	/* The port that will be used in the redirected request instead of the one that was supplied in the request. */
 	// +optional
-	PortRedirect *int `json:"portRedirect,omitempty"`
+	PortRedirect *int64 `json:"portRedirect,omitempty"`
 
 	/* Indicates that during redirection, the matched prefix (or path) should be swapped with this value. This option allows URLs be dynamically created based on the request. */
 	// +optional
@@ -314,7 +314,7 @@ type HttprouteResponseHeaderModifier struct {
 type HttprouteRetryPolicy struct {
 	/* Specifies the allowed number of retries. This number must be > 0. If not specified, default to 1. */
 	// +optional
-	NumRetries *int `json:"numRetries,omitempty"`
+	NumRetries *int64 `json:"numRetries,omitempty"`
 
 	/* Specifies a non-zero timeout per retry attempt. */
 	// +optional
@@ -383,7 +383,7 @@ type NetworkServicesHTTPRouteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesmesh_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicesmesh_types.go
@@ -42,7 +42,7 @@ type NetworkServicesMeshSpec struct {
 
 	/* Optional. If set to a valid TCP port (1-65535), instructs the SIDECAR proxy to listen on the specified port of localhost (127.0.0.1) address. The SIDECAR proxy will expect all traffic to be redirected to this port regardless of its actual ip:port destination. If unset, a port '15001' is used as the interception port. This field is only valid if the type of Mesh is SIDECAR. */
 	// +optional
-	InterceptionPort *int `json:"interceptionPort,omitempty"`
+	InterceptionPort *int64 `json:"interceptionPort,omitempty"`
 
 	/* Immutable. The location for the resource */
 	Location string `json:"location"`
@@ -65,7 +65,7 @@ type NetworkServicesMeshStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicestcproute_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicestcproute_types.go
@@ -50,7 +50,7 @@ type TcprouteDestinations struct {
 
 	/* Optional. Specifies the proportion of requests forwarded to the backend referenced by the serviceName field. This is computed as: weight/Sum(weights in this destination list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. If only one serviceName is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weights are specified for any one service name, they need to be specified for all of them. If weights are unspecified for all services, then, traffic is distributed in equal proportions to all of them. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type TcprouteMatches struct {
@@ -105,7 +105,7 @@ type NetworkServicesTCPRouteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/networkservicestlsroute_types.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/networkservicestlsroute_types.go
@@ -45,7 +45,7 @@ type TlsrouteDestinations struct {
 
 	/* Optional. Specifies the proportion of requests forwareded to the backend referenced by the service_name field. This is computed as: weight/Sum(weights in destinations) Weights in all destinations does not need to sum up to 100. */
 	// +optional
-	Weight *int `json:"weight,omitempty"`
+	Weight *int64 `json:"weight,omitempty"`
 }
 
 type TlsrouteMatches struct {
@@ -101,7 +101,7 @@ type NetworkServicesTLSRouteStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Server-defined URL of this resource */
 	// +optional

--- a/pkg/clients/generated/apis/networkservices/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/networkservices/v1beta1/zz_generated.deepcopy.go
@@ -118,12 +118,12 @@ func (in *GrpcrouteAbort) DeepCopyInto(out *GrpcrouteAbort) {
 	*out = *in
 	if in.HttpStatus != nil {
 		in, out := &in.HttpStatus, &out.HttpStatus
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percentage != nil {
 		in, out := &in.Percentage, &out.Percentage
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -187,7 +187,7 @@ func (in *GrpcrouteDelay) DeepCopyInto(out *GrpcrouteDelay) {
 	}
 	if in.Percentage != nil {
 		in, out := &in.Percentage, &out.Percentage
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -209,7 +209,7 @@ func (in *GrpcrouteDestinations) DeepCopyInto(out *GrpcrouteDestinations) {
 	out.ServiceRef = in.ServiceRef
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -331,7 +331,7 @@ func (in *GrpcrouteRetryPolicy) DeepCopyInto(out *GrpcrouteRetryPolicy) {
 	*out = *in
 	if in.NumRetries != nil {
 		in, out := &in.NumRetries, &out.NumRetries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RetryConditions != nil {
@@ -381,12 +381,12 @@ func (in *HttprouteAbort) DeepCopyInto(out *HttprouteAbort) {
 	*out = *in
 	if in.HttpStatus != nil {
 		in, out := &in.HttpStatus, &out.HttpStatus
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percentage != nil {
 		in, out := &in.Percentage, &out.Percentage
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -536,7 +536,7 @@ func (in *HttprouteDelay) DeepCopyInto(out *HttprouteDelay) {
 	}
 	if in.Percentage != nil {
 		in, out := &in.Percentage, &out.Percentage
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -562,7 +562,7 @@ func (in *HttprouteDestination) DeepCopyInto(out *HttprouteDestination) {
 	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -588,7 +588,7 @@ func (in *HttprouteDestinations) DeepCopyInto(out *HttprouteDestinations) {
 	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -777,12 +777,12 @@ func (in *HttprouteRangeMatch) DeepCopyInto(out *HttprouteRangeMatch) {
 	*out = *in
 	if in.End != nil {
 		in, out := &in.End, &out.End
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Start != nil {
 		in, out := &in.Start, &out.Start
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -818,7 +818,7 @@ func (in *HttprouteRedirect) DeepCopyInto(out *HttprouteRedirect) {
 	}
 	if in.PortRedirect != nil {
 		in, out := &in.PortRedirect, &out.PortRedirect
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrefixRewrite != nil {
@@ -945,7 +945,7 @@ func (in *HttprouteRetryPolicy) DeepCopyInto(out *HttprouteRetryPolicy) {
 	*out = *in
 	if in.NumRetries != nil {
 		in, out := &in.NumRetries, &out.NumRetries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PerTryTimeout != nil {
@@ -1149,7 +1149,7 @@ func (in *NetworkServicesEndpointPolicyStatus) DeepCopyInto(out *NetworkServices
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -1295,7 +1295,7 @@ func (in *NetworkServicesGRPCRouteStatus) DeepCopyInto(out *NetworkServicesGRPCR
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1397,7 +1397,7 @@ func (in *NetworkServicesGatewaySpec) DeepCopyInto(out *NetworkServicesGatewaySp
 	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	out.ProjectRef = in.ProjectRef
@@ -1444,7 +1444,7 @@ func (in *NetworkServicesGatewayStatus) DeepCopyInto(out *NetworkServicesGateway
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1595,7 +1595,7 @@ func (in *NetworkServicesHTTPRouteStatus) DeepCopyInto(out *NetworkServicesHTTPR
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1692,7 +1692,7 @@ func (in *NetworkServicesMeshSpec) DeepCopyInto(out *NetworkServicesMeshSpec) {
 	}
 	if in.InterceptionPort != nil {
 		in, out := &in.InterceptionPort, &out.InterceptionPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -1729,7 +1729,7 @@ func (in *NetworkServicesMeshStatus) DeepCopyInto(out *NetworkServicesMeshStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1875,7 +1875,7 @@ func (in *NetworkServicesTCPRouteStatus) DeepCopyInto(out *NetworkServicesTCPRou
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2021,7 +2021,7 @@ func (in *NetworkServicesTLSRouteStatus) DeepCopyInto(out *NetworkServicesTLSRou
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -2081,7 +2081,7 @@ func (in *TcprouteDestinations) DeepCopyInto(out *TcprouteDestinations) {
 	out.ServiceRef = in.ServiceRef
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2164,7 +2164,7 @@ func (in *TlsrouteDestinations) DeepCopyInto(out *TlsrouteDestinations) {
 	out.ServiceRef = in.ServiceRef
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/notebooks/v1alpha1/notebooksenvironment_types.go
+++ b/pkg/clients/generated/apis/notebooks/v1alpha1/notebooksenvironment_types.go
@@ -101,7 +101,7 @@ type NotebooksEnvironmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/notebooks/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/notebooks/v1alpha1/zz_generated.deepcopy.go
@@ -200,7 +200,7 @@ func (in *NotebooksEnvironmentStatus) DeepCopyInto(out *NotebooksEnvironmentStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/orgpolicy/v1alpha1/orgpolicycustomconstraint_types.go
+++ b/pkg/clients/generated/apis/orgpolicy/v1alpha1/orgpolicycustomconstraint_types.go
@@ -70,7 +70,7 @@ type OrgPolicyCustomConstraintStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The timestamp representing when the constraint was last updated. */
 	// +optional

--- a/pkg/clients/generated/apis/orgpolicy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/orgpolicy/v1alpha1/zz_generated.deepcopy.go
@@ -141,7 +141,7 @@ func (in *OrgPolicyCustomConstraintStatus) DeepCopyInto(out *OrgPolicyCustomCons
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/osconfig/v1alpha1/osconfigpatchdeployment_types.go
+++ b/pkg/clients/generated/apis/osconfig/v1alpha1/osconfigpatchdeployment_types.go
@@ -54,11 +54,11 @@ type PatchdeploymentApt struct {
 type PatchdeploymentDisruptionBudget struct {
 	/* Immutable. Specifies a fixed value. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Immutable. Specifies the relative value defined as a percentage, which will be multiplied by a reference value. */
 	// +optional
-	Percentage *int `json:"percentage,omitempty"`
+	Percentage *int64 `json:"percentage,omitempty"`
 }
 
 type PatchdeploymentGcsObject struct {
@@ -110,7 +110,7 @@ type PatchdeploymentInstanceFilter struct {
 type PatchdeploymentLinuxExecStepConfig struct {
 	/* Immutable. Defaults to [0]. A list of possible return values that the execution can return to indicate a success. */
 	// +optional
-	AllowedSuccessCodes []int `json:"allowedSuccessCodes,omitempty"`
+	AllowedSuccessCodes []int64 `json:"allowedSuccessCodes,omitempty"`
 
 	/* Immutable. A Cloud Storage object containing the executable. */
 	// +optional
@@ -131,7 +131,7 @@ type PatchdeploymentMonthly struct {
 	Months without the target day will be skipped. For example, a schedule to run "every month on the 31st"
 	will not run in February, April, June, etc. */
 	// +optional
-	MonthDay *int `json:"monthDay,omitempty"`
+	MonthDay *int64 `json:"monthDay,omitempty"`
 
 	/* Immutable. Week day in a month. */
 	// +optional
@@ -255,19 +255,19 @@ type PatchdeploymentTimeOfDay struct {
 	/* Immutable. Hours of day in 24 hour format. Should be from 0 to 23.
 	An API may choose to allow the value "24:00:00" for scenarios like business closing time. */
 	// +optional
-	Hours *int `json:"hours,omitempty"`
+	Hours *int64 `json:"hours,omitempty"`
 
 	/* Immutable. Minutes of hour of day. Must be from 0 to 59. */
 	// +optional
-	Minutes *int `json:"minutes,omitempty"`
+	Minutes *int64 `json:"minutes,omitempty"`
 
 	/* Immutable. Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Immutable. Seconds of minutes of the time. Must normally be from 0 to 59. An API may allow the value 60 if it allows leap-seconds. */
 	// +optional
-	Seconds *int `json:"seconds,omitempty"`
+	Seconds *int64 `json:"seconds,omitempty"`
 }
 
 type PatchdeploymentTimeZone struct {
@@ -284,7 +284,7 @@ type PatchdeploymentWeekDayOfMonth struct {
 	DayOfWeek string `json:"dayOfWeek"`
 
 	/* Immutable. Week number in a month. 1-4 indicates the 1st to 4th week of the month. -1 indicates the last week of the month. */
-	WeekOrdinal int `json:"weekOrdinal"`
+	WeekOrdinal int64 `json:"weekOrdinal"`
 }
 
 type PatchdeploymentWeekly struct {
@@ -295,7 +295,7 @@ type PatchdeploymentWeekly struct {
 type PatchdeploymentWindowsExecStepConfig struct {
 	/* Immutable. Defaults to [0]. A list of possible return values that the execution can return to indicate a success. */
 	// +optional
-	AllowedSuccessCodes []int `json:"allowedSuccessCodes,omitempty"`
+	AllowedSuccessCodes []int64 `json:"allowedSuccessCodes,omitempty"`
 
 	/* Immutable. A Cloud Storage object containing the executable. */
 	// +optional
@@ -439,7 +439,7 @@ type OSConfigPatchDeploymentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Time the patch deployment was last updated. Timestamp is in RFC3339 text format.
 	A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z". */

--- a/pkg/clients/generated/apis/osconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/osconfig/v1alpha1/zz_generated.deepcopy.go
@@ -168,7 +168,7 @@ func (in *OSConfigPatchDeploymentStatus) DeepCopyInto(out *OSConfigPatchDeployme
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -225,12 +225,12 @@ func (in *PatchdeploymentDisruptionBudget) DeepCopyInto(out *PatchdeploymentDisr
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percentage != nil {
 		in, out := &in.Percentage, &out.Percentage
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -349,7 +349,7 @@ func (in *PatchdeploymentLinuxExecStepConfig) DeepCopyInto(out *PatchdeploymentL
 	*out = *in
 	if in.AllowedSuccessCodes != nil {
 		in, out := &in.AllowedSuccessCodes, &out.AllowedSuccessCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.GcsObject != nil {
@@ -385,7 +385,7 @@ func (in *PatchdeploymentMonthly) DeepCopyInto(out *PatchdeploymentMonthly) {
 	*out = *in
 	if in.MonthDay != nil {
 		in, out := &in.MonthDay, &out.MonthDay
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.WeekDayOfMonth != nil {
@@ -605,22 +605,22 @@ func (in *PatchdeploymentTimeOfDay) DeepCopyInto(out *PatchdeploymentTimeOfDay) 
 	*out = *in
 	if in.Hours != nil {
 		in, out := &in.Hours, &out.Hours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minutes != nil {
 		in, out := &in.Minutes, &out.Minutes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Seconds != nil {
 		in, out := &in.Seconds, &out.Seconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -694,7 +694,7 @@ func (in *PatchdeploymentWindowsExecStepConfig) DeepCopyInto(out *Patchdeploymen
 	*out = *in
 	if in.AllowedSuccessCodes != nil {
 		in, out := &in.AllowedSuccessCodes, &out.AllowedSuccessCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.GcsObject != nil {

--- a/pkg/clients/generated/apis/osconfig/v1beta1/osconfigguestpolicy_types.go
+++ b/pkg/clients/generated/apis/osconfig/v1beta1/osconfigguestpolicy_types.go
@@ -135,7 +135,7 @@ type GuestpolicyFileCopy struct {
 type GuestpolicyFileExec struct {
 	/* Defaults to [0]. A list of possible return values that the program can return to indicate a success. */
 	// +optional
-	AllowedExitCodes []int `json:"allowedExitCodes,omitempty"`
+	AllowedExitCodes []int64 `json:"allowedExitCodes,omitempty"`
 
 	/* Arguments to be passed to the provided executable. */
 	// +optional
@@ -156,7 +156,7 @@ type GuestpolicyGcs struct {
 
 	/* Must be provided if allow_insecure is false. Generation number of the Google Cloud Storage object. `https://storage.googleapis.com/my-bucket/foo/bar#1234567` this value would be `1234567`. */
 	// +optional
-	Generation *int `json:"generation,omitempty"`
+	Generation *int64 `json:"generation,omitempty"`
 
 	/* Name of the Google Cloud Storage object. As specified [here] (https://cloud.google.com/storage/docs/naming#objectnames) Given an example URL: `https://storage.googleapis.com/my-bucket/foo/bar#1234567` this value would be `foo/bar`. */
 	// +optional
@@ -210,7 +210,7 @@ type GuestpolicyInstallSteps struct {
 type GuestpolicyMsiInstallation struct {
 	/* Return codes that indicate that the software installed or updated successfully. Behaviour defaults to [0] */
 	// +optional
-	AllowedExitCodes []int `json:"allowedExitCodes,omitempty"`
+	AllowedExitCodes []int64 `json:"allowedExitCodes,omitempty"`
 
 	/* Required. The id of the relevant artifact in the recipe. */
 	// +optional
@@ -312,7 +312,7 @@ type GuestpolicyRpmInstallation struct {
 type GuestpolicyScriptRun struct {
 	/* Return codes that indicate that the software installed or updated successfully. Behaviour defaults to [0] */
 	// +optional
-	AllowedExitCodes []int `json:"allowedExitCodes,omitempty"`
+	AllowedExitCodes []int64 `json:"allowedExitCodes,omitempty"`
 
 	/* The script interpreter to use to run the script. If no interpreter is specified the script is executed directly, which likely only succeed for scripts with [shebang lines](https://en.wikipedia.org/wiki/Shebang_(Unix)). Possible values: INTERPRETER_UNSPECIFIED, NONE, SHELL, POWERSHELL */
 	// +optional
@@ -425,7 +425,7 @@ type OSConfigGuestPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Last time this GuestPolicy was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/osconfig/v1beta1/osconfigospolicyassignment_types.go
+++ b/pkg/clients/generated/apis/osconfig/v1beta1/osconfigospolicyassignment_types.go
@@ -65,11 +65,11 @@ type OspolicyassignmentDeb struct {
 type OspolicyassignmentDisruptionBudget struct {
 	/* Specifies a fixed value. */
 	// +optional
-	Fixed *int `json:"fixed,omitempty"`
+	Fixed *int64 `json:"fixed,omitempty"`
 
 	/* Specifies the relative value defined as a percentage, which will be multiplied by a reference value. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 }
 
 type OspolicyassignmentEnforce struct {
@@ -132,7 +132,7 @@ type OspolicyassignmentGcs struct {
 
 	/* Generation number of the Cloud Storage object. */
 	// +optional
-	Generation *int `json:"generation,omitempty"`
+	Generation *int64 `json:"generation,omitempty"`
 
 	/* Required. Name of the Cloud Storage object. */
 	Object string `json:"object"`
@@ -446,7 +446,7 @@ type OSConfigOSPolicyAssignmentStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Indicates that reconciliation is in progress for the revision. This value is `true` when the `rollout_state` is one of: * IN_PROGRESS * CANCELLING */
 	// +optional

--- a/pkg/clients/generated/apis/osconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/osconfig/v1beta1/zz_generated.deepcopy.go
@@ -234,7 +234,7 @@ func (in *GuestpolicyFileExec) DeepCopyInto(out *GuestpolicyFileExec) {
 	*out = *in
 	if in.AllowedExitCodes != nil {
 		in, out := &in.AllowedExitCodes, &out.AllowedExitCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Args != nil {
@@ -275,7 +275,7 @@ func (in *GuestpolicyGcs) DeepCopyInto(out *GuestpolicyGcs) {
 	}
 	if in.Generation != nil {
 		in, out := &in.Generation, &out.Generation
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Object != nil {
@@ -391,7 +391,7 @@ func (in *GuestpolicyMsiInstallation) DeepCopyInto(out *GuestpolicyMsiInstallati
 	*out = *in
 	if in.AllowedExitCodes != nil {
 		in, out := &in.AllowedExitCodes, &out.AllowedExitCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.ArtifactId != nil {
@@ -619,7 +619,7 @@ func (in *GuestpolicyScriptRun) DeepCopyInto(out *GuestpolicyScriptRun) {
 	*out = *in
 	if in.AllowedExitCodes != nil {
 		in, out := &in.AllowedExitCodes, &out.AllowedExitCodes
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	if in.Interpreter != nil {
@@ -881,7 +881,7 @@ func (in *OSConfigGuestPolicyStatus) DeepCopyInto(out *OSConfigGuestPolicyStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -1029,7 +1029,7 @@ func (in *OSConfigOSPolicyAssignmentStatus) DeepCopyInto(out *OSConfigOSPolicyAs
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {
@@ -1123,12 +1123,12 @@ func (in *OspolicyassignmentDisruptionBudget) DeepCopyInto(out *Ospolicyassignme
 	*out = *in
 	if in.Fixed != nil {
 		in, out := &in.Fixed, &out.Fixed
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1266,7 +1266,7 @@ func (in *OspolicyassignmentGcs) DeepCopyInto(out *OspolicyassignmentGcs) {
 	*out = *in
 	if in.Generation != nil {
 		in, out := &in.Generation, &out.Generation
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/oslogin/v1alpha1/osloginsshpublickey_types.go
+++ b/pkg/clients/generated/apis/oslogin/v1alpha1/osloginsshpublickey_types.go
@@ -65,7 +65,7 @@ type OSLoginSSHPublicKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/oslogin/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/oslogin/v1alpha1/zz_generated.deepcopy.go
@@ -136,7 +136,7 @@ func (in *OSLoginSSHPublicKeyStatus) DeepCopyInto(out *OSLoginSSHPublicKeyStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/privateca/v1beta1/privatecacapool_types.go
+++ b/pkg/clients/generated/apis/privateca/v1beta1/privatecacapool_types.go
@@ -37,7 +37,7 @@ import (
 
 type CapoolAdditionalExtensions struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CapoolAllowedIssuanceModes struct {
@@ -127,7 +127,7 @@ type CapoolCaOptions struct {
 
 	/* Optional. Refers to the path length restriction X.509 extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. If this value is missing, the max path length will be omitted from the CA certificate. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 
 	/* Optional. When true, the "path length constraint" in Basic Constraints extension will be set to 0. if both max_issuer_path_length and zero_max_issuer_path_length are unset, the max path length will be omitted from the CA certificate. */
 	// +optional
@@ -238,7 +238,7 @@ type CapoolKeyUsage struct {
 
 type CapoolObjectId struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CapoolPassthroughExtensions struct {
@@ -253,7 +253,7 @@ type CapoolPassthroughExtensions struct {
 
 type CapoolPolicyIds struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CapoolPublishingOptions struct {
@@ -269,16 +269,16 @@ type CapoolPublishingOptions struct {
 type CapoolRsa struct {
 	/* Optional. The maximum allowed RSA modulus size, in bits. If this is not set, or if set to zero, the service will not enforce an explicit upper bound on RSA modulus sizes. */
 	// +optional
-	MaxModulusSize *int `json:"maxModulusSize,omitempty"`
+	MaxModulusSize *int64 `json:"maxModulusSize,omitempty"`
 
 	/* Optional. The minimum allowed RSA modulus size, in bits. If this is not set, or if set to zero, the service-level min RSA modulus size will continue to apply. */
 	// +optional
-	MinModulusSize *int `json:"minModulusSize,omitempty"`
+	MinModulusSize *int64 `json:"minModulusSize,omitempty"`
 }
 
 type CapoolUnknownExtendedKeyUsages struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type PrivateCACAPoolSpec struct {
@@ -310,7 +310,7 @@ type PrivateCACAPoolStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificate_types.go
+++ b/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificate_types.go
@@ -92,7 +92,7 @@ type CertificateCaOptions struct {
 
 	/* Immutable. Optional. Refers to the "path length constraint" in Basic Constraints extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 
 	/* Immutable. Optional. When true, the "CA" in Basic Constraints extension will be set to false. If both `is_ca` and `non_ca` are unset, the extension will be omitted from the CA certificate. */
 	// +optional
@@ -157,12 +157,12 @@ type CertificateKeyUsage struct {
 
 type CertificateObjectId struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificatePolicyIds struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificatePublicKey struct {
@@ -236,7 +236,7 @@ type CertificateSubjectConfig struct {
 
 type CertificateUnknownExtendedKeyUsages struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificateX509Config struct {
@@ -364,7 +364,7 @@ type CertificateCaOptionsStatus struct {
 
 	/* Optional. Refers to the path length restriction X.509 extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. If this value is missing, the max path length will be omitted from the CA certificate. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 }
 
 type CertificateCertFingerprintStatus struct {
@@ -464,13 +464,13 @@ type CertificateKeyUsageStatus struct {
 type CertificateObjectIdStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificatePolicyIdsStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificatePublicKeyStatus struct {
@@ -584,7 +584,7 @@ type CertificateSubjectStatus struct {
 type CertificateUnknownExtendedKeyUsagesStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificateX509DescriptionStatus struct {
@@ -627,7 +627,7 @@ type PrivateCACertificateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The pem-encoded, signed X.509 certificate. */
 	// +optional

--- a/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificateauthority_types.go
+++ b/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificateauthority_types.go
@@ -92,7 +92,7 @@ type CertificateauthorityCaOptions struct {
 
 	/* Immutable. Optional. Refers to the path length restriction X.509 extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. If this value is missing, the max path length will be omitted from the CA certificate. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 
 	/* Immutable. Optional. When true, the "path length constraint" in Basic Constraints extension will be set to 0. if both max_issuer_path_length and zero_max_issuer_path_length are unset, the max path length will be omitted from the CA certificate. */
 	// +optional
@@ -171,12 +171,12 @@ type CertificateauthorityKeyUsage struct {
 
 type CertificateauthorityObjectId struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificateauthorityPolicyIds struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificateauthoritySubject struct {
@@ -246,7 +246,7 @@ type CertificateauthoritySubjectConfig struct {
 
 type CertificateauthorityUnknownExtendedKeyUsages struct {
 	/* Immutable. Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificateauthorityX509Config struct {
@@ -407,7 +407,7 @@ type CertificateauthorityCaOptionsStatus struct {
 
 	/* Optional. Refers to the path length restriction X.509 extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. If this value is missing, the max path length will be omitted from the CA certificate. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 }
 
 type CertificateauthorityCertFingerprintStatus struct {
@@ -482,7 +482,7 @@ type CertificateauthorityKeyUsageStatus struct {
 type CertificateauthorityObjectIdStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificateauthorityPemIssuerChainStatus struct {
@@ -494,7 +494,7 @@ type CertificateauthorityPemIssuerChainStatus struct {
 type CertificateauthorityPolicyIdsStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificateauthorityPublicKeyStatus struct {
@@ -608,7 +608,7 @@ type CertificateauthoritySubordinateConfigStatus struct {
 type CertificateauthorityUnknownExtendedKeyUsagesStatus struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
 	// +optional
-	ObjectIdPath []int `json:"objectIdPath,omitempty"`
+	ObjectIdPath []int64 `json:"objectIdPath,omitempty"`
 }
 
 type CertificateauthorityX509ConfigStatus struct {
@@ -668,7 +668,7 @@ type PrivateCACertificateAuthorityStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. This CertificateAuthority's certificate chain, including the current CertificateAuthority's certificate. Ordered such that the root issuer is the final element (consistent with RFC 5246). For a self-signed CA, this will only list the current CertificateAuthority's certificate. */
 	// +optional

--- a/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificatetemplate_types.go
+++ b/pkg/clients/generated/apis/privateca/v1beta1/privatecacertificatetemplate_types.go
@@ -92,7 +92,7 @@ type CertificatetemplateCaOptions struct {
 
 	/* Optional. Refers to the path length restriction X.509 extension. For a CA certificate, this value describes the depth of subordinate CA certificates that are allowed. If this value is less than 0, the request will fail. If this value is missing, the max path length will be omitted from the CA certificate. */
 	// +optional
-	MaxIssuerPathLength *int `json:"maxIssuerPathLength,omitempty"`
+	MaxIssuerPathLength *int64 `json:"maxIssuerPathLength,omitempty"`
 }
 
 type CertificatetemplateCelExpression struct {
@@ -167,7 +167,7 @@ type CertificatetemplateKeyUsage struct {
 
 type CertificatetemplateObjectId struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificatetemplatePassthroughExtensions struct {
@@ -182,7 +182,7 @@ type CertificatetemplatePassthroughExtensions struct {
 
 type CertificatetemplatePolicyIds struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type CertificatetemplatePredefinedValues struct {
@@ -209,7 +209,7 @@ type CertificatetemplatePredefinedValues struct {
 
 type CertificatetemplateUnknownExtendedKeyUsages struct {
 	/* Required. The parts of an OID path. The most significant parts of the path come first. */
-	ObjectIdPath []int `json:"objectIdPath"`
+	ObjectIdPath []int64 `json:"objectIdPath"`
 }
 
 type PrivateCACertificateTemplateSpec struct {
@@ -250,7 +250,7 @@ type PrivateCACertificateTemplateStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. The time at which this CertificateTemplate was updated. */
 	// +optional

--- a/pkg/clients/generated/apis/privateca/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/privateca/v1beta1/zz_generated.deepcopy.go
@@ -34,7 +34,7 @@ func (in *CapoolAdditionalExtensions) DeepCopyInto(out *CapoolAdditionalExtensio
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -218,7 +218,7 @@ func (in *CapoolCaOptions) DeepCopyInto(out *CapoolCaOptions) {
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ZeroMaxIssuerPathLength != nil {
@@ -449,7 +449,7 @@ func (in *CapoolObjectId) DeepCopyInto(out *CapoolObjectId) {
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -498,7 +498,7 @@ func (in *CapoolPolicyIds) DeepCopyInto(out *CapoolPolicyIds) {
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -545,12 +545,12 @@ func (in *CapoolRsa) DeepCopyInto(out *CapoolRsa) {
 	*out = *in
 	if in.MaxModulusSize != nil {
 		in, out := &in.MaxModulusSize, &out.MaxModulusSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinModulusSize != nil {
 		in, out := &in.MinModulusSize, &out.MinModulusSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -571,7 +571,7 @@ func (in *CapoolUnknownExtendedKeyUsages) DeepCopyInto(out *CapoolUnknownExtende
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -793,7 +793,7 @@ func (in *CertificateCaOptions) DeepCopyInto(out *CertificateCaOptions) {
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NonCa != nil {
@@ -829,7 +829,7 @@ func (in *CertificateCaOptionsStatus) DeepCopyInto(out *CertificateCaOptionsStat
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1139,7 +1139,7 @@ func (in *CertificateObjectId) DeepCopyInto(out *CertificateObjectId) {
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1160,7 +1160,7 @@ func (in *CertificateObjectIdStatus) DeepCopyInto(out *CertificateObjectIdStatus
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1181,7 +1181,7 @@ func (in *CertificatePolicyIds) DeepCopyInto(out *CertificatePolicyIds) {
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1202,7 +1202,7 @@ func (in *CertificatePolicyIdsStatus) DeepCopyInto(out *CertificatePolicyIdsStat
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1571,7 +1571,7 @@ func (in *CertificateUnknownExtendedKeyUsages) DeepCopyInto(out *CertificateUnkn
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1592,7 +1592,7 @@ func (in *CertificateUnknownExtendedKeyUsagesStatus) DeepCopyInto(out *Certifica
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -1986,7 +1986,7 @@ func (in *CertificateauthorityCaOptions) DeepCopyInto(out *CertificateauthorityC
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ZeroMaxIssuerPathLength != nil {
@@ -2017,7 +2017,7 @@ func (in *CertificateauthorityCaOptionsStatus) DeepCopyInto(out *Certificateauth
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -2340,7 +2340,7 @@ func (in *CertificateauthorityObjectId) DeepCopyInto(out *CertificateauthorityOb
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -2361,7 +2361,7 @@ func (in *CertificateauthorityObjectIdStatus) DeepCopyInto(out *Certificateautho
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -2403,7 +2403,7 @@ func (in *CertificateauthorityPolicyIds) DeepCopyInto(out *CertificateauthorityP
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -2424,7 +2424,7 @@ func (in *CertificateauthorityPolicyIdsStatus) DeepCopyInto(out *Certificateauth
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -2784,7 +2784,7 @@ func (in *CertificateauthorityUnknownExtendedKeyUsages) DeepCopyInto(out *Certif
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -2805,7 +2805,7 @@ func (in *CertificateauthorityUnknownExtendedKeyUsagesStatus) DeepCopyInto(out *
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -3020,7 +3020,7 @@ func (in *CertificatetemplateCaOptions) DeepCopyInto(out *CertificatetemplateCaO
 	}
 	if in.MaxIssuerPathLength != nil {
 		in, out := &in.MaxIssuerPathLength, &out.MaxIssuerPathLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3177,7 +3177,7 @@ func (in *CertificatetemplateObjectId) DeepCopyInto(out *CertificatetemplateObje
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -3226,7 +3226,7 @@ func (in *CertificatetemplatePolicyIds) DeepCopyInto(out *CertificatetemplatePol
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -3292,7 +3292,7 @@ func (in *CertificatetemplateUnknownExtendedKeyUsages) DeepCopyInto(out *Certifi
 	*out = *in
 	if in.ObjectIdPath != nil {
 		in, out := &in.ObjectIdPath, &out.ObjectIdPath
-		*out = make([]int, len(*in))
+		*out = make([]int64, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -3411,7 +3411,7 @@ func (in *PrivateCACAPoolStatus) DeepCopyInto(out *PrivateCACAPoolStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -3588,7 +3588,7 @@ func (in *PrivateCACertificateAuthorityStatus) DeepCopyInto(out *PrivateCACertif
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PemCaCertificates != nil {
@@ -3735,7 +3735,7 @@ func (in *PrivateCACertificateStatus) DeepCopyInto(out *PrivateCACertificateStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PemCertificate != nil {
@@ -3889,7 +3889,7 @@ func (in *PrivateCACertificateTemplateStatus) DeepCopyInto(out *PrivateCACertifi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/pubsub/v1beta1/pubsubschema_types.go
+++ b/pkg/clients/generated/apis/pubsub/v1beta1/pubsubschema_types.go
@@ -60,7 +60,7 @@ type PubSubSchemaStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsub/v1beta1/pubsubsubscription_types.go
+++ b/pkg/clients/generated/apis/pubsub/v1beta1/pubsubsubscription_types.go
@@ -79,7 +79,7 @@ type SubscriptionCloudStorageConfig struct {
 	/* The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB.
 	The maxBytes limit may be exceeded in cases where messages are larger than the limit. */
 	// +optional
-	MaxBytes *int `json:"maxBytes,omitempty"`
+	MaxBytes *int64 `json:"maxBytes,omitempty"`
 
 	/* The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes.
 	May not exceed the subscription's acknowledgement deadline.
@@ -109,7 +109,7 @@ type SubscriptionDeadLetterPolicy struct {
 
 	If this parameter is 0, a default value of 5 is used. */
 	// +optional
-	MaxDeliveryAttempts *int `json:"maxDeliveryAttempts,omitempty"`
+	MaxDeliveryAttempts *int64 `json:"maxDeliveryAttempts,omitempty"`
 }
 
 type SubscriptionExpirationPolicy struct {
@@ -220,7 +220,7 @@ type PubSubSubscriptionSpec struct {
 	If the subscriber never acknowledges the message, the Pub/Sub system
 	will eventually redeliver the message. */
 	// +optional
-	AckDeadlineSeconds *int `json:"ackDeadlineSeconds,omitempty"`
+	AckDeadlineSeconds *int64 `json:"ackDeadlineSeconds,omitempty"`
 
 	/* If delivery to BigQuery is used with this subscription, this field is used to configure it.
 	Either pushConfig, bigQueryConfig or cloudStorageConfig can be set, but not combined.
@@ -326,7 +326,7 @@ type PubSubSubscriptionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsub/v1beta1/pubsubtopic_types.go
+++ b/pkg/clients/generated/apis/pubsub/v1beta1/pubsubtopic_types.go
@@ -93,7 +93,7 @@ type PubSubTopicStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsub/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/pubsub/v1beta1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *PubSubSchemaStatus) DeepCopyInto(out *PubSubSchemaStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -214,7 +214,7 @@ func (in *PubSubSubscriptionSpec) DeepCopyInto(out *PubSubSubscriptionSpec) {
 	*out = *in
 	if in.AckDeadlineSeconds != nil {
 		in, out := &in.AckDeadlineSeconds, &out.AckDeadlineSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.BigqueryConfig != nil {
@@ -301,7 +301,7 @@ func (in *PubSubSubscriptionStatus) DeepCopyInto(out *PubSubSubscriptionStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -429,7 +429,7 @@ func (in *PubSubTopicStatus) DeepCopyInto(out *PubSubTopicStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -519,7 +519,7 @@ func (in *SubscriptionCloudStorageConfig) DeepCopyInto(out *SubscriptionCloudSto
 	}
 	if in.MaxBytes != nil {
 		in, out := &in.MaxBytes, &out.MaxBytes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxDuration != nil {
@@ -555,7 +555,7 @@ func (in *SubscriptionDeadLetterPolicy) DeepCopyInto(out *SubscriptionDeadLetter
 	}
 	if in.MaxDeliveryAttempts != nil {
 		in, out := &in.MaxDeliveryAttempts, &out.MaxDeliveryAttempts
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/pubsublite/v1alpha1/pubsublitesubscription_types.go
+++ b/pkg/clients/generated/apis/pubsublite/v1alpha1/pubsublitesubscription_types.go
@@ -69,7 +69,7 @@ type PubSubLiteSubscriptionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsublite/v1alpha1/pubsublitetopic_types.go
+++ b/pkg/clients/generated/apis/pubsublite/v1alpha1/pubsublitetopic_types.go
@@ -37,10 +37,10 @@ import (
 
 type TopicCapacity struct {
 	/* Subscribe throughput capacity per partition in MiB/s. Must be >= 4 and <= 16. */
-	PublishMibPerSec int `json:"publishMibPerSec"`
+	PublishMibPerSec int64 `json:"publishMibPerSec"`
 
 	/* Publish throughput capacity per partition in MiB/s. Must be >= 4 and <= 16. */
-	SubscribeMibPerSec int `json:"subscribeMibPerSec"`
+	SubscribeMibPerSec int64 `json:"subscribeMibPerSec"`
 }
 
 type TopicPartitionConfig struct {
@@ -49,7 +49,7 @@ type TopicPartitionConfig struct {
 	Capacity *TopicCapacity `json:"capacity,omitempty"`
 
 	/* The number of partitions in the topic. Must be at least 1. */
-	Count int `json:"count"`
+	Count int64 `json:"count"`
 }
 
 type TopicReservationConfig struct {
@@ -106,7 +106,7 @@ type PubSubLiteTopicStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsublite/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/pubsublite/v1alpha1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *PubSubLiteSubscriptionStatus) DeepCopyInto(out *PubSubLiteSubscription
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -261,7 +261,7 @@ func (in *PubSubLiteTopicStatus) DeepCopyInto(out *PubSubLiteTopicStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/pubsublite/v1beta1/pubsublitereservation_types.go
+++ b/pkg/clients/generated/apis/pubsublite/v1beta1/pubsublitereservation_types.go
@@ -49,7 +49,7 @@ type PubSubLiteReservationSpec struct {
 	/* The reserved throughput capacity. Every unit of throughput capacity is
 	equivalent to 1 MiB/s of published messages or 2 MiB/s of subscribed
 	messages. */
-	ThroughputCapacity int `json:"throughputCapacity"`
+	ThroughputCapacity int64 `json:"throughputCapacity"`
 }
 
 type PubSubLiteReservationStatus struct {
@@ -58,7 +58,7 @@ type PubSubLiteReservationStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/pubsublite/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/pubsublite/v1beta1/zz_generated.deepcopy.go
@@ -122,7 +122,7 @@ func (in *PubSubLiteReservationStatus) DeepCopyInto(out *PubSubLiteReservationSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/recaptchaenterprise/v1beta1/recaptchaenterprisekey_types.go
+++ b/pkg/clients/generated/apis/recaptchaenterprise/v1beta1/recaptchaenterprisekey_types.go
@@ -136,7 +136,7 @@ type RecaptchaEnterpriseKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/recaptchaenterprise/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/recaptchaenterprise/v1beta1/zz_generated.deepcopy.go
@@ -282,7 +282,7 @@ func (in *RecaptchaEnterpriseKeyStatus) DeepCopyInto(out *RecaptchaEnterpriseKey
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/redis/v1beta1/redisinstance_types.go
+++ b/pkg/clients/generated/apis/redis/v1beta1/redisinstance_types.go
@@ -120,20 +120,20 @@ type InstanceStartTime struct {
 	/* Hours of day in 24 hour format. Should be from 0 to 23.
 	An API may choose to allow the value "24:00:00" for scenarios like business closing time. */
 	// +optional
-	Hours *int `json:"hours,omitempty"`
+	Hours *int64 `json:"hours,omitempty"`
 
 	/* Minutes of hour of day. Must be from 0 to 59. */
 	// +optional
-	Minutes *int `json:"minutes,omitempty"`
+	Minutes *int64 `json:"minutes,omitempty"`
 
 	/* Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999. */
 	// +optional
-	Nanos *int `json:"nanos,omitempty"`
+	Nanos *int64 `json:"nanos,omitempty"`
 
 	/* Seconds of minutes of the time. Must normally be from 0 to 59.
 	An API may allow the value 60 if it allows leap-seconds. */
 	// +optional
-	Seconds *int `json:"seconds,omitempty"`
+	Seconds *int64 `json:"seconds,omitempty"`
 }
 
 type InstanceWeeklyMaintenanceWindow struct {
@@ -214,7 +214,7 @@ type RedisInstanceSpec struct {
 	MaintenanceSchedule []InstanceMaintenanceSchedule `json:"maintenanceSchedule,omitempty"`
 
 	/* Redis memory size in GiB. */
-	MemorySizeGb int `json:"memorySizeGb"`
+	MemorySizeGb int64 `json:"memorySizeGb"`
 
 	/* Persistence configuration for an instance. */
 	// +optional
@@ -249,7 +249,7 @@ type RedisInstanceSpec struct {
 	for a Standard Tier instance, the only valid value is 1 and the default is 1.
 	The valid value for basic tier is 0 and the default is also 0. */
 	// +optional
-	ReplicaCount *int `json:"replicaCount,omitempty"`
+	ReplicaCount *int64 `json:"replicaCount,omitempty"`
 
 	/* Immutable. The CIDR range of internal addresses that are reserved for this
 	instance. If not provided, the service will choose an unused /29
@@ -375,7 +375,7 @@ type RedisInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional
@@ -390,7 +390,7 @@ type RedisInstanceStatus struct {
 
 	/* The port number of the exposed Redis endpoint. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Output only. Hostname or IP address of the exposed readonly Redis endpoint. Standard tier only.
 	Targets all healthy replica nodes in instance. Replication is asynchronous and replica nodes
@@ -401,7 +401,7 @@ type RedisInstanceStatus struct {
 	/* Output only. The port number of the exposed readonly redis endpoint. Standard tier only.
 	Write requests should target 'port'. */
 	// +optional
-	ReadEndpointPort *int `json:"readEndpointPort,omitempty"`
+	ReadEndpointPort *int64 `json:"readEndpointPort,omitempty"`
 
 	/* List of server CA certificates for the instance. */
 	// +optional

--- a/pkg/clients/generated/apis/redis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/redis/v1beta1/zz_generated.deepcopy.go
@@ -258,22 +258,22 @@ func (in *InstanceStartTime) DeepCopyInto(out *InstanceStartTime) {
 	*out = *in
 	if in.Hours != nil {
 		in, out := &in.Hours, &out.Hours
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minutes != nil {
 		in, out := &in.Minutes, &out.Minutes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Nanos != nil {
 		in, out := &in.Nanos, &out.Nanos
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Seconds != nil {
 		in, out := &in.Seconds, &out.Seconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -451,7 +451,7 @@ func (in *RedisInstanceSpec) DeepCopyInto(out *RedisInstanceSpec) {
 	}
 	if in.ReplicaCount != nil {
 		in, out := &in.ReplicaCount, &out.ReplicaCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ReservedIpRange != nil {
@@ -531,7 +531,7 @@ func (in *RedisInstanceStatus) DeepCopyInto(out *RedisInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -546,7 +546,7 @@ func (in *RedisInstanceStatus) DeepCopyInto(out *RedisInstanceStatus) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ReadEndpoint != nil {
@@ -556,7 +556,7 @@ func (in *RedisInstanceStatus) DeepCopyInto(out *RedisInstanceStatus) {
 	}
 	if in.ReadEndpointPort != nil {
 		in, out := &in.ReadEndpointPort, &out.ReadEndpointPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServerCaCerts != nil {

--- a/pkg/clients/generated/apis/resourcemanager/v1beta1/folder_types.go
+++ b/pkg/clients/generated/apis/resourcemanager/v1beta1/folder_types.go
@@ -79,7 +79,7 @@ type FolderStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/resourcemanager/v1beta1/project_types.go
+++ b/pkg/clients/generated/apis/resourcemanager/v1beta1/project_types.go
@@ -70,7 +70,7 @@ type ProjectStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/resourcemanager/v1beta1/resourcemanagerlien_types.go
+++ b/pkg/clients/generated/apis/resourcemanager/v1beta1/resourcemanagerlien_types.go
@@ -78,7 +78,7 @@ type ResourceManagerLienStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/resourcemanager/v1beta1/resourcemanagerpolicy_types.go
+++ b/pkg/clients/generated/apis/resourcemanager/v1beta1/resourcemanagerpolicy_types.go
@@ -116,7 +116,7 @@ type ResourceManagerPolicySpec struct {
 
 	/* Version of the Policy. Default version is 0. */
 	// +optional
-	Version *int `json:"version,omitempty"`
+	Version *int64 `json:"version,omitempty"`
 }
 
 type ResourceManagerPolicyStatus struct {
@@ -129,7 +129,7 @@ type ResourceManagerPolicyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds, representing when the variable was last updated. Example: "2016-10-09T12:33:37.578138407Z". */
 	// +optional

--- a/pkg/clients/generated/apis/resourcemanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/resourcemanager/v1beta1/zz_generated.deepcopy.go
@@ -151,7 +151,7 @@ func (in *FolderStatus) DeepCopyInto(out *FolderStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -420,7 +420,7 @@ func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -544,7 +544,7 @@ func (in *ResourceManagerLienStatus) DeepCopyInto(out *ResourceManagerLienStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -656,7 +656,7 @@ func (in *ResourceManagerPolicySpec) DeepCopyInto(out *ResourceManagerPolicySpec
 	}
 	if in.Version != nil {
 		in, out := &in.Version, &out.Version
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -687,7 +687,7 @@ func (in *ResourceManagerPolicyStatus) DeepCopyInto(out *ResourceManagerPolicySt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/run/v1beta1/runjob_types.go
+++ b/pkg/clients/generated/apis/run/v1beta1/runjob_types.go
@@ -139,7 +139,7 @@ type JobHttpHeaders struct {
 type JobItems struct {
 	/* Integer octal mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used. */
 	// +optional
-	Mode *int `json:"mode,omitempty"`
+	Mode *int64 `json:"mode,omitempty"`
 
 	/* The relative path of the secret in the container. */
 	Path string `json:"path"`
@@ -151,7 +151,7 @@ type JobItems struct {
 type JobLivenessProbe struct {
 	/* Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. */
 	// +optional
-	FailureThreshold *int `json:"failureThreshold,omitempty"`
+	FailureThreshold *int64 `json:"failureThreshold,omitempty"`
 
 	/* HTTPGet specifies the http request to perform. Exactly one of HTTPGet or TCPSocket must be specified. */
 	// +optional
@@ -159,11 +159,11 @@ type JobLivenessProbe struct {
 
 	/* Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	InitialDelaySeconds *int `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds *int64 `json:"initialDelaySeconds,omitempty"`
 
 	/* How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeoutSeconds. */
 	// +optional
-	PeriodSeconds *int `json:"periodSeconds,omitempty"`
+	PeriodSeconds *int64 `json:"periodSeconds,omitempty"`
 
 	/* TCPSocket specifies an action involving a TCP port. Exactly one of HTTPGet or TCPSocket must be specified. */
 	// +optional
@@ -171,7 +171,7 @@ type JobLivenessProbe struct {
 
 	/* Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than periodSeconds. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	TimeoutSeconds *int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 type JobNetworkInterfaces struct {
@@ -195,7 +195,7 @@ type JobNetworkInterfaces struct {
 type JobPorts struct {
 	/* Port number the container listens on. This must be a valid TCP port number, 0 < containerPort < 65536. */
 	// +optional
-	ContainerPort *int `json:"containerPort,omitempty"`
+	ContainerPort *int64 `json:"containerPort,omitempty"`
 
 	/* If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c". */
 	// +optional
@@ -211,7 +211,7 @@ type JobResources struct {
 type JobSecret struct {
 	/* Integer representation of mode bits to use on created files by default. Must be a value between 0000 and 0777 (octal), defaulting to 0444. Directories within the path are not affected by this setting. */
 	// +optional
-	DefaultMode *int `json:"defaultMode,omitempty"`
+	DefaultMode *int64 `json:"defaultMode,omitempty"`
 
 	/* If unspecified, the volume will expose a file whose name is the secret, relative to VolumeMount.mount_path. If specified, the key will be used as the version to fetch from Cloud Secret Manager and the path will be the name of the file exposed in the volume. When items are defined, they must specify a path and a version. */
 	// +optional
@@ -232,7 +232,7 @@ type JobSecretKeyRef struct {
 type JobStartupProbe struct {
 	/* Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. */
 	// +optional
-	FailureThreshold *int `json:"failureThreshold,omitempty"`
+	FailureThreshold *int64 `json:"failureThreshold,omitempty"`
 
 	/* HTTPGet specifies the http request to perform. Exactly one of HTTPGet or TCPSocket must be specified. */
 	// +optional
@@ -240,11 +240,11 @@ type JobStartupProbe struct {
 
 	/* Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	InitialDelaySeconds *int `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds *int64 `json:"initialDelaySeconds,omitempty"`
 
 	/* How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeoutSeconds. */
 	// +optional
-	PeriodSeconds *int `json:"periodSeconds,omitempty"`
+	PeriodSeconds *int64 `json:"periodSeconds,omitempty"`
 
 	/* TCPSocket specifies an action involving a TCP port. Exactly one of HTTPGet or TCPSocket must be specified. */
 	// +optional
@@ -252,13 +252,13 @@ type JobStartupProbe struct {
 
 	/* Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than periodSeconds. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	TimeoutSeconds *int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 type JobTcpSocket struct {
 	/* Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to 8080. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 }
 
 type JobTemplate struct {
@@ -276,7 +276,7 @@ type JobTemplate struct {
 
 	/* Number of retries allowed per Task, before marking this Task failed. */
 	// +optional
-	MaxRetries *int `json:"maxRetries,omitempty"`
+	MaxRetries *int64 `json:"maxRetries,omitempty"`
 
 	/* Email address of the IAM service account associated with the revision of the service. The service account represents the identity of the running revision, and determines what permissions the revision has. If not provided, the revision will use the project's default service account. */
 	// +optional
@@ -457,7 +457,7 @@ type RunJobStatus struct {
 
 	/* Number of executions created for this job. */
 	// +optional
-	ExecutionCount *int `json:"executionCount,omitempty"`
+	ExecutionCount *int64 `json:"executionCount,omitempty"`
 
 	/* For a deleted resource, the time after which it will be permamently deleted. */
 	// +optional
@@ -473,7 +473,7 @@ type RunJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Returns true if the Job is currently being acted upon by the system to bring it into the desired state.
 

--- a/pkg/clients/generated/apis/run/v1beta1/runservice_types.go
+++ b/pkg/clients/generated/apis/run/v1beta1/runservice_types.go
@@ -128,7 +128,7 @@ type ServiceGrpc struct {
 	/* Port number to access on the container. Number must be in the range 1 to 65535.
 	If not specified, defaults to the same value as container.ports[0].containerPort. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* The name of the service to place in the gRPC HealthCheckRequest
 	(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
@@ -149,7 +149,7 @@ type ServiceHttpGet struct {
 	/* Port number to access on the container. Must be in the range 1 to 65535.
 	If not specified, defaults to the same value as container.ports[0].containerPort. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 }
 
 type ServiceHttpHeaders struct {
@@ -164,7 +164,7 @@ type ServiceHttpHeaders struct {
 type ServiceItems struct {
 	/* Integer octal mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used. */
 	// +optional
-	Mode *int `json:"mode,omitempty"`
+	Mode *int64 `json:"mode,omitempty"`
 
 	/* The relative path of the secret in the container. */
 	Path string `json:"path"`
@@ -177,7 +177,7 @@ type ServiceItems struct {
 type ServiceLivenessProbe struct {
 	/* Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. */
 	// +optional
-	FailureThreshold *int `json:"failureThreshold,omitempty"`
+	FailureThreshold *int64 `json:"failureThreshold,omitempty"`
 
 	/* GRPC specifies an action involving a GRPC port. */
 	// +optional
@@ -189,15 +189,15 @@ type ServiceLivenessProbe struct {
 
 	/* Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	InitialDelaySeconds *int `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds *int64 `json:"initialDelaySeconds,omitempty"`
 
 	/* How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeoutSeconds. */
 	// +optional
-	PeriodSeconds *int `json:"periodSeconds,omitempty"`
+	PeriodSeconds *int64 `json:"periodSeconds,omitempty"`
 
 	/* Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than periodSeconds. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	TimeoutSeconds *int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 type ServiceNetworkInterfaces struct {
@@ -221,7 +221,7 @@ type ServiceNetworkInterfaces struct {
 type ServicePorts struct {
 	/* Port number the container listens on. This must be a valid TCP port number, 0 < containerPort < 65536. */
 	// +optional
-	ContainerPort *int `json:"containerPort,omitempty"`
+	ContainerPort *int64 `json:"containerPort,omitempty"`
 
 	/* If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c". */
 	// +optional
@@ -245,17 +245,17 @@ type ServiceResources struct {
 type ServiceScaling struct {
 	/* Maximum number of serving instances that this resource should have. */
 	// +optional
-	MaxInstanceCount *int `json:"maxInstanceCount,omitempty"`
+	MaxInstanceCount *int64 `json:"maxInstanceCount,omitempty"`
 
 	/* Minimum number of serving instances that this resource should have. */
 	// +optional
-	MinInstanceCount *int `json:"minInstanceCount,omitempty"`
+	MinInstanceCount *int64 `json:"minInstanceCount,omitempty"`
 }
 
 type ServiceSecret struct {
 	/* Integer representation of mode bits to use on created files by default. Must be a value between 0000 and 0777 (octal), defaulting to 0444. Directories within the path are not affected by this setting. */
 	// +optional
-	DefaultMode *int `json:"defaultMode,omitempty"`
+	DefaultMode *int64 `json:"defaultMode,omitempty"`
 
 	/* If unspecified, the volume will expose a file whose name is the secret, relative to VolumeMount.mount_path. If specified, the key will be used as the version to fetch from Cloud Secret Manager and the path will be the name of the file exposed in the volume. When items are defined, they must specify a path and a version. */
 	// +optional
@@ -277,7 +277,7 @@ type ServiceSecretKeyRef struct {
 type ServiceStartupProbe struct {
 	/* Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. */
 	// +optional
-	FailureThreshold *int `json:"failureThreshold,omitempty"`
+	FailureThreshold *int64 `json:"failureThreshold,omitempty"`
 
 	/* GRPC specifies an action involving a GRPC port. */
 	// +optional
@@ -289,11 +289,11 @@ type ServiceStartupProbe struct {
 
 	/* Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	InitialDelaySeconds *int `json:"initialDelaySeconds,omitempty"`
+	InitialDelaySeconds *int64 `json:"initialDelaySeconds,omitempty"`
 
 	/* How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeoutSeconds. */
 	// +optional
-	PeriodSeconds *int `json:"periodSeconds,omitempty"`
+	PeriodSeconds *int64 `json:"periodSeconds,omitempty"`
 
 	/* TCPSocket specifies an action involving a TCP port. Exactly one of HTTPGet or TCPSocket must be specified. */
 	// +optional
@@ -301,14 +301,14 @@ type ServiceStartupProbe struct {
 
 	/* Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than periodSeconds. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes. */
 	// +optional
-	TimeoutSeconds *int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }
 
 type ServiceTcpSocket struct {
 	/* Port number to access on the container. Must be in the range 1 to 65535.
 	If not specified, defaults to the same value as container.ports[0].containerPort. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 }
 
 type ServiceTemplate struct {
@@ -343,7 +343,7 @@ type ServiceTemplate struct {
 
 	/* Sets the maximum number of requests that each serving instance can receive. */
 	// +optional
-	MaxInstanceRequestConcurrency *int `json:"maxInstanceRequestConcurrency,omitempty"`
+	MaxInstanceRequestConcurrency *int64 `json:"maxInstanceRequestConcurrency,omitempty"`
 
 	/* The unique name for the revision. If this field is omitted, it will be automatically generated based on the Service name. */
 	// +optional
@@ -379,7 +379,7 @@ type ServiceTemplate struct {
 type ServiceTraffic struct {
 	/* Specifies percent of the traffic to this Revision. This defaults to zero if unspecified. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 
 	/* Revision to which to send this portion of traffic, if traffic allocation is by revision. */
 	// +optional
@@ -532,7 +532,7 @@ type ServiceTerminalConditionStatus struct {
 type ServiceTrafficStatusesStatus struct {
 	/* Specifies percent of the traffic to this Revision. */
 	// +optional
-	Percent *int `json:"percent,omitempty"`
+	Percent *int64 `json:"percent,omitempty"`
 
 	/* Revision to which this traffic is sent. */
 	// +optional
@@ -589,7 +589,7 @@ type RunServiceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Returns true if the Service is currently being acted upon by the system to bring it into the desired state.
 

--- a/pkg/clients/generated/apis/run/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/run/v1beta1/zz_generated.deepcopy.go
@@ -231,7 +231,7 @@ func (in *JobItems) DeepCopyInto(out *JobItems) {
 	*out = *in
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.VersionRef = in.VersionRef
@@ -284,7 +284,7 @@ func (in *JobLivenessProbe) DeepCopyInto(out *JobLivenessProbe) {
 	*out = *in
 	if in.FailureThreshold != nil {
 		in, out := &in.FailureThreshold, &out.FailureThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.HttpGet != nil {
@@ -294,12 +294,12 @@ func (in *JobLivenessProbe) DeepCopyInto(out *JobLivenessProbe) {
 	}
 	if in.InitialDelaySeconds != nil {
 		in, out := &in.InitialDelaySeconds, &out.InitialDelaySeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PeriodSeconds != nil {
 		in, out := &in.PeriodSeconds, &out.PeriodSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TcpSocket != nil {
@@ -309,7 +309,7 @@ func (in *JobLivenessProbe) DeepCopyInto(out *JobLivenessProbe) {
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -361,7 +361,7 @@ func (in *JobPorts) DeepCopyInto(out *JobPorts) {
 	*out = *in
 	if in.ContainerPort != nil {
 		in, out := &in.ContainerPort, &out.ContainerPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Name != nil {
@@ -410,7 +410,7 @@ func (in *JobSecret) DeepCopyInto(out *JobSecret) {
 	*out = *in
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Items != nil {
@@ -457,7 +457,7 @@ func (in *JobStartupProbe) DeepCopyInto(out *JobStartupProbe) {
 	*out = *in
 	if in.FailureThreshold != nil {
 		in, out := &in.FailureThreshold, &out.FailureThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.HttpGet != nil {
@@ -467,12 +467,12 @@ func (in *JobStartupProbe) DeepCopyInto(out *JobStartupProbe) {
 	}
 	if in.InitialDelaySeconds != nil {
 		in, out := &in.InitialDelaySeconds, &out.InitialDelaySeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PeriodSeconds != nil {
 		in, out := &in.PeriodSeconds, &out.PeriodSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TcpSocket != nil {
@@ -482,7 +482,7 @@ func (in *JobStartupProbe) DeepCopyInto(out *JobStartupProbe) {
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -503,7 +503,7 @@ func (in *JobTcpSocket) DeepCopyInto(out *JobTcpSocket) {
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -541,7 +541,7 @@ func (in *JobTemplate) DeepCopyInto(out *JobTemplate) {
 	}
 	if in.MaxRetries != nil {
 		in, out := &in.MaxRetries, &out.MaxRetries
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServiceAccountRef != nil {
@@ -872,7 +872,7 @@ func (in *RunJobStatus) DeepCopyInto(out *RunJobStatus) {
 	}
 	if in.ExecutionCount != nil {
 		in, out := &in.ExecutionCount, &out.ExecutionCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ExpireTime != nil {
@@ -894,7 +894,7 @@ func (in *RunJobStatus) DeepCopyInto(out *RunJobStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {
@@ -1115,7 +1115,7 @@ func (in *RunServiceStatus) DeepCopyInto(out *RunServiceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Reconciling != nil {
@@ -1342,7 +1342,7 @@ func (in *ServiceGrpc) DeepCopyInto(out *ServiceGrpc) {
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Service != nil {
@@ -1380,7 +1380,7 @@ func (in *ServiceHttpGet) DeepCopyInto(out *ServiceHttpGet) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1422,7 +1422,7 @@ func (in *ServiceItems) DeepCopyInto(out *ServiceItems) {
 	*out = *in
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VersionRef != nil {
@@ -1448,7 +1448,7 @@ func (in *ServiceLivenessProbe) DeepCopyInto(out *ServiceLivenessProbe) {
 	*out = *in
 	if in.FailureThreshold != nil {
 		in, out := &in.FailureThreshold, &out.FailureThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Grpc != nil {
@@ -1463,17 +1463,17 @@ func (in *ServiceLivenessProbe) DeepCopyInto(out *ServiceLivenessProbe) {
 	}
 	if in.InitialDelaySeconds != nil {
 		in, out := &in.InitialDelaySeconds, &out.InitialDelaySeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PeriodSeconds != nil {
 		in, out := &in.PeriodSeconds, &out.PeriodSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1525,7 +1525,7 @@ func (in *ServicePorts) DeepCopyInto(out *ServicePorts) {
 	*out = *in
 	if in.ContainerPort != nil {
 		in, out := &in.ContainerPort, &out.ContainerPort
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Name != nil {
@@ -1584,12 +1584,12 @@ func (in *ServiceScaling) DeepCopyInto(out *ServiceScaling) {
 	*out = *in
 	if in.MaxInstanceCount != nil {
 		in, out := &in.MaxInstanceCount, &out.MaxInstanceCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinInstanceCount != nil {
 		in, out := &in.MinInstanceCount, &out.MinInstanceCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1610,7 +1610,7 @@ func (in *ServiceSecret) DeepCopyInto(out *ServiceSecret) {
 	*out = *in
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Items != nil {
@@ -1661,7 +1661,7 @@ func (in *ServiceStartupProbe) DeepCopyInto(out *ServiceStartupProbe) {
 	*out = *in
 	if in.FailureThreshold != nil {
 		in, out := &in.FailureThreshold, &out.FailureThreshold
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Grpc != nil {
@@ -1676,12 +1676,12 @@ func (in *ServiceStartupProbe) DeepCopyInto(out *ServiceStartupProbe) {
 	}
 	if in.InitialDelaySeconds != nil {
 		in, out := &in.InitialDelaySeconds, &out.InitialDelaySeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PeriodSeconds != nil {
 		in, out := &in.PeriodSeconds, &out.PeriodSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.TcpSocket != nil {
@@ -1691,7 +1691,7 @@ func (in *ServiceStartupProbe) DeepCopyInto(out *ServiceStartupProbe) {
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1712,7 +1712,7 @@ func (in *ServiceTcpSocket) DeepCopyInto(out *ServiceTcpSocket) {
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -1764,7 +1764,7 @@ func (in *ServiceTemplate) DeepCopyInto(out *ServiceTemplate) {
 	}
 	if in.MaxInstanceRequestConcurrency != nil {
 		in, out := &in.MaxInstanceRequestConcurrency, &out.MaxInstanceRequestConcurrency
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Revision != nil {
@@ -1873,7 +1873,7 @@ func (in *ServiceTraffic) DeepCopyInto(out *ServiceTraffic) {
 	*out = *in
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Revision != nil {
@@ -1909,7 +1909,7 @@ func (in *ServiceTrafficStatusesStatus) DeepCopyInto(out *ServiceTrafficStatuses
 	*out = *in
 	if in.Percent != nil {
 		in, out := &in.Percent, &out.Percent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Revision != nil {

--- a/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecret_types.go
+++ b/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecret_types.go
@@ -167,7 +167,7 @@ type SecretManagerSecretStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecretversion_types.go
+++ b/pkg/clients/generated/apis/secretmanager/v1beta1/secretmanagersecretversion_types.go
@@ -99,7 +99,7 @@ type SecretManagerSecretVersionStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The version of the Secret. */
 	// +optional

--- a/pkg/clients/generated/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
@@ -204,7 +204,7 @@ func (in *SecretManagerSecretStatus) DeepCopyInto(out *SecretManagerSecretStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -344,7 +344,7 @@ func (in *SecretManagerSecretVersionStatus) DeepCopyInto(out *SecretManagerSecre
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Version != nil {

--- a/pkg/clients/generated/apis/securitycenter/v1alpha1/securitycenternotificationconfig_types.go
+++ b/pkg/clients/generated/apis/securitycenter/v1alpha1/securitycenternotificationconfig_types.go
@@ -98,7 +98,7 @@ type SecurityCenterNotificationConfigStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The service account that needs "pubsub.topics.publish" permission to
 	publish to the Pub/Sub topic. */

--- a/pkg/clients/generated/apis/securitycenter/v1alpha1/securitycentersource_types.go
+++ b/pkg/clients/generated/apis/securitycenter/v1alpha1/securitycentersource_types.go
@@ -66,7 +66,7 @@ type SecurityCenterSourceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/securitycenter/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/securitycenter/v1alpha1/zz_generated.deepcopy.go
@@ -149,7 +149,7 @@ func (in *SecurityCenterNotificationConfigStatus) DeepCopyInto(out *SecurityCent
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServiceAccount != nil {
@@ -273,7 +273,7 @@ func (in *SecurityCenterSourceStatus) DeepCopyInto(out *SecurityCenterSourceStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectoryendpoint_types.go
+++ b/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectoryendpoint_types.go
@@ -53,7 +53,7 @@ type ServiceDirectoryEndpointSpec struct {
 	/* Port that the endpoint is running on, must be in the
 	range of [0, 65535]. If unspecified, the default is 0. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 
 	/* Immutable. Optional. The endpointId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
@@ -74,7 +74,7 @@ type ServiceDirectoryEndpointStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectorynamespace_types.go
+++ b/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectorynamespace_types.go
@@ -60,7 +60,7 @@ type ServiceDirectoryNamespaceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectoryservice_types.go
+++ b/pkg/clients/generated/apis/servicedirectory/v1beta1/servicedirectoryservice_types.go
@@ -55,7 +55,7 @@ type ServiceDirectoryServiceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/servicedirectory/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/servicedirectory/v1beta1/zz_generated.deepcopy.go
@@ -105,7 +105,7 @@ func (in *ServiceDirectoryEndpointSpec) DeepCopyInto(out *ServiceDirectoryEndpoi
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -142,7 +142,7 @@ func (in *ServiceDirectoryEndpointStatus) DeepCopyInto(out *ServiceDirectoryEndp
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -256,7 +256,7 @@ func (in *ServiceDirectoryNamespaceStatus) DeepCopyInto(out *ServiceDirectoryNam
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -370,7 +370,7 @@ func (in *ServiceDirectoryServiceStatus) DeepCopyInto(out *ServiceDirectoryServi
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/servicenetworking/v1beta1/servicenetworkingconnection_types.go
+++ b/pkg/clients/generated/apis/servicenetworking/v1beta1/servicenetworkingconnection_types.go
@@ -50,7 +50,7 @@ type ServiceNetworkingConnectionStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	Peering *string `json:"peering,omitempty"`

--- a/pkg/clients/generated/apis/servicenetworking/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/servicenetworking/v1beta1/zz_generated.deepcopy.go
@@ -122,7 +122,7 @@ func (in *ServiceNetworkingConnectionStatus) DeepCopyInto(out *ServiceNetworking
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Peering != nil {

--- a/pkg/clients/generated/apis/serviceusage/v1alpha1/serviceusageconsumerquotaoverride_types.go
+++ b/pkg/clients/generated/apis/serviceusage/v1alpha1/serviceusageconsumerquotaoverride_types.go
@@ -78,7 +78,7 @@ type ServiceUsageConsumerQuotaOverrideStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/serviceusage/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/serviceusage/v1alpha1/zz_generated.deepcopy.go
@@ -139,7 +139,7 @@ func (in *ServiceUsageConsumerQuotaOverrideStatus) DeepCopyInto(out *ServiceUsag
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/serviceusage/v1beta1/service_types.go
+++ b/pkg/clients/generated/apis/serviceusage/v1beta1/service_types.go
@@ -51,7 +51,7 @@ type ServiceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/serviceusage/v1beta1/serviceidentity_types.go
+++ b/pkg/clients/generated/apis/serviceusage/v1beta1/serviceidentity_types.go
@@ -53,7 +53,7 @@ type ServiceIdentityStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/serviceusage/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/serviceusage/v1beta1/zz_generated.deepcopy.go
@@ -155,7 +155,7 @@ func (in *ServiceIdentityStatus) DeepCopyInto(out *ServiceIdentityStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -240,7 +240,7 @@ func (in *ServiceStatus) DeepCopyInto(out *ServiceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/sourcerepo/v1beta1/sourcereporepository_types.go
+++ b/pkg/clients/generated/apis/sourcerepo/v1beta1/sourcereporepository_types.go
@@ -70,11 +70,11 @@ type SourceRepoRepositoryStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The disk usage of the repo, in bytes. */
 	// +optional
-	Size *int `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	/* URL to clone the repository from Google Cloud Source Repositories. */
 	// +optional

--- a/pkg/clients/generated/apis/sourcerepo/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/sourcerepo/v1beta1/zz_generated.deepcopy.go
@@ -150,12 +150,12 @@ func (in *SourceRepoRepositoryStatus) DeepCopyInto(out *SourceRepoRepositoryStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Size != nil {
 		in, out := &in.Size, &out.Size
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Url != nil {

--- a/pkg/clients/generated/apis/spanner/v1beta1/spannerdatabase_types.go
+++ b/pkg/clients/generated/apis/spanner/v1beta1/spannerdatabase_types.go
@@ -83,7 +83,7 @@ type SpannerDatabaseStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* An explanation of the status of the database. */
 	// +optional

--- a/pkg/clients/generated/apis/spanner/v1beta1/spannerinstance_types.go
+++ b/pkg/clients/generated/apis/spanner/v1beta1/spannerinstance_types.go
@@ -49,10 +49,10 @@ type SpannerInstanceSpec struct {
 	DisplayName string `json:"displayName"`
 
 	// +optional
-	NumNodes *int `json:"numNodes,omitempty"`
+	NumNodes *int64 `json:"numNodes,omitempty"`
 
 	// +optional
-	ProcessingUnits *int `json:"processingUnits,omitempty"`
+	ProcessingUnits *int64 `json:"processingUnits,omitempty"`
 
 	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
@@ -65,7 +65,7 @@ type SpannerInstanceStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Instance status: 'CREATING' or 'READY'. */
 	// +optional

--- a/pkg/clients/generated/apis/spanner/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/spanner/v1beta1/zz_generated.deepcopy.go
@@ -164,7 +164,7 @@ func (in *SpannerDatabaseStatus) DeepCopyInto(out *SpannerDatabaseStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -251,12 +251,12 @@ func (in *SpannerInstanceSpec) DeepCopyInto(out *SpannerInstanceSpec) {
 	*out = *in
 	if in.NumNodes != nil {
 		in, out := &in.NumNodes, &out.NumNodes
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProcessingUnits != nil {
 		in, out := &in.ProcessingUnits, &out.ProcessingUnits
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -287,7 +287,7 @@ func (in *SpannerInstanceStatus) DeepCopyInto(out *SpannerInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/sql/v1beta1/sqldatabase_types.go
+++ b/pkg/clients/generated/apis/sql/v1beta1/sqldatabase_types.go
@@ -73,7 +73,7 @@ type SQLDatabaseStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SelfLink *string `json:"selfLink,omitempty"`

--- a/pkg/clients/generated/apis/sql/v1beta1/sqlinstance_types.go
+++ b/pkg/clients/generated/apis/sql/v1beta1/sqlinstance_types.go
@@ -43,7 +43,7 @@ type InstanceActiveDirectoryConfig struct {
 type InstanceAdvancedMachineFeatures struct {
 	/* The number of threads per physical core. Can be 1 or 2. */
 	// +optional
-	ThreadsPerCore *int `json:"threadsPerCore,omitempty"`
+	ThreadsPerCore *int64 `json:"threadsPerCore,omitempty"`
 }
 
 type InstanceAuthorizedNetworks struct {
@@ -82,12 +82,12 @@ type InstanceBackupConfiguration struct {
 
 	/* The number of days of transaction logs we retain for point in time restore, from 1-7. (For PostgreSQL Enterprise Plus instances, from 1 to 35.). */
 	// +optional
-	TransactionLogRetentionDays *int `json:"transactionLogRetentionDays,omitempty"`
+	TransactionLogRetentionDays *int64 `json:"transactionLogRetentionDays,omitempty"`
 }
 
 type InstanceBackupRetentionSettings struct {
 	/* Number of backups to retain. */
-	RetainedBackups int `json:"retainedBackups"`
+	RetainedBackups int64 `json:"retainedBackups"`
 
 	/* The unit that 'retainedBackups' represents. Defaults to COUNT. */
 	// +optional
@@ -126,11 +126,11 @@ type InstanceInsightsConfig struct {
 
 	/* Number of query execution plans captured by Insights per minute for all queries combined. Between 0 and 20. Default to 5. */
 	// +optional
-	QueryPlansPerMinute *int `json:"queryPlansPerMinute,omitempty"`
+	QueryPlansPerMinute *int64 `json:"queryPlansPerMinute,omitempty"`
 
 	/* Maximum query length stored in bytes. Between 256 and 4500. Default to 1024. */
 	// +optional
-	QueryStringLength *int `json:"queryStringLength,omitempty"`
+	QueryStringLength *int64 `json:"queryStringLength,omitempty"`
 
 	/* True if Query Insights will record application tags from query when enabled. */
 	// +optional
@@ -185,11 +185,11 @@ type InstanceLocationPreference struct {
 type InstanceMaintenanceWindow struct {
 	/* Day of week (1-7), starting on Monday. */
 	// +optional
-	Day *int `json:"day,omitempty"`
+	Day *int64 `json:"day,omitempty"`
 
 	/* Hour of day (0-23), ignored if day not set. */
 	// +optional
-	Hour *int `json:"hour,omitempty"`
+	Hour *int64 `json:"hour,omitempty"`
 
 	/* Receive updates earlier (canary) or later (stable). */
 	// +optional
@@ -220,7 +220,7 @@ type InstancePasswordValidationPolicy struct {
 
 	/* Minimum number of characters allowed. */
 	// +optional
-	MinLength *int `json:"minLength,omitempty"`
+	MinLength *int64 `json:"minLength,omitempty"`
 
 	/* Minimum interval after which the password can be changed. This flag is only supported for PostgresSQL. */
 	// +optional
@@ -228,7 +228,7 @@ type InstancePasswordValidationPolicy struct {
 
 	/* Number of previous passwords that cannot be reused. */
 	// +optional
-	ReuseInterval *int `json:"reuseInterval,omitempty"`
+	ReuseInterval *int64 `json:"reuseInterval,omitempty"`
 }
 
 type InstancePscConfig struct {
@@ -256,7 +256,7 @@ type InstanceReplicaConfiguration struct {
 
 	/* Immutable. The number of seconds between connect retries. MySQL's default is 60 seconds. */
 	// +optional
-	ConnectRetryInterval *int `json:"connectRetryInterval,omitempty"`
+	ConnectRetryInterval *int64 `json:"connectRetryInterval,omitempty"`
 
 	/* Immutable. Path to a SQL file in Google Cloud Storage from which replica instances are created. Format is gs://bucket/filename. */
 	// +optional
@@ -268,7 +268,7 @@ type InstanceReplicaConfiguration struct {
 
 	/* Immutable. Time in ms between replication heartbeats. */
 	// +optional
-	MasterHeartbeatPeriod *int `json:"masterHeartbeatPeriod,omitempty"`
+	MasterHeartbeatPeriod *int64 `json:"masterHeartbeatPeriod,omitempty"`
 
 	/* Immutable. Password for the replication connection. */
 	// +optional
@@ -358,11 +358,11 @@ type InstanceSettings struct {
 
 	/* The maximum size, in GB, to which storage capacity can be automatically increased. The default value is 0, which specifies that there is no limit. */
 	// +optional
-	DiskAutoresizeLimit *int `json:"diskAutoresizeLimit,omitempty"`
+	DiskAutoresizeLimit *int64 `json:"diskAutoresizeLimit,omitempty"`
 
 	/* The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB. */
 	// +optional
-	DiskSize *int `json:"diskSize,omitempty"`
+	DiskSize *int64 `json:"diskSize,omitempty"`
 
 	/* Immutable. The type of data disk: PD_SSD or PD_HDD. Defaults to PD_SSD. */
 	// +optional
@@ -529,7 +529,7 @@ type SQLInstanceStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	PrivateIpAddress *string `json:"privateIpAddress,omitempty"`

--- a/pkg/clients/generated/apis/sql/v1beta1/sqlsslcert_types.go
+++ b/pkg/clients/generated/apis/sql/v1beta1/sqlsslcert_types.go
@@ -69,7 +69,7 @@ type SQLSSLCertStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The private key associated with the client certificate. */
 	// +optional

--- a/pkg/clients/generated/apis/sql/v1beta1/sqluser_types.go
+++ b/pkg/clients/generated/apis/sql/v1beta1/sqluser_types.go
@@ -48,7 +48,7 @@ type UserPassword struct {
 type UserPasswordPolicy struct {
 	/* Number of failed attempts allowed before the user get locked. */
 	// +optional
-	AllowedFailedAttempts *int `json:"allowedFailedAttempts,omitempty"`
+	AllowedFailedAttempts *int64 `json:"allowedFailedAttempts,omitempty"`
 
 	/* If true, the check that will lock user after too many failed login attempts will be enabled. */
 	// +optional
@@ -123,7 +123,7 @@ type SQLUserStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	// +optional
 	SqlServerUserDetails []UserSqlServerUserDetailsStatus `json:"sqlServerUserDetails,omitempty"`

--- a/pkg/clients/generated/apis/sql/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/sql/v1beta1/zz_generated.deepcopy.go
@@ -50,7 +50,7 @@ func (in *InstanceAdvancedMachineFeatures) DeepCopyInto(out *InstanceAdvancedMac
 	*out = *in
 	if in.ThreadsPerCore != nil {
 		in, out := &in.ThreadsPerCore, &out.ThreadsPerCore
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -127,7 +127,7 @@ func (in *InstanceBackupConfiguration) DeepCopyInto(out *InstanceBackupConfigura
 	}
 	if in.TransactionLogRetentionDays != nil {
 		in, out := &in.TransactionLogRetentionDays, &out.TransactionLogRetentionDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -227,12 +227,12 @@ func (in *InstanceInsightsConfig) DeepCopyInto(out *InstanceInsightsConfig) {
 	}
 	if in.QueryPlansPerMinute != nil {
 		in, out := &in.QueryPlansPerMinute, &out.QueryPlansPerMinute
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.QueryStringLength != nil {
 		in, out := &in.QueryStringLength, &out.QueryStringLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RecordApplicationTags != nil {
@@ -380,12 +380,12 @@ func (in *InstanceMaintenanceWindow) DeepCopyInto(out *InstanceMaintenanceWindow
 	*out = *in
 	if in.Day != nil {
 		in, out := &in.Day, &out.Day
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Hour != nil {
 		in, out := &in.Hour, &out.Hour
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTrack != nil {
@@ -447,7 +447,7 @@ func (in *InstancePasswordValidationPolicy) DeepCopyInto(out *InstancePasswordVa
 	}
 	if in.MinLength != nil {
 		in, out := &in.MinLength, &out.MinLength
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PasswordChangeInterval != nil {
@@ -457,7 +457,7 @@ func (in *InstancePasswordValidationPolicy) DeepCopyInto(out *InstancePasswordVa
 	}
 	if in.ReuseInterval != nil {
 		in, out := &in.ReuseInterval, &out.ReuseInterval
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -519,7 +519,7 @@ func (in *InstanceReplicaConfiguration) DeepCopyInto(out *InstanceReplicaConfigu
 	}
 	if in.ConnectRetryInterval != nil {
 		in, out := &in.ConnectRetryInterval, &out.ConnectRetryInterval
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DumpFilePath != nil {
@@ -534,7 +534,7 @@ func (in *InstanceReplicaConfiguration) DeepCopyInto(out *InstanceReplicaConfigu
 	}
 	if in.MasterHeartbeatPeriod != nil {
 		in, out := &in.MasterHeartbeatPeriod, &out.MasterHeartbeatPeriod
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Password != nil {
@@ -712,12 +712,12 @@ func (in *InstanceSettings) DeepCopyInto(out *InstanceSettings) {
 	}
 	if in.DiskAutoresizeLimit != nil {
 		in, out := &in.DiskAutoresizeLimit, &out.DiskAutoresizeLimit
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskSize != nil {
 		in, out := &in.DiskSize, &out.DiskSize
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DiskType != nil {
@@ -948,7 +948,7 @@ func (in *SQLDatabaseStatus) DeepCopyInto(out *SQLDatabaseStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -1134,7 +1134,7 @@ func (in *SQLInstanceStatus) DeepCopyInto(out *SQLInstanceStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrivateIpAddress != nil {
@@ -1293,7 +1293,7 @@ func (in *SQLSSLCertStatus) DeepCopyInto(out *SQLSSLCertStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PrivateKey != nil {
@@ -1437,7 +1437,7 @@ func (in *SQLUserStatus) DeepCopyInto(out *SQLUserStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SqlServerUserDetails != nil {
@@ -1491,7 +1491,7 @@ func (in *UserPasswordPolicy) DeepCopyInto(out *UserPasswordPolicy) {
 	*out = *in
 	if in.AllowedFailedAttempts != nil {
 		in, out := &in.AllowedFailedAttempts, &out.AllowedFailedAttempts
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.EnableFailedAttemptsCheck != nil {

--- a/pkg/clients/generated/apis/storage/v1alpha1/storagehmackey_types.go
+++ b/pkg/clients/generated/apis/storage/v1alpha1/storagehmackey_types.go
@@ -61,7 +61,7 @@ type StorageHMACKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* HMAC secret key material. */
 	// +optional

--- a/pkg/clients/generated/apis/storage/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/storage/v1alpha1/zz_generated.deepcopy.go
@@ -132,7 +132,7 @@ func (in *StorageHMACKeyStatus) DeepCopyInto(out *StorageHMACKeyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Secret != nil {

--- a/pkg/clients/generated/apis/storage/v1beta1/storagebucket_types.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/storagebucket_types.go
@@ -52,7 +52,7 @@ type BucketAutoclass struct {
 type BucketCondition struct {
 	/* Minimum age of an object in days to satisfy this condition. */
 	// +optional
-	Age *int `json:"age,omitempty"`
+	Age *int64 `json:"age,omitempty"`
 
 	/* Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition. */
 	// +optional
@@ -64,12 +64,12 @@ type BucketCondition struct {
 
 	/* Number of days elapsed since the user-specified timestamp set on an object. */
 	// +optional
-	DaysSinceCustomTime *int `json:"daysSinceCustomTime,omitempty"`
+	DaysSinceCustomTime *int64 `json:"daysSinceCustomTime,omitempty"`
 
 	/* Number of days elapsed since the noncurrent timestamp of an object. This
 	condition is relevant only for versioned objects. */
 	// +optional
-	DaysSinceNoncurrentTime *int `json:"daysSinceNoncurrentTime,omitempty"`
+	DaysSinceNoncurrentTime *int64 `json:"daysSinceNoncurrentTime,omitempty"`
 
 	/* One or more matching name prefixes to satisfy this condition. */
 	// +optional
@@ -89,7 +89,7 @@ type BucketCondition struct {
 
 	/* Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition. */
 	// +optional
-	NumNewerVersions *int `json:"numNewerVersions,omitempty"`
+	NumNewerVersions *int64 `json:"numNewerVersions,omitempty"`
 
 	/* Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: "LIVE", "ARCHIVED", "ANY". */
 	// +optional
@@ -99,7 +99,7 @@ type BucketCondition struct {
 type BucketCors struct {
 	/* The value, in seconds, to return in the Access-Control-Max-Age header used in preflight responses. */
 	// +optional
-	MaxAgeSeconds *int `json:"maxAgeSeconds,omitempty"`
+	MaxAgeSeconds *int64 `json:"maxAgeSeconds,omitempty"`
 
 	/* The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list of methods, and means "any method". */
 	// +optional
@@ -146,7 +146,7 @@ type BucketRetentionPolicy struct {
 	IsLocked *bool `json:"isLocked,omitempty"`
 
 	/* The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 3,155,760,000 seconds. */
-	RetentionPeriod int `json:"retentionPeriod"`
+	RetentionPeriod int64 `json:"retentionPeriod"`
 }
 
 type BucketVersioning struct {
@@ -241,7 +241,7 @@ type StorageBucketStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/storage/v1beta1/storagebucketaccesscontrol_types.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/storagebucketaccesscontrol_types.go
@@ -75,7 +75,7 @@ type StorageBucketAccessControlStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/storage/v1beta1/storagedefaultobjectaccesscontrol_types.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/storagedefaultobjectaccesscontrol_types.go
@@ -86,11 +86,11 @@ type StorageDefaultObjectAccessControlStatus struct {
 
 	/* The content generation of the object, if applied to an object. */
 	// +optional
-	Generation *int `json:"generation,omitempty"`
+	Generation *int64 `json:"generation,omitempty"`
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The project team associated with the entity. */
 	// +optional

--- a/pkg/clients/generated/apis/storage/v1beta1/storagenotification_types.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/storagenotification_types.go
@@ -70,7 +70,7 @@ type StorageNotificationStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The URI of the created resource. */
 	// +optional

--- a/pkg/clients/generated/apis/storage/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/zz_generated.deepcopy.go
@@ -71,7 +71,7 @@ func (in *BucketCondition) DeepCopyInto(out *BucketCondition) {
 	*out = *in
 	if in.Age != nil {
 		in, out := &in.Age, &out.Age
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.CreatedBefore != nil {
@@ -86,12 +86,12 @@ func (in *BucketCondition) DeepCopyInto(out *BucketCondition) {
 	}
 	if in.DaysSinceCustomTime != nil {
 		in, out := &in.DaysSinceCustomTime, &out.DaysSinceCustomTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DaysSinceNoncurrentTime != nil {
 		in, out := &in.DaysSinceNoncurrentTime, &out.DaysSinceNoncurrentTime
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MatchesPrefix != nil {
@@ -116,7 +116,7 @@ func (in *BucketCondition) DeepCopyInto(out *BucketCondition) {
 	}
 	if in.NumNewerVersions != nil {
 		in, out := &in.NumNewerVersions, &out.NumNewerVersions
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.WithState != nil {
@@ -142,7 +142,7 @@ func (in *BucketCors) DeepCopyInto(out *BucketCors) {
 	*out = *in
 	if in.MaxAgeSeconds != nil {
 		in, out := &in.MaxAgeSeconds, &out.MaxAgeSeconds
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Method != nil {
@@ -470,7 +470,7 @@ func (in *StorageBucketAccessControlStatus) DeepCopyInto(out *StorageBucketAcces
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -634,7 +634,7 @@ func (in *StorageBucketStatus) DeepCopyInto(out *StorageBucketStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {
@@ -768,12 +768,12 @@ func (in *StorageDefaultObjectAccessControlStatus) DeepCopyInto(out *StorageDefa
 	}
 	if in.Generation != nil {
 		in, out := &in.Generation, &out.Generation
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ProjectTeam != nil {
@@ -910,7 +910,7 @@ func (in *StorageNotificationStatus) DeepCopyInto(out *StorageNotificationStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/storagetransfer/v1alpha1/storagetransferagentpool_types.go
+++ b/pkg/clients/generated/apis/storagetransfer/v1alpha1/storagetransferagentpool_types.go
@@ -63,7 +63,7 @@ type StorageTransferAgentPoolStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Specifies the state of the AgentPool. */
 	// +optional

--- a/pkg/clients/generated/apis/storagetransfer/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/storagetransfer/v1alpha1/zz_generated.deepcopy.go
@@ -148,7 +148,7 @@ func (in *StorageTransferAgentPoolStatus) DeepCopyInto(out *StorageTransferAgent
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {

--- a/pkg/clients/generated/apis/storagetransfer/v1beta1/storagetransferjob_types.go
+++ b/pkg/clients/generated/apis/storagetransfer/v1beta1/storagetransferjob_types.go
@@ -188,24 +188,24 @@ type JobSchedule struct {
 
 type JobScheduleEndDate struct {
 	/* Day of month. Must be from 1 to 31 and valid for the year and month. */
-	Day int `json:"day"`
+	Day int64 `json:"day"`
 
 	/* Month of year. Must be from 1 to 12. */
-	Month int `json:"month"`
+	Month int64 `json:"month"`
 
 	/* Year of date. Must be from 1 to 9999. */
-	Year int `json:"year"`
+	Year int64 `json:"year"`
 }
 
 type JobScheduleStartDate struct {
 	/* Day of month. Must be from 1 to 31 and valid for the year and month. */
-	Day int `json:"day"`
+	Day int64 `json:"day"`
 
 	/* Month of year. Must be from 1 to 12. */
-	Month int `json:"month"`
+	Month int64 `json:"month"`
 
 	/* Year of date. Must be from 1 to 9999. */
-	Year int `json:"year"`
+	Year int64 `json:"year"`
 }
 
 type JobSecretAccessKey struct {
@@ -220,16 +220,16 @@ type JobSecretAccessKey struct {
 
 type JobStartTimeOfDay struct {
 	/* Hours of day in 24 hour format. Should be from 0 to 23. */
-	Hours int `json:"hours"`
+	Hours int64 `json:"hours"`
 
 	/* Minutes of hour of day. Must be from 0 to 59. */
-	Minutes int `json:"minutes"`
+	Minutes int64 `json:"minutes"`
 
 	/* Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999. */
-	Nanos int `json:"nanos"`
+	Nanos int64 `json:"nanos"`
 
 	/* Seconds of minutes of the time. Must normally be from 0 to 59. */
-	Seconds int `json:"seconds"`
+	Seconds int64 `json:"seconds"`
 }
 
 type JobTransferOptions struct {
@@ -348,7 +348,7 @@ type StorageTransferJobStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/storagetransfer/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/storagetransfer/v1beta1/zz_generated.deepcopy.go
@@ -691,7 +691,7 @@ func (in *StorageTransferJobStatus) DeepCopyInto(out *StorageTransferJobStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/tags/v1alpha1/tagslocationtagbinding_types.go
+++ b/pkg/clients/generated/apis/tags/v1alpha1/tagslocationtagbinding_types.go
@@ -59,7 +59,7 @@ type TagsLocationTagBindingStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/tags/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/tags/v1alpha1/zz_generated.deepcopy.go
@@ -128,7 +128,7 @@ func (in *TagsLocationTagBindingStatus) DeepCopyInto(out *TagsLocationTagBinding
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return

--- a/pkg/clients/generated/apis/tags/v1beta1/tagstagbinding_types.go
+++ b/pkg/clients/generated/apis/tags/v1beta1/tagstagbinding_types.go
@@ -55,7 +55,7 @@ type TagsTagBindingStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/tags/v1beta1/tagstagkey_types.go
+++ b/pkg/clients/generated/apis/tags/v1beta1/tagstagkey_types.go
@@ -85,7 +85,7 @@ type TagsTagKeyStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Update time.
 

--- a/pkg/clients/generated/apis/tags/v1beta1/tagstagvalue_types.go
+++ b/pkg/clients/generated/apis/tags/v1beta1/tagstagvalue_types.go
@@ -72,7 +72,7 @@ type TagsTagValueStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Output only. Update time.
 	A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z". */

--- a/pkg/clients/generated/apis/tags/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/tags/v1beta1/zz_generated.deepcopy.go
@@ -128,7 +128,7 @@ func (in *TagsTagBindingStatus) DeepCopyInto(out *TagsTagBindingStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -268,7 +268,7 @@ func (in *TagsTagKeyStatus) DeepCopyInto(out *TagsTagKeyStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -402,7 +402,7 @@ func (in *TagsTagValueStatus) DeepCopyInto(out *TagsTagValueStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {

--- a/pkg/clients/generated/apis/tpu/v1alpha1/tpunode_types.go
+++ b/pkg/clients/generated/apis/tpu/v1alpha1/tpunode_types.go
@@ -99,7 +99,7 @@ type NodeNetworkEndpointsStatus struct {
 
 	/* The port of this network endpoint. */
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *int64 `json:"port,omitempty"`
 }
 
 type TPUNodeStatus struct {
@@ -114,7 +114,7 @@ type TPUNodeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The service account used to run the tensor flow services within the
 	node. To share resources, including Google Cloud Storage data, with

--- a/pkg/clients/generated/apis/tpu/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/tpu/v1alpha1/zz_generated.deepcopy.go
@@ -39,7 +39,7 @@ func (in *NodeNetworkEndpointsStatus) DeepCopyInto(out *NodeNetworkEndpointsStat
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -196,7 +196,7 @@ func (in *TPUNodeStatus) DeepCopyInto(out *TPUNodeStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ServiceAccount != nil {

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestore_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestore_types.go
@@ -43,7 +43,7 @@ type FeaturestoreEncryptionSpec struct {
 type FeaturestoreOnlineServingConfig struct {
 	/* The number of nodes for each cluster. The number of nodes will not scale automatically but can be scaled manually by providing different values when updating. */
 	// +optional
-	FixedNodeCount *int `json:"fixedNodeCount,omitempty"`
+	FixedNodeCount *int64 `json:"fixedNodeCount,omitempty"`
 
 	/* Online serving scaling configuration. Only one of fixedNodeCount and scaling can be set. Setting one will reset the other. */
 	// +optional
@@ -52,10 +52,10 @@ type FeaturestoreOnlineServingConfig struct {
 
 type FeaturestoreScaling struct {
 	/* The maximum number of nodes to scale up to. Must be greater than minNodeCount, and less than or equal to 10 times of 'minNodeCount'. */
-	MaxNodeCount int `json:"maxNodeCount"`
+	MaxNodeCount int64 `json:"maxNodeCount"`
 
 	/* The minimum number of nodes to scale down to. Must be greater than or equal to 1. */
-	MinNodeCount int `json:"minNodeCount"`
+	MinNodeCount int64 `json:"minNodeCount"`
 }
 
 type VertexAIFeaturestoreSpec struct {
@@ -73,7 +73,7 @@ type VertexAIFeaturestoreSpec struct {
 
 	/* TTL in days for feature values that will be stored in online serving storage. The Feature Store online storage periodically removes obsolete feature values older than onlineStorageTtlDays since the feature generation time. Note that onlineStorageTtlDays should be less than or equal to offlineStorageTtlDays for each EntityType under a featurestore. If not set, default to 4000 days. */
 	// +optional
-	OnlineStorageTtlDays *int `json:"onlineStorageTtlDays,omitempty"`
+	OnlineStorageTtlDays *int64 `json:"onlineStorageTtlDays,omitempty"`
 
 	/* The project that this resource belongs to. */
 	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
@@ -100,7 +100,7 @@ type VertexAIFeaturestoreStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The timestamp of when the featurestore was last updated in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestoreentitytype_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestoreentitytype_types.go
@@ -93,11 +93,11 @@ type FeaturestoreentitytypeSnapshotAnalysis struct {
 	/* Configuration of the snapshot analysis based monitoring pipeline running interval. The value indicates number of days. The default value is 1.
 	If both FeaturestoreMonitoringConfig.SnapshotAnalysis.monitoring_interval_days and [FeaturestoreMonitoringConfig.SnapshotAnalysis.monitoring_interval][] are set when creating/updating EntityTypes/Features, FeaturestoreMonitoringConfig.SnapshotAnalysis.monitoring_interval_days will be used. */
 	// +optional
-	MonitoringIntervalDays *int `json:"monitoringIntervalDays,omitempty"`
+	MonitoringIntervalDays *int64 `json:"monitoringIntervalDays,omitempty"`
 
 	/* Customized export features time window for snapshot analysis. Unit is one day. The default value is 21 days. Minimum value is 1 day. Maximum value is 4000 days. */
 	// +optional
-	StalenessDays *int `json:"stalenessDays,omitempty"`
+	StalenessDays *int64 `json:"stalenessDays,omitempty"`
 }
 
 type VertexAIFeaturestoreEntityTypeSpec struct {
@@ -116,7 +116,7 @@ type VertexAIFeaturestoreEntityTypeSpec struct {
 
 	/* Config for data retention policy in offline storage. TTL in days for feature values that will be stored in offline storage. The Feature Store offline storage periodically removes obsolete feature values older than offlineStorageTtlDays since the feature generation time. If unset (or explicitly set to 0), default to 4000 days TTL. */
 	// +optional
-	OfflineStorageTtlDays *int `json:"offlineStorageTtlDays,omitempty"`
+	OfflineStorageTtlDays *int64 `json:"offlineStorageTtlDays,omitempty"`
 
 	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
@@ -137,7 +137,7 @@ type VertexAIFeaturestoreEntityTypeStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The region of the EntityType. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestoreentitytypefeature_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaifeaturestoreentitytypefeature_types.go
@@ -65,7 +65,7 @@ type VertexAIFeaturestoreEntityTypeFeatureStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The region of the feature. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaiindexendpoint_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaiindexendpoint_types.go
@@ -83,7 +83,7 @@ type VertexAIIndexEndpointStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* If publicEndpointEnabled is true, this field will be populated with the domain name to use for this index endpoint. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaimetadatastore_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaimetadatastore_types.go
@@ -78,7 +78,7 @@ type VertexAIMetadataStoreStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* State information of the MetadataStore. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaitensorboard_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/vertexaitensorboard_types.go
@@ -82,7 +82,7 @@ type VertexAITensorboardStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The number of Runs stored in this Tensorboard. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/vertexai/v1alpha1/zz_generated.deepcopy.go
@@ -50,7 +50,7 @@ func (in *FeaturestoreOnlineServingConfig) DeepCopyInto(out *FeaturestoreOnlineS
 	*out = *in
 	if in.FixedNodeCount != nil {
 		in, out := &in.FixedNodeCount, &out.FixedNodeCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Scaling != nil {
@@ -196,12 +196,12 @@ func (in *FeaturestoreentitytypeSnapshotAnalysis) DeepCopyInto(out *Featurestore
 	}
 	if in.MonitoringIntervalDays != nil {
 		in, out := &in.MonitoringIntervalDays, &out.MonitoringIntervalDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.StalenessDays != nil {
 		in, out := &in.StalenessDays, &out.StalenessDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -438,7 +438,7 @@ func (in *VertexAIFeaturestoreEntityTypeFeatureStatus) DeepCopyInto(out *VertexA
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Region != nil {
@@ -512,7 +512,7 @@ func (in *VertexAIFeaturestoreEntityTypeSpec) DeepCopyInto(out *VertexAIFeatures
 	}
 	if in.OfflineStorageTtlDays != nil {
 		in, out := &in.OfflineStorageTtlDays, &out.OfflineStorageTtlDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceID != nil {
@@ -553,7 +553,7 @@ func (in *VertexAIFeaturestoreEntityTypeStatus) DeepCopyInto(out *VertexAIFeatur
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Region != nil {
@@ -632,7 +632,7 @@ func (in *VertexAIFeaturestoreSpec) DeepCopyInto(out *VertexAIFeaturestoreSpec) 
 	}
 	if in.OnlineStorageTtlDays != nil {
 		in, out := &in.OnlineStorageTtlDays, &out.OnlineStorageTtlDays
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	out.ProjectRef = in.ProjectRef
@@ -674,7 +674,7 @@ func (in *VertexAIFeaturestoreStatus) DeepCopyInto(out *VertexAIFeaturestoreStat
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.UpdateTime != nil {
@@ -818,7 +818,7 @@ func (in *VertexAIIndexEndpointStatus) DeepCopyInto(out *VertexAIIndexEndpointSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.PublicEndpointDomainName != nil {
@@ -952,7 +952,7 @@ func (in *VertexAIMetadataStoreStatus) DeepCopyInto(out *VertexAIMetadataStoreSt
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.State != nil {
@@ -1098,7 +1098,7 @@ func (in *VertexAITensorboardStatus) DeepCopyInto(out *VertexAITensorboardStatus
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RunCount != nil {

--- a/pkg/clients/generated/apis/vertexai/v1beta1/vertexaidataset_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1beta1/vertexaidataset_types.go
@@ -82,7 +82,7 @@ type VertexAIDatasetStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1beta1/vertexaiendpoint_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1beta1/vertexaiendpoint_types.go
@@ -88,7 +88,7 @@ type VertexAIEndpointStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1beta1/vertexaiindex_types.go
+++ b/pkg/clients/generated/apis/vertexai/v1beta1/vertexaiindex_types.go
@@ -60,10 +60,10 @@ type IndexConfig struct {
 	approximate search algorithm are reordered via a more expensive distance computation.
 	Required if tree-AH algorithm is used. */
 	// +optional
-	ApproximateNeighborsCount *int `json:"approximateNeighborsCount,omitempty"`
+	ApproximateNeighborsCount *int64 `json:"approximateNeighborsCount,omitempty"`
 
 	/* The number of dimensions of the input vectors. */
-	Dimensions int `json:"dimensions"`
+	Dimensions int64 `json:"dimensions"`
 
 	/* The distance measure used in nearest neighbor search. The value must be one of the followings:
 	* SQUARED_L2_DISTANCE: Euclidean (L_2) Distance
@@ -108,12 +108,12 @@ type IndexMetadata struct {
 type IndexTreeAhConfig struct {
 	/* Number of embeddings on each leaf node. The default value is 1000 if not set. */
 	// +optional
-	LeafNodeEmbeddingCount *int `json:"leafNodeEmbeddingCount,omitempty"`
+	LeafNodeEmbeddingCount *int64 `json:"leafNodeEmbeddingCount,omitempty"`
 
 	/* The default percentage of leaf nodes that any query may be searched. Must be in
 	range 1-100, inclusive. The default value is 10 (means 10%) if not set. */
 	// +optional
-	LeafNodesToSearchPercent *int `json:"leafNodesToSearchPercent,omitempty"`
+	LeafNodesToSearchPercent *int64 `json:"leafNodesToSearchPercent,omitempty"`
 }
 
 type VertexAIIndexSpec struct {
@@ -148,7 +148,7 @@ type VertexAIIndexSpec struct {
 type IndexIndexStatsStatus struct {
 	/* The number of shards in the Index. */
 	// +optional
-	ShardsCount *int `json:"shardsCount,omitempty"`
+	ShardsCount *int64 `json:"shardsCount,omitempty"`
 
 	/* The number of vectors in the Index. */
 	// +optional
@@ -179,7 +179,7 @@ type VertexAIIndexStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The observed state of the underlying GCP resource. */
 	// +optional

--- a/pkg/clients/generated/apis/vertexai/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/vertexai/v1beta1/zz_generated.deepcopy.go
@@ -171,7 +171,7 @@ func (in *IndexConfig) DeepCopyInto(out *IndexConfig) {
 	}
 	if in.ApproximateNeighborsCount != nil {
 		in, out := &in.ApproximateNeighborsCount, &out.ApproximateNeighborsCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.DistanceMeasureType != nil {
@@ -207,7 +207,7 @@ func (in *IndexIndexStatsStatus) DeepCopyInto(out *IndexIndexStatsStatus) {
 	*out = *in
 	if in.ShardsCount != nil {
 		in, out := &in.ShardsCount, &out.ShardsCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.VectorsCount != nil {
@@ -297,12 +297,12 @@ func (in *IndexTreeAhConfig) DeepCopyInto(out *IndexTreeAhConfig) {
 	*out = *in
 	if in.LeafNodeEmbeddingCount != nil {
 		in, out := &in.LeafNodeEmbeddingCount, &out.LeafNodeEmbeddingCount
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LeafNodesToSearchPercent != nil {
 		in, out := &in.LeafNodesToSearchPercent, &out.LeafNodesToSearchPercent
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	return
@@ -421,7 +421,7 @@ func (in *VertexAIDatasetStatus) DeepCopyInto(out *VertexAIDatasetStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -550,7 +550,7 @@ func (in *VertexAIEndpointStatus) DeepCopyInto(out *VertexAIEndpointStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {
@@ -679,7 +679,7 @@ func (in *VertexAIIndexStatus) DeepCopyInto(out *VertexAIIndexStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ObservedState != nil {

--- a/pkg/clients/generated/apis/vpcaccess/v1beta1/vpcaccessconnector_types.go
+++ b/pkg/clients/generated/apis/vpcaccess/v1beta1/vpcaccessconnector_types.go
@@ -60,19 +60,19 @@ type VPCAccessConnectorSpec struct {
 
 	/* Immutable. Maximum value of instances in autoscaling group underlying the connector. */
 	// +optional
-	MaxInstances *int `json:"maxInstances,omitempty"`
+	MaxInstances *int64 `json:"maxInstances,omitempty"`
 
 	/* Immutable. Maximum throughput of the connector in Mbps, must be greater than 'min_throughput'. Default is 300. */
 	// +optional
-	MaxThroughput *int `json:"maxThroughput,omitempty"`
+	MaxThroughput *int64 `json:"maxThroughput,omitempty"`
 
 	/* Immutable. Minimum value of instances in autoscaling group underlying the connector. */
 	// +optional
-	MinInstances *int `json:"minInstances,omitempty"`
+	MinInstances *int64 `json:"minInstances,omitempty"`
 
 	/* Immutable. Minimum throughput of the connector in Mbps. Default and min is 200. */
 	// +optional
-	MinThroughput *int `json:"minThroughput,omitempty"`
+	MinThroughput *int64 `json:"minThroughput,omitempty"`
 
 	/* Immutable. Name or self_link of the VPC network. Required if 'ip_cidr_range' is set. */
 	// +optional
@@ -100,7 +100,7 @@ type VPCAccessConnectorStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The fully qualified name of this VPC connector. */
 	// +optional

--- a/pkg/clients/generated/apis/vpcaccess/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/vpcaccess/v1beta1/zz_generated.deepcopy.go
@@ -131,22 +131,22 @@ func (in *VPCAccessConnectorSpec) DeepCopyInto(out *VPCAccessConnectorSpec) {
 	}
 	if in.MaxInstances != nil {
 		in, out := &in.MaxInstances, &out.MaxInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MaxThroughput != nil {
 		in, out := &in.MaxThroughput, &out.MaxThroughput
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinInstances != nil {
 		in, out := &in.MinInstances, &out.MinInstances
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.MinThroughput != nil {
 		in, out := &in.MinThroughput, &out.MinThroughput
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.NetworkRef != nil {
@@ -193,7 +193,7 @@ func (in *VPCAccessConnectorStatus) DeepCopyInto(out *VPCAccessConnectorStatus) 
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.SelfLink != nil {

--- a/pkg/clients/generated/apis/workflows/v1alpha1/workflowsworkflow_types.go
+++ b/pkg/clients/generated/apis/workflows/v1alpha1/workflowsworkflow_types.go
@@ -85,7 +85,7 @@ type WorkflowsWorkflowStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* The revision of the workflow. A new one is generated if the service account or source contents is changed. */
 	// +optional

--- a/pkg/clients/generated/apis/workflows/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/workflows/v1alpha1/zz_generated.deepcopy.go
@@ -152,7 +152,7 @@ func (in *WorkflowsWorkflowStatus) DeepCopyInto(out *WorkflowsWorkflowStatus) {
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.RevisionId != nil {

--- a/pkg/clients/generated/apis/workstations/v1alpha1/workstationsworkstationcluster_types.go
+++ b/pkg/clients/generated/apis/workstations/v1alpha1/workstationsworkstationcluster_types.go
@@ -95,7 +95,7 @@ type WorkstationclusterDetailsStatus struct {
 type WorkstationclusterResourceConditionsStatus struct {
 	/* The status code, which should be an enum value of google.rpc.Code. */
 	// +optional
-	Code *int `json:"code,omitempty"`
+	Code *int64 `json:"code,omitempty"`
 
 	/* A list of messages that carry the error details. */
 	// +optional
@@ -130,7 +130,7 @@ type WorkstationsWorkstationClusterStatus struct {
 
 	/* ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource. */
 	// +optional
-	ObservedGeneration *int `json:"observedGeneration,omitempty"`
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 
 	/* Status conditions describing the current resource state. */
 	// +optional

--- a/pkg/clients/generated/apis/workstations/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/workstations/v1alpha1/zz_generated.deepcopy.go
@@ -81,7 +81,7 @@ func (in *WorkstationclusterResourceConditionsStatus) DeepCopyInto(out *Workstat
 	*out = *in
 	if in.Code != nil {
 		in, out := &in.Code, &out.Code
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Details != nil {
@@ -237,7 +237,7 @@ func (in *WorkstationsWorkstationClusterStatus) DeepCopyInto(out *WorkstationsWo
 	}
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.ResourceConditions != nil {

--- a/pkg/crd/fielddesc/fielddesc.go
+++ b/pkg/crd/fielddesc/fielddesc.go
@@ -36,6 +36,7 @@ type FieldDescription struct {
 	ShortName            string
 	Description          string
 	Type                 string
+	Format               string
 	RequirementLevel     RequirementLevel
 	Children             []FieldDescription
 	AdditionalProperties []FieldDescription
@@ -155,6 +156,7 @@ func newFieldDescription(props apiextensions.JSONSchemaProps, parent FieldDescri
 	}
 	fd := FieldDescription{
 		Type:        props.Type,
+		Format:      props.Format,
 		Description: props.Description,
 		FullName:    fullName,
 		ShortName:   name,

--- a/pkg/crd/fielddesc/testdata/accesscontextmanageraccesslevel-spec.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/accesscontextmanageraccesslevel-spec.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: spec
 description: ""
 type: object
+format: ""
 requirementlevel: Required
 children:
 - fullname:
@@ -27,6 +28,7 @@ children:
     The AccessContextManagerAccessPolicy this
     AccessContextManagerAccessLevel lives in.
   type: object
+  format: ""
   requirementlevel: Required
   children:
   - fullname:
@@ -38,6 +40,7 @@ children:
       where {{value}} is the `name` field of an `AccessContextManagerAccessPolicy`
       resource.'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -48,6 +51,7 @@ children:
     shortname: name
     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -58,6 +62,7 @@ children:
     shortname: namespace
     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -69,6 +74,7 @@ children:
   description: A set of predefined conditions for the access level and a combining
     function.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -83,6 +89,7 @@ children:
       OR is used, at least one Condition in conditions must be satisfied
       for the AccessLevel to be applied. Default value: "AND" Possible values: ["AND", "OR"].
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -93,6 +100,7 @@ children:
     shortname: conditions
     description: A set of requirements for the AccessLevel to be granted.
     type: list (object)
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children:
     - fullname:
@@ -103,6 +111,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: RequiredWhenParentPresent
       children:
       - fullname:
@@ -117,6 +126,7 @@ children:
           the Condition to be true. If not specified, all devices are
           allowed.
         type: object
+        format: ""
         requirementlevel: Optional
         children:
         - fullname:
@@ -131,6 +141,7 @@ children:
             A list of allowed device management levels.
             An empty list allows all management levels. Possible values: ["MANAGEMENT_UNSPECIFIED", "NONE", "BASIC", "COMPLETE"].
           type: list (string)
+          format: ""
           requirementlevel: Optional
           children:
           - fullname:
@@ -144,6 +155,7 @@ children:
             shortname: '[]'
             description: ""
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -160,6 +172,7 @@ children:
             A list of allowed encryptions statuses.
             An empty list allows all statuses. Possible values: ["ENCRYPTION_UNSPECIFIED", "ENCRYPTION_UNSUPPORTED", "UNENCRYPTED", "ENCRYPTED"].
           type: list (string)
+          format: ""
           requirementlevel: Optional
           children:
           - fullname:
@@ -173,6 +186,7 @@ children:
             shortname: '[]'
             description: ""
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -189,6 +203,7 @@ children:
             A list of allowed OS versions.
             An empty list allows all types and all versions.
           type: list (object)
+          format: ""
           requirementlevel: Optional
           children:
           - fullname:
@@ -202,6 +217,7 @@ children:
             shortname: '[]'
             description: ""
             type: object
+            format: ""
             requirementlevel: Optional
             children:
             - fullname:
@@ -219,6 +235,7 @@ children:
                 of this OS satisfies the constraint.
                 Format: "major.minor.patch" such as "10.5.301", "9.2.1".
               type: string
+              format: ""
               requirementlevel: Optional
               children: []
               additionalproperties: []
@@ -236,6 +253,7 @@ children:
                 ["OS_UNSPECIFIED", "DESKTOP_MAC", "DESKTOP_WINDOWS", "DESKTOP_LINUX",
                 "DESKTOP_CHROME_OS", "ANDROID", "IOS"].'
               type: string
+              format: ""
               requirementlevel: RequiredWhenParentPresent
               children: []
               additionalproperties: []
@@ -252,6 +270,7 @@ children:
               description: If you specify DESKTOP_CHROME_OS for osType, you can optionally
                 include requireVerifiedChromeOs to require Chrome Verified Access.
               type: boolean
+              format: ""
               requirementlevel: Optional
               children: []
               additionalproperties: []
@@ -267,6 +286,7 @@ children:
           shortname: requireAdminApproval
           description: Whether the device needs to be approved by the customer admin.
           type: boolean
+          format: ""
           requirementlevel: Optional
           children: []
           additionalproperties: []
@@ -280,6 +300,7 @@ children:
           shortname: requireCorpOwned
           description: Whether the device needs to be corp owned.
           type: boolean
+          format: ""
           requirementlevel: Optional
           children: []
           additionalproperties: []
@@ -295,6 +316,7 @@ children:
             Whether or not screenlock is required for the DevicePolicy
             to be true. Defaults to false.
           type: boolean
+          format: ""
           requirementlevel: Optional
           children: []
           additionalproperties: []
@@ -318,6 +340,7 @@ children:
           listed subnets in order for this Condition to be true.
           If empty, all IP addresses are allowed.
         type: list (string)
+        format: ""
         requirementlevel: Optional
         children:
         - fullname:
@@ -330,6 +353,7 @@ children:
           shortname: '[]'
           description: ""
           type: string
+          format: ""
           requirementlevel: Optional
           children: []
           additionalproperties: []
@@ -343,6 +367,7 @@ children:
         shortname: members
         description: ""
         type: list (object)
+        format: ""
         requirementlevel: Optional
         children:
         - fullname:
@@ -362,6 +387,7 @@ children:
             from any user (logged in/not logged in, not present in any
             groups, etc.).
           type: object
+          format: ""
           requirementlevel: Optional
           children:
           - fullname:
@@ -375,6 +401,7 @@ children:
             shortname: serviceAccountRef
             description: ""
             type: object
+            format: ""
             requirementlevel: Optional
             children:
             - fullname:
@@ -390,6 +417,7 @@ children:
               description: 'Allowed value: string of the format `serviceAccount:{{value}}`,
                 where {{value}} is the `email` field of an `IAMServiceAccount` resource.'
               type: string
+              format: ""
               requirementlevel: Optional
               children: []
               additionalproperties: []
@@ -405,6 +433,7 @@ children:
               shortname: name
               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
               type: string
+              format: ""
               requirementlevel: Optional
               children: []
               additionalproperties: []
@@ -420,6 +449,7 @@ children:
               shortname: namespace
               description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
               type: string
+              format: ""
               requirementlevel: Optional
               children: []
               additionalproperties: []
@@ -435,6 +465,7 @@ children:
             shortname: user
             description: ""
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -452,6 +483,7 @@ children:
           a NAND over its non-empty fields, each field must be false for
           the Condition overall to be satisfied. Defaults to false.
         type: boolean
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -467,6 +499,7 @@ children:
           countries/regions.
           Format: A valid ISO 3166-1 alpha-2 code.
         type: list (string)
+        format: ""
         requirementlevel: Optional
         children:
         - fullname:
@@ -479,6 +512,7 @@ children:
           shortname: '[]'
           description: ""
           type: string
+          format: ""
           requirementlevel: Optional
           children: []
           additionalproperties: []
@@ -492,6 +526,7 @@ children:
         shortname: requiredAccessLevels
         description: ""
         type: list (object)
+        format: ""
         requirementlevel: Optional
         children:
         - fullname:
@@ -508,6 +543,7 @@ children:
             is an error. All access levels listed must be granted for the
             condition to be true.
           type: object
+          format: ""
           requirementlevel: Optional
           children:
           - fullname:
@@ -522,6 +558,7 @@ children:
             description: 'Allowed value: The `name` field of an `AccessContextManagerAccessLevel`
               resource.'
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -536,6 +573,7 @@ children:
             shortname: name
             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -550,6 +588,7 @@ children:
             shortname: namespace
             description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
             type: string
+            format: ""
             requirementlevel: Optional
             children: []
             additionalproperties: []
@@ -566,6 +605,7 @@ children:
     Custom access level conditions are set using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request.
     See CEL spec at: https://github.com/google/cel-spec.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -578,6 +618,7 @@ children:
       This page details the objects and attributes that are used to the build the CEL expressions for
       custom access levels - https://cloud.google.com/access-context-manager/docs/custom-access-level-spec.
     type: object
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children:
     - fullname:
@@ -588,6 +629,7 @@ children:
       shortname: description
       description: Description of the expression.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -600,6 +642,7 @@ children:
       description: Textual representation of an expression in Common Expression Language
         syntax.
       type: string
+      format: ""
       requirementlevel: RequiredWhenParentPresent
       children: []
       additionalproperties: []
@@ -612,6 +655,7 @@ children:
       description: String indicating the location of the expression for error reporting,
         e.g. a file name and a position in the file.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -623,6 +667,7 @@ children:
       shortname: title
       description: Title for the expression, i.e. a short string describing its purpose.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -634,6 +679,7 @@ children:
   shortname: description
   description: Description of the AccessLevel and its use. Does not affect behavior.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -644,6 +690,7 @@ children:
   description: Immutable. Optional. The name of the resource. Used for creation and
     acquisition. When unset, the value of `metadata.name` is used as the default.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -653,6 +700,7 @@ children:
   shortname: title
   description: Human readable title. Must be unique within the Policy.
   type: string
+  format: ""
   requirementlevel: Required
   children: []
   additionalproperties: []

--- a/pkg/crd/fielddesc/testdata/accesscontextmanageraccesslevel-status.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/accesscontextmanageraccesslevel-status.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: status
 description: ""
 type: object
+format: ""
 requirementlevel: Optional
 children:
 - fullname:
@@ -26,6 +27,7 @@ children:
   description: Conditions represent the latest available observation of the resource's
     current state.
   type: list (object)
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -35,6 +37,7 @@ children:
     shortname: '[]'
     description: ""
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -45,6 +48,7 @@ children:
       shortname: lastTransitionTime
       description: Last time the condition transitioned from one status to another.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -56,6 +60,7 @@ children:
       shortname: message
       description: Human-readable message indicating details about last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -67,6 +72,7 @@ children:
       shortname: reason
       description: Unique, one-word, CamelCase reason for the condition's last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -78,6 +84,7 @@ children:
       shortname: status
       description: Status is the status of the condition. Can be True, False, Unknown.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -89,6 +96,7 @@ children:
       shortname: type
       description: Type is the type of the condition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -103,6 +111,7 @@ children:
     then that means that the current reported status reflects the most recent desired
     state of the resource.
   type: integer
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []

--- a/pkg/crd/fielddesc/testdata/binaryauthorizationpolicy-spec.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/binaryauthorizationpolicy-spec.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: spec
 description: ""
 type: object
+format: ""
 requirementlevel: Required
 children:
 - fullname:
@@ -27,6 +28,7 @@ children:
     will always be permitted. This feature is typically used to exclude Google or
     third-party infrastructure images from Binary Authorization policies.
   type: list (object)
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -36,6 +38,7 @@ children:
     shortname: '[]'
     description: ""
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -48,6 +51,7 @@ children:
         This supports a trailing `*` as a wildcard, but this is allowed only in text
         after the `registry/` part.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -62,6 +66,7 @@ children:
     a compute zone (e.g. us-central1-a) or a region (e.g. us-central1). For clusterId
     syntax restrictions see https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters.'
   type: 'map (key: string, value: object)'
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties:
@@ -74,6 +79,7 @@ children:
       rule. Possible values: ENFORCEMENT_MODE_UNSPECIFIED, ENFORCED_BLOCK_AND_AUDIT_LOG,
       DRYRUN_AUDIT_LOG_ONLY'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -85,6 +91,7 @@ children:
     description: 'Required. How this admission rule will be evaluated. Possible values:
       ALWAYS_ALLOW, ALWAYS_DENY, REQUIRE_ATTESTATION'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -95,6 +102,7 @@ children:
     shortname: requireAttestationsBy
     description: ""
     type: list (object)
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -105,6 +113,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: Optional
       children:
       - fullname:
@@ -117,6 +126,7 @@ children:
         description: 'Allowed value: The Google Cloud resource name of a `BinaryAuthorizationAttestor`
           resource (format: `projects/{{project}}/attestors/{{name}}`).'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -129,6 +139,7 @@ children:
         shortname: name
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -141,6 +152,7 @@ children:
         shortname: namespace
         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -153,6 +165,7 @@ children:
   description: Required. Default admission rule for a cluster without a per-cluster,
     per-kubernetes-service-account, or per-istio-service-identity admission rule.
   type: object
+  format: ""
   requirementlevel: Required
   children:
   - fullname:
@@ -164,6 +177,7 @@ children:
       rule. Possible values: ENFORCEMENT_MODE_UNSPECIFIED, ENFORCED_BLOCK_AND_AUDIT_LOG,
       DRYRUN_AUDIT_LOG_ONLY'
     type: string
+    format: ""
     requirementlevel: Required
     children: []
     additionalproperties: []
@@ -175,6 +189,7 @@ children:
     description: 'Required. How this admission rule will be evaluated. Possible values:
       ALWAYS_ALLOW, ALWAYS_DENY, REQUIRE_ATTESTATION'
     type: string
+    format: ""
     requirementlevel: Required
     children: []
     additionalproperties: []
@@ -185,6 +200,7 @@ children:
     shortname: requireAttestationsBy
     description: ""
     type: list (object)
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -195,6 +211,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: Optional
       children:
       - fullname:
@@ -207,6 +224,7 @@ children:
         description: 'Allowed value: The Google Cloud resource name of a `BinaryAuthorizationAttestor`
           resource (format: `projects/{{project}}/attestors/{{name}}`).'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -219,6 +237,7 @@ children:
         shortname: name
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -231,6 +250,7 @@ children:
         shortname: namespace
         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -243,6 +263,7 @@ children:
   shortname: description
   description: Optional. A descriptive comment.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -256,6 +277,7 @@ children:
     specified inside a global admission policy. Possible values: GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED,
     ENABLE, DISABLE'
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -266,6 +288,7 @@ children:
   description: 'Optional. Per-istio-service-identity admission rules. Istio service
     identity spec format: spiffe:///ns//sa/ or /ns//sa/ e.g. spiffe://example.com/ns/test-ns/sa/default'
   type: 'map (key: string, value: object)'
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties:
@@ -278,6 +301,7 @@ children:
       rule. Possible values: ENFORCEMENT_MODE_UNSPECIFIED, ENFORCED_BLOCK_AND_AUDIT_LOG,
       DRYRUN_AUDIT_LOG_ONLY'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -289,6 +313,7 @@ children:
     description: 'Required. How this admission rule will be evaluated. Possible values:
       ALWAYS_ALLOW, ALWAYS_DENY, REQUIRE_ATTESTATION'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -299,6 +324,7 @@ children:
     shortname: requireAttestationsBy
     description: ""
     type: list (object)
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -309,6 +335,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: Optional
       children:
       - fullname:
@@ -321,6 +348,7 @@ children:
         description: 'Allowed value: The Google Cloud resource name of a `BinaryAuthorizationAttestor`
           resource (format: `projects/{{project}}/attestors/{{name}}`).'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -333,6 +361,7 @@ children:
         shortname: name
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -345,6 +374,7 @@ children:
         shortname: namespace
         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -357,6 +387,7 @@ children:
   description: 'Optional. Per-kubernetes-namespace admission rules. K8s namespace
     spec format: [a-z.-]+, e.g. ''some-namespace'''
   type: 'map (key: string, value: object)'
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties:
@@ -369,6 +400,7 @@ children:
       rule. Possible values: ENFORCEMENT_MODE_UNSPECIFIED, ENFORCED_BLOCK_AND_AUDIT_LOG,
       DRYRUN_AUDIT_LOG_ONLY'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -380,6 +412,7 @@ children:
     description: 'Required. How this admission rule will be evaluated. Possible values:
       ALWAYS_ALLOW, ALWAYS_DENY, REQUIRE_ATTESTATION'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -390,6 +423,7 @@ children:
     shortname: requireAttestationsBy
     description: ""
     type: list (object)
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -400,6 +434,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: Optional
       children:
       - fullname:
@@ -412,6 +447,7 @@ children:
         description: 'Allowed value: The Google Cloud resource name of a `BinaryAuthorizationAttestor`
           resource (format: `projects/{{project}}/attestors/{{name}}`).'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -424,6 +460,7 @@ children:
         shortname: name
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -436,6 +473,7 @@ children:
         shortname: namespace
         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -448,6 +486,7 @@ children:
   description: 'Optional. Per-kubernetes-service-account admission rules. Service
     account spec format: namespace:serviceaccount. e.g. ''test-ns:default'''
   type: 'map (key: string, value: object)'
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties:
@@ -460,6 +499,7 @@ children:
       rule. Possible values: ENFORCEMENT_MODE_UNSPECIFIED, ENFORCED_BLOCK_AND_AUDIT_LOG,
       DRYRUN_AUDIT_LOG_ONLY'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -471,6 +511,7 @@ children:
     description: 'Required. How this admission rule will be evaluated. Possible values:
       ALWAYS_ALLOW, ALWAYS_DENY, REQUIRE_ATTESTATION'
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -481,6 +522,7 @@ children:
     shortname: requireAttestationsBy
     description: ""
     type: list (object)
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -491,6 +533,7 @@ children:
       shortname: '[]'
       description: ""
       type: object
+      format: ""
       requirementlevel: Optional
       children:
       - fullname:
@@ -503,6 +546,7 @@ children:
         description: 'Allowed value: The Google Cloud resource name of a `BinaryAuthorizationAttestor`
           resource (format: `projects/{{project}}/attestors/{{name}}`).'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -515,6 +559,7 @@ children:
         shortname: name
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -527,6 +572,7 @@ children:
         shortname: namespace
         description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
         type: string
+        format: ""
         requirementlevel: Optional
         children: []
         additionalproperties: []
@@ -538,6 +584,7 @@ children:
   shortname: projectRef
   description: Immutable. The Project that this resource belongs to.
   type: object
+  format: ""
   requirementlevel: Required
   children:
   - fullname:
@@ -550,6 +597,7 @@ children:
 
       Allowed value: The Google Cloud resource name of a `Project` resource (format: `projects/{{name}}`).
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -560,6 +608,7 @@ children:
     shortname: name
     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -570,6 +619,7 @@ children:
     shortname: namespace
     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []

--- a/pkg/crd/fielddesc/testdata/binaryauthorizationpolicy-status.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/binaryauthorizationpolicy-status.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: status
 description: ""
 type: object
+format: ""
 requirementlevel: Optional
 children:
 - fullname:
@@ -26,6 +27,7 @@ children:
   description: Conditions represent the latest available observation of the resource's
     current state.
   type: list (object)
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -35,6 +37,7 @@ children:
     shortname: '[]'
     description: ""
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -45,6 +48,7 @@ children:
       shortname: lastTransitionTime
       description: Last time the condition transitioned from one status to another.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -56,6 +60,7 @@ children:
       shortname: message
       description: Human-readable message indicating details about last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -67,6 +72,7 @@ children:
       shortname: reason
       description: Unique, one-word, CamelCase reason for the condition's last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -78,6 +84,7 @@ children:
       shortname: status
       description: Status is the status of the condition. Can be True, False, Unknown.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -89,6 +96,7 @@ children:
       shortname: type
       description: Type is the type of the condition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -103,6 +111,7 @@ children:
     then that means that the current reported status reflects the most recent desired
     state of the resource.
   type: integer
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -113,6 +122,7 @@ children:
   description: Output only. The resource name, in the format `projects/*/policy`.
     There is at most one policy per project.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -122,6 +132,7 @@ children:
   shortname: updateTime
   description: Output only. Time when the policy was last updated.
   type: string
+  format: date-time
   requirementlevel: Optional
   children: []
   additionalproperties: []

--- a/pkg/crd/fielddesc/testdata/pubsubsubscription-spec.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/pubsubsubscription-spec.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: spec
 description: ""
 type: object
+format: ""
 requirementlevel: Required
 children:
 - fullname:
@@ -43,6 +44,7 @@ children:
     If the subscriber never acknowledges the message, the Pub/Sub system
     will eventually redeliver the message.
   type: integer
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -55,6 +57,7 @@ children:
     Either pushConfig, bigQueryConfig or cloudStorageConfig can be set, but not combined.
     If all three are empty, then the subscriber will pull and ack messages using API methods.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -66,6 +69,7 @@ children:
       When true and useTopicSchema is true, any fields that are a part of the topic schema that are not part of the BigQuery table schema are dropped when writing to BigQuery.
       Otherwise, the schemas must be kept in sync and any messages with extra fields are not written and remain in the subscription's backlog.
     type: boolean
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -76,6 +80,7 @@ children:
     shortname: tableRef
     description: The name of the table to which to write data.
     type: object
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children:
     - fullname:
@@ -87,6 +92,7 @@ children:
       description: 'Allowed value: string of the format `{{project}}.{{dataset_id}}.{{value}}`,
         where {{value}} is the `name` field of a `BigQueryTable` resource.'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -98,6 +104,7 @@ children:
       shortname: name
       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -109,6 +116,7 @@ children:
       shortname: namespace
       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -121,6 +129,7 @@ children:
     description: When true, use the topic's schema as the columns to write to in BigQuery,
       if it exists.
     type: boolean
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -133,6 +142,7 @@ children:
       When true, write the subscription name, messageId, publishTime, attributes, and orderingKey to additional columns in the table.
       The subscription name, messageId, and publishTime fields are put in their own columns while all other message properties (other than data) are written to a JSON object in the attributes column.
     type: boolean
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -146,6 +156,7 @@ children:
     Either pushConfig, bigQueryConfig or cloudStorageConfig can be set, but not combined.
     If all three are empty, then the subscriber will pull and ack messages using API methods.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -155,6 +166,7 @@ children:
     shortname: avroConfig
     description: If set, message data will be written to Cloud Storage in Avro format.
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -166,6 +178,7 @@ children:
       description: When true, write the subscription name, messageId, publishTime,
         attributes, and orderingKey as additional fields in the output.
       type: boolean
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -178,6 +191,7 @@ children:
     description: User-provided name for the Cloud Storage bucket. The bucket must
       be created by the user. The bucket name must be without any prefix like "gs://".
     type: object
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children:
     - fullname:
@@ -188,6 +202,7 @@ children:
       shortname: external
       description: 'Allowed value: The `name` field of a `StorageBucket` resource.'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -199,6 +214,7 @@ children:
       shortname: name
       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -210,6 +226,7 @@ children:
       shortname: namespace
       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -221,6 +238,7 @@ children:
     shortname: filenamePrefix
     description: User-provided prefix for Cloud Storage filename.
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -232,6 +250,7 @@ children:
     description: User-provided suffix for Cloud Storage filename. Must not end in
       "/".
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -244,6 +263,7 @@ children:
       The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB.
       The maxBytes limit may be exceeded in cases where messages are larger than the limit.
     type: integer
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -257,6 +277,7 @@ children:
       May not exceed the subscription's acknowledgement deadline.
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -268,6 +289,7 @@ children:
     description: An output-only field that indicates whether or not the subscription
       can receive messages.
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -286,6 +308,7 @@ children:
     service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
     permission to Acknowledge() messages on this subscription.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -295,6 +318,7 @@ children:
     shortname: deadLetterTopicRef
     description: ""
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -306,6 +330,7 @@ children:
       description: 'Allowed value: string of the format `projects/{{project}}/topics/{{value}}`,
         where {{value}} is the `name` field of a `PubSubTopic` resource.'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -317,6 +342,7 @@ children:
       shortname: name
       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -328,6 +354,7 @@ children:
       shortname: namespace
       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -351,6 +378,7 @@ children:
 
       If this parameter is 0, a default value of 5 is used.
     type: integer
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -370,6 +398,7 @@ children:
     Note that subscribers may still receive multiple copies of a message when 'enable_exactly_once_delivery'
     is true if the message was published multiple times by a publisher client. These copies are considered distinct by Pub/Sub and have distinct messageId values.
   type: boolean
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -382,6 +411,7 @@ children:
     the subscribers in the order in which they are received by the Pub/Sub system. Otherwise, they
     may be delivered in any order.
   type: boolean
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -398,6 +428,7 @@ children:
     resource never expires.  The minimum allowed value for expirationPolicy.ttl
     is 1 day.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -412,6 +443,7 @@ children:
       A duration in seconds with up to nine fractional digits, terminated by 's'.
       Example - "3.5s".
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -426,6 +458,7 @@ children:
     by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription,
     you can't modify the filter.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -444,6 +477,7 @@ children:
     A duration in seconds with up to nine fractional digits, terminated
     by 's'. Example: '"600.5s"'.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -456,6 +490,7 @@ children:
     configure it. An empty pushConfig signifies that the subscriber will
     pull and ack messages using API methods.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -488,6 +523,7 @@ children:
       - v1beta1: uses the push format defined in the v1beta1 Pub/Sub API.
       - v1 or v1beta2: uses the push format defined in the v1 Pub/Sub API.
     type: 'map (key: string, value: string)'
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -500,6 +536,7 @@ children:
       When set, the payload to the push endpoint is not wrapped.Sets the
       'data' field as the HTTP body for delivery.
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -513,6 +550,7 @@ children:
         'x-goog-pubsub-<KEY>:<VAL>' headers of the HTTP request. Writes the
         Pub/Sub message attributes to '<KEY>:<VAL>' headers of the HTTP request.
       type: boolean
+      format: ""
       requirementlevel: RequiredWhenParentPresent
       children: []
       additionalproperties: []
@@ -526,6 +564,7 @@ children:
       If specified, Pub/Sub will generate and attach an OIDC JWT token as
       an Authorization header in the HTTP request for every pushed message.
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -542,6 +581,7 @@ children:
         token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
         Note: if not specified, the Push endpoint URL will be used.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -557,6 +597,7 @@ children:
         subscriptions.modifyPushConfig RPCs) must have the
         iam.serviceAccounts.actAs permission for the service account.
       type: string
+      format: ""
       requirementlevel: RequiredWhenParentPresent
       children: []
       additionalproperties: []
@@ -571,6 +612,7 @@ children:
       For example, a Webhook endpoint might use
       "https://example.com/push".
     type: string
+    format: ""
     requirementlevel: RequiredWhenParentPresent
     children: []
     additionalproperties: []
@@ -582,6 +624,7 @@ children:
   description: Immutable. Optional. The name of the resource. Used for creation and
     acquisition. When unset, the value of `metadata.name` is used as the default.
   type: string
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -595,6 +638,7 @@ children:
     they are acknowledged, until they fall out of the
     messageRetentionDuration window.
   type: boolean
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []
@@ -608,6 +652,7 @@ children:
     If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers.
     RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message.
   type: object
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -619,6 +664,7 @@ children:
       The maximum delay between consecutive deliveries of a given message. Value should be between 0 and 600 seconds. Defaults to 600 seconds.
       A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -631,6 +677,7 @@ children:
       The minimum delay between consecutive deliveries of a given message. Value should be between 0 and 600 seconds. Defaults to 10 seconds.
       A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -641,6 +688,7 @@ children:
   shortname: topicRef
   description: Reference to a PubSubTopic.
   type: object
+  format: ""
   requirementlevel: Required
   children:
   - fullname:
@@ -651,6 +699,7 @@ children:
     description: 'Allowed value: string of the format `projects/{{project}}/topics/{{value}}`,
       where {{value}} is the `name` field of a `PubSubTopic` resource.'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -661,6 +710,7 @@ children:
     shortname: name
     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []
@@ -671,6 +721,7 @@ children:
     shortname: namespace
     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
     type: string
+    format: ""
     requirementlevel: Optional
     children: []
     additionalproperties: []

--- a/pkg/crd/fielddesc/testdata/pubsubsubscription-status.golden.yaml
+++ b/pkg/crd/fielddesc/testdata/pubsubsubscription-status.golden.yaml
@@ -17,6 +17,7 @@ fullname:
 shortname: status
 description: ""
 type: object
+format: ""
 requirementlevel: Optional
 children:
 - fullname:
@@ -26,6 +27,7 @@ children:
   description: Conditions represent the latest available observation of the resource's
     current state.
   type: list (object)
+  format: ""
   requirementlevel: Optional
   children:
   - fullname:
@@ -35,6 +37,7 @@ children:
     shortname: '[]'
     description: ""
     type: object
+    format: ""
     requirementlevel: Optional
     children:
     - fullname:
@@ -45,6 +48,7 @@ children:
       shortname: lastTransitionTime
       description: Last time the condition transitioned from one status to another.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -56,6 +60,7 @@ children:
       shortname: message
       description: Human-readable message indicating details about last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -67,6 +72,7 @@ children:
       shortname: reason
       description: Unique, one-word, CamelCase reason for the condition's last transition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -78,6 +84,7 @@ children:
       shortname: status
       description: Status is the status of the condition. Can be True, False, Unknown.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -89,6 +96,7 @@ children:
       shortname: type
       description: Type is the type of the condition.
       type: string
+      format: ""
       requirementlevel: Optional
       children: []
       additionalproperties: []
@@ -103,6 +111,7 @@ children:
     then that means that the current reported status reflects the most recent desired
     state of the resource.
   type: integer
+  format: ""
   requirementlevel: Optional
   children: []
   additionalproperties: []

--- a/scripts/generate-go-crd-clients/client_test.go
+++ b/scripts/generate-go-crd-clients/client_test.go
@@ -119,7 +119,7 @@ func TestComputeInstanceGoClient(t *testing.T) {
 
 	computeInstanceName := "computeinstance"
 	autoDelete := true
-	bootDiskSize := 20
+	bootDiskSize := int64(20)
 	bootDiskType := "pd-ssd"
 	machineType := "n1-standard-1"
 	zone := "europe-west1-b"

--- a/scripts/generate-go-crd-clients/generate-types-file.go
+++ b/scripts/generate-go-crd-clients/generate-types-file.go
@@ -32,8 +32,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/fielddesc"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
-
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/klog/v2"
 )
 
 var handwrittenIAMTypes = []string{
@@ -475,7 +475,16 @@ func formatType(desc fielddesc.FieldDescription, isRef, isSec, isIAMRef bool) st
 	case "boolean":
 		return "bool"
 	case "integer":
-		return "int"
+		switch desc.Format {
+		case "int64":
+			return "int64"
+		case "":
+			// The default is int64 (and not int, we don't want the schema to vary across architectures)
+			return "int64"
+		default:
+			klog.Fatalf("unhandled case in formatType: %+v", desc)
+			return ""
+		}
 	case "float", "number":
 		return "float64"
 	case "object":
@@ -527,7 +536,7 @@ func formatToGoLiteral(t string) string {
 	case "boolean":
 		return "bool"
 	case "integer":
-		return "int"
+		return "int64"
 	case "float", "number":
 		return "float64"
 	default:


### PR DESCRIPTION
- chore: generate int64 instead of int in client types
- autogen: make generate-go-clients
