### PR TITLE
tests: relax panic on record

### DIFF
--- a/pkg/test/http_recorder.go
+++ b/pkg/test/http_recorder.go
@@ -123,7 +123,7 @@ func (r *HTTPRecorder) record(entry *LogEntry, req *http.Request, resp *http.Res
 		} else if resp.Body != nil {
 			requestBody, err := io.ReadAll(resp.Body)
 			if err != nil {
-				panic(fmt.Sprintf("failed to read response body for request %q: %v", req.URL, err))
+				return fmt.Errorf("failed to read response body for request %q: %w", req.URL, err)
 			}
 			entry.Response.Body = string(requestBody)
 			resp.Body = io.NopCloser(bytes.NewReader(requestBody))


### PR DESCRIPTION
There's no good reason for us to panic if we cannot read the request body because the context has been canceled. I think that is an OK situation to be in.

Relaxing this check should eliminate the class of racing that has been making the pause tests flaky!

before
```
{"severity":"error","timestamp":"2024-04-18T18:36:52.713Z","msg":"Reconciler error","controller":"edgecontainercluster-controller","controllerGroup":"edgecontainer.cnrm.cloud.google.com","controllerKind":"EdgeContainerCluster","EdgeContainerCluster":{"name":"edgecontainercluster-stor3b7gzoni2vdypela","namespace":"stor3b7gzoni2vdypela"},"namespace":"stor3b7gzoni2vdypela","name":"edgecontainercluster-stor3b7gzoni2vdypela","reconcileID":"1e21bbd9-c92f-442c-b171-98c230ad9a18","error":"Get \"[https://127.0.0.1:37865/apis/edgecontainer.cnrm.cloud.google.com/v1beta1/namespaces/stor3b7gzoni2vdypela/edgecontainerclusters/edgecontainercluster-stor3b7gzoni2vdypela\](https://127.0.0.1:37865/apis/edgecontainer.cnrm.cloud.google.com/v1beta1/namespaces/stor3b7gzoni2vdypela/edgecontainerclusters/edgecontainercluster-stor3b7gzoni2vdypela/)": context canceled"}
3747
{"severity":"info","timestamp":"2024-04-18T18:36:52.713Z","msg":"Observed a panic in reconciler: failed to read response body for request \"[https://127.0.0.1:37865/api/v1/namespaces/stor3b7gzoni2vdypela\](https://127.0.0.1:37865/api/v1/namespaces/stor3b7gzoni2vdypela/)": context canceled","controller":"project-controller","controllerGroup":"resourcemanager.cnrm.cloud.google.com","controllerKind":"Project","Project":{"name":"project-stor3b7gzoni2vdypela","namespace":"stor3b7gzoni2vdypela"},"namespace":"stor3b7gzoni2vdypela","name":"project-stor3b7gzoni2vdypela","reconcileID":"40f5e494-e8a7-43fd-8524-797ede9801e2"}
3748
panic: failed to read response body for request "https://127.0.0.1:37865/api/v1/namespaces/stor3b7gzoni2vdypela": context canceled [recovered]
3749
	panic: failed to read response body for request "https://127.0.0.1:37865/api/v1/namespaces/stor3b7gzoni2vdypela": context canceled
3750

3751
goroutine 318274 [running]:
3752
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
3753
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.2/pkg/internal/controller/controller.go:115 +0x1e5
3754
panic({0x5aeb700?, 0xc001bdd6c0?})
3755
	/opt/hostedtoolcache/go/1.21.5/x64/src/runtime/panic.go:914 +0x21f
3756
github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test.(*HTTPRecorder).record(0xc0561a6720, 0xc05748ec60, 0xc04abf0e00, 0xc056e73560)
3757
	/home/runner/work/k8s-config-connector/k8s-config-connector/pkg/test/http_recorder.go:126 +0x5c5
3758
github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test.(*HTTPRecorder).RoundTrip(0xc0561a6720, 0xc04abf0e00)
3759
	/home/runner/work/k8s-config-connector/k8s-config-connector/pkg/test/http_recorder.go:94 +0x578
3760
k8s.io/client-go/transport.(*userAgentRoundTripper).RoundTrip(0xc04e4652c0, 0xc04abf0d00)
3761
	/home/runner/go/pkg/mod/k8s.io/client-go@v0.27.11/transport/round_trippers.go:168 +0x326
3762
net/http.send(0xc04abf0d00, {0x7600d00, 0xc04e4652c0}, {0x1?, 0xc0300a1e20?, 0x0?})

```

after
```
{"severity":"error","timestamp":"2024-04-18T19:02:26.082Z","msg":"Reconciler error","controller":"computenodegroup-deletion-defender-controller","controllerGroup":"compute.cnrm.cloud.google.com","controllerKind":"ComputeNodeGroup","ComputeNodeGroup":{"name":"computenodegroup-rkxsumjre4uvtoirthma","namespace":"rkxsumjre4uvtoirthma"},"namespace":"rkxsumjre4uvtoirthma","name":"computenodegroup-rkxsumjre4uvtoirthma","reconcileID":"2069a37c-b197-441e-8847-a55ac0b4cf9c","error":"error determining if CRD is uninstalling: error getting CRD 'computenodegroups.compute.cnrm.cloud.google.com': Get \"[https://127.0.0.1:46821/apis/apiextensions.k8s.io/v1/customresourcedefinitions/computenodegroups.compute.cnrm.cloud.google.com\](https://127.0.0.1:46821/apis/apiextensions.k8s.io/v1/customresourcedefinitions/computenodegroups.compute.cnrm.cloud.google.com/)": context canceled"}
3311
W0418 19:02:26.082218   18758 http_recorder.go:95] failed to record HTTP request: failed to read response body for request "https://127.0.0.1:46821/apis/compute.cnrm.cloud.google.com/v1beta1/namespaces/rkxsumjre4uvtoirthma/computenodegroups/computenodegroup-rkxsumjre4uvtoirthma": context canceled
3312
E0418 19:02:26.082240   18758 request.go:1092] Unexpected error when reading response body: context canceled
3313
{"severity":"error","timestamp":"2024-04-18T19:02:26.082Z","msg":"Reconciler error","controller":"computenodegroup-controller","controllerGroup":"compute.cnrm.cloud.google.com","controllerKind":"ComputeNodeGroup","ComputeNodeGroup":{"name":"computenodegroup-rkxsumjre4uvtoirthma","namespace":"rkxsumjre4uvtoirthma"},"namespace":"rkxsumjre4uvtoirthma","name":"computenodegroup-rkxsumjre4uvtoirthma","reconcileID":"8d4d42e6-37e4-4de8-9640-6a8ee55679f2","error":"unexpected error when reading response body. Please retry. Original error: context canceled"}
```