### PR TITLE
tests: use cmp.Diff for golden object check

### DIFF
--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -166,37 +165,7 @@ func CompareGoldenObject(t *testing.T, path string, got []byte) {
 	if err != nil {
 		t.Errorf("Failed parsing file: %s", err)
 	}
-	if ok, err := compareNestedFields(wantMap, gotMap); !ok {
-		t.Fatalf("unexpected diff in %s: %s", path, err)
+	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
+		t.Errorf("unexpected diff in %s: %s", path, diff)
 	}
-}
-
-func compareNestedFields(wantMap, gotMap map[string]interface{}) (bool, error) {
-	for wantKey := range wantMap {
-		if _, exists := gotMap[wantKey]; !exists {
-			err := fmt.Errorf("field %s in the golden file is missing", wantKey)
-			return false, err
-		}
-	}
-
-	for gotKey := range gotMap {
-		if _, exists := wantMap[gotKey]; !exists {
-			err := fmt.Errorf("field %s does not exist in golden file", gotKey)
-			return false, err
-		}
-	}
-
-	//  Check nested structures recursively
-	for wantKey, wantVal := range wantMap {
-		if gotVal, exists := gotMap[wantKey]; exists {
-			if wantNestedMap, ok1 := wantVal.(map[string]interface{}); ok1 {
-				if gotNestedMap, ok2 := gotVal.(map[string]interface{}); ok2 {
-					if ok, err := compareNestedFields(wantNestedMap, gotNestedMap); !ok {
-						return false, err
-					}
-				}
-			}
-		}
-	}
-	return true, nil
 }


### PR DESCRIPTION
While trying to diff 2 KRM exports, I figured it could be easier to use `cmp.Diff` to get all the diff at once!

before
```
...
    utils.go:170: unexpected diff in <MY_PATH>/k8s-config-connector/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/linearlogmetric/_generated_object_linearlogmetric.golden.yaml: field metricDescriptor in the golden file is missing

...
```

after
```
  utils.go:170: unexpected diff in<MY_PATH>/k8s-config-connector/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/linearlogmetric/_generated_object_linearlogmetric.golden.yaml:   map[string]any{
                ... // 2 identical entries
                "metadata": map[string]any{"annotations": map[string]any{"cnrm.cloud.google.com/management-conflict-prevention-policy": string("none")}, "finalizers": []any{string("cnrm.cloud.google.com/finalizer"), string("cnrm.cloud.google.com/deletion-defender")}, "generation": float64(3), "labels": map[string]any{"cnrm-test": string("true")}, ...},
                "spec":     map[string]any{"bucketOptions": map[string]any{"linearBuckets": map[string]any{"numFiniteBuckets": float64(4), "offset": float64(0.5), "width": float64(2.5)}}, "description": string("An updated sample log metric"), "disabled": bool(true), "filter": string("resource.type=gae_app AND severity>=ERROR"), ...},
                "status": map[string]any{
                        "conditions": []any{map[string]any{"lastTransitionTime": string("1970-01-01T00:00:00Z"), "message": string("The resource is up to date"), "reason": string("UpToDate"), "status": string("True"), ...}},
                        "createTime": string("1970-01-01T00:00:00Z"),
        -               "metricDescriptor": map[string]any{
        -                       "description": string("An updated sample log metric"),
        -                       "name":        string("projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}"),
        -                       "type":        string("logging.googleapis.com/user/logginglogmetric-${uniqueId}"),
        -               },
                        "observedGeneration": float64(3),
                        "updateTime":         string("1970-01-01T00:00:00Z"),
                },
          }
```