### PR TITLE
Temporarily skip alloydb instance sample tests

### DIFF
--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -221,9 +221,15 @@ var testDisabledList = map[string]bool{
 	// b/309167136
 	"alloydbbackup":                true,
 	"restored-from-backup-cluster": true,
-	// Similarly want to temporarily disable secondary-instance test
-	// until we can delay second creation until primary is ready
+	// Temporarily disable alloydbinstance sample tests as they raise alerts
+	// due to expected failures during create instance operation with service
+	// networking connection not being ready.
+	// Will enable this after adding fix for the alert mechanism or by adding
+	// precondition failure to not account this as an error.
+	"primary-instance":   true,
+	"read-instance":      true,
 	"secondary-instance": true,
+	"zonal-instance":     true,
 	// This sample test need physical rack which is not suitable for e2e testing due to
 	// limited budget.
 	"edgecontainercluster-local-control-plane":  true,


### PR DESCRIPTION
We now enforce that secondary instance can only be created once primary instance is created. So can remove the sample test from the list.
However, we do see create instance failures as the service networking connection is not ready and it leads to alerts. This is an expected behavior from KCC  as there is no explicit dependency between instance and service networking connection.
Trying to fix this issue either from the AlloyDB API backend by not accounting this as an error or by fixing the alerts to add this alert as an exemption for KCC resources. Will enable them back as soon as it gets fixed.  