### PR TITLE
chore: add direct CRD for LoggingLogMetric, chore: patch existing LoggingLogMetric CRD, feat: switch LLM to direct controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ manifests: generate
 	rm kustomization.yaml
 
 	# for direct controllers
-	cp -rf config/crds/direct/* config/crds/resources/
+	cp -rf config/crds/direct/*.yaml config/crds/resources/
 
 # Format code
 .PHONY: fmt

--- a/apis/resources/logging/v1beta1/doc.go
+++ b/apis/resources/logging/v1beta1/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen=package,register
+//+groupName=logging.cnrm.cloud.google.com
+
+package v1beta1

--- a/apis/resources/logging/v1beta1/logmetric_types.go
+++ b/apis/resources/logging/v1beta1/logmetric_types.go
@@ -140,6 +140,14 @@ type LogmetricMetricDescriptor struct {
 }
 
 type LoggingLogMetricSpec struct {
+	// BucketName: Optional. The resource name of the Log Bucket that owns
+	// the Log Metric. Only Log Buckets in projects are supported. The
+	// bucket has to be in the same project as the metric.For
+	// example:projects/my-project/locations/global/buckets/my-bucket
+	// If empty, then the Log Metric is considered a non-Bucket Log Metric.
+	// +optional
+	BucketName string `json:"bucketName,omitempty"`
+
 	/* Optional. The `bucket_options` are required when the logs-based metric is using a DISTRIBUTION value type and it describes the bucket boundaries used to create a histogram of the extracted values. */
 	// +optional
 	BucketOptions *LogmetricBucketOptions `json:"bucketOptions,omitempty"`
@@ -217,6 +225,12 @@ type LoggingLogMetricStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=gcp,shortName=gcplogginglogmetric;gcplogginglogmetrics
 // +kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Status Age",type="date",JSONPath=".status.conditions[?(@.type=='Ready')].lastTransitionTime"
 
 // LoggingLogMetric is the Schema for the logging API
 // +k8s:openapi-gen=true
@@ -229,6 +243,7 @@ type LoggingLogMetric struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // LoggingLogMetricList contains a list of LoggingLogMetric
 type LoggingLogMetricList struct {

--- a/apis/resources/logging/v1beta1/logmetric_types.go
+++ b/apis/resources/logging/v1beta1/logmetric_types.go
@@ -140,13 +140,14 @@ type LogmetricMetricDescriptor struct {
 }
 
 type LoggingLogMetricSpec struct {
-	// BucketName: Optional. The resource name of the Log Bucket that owns
+	// The reference to the Log Bucket that owns
 	// the Log Metric. Only Log Buckets in projects are supported. The
-	// bucket has to be in the same project as the metric.For
+	// bucket has to be in the same project as the metric. For
 	// example:projects/my-project/locations/global/buckets/my-bucket
 	// If empty, then the Log Metric is considered a non-Bucket Log Metric.
+	/* Only `external` field is supported to configure the reference for now. */
 	// +optional
-	BucketName string `json:"bucketName,omitempty"`
+	LoggingLogBucketRef *v1alpha1.ResourceRef `json:"loggingLogBucketRef,omitempty"`
 
 	/* Optional. The `bucket_options` are required when the logs-based metric is using a DISTRIBUTION value type and it describes the bucket boundaries used to create a histogram of the extracted values. */
 	// +optional

--- a/apis/resources/logging/v1beta1/zz_generated.deepcopy.go
+++ b/apis/resources/logging/v1beta1/zz_generated.deepcopy.go
@@ -115,6 +115,11 @@ func (in *LoggingLogMetricSpec) DeepCopyInto(out *LoggingLogMetricSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.LoggingLogBucketRef != nil {
+		in, out := &in.LoggingLogBucketRef, &out.LoggingLogBucketRef
+		*out = new(v1alpha1.ResourceRef)
+		**out = **in
+	}
 	if in.MetricDescriptor != nil {
 		in, out := &in.MetricDescriptor, &out.MetricDescriptor
 		*out = new(LogmetricMetricDescriptor)

--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.22 AS builder
+
+RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
+
+RUN mkdir /wkdir
+WORKDIR /wkdir

--- a/config/crds/direct/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
+++ b/config/crds/direct/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
@@ -5,7 +5,6 @@ metadata:
     cnrm.cloud.google.com/version: 0.0.0-dev
   creationTimestamp: null
   labels:
-    cnrm.cloud.google.com/dcl2crd: "true"
     cnrm.cloud.google.com/managed-by-kcc: "true"
     cnrm.cloud.google.com/stability-level: stable
     cnrm.cloud.google.com/system: "true"

--- a/config/crds/direct/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
+++ b/config/crds/direct/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
@@ -60,14 +60,6 @@ spec:
             type: object
           spec:
             properties:
-              bucketName:
-                description: |-
-                  BucketName: Optional. The resource name of the Log Bucket that owns
-                  the Log Metric. Only Log Buckets in projects are supported. The
-                  bucket has to be in the same project as the metric.For
-                  example:projects/my-project/locations/global/buckets/my-bucket
-                  If empty, then the Log Metric is considered a non-Bucket Log Metric.
-                type: string
               bucketOptions:
                 description: Optional. The `bucket_options` are required when the
                   logs-based metric is using a DISTRIBUTION value type and it describes
@@ -146,6 +138,45 @@ spec:
                   for a boolean label its `false`. Note that there are upper bounds
                   on the maximum number of labels and the number of active time series
                   that are allowed in a project.
+                type: object
+              loggingLogBucketRef:
+                description: |-
+                  The reference to the Log Bucket that owns
+                  the Log Metric. Only Log Buckets in projects are supported. The
+                  bucket has to be in the same project as the metric. For
+                  example:projects/my-project/locations/global/buckets/my-bucket
+                  If empty, then the Log Metric is considered a non-Bucket Log Metric.
+                  Only `external` field is supported to configure the reference.
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                  - kind
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                    - required:
+                      - kind
+                  required:
+                  - external
+                properties:
+                  external:
+                    description: The external name of the referenced resource
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
                 type: object
               metricDescriptor:
                 description: Optional. The metric descriptor associated with the logs-based

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
@@ -5,7 +5,6 @@ metadata:
     cnrm.cloud.google.com/version: 0.0.0-dev
   creationTimestamp: null
   labels:
-    cnrm.cloud.google.com/dcl2crd: "true"
     cnrm.cloud.google.com/managed-by-kcc: "true"
     cnrm.cloud.google.com/stability-level: stable
     cnrm.cloud.google.com/system: "true"
@@ -60,14 +59,6 @@ spec:
             type: object
           spec:
             properties:
-              bucketName:
-                description: |-
-                  BucketName: Optional. The resource name of the Log Bucket that owns
-                  the Log Metric. Only Log Buckets in projects are supported. The
-                  bucket has to be in the same project as the metric.For
-                  example:projects/my-project/locations/global/buckets/my-bucket
-                  If empty, then the Log Metric is considered a non-Bucket Log Metric.
-                type: string
               bucketOptions:
                 description: Optional. The `bucket_options` are required when the
                   logs-based metric is using a DISTRIBUTION value type and it describes
@@ -146,6 +137,45 @@ spec:
                   for a boolean label its `false`. Note that there are upper bounds
                   on the maximum number of labels and the number of active time series
                   that are allowed in a project.
+                type: object
+              loggingLogBucketRef:
+                description: |-
+                  The reference to the Log Bucket that owns
+                  the Log Metric. Only Log Buckets in projects are supported. The
+                  bucket has to be in the same project as the metric. For
+                  example:projects/my-project/locations/global/buckets/my-bucket
+                  If empty, then the Log Metric is considered a non-Bucket Log Metric.
+                  Only `external` field is supported to configure the reference.
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                  - kind
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                    - required:
+                      - kind
+                  required:
+                  - external
+                properties:
+                  external:
+                    description: The external name of the referenced resource
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
                 type: object
               metricDescriptor:
                 description: Optional. The metric descriptor associated with the logs-based

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
@@ -224,7 +224,7 @@ type LoggingLogMetricStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=gcp,shortName=gcplogginglogmetric;gcplogginglogmetrics
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:labels="cnrm.cloud.google.com/dcl2crd=true";"cnrm.cloud.google.com/managed-by-kcc=true";"cnrm.cloud.google.com/stability-level=stable";"cnrm.cloud.google.com/system=true"
+// +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true";"cnrm.cloud.google.com/stability-level=stable";"cnrm.cloud.google.com/system=true"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date"
 // +kubebuilder:printcolumn:name="Ready",JSONPath=".status.conditions[?(@.type=='Ready')].status",type="string",description="When 'True', the most recent reconcile of the resource succeeded"
 // +kubebuilder:printcolumn:name="Status",JSONPath=".status.conditions[?(@.type=='Ready')].reason",type="string",description="The reason for the value in 'Ready'"

--- a/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/logginglogmetric_types.go
@@ -157,6 +157,15 @@ type LoggingLogMetricSpec struct {
 	// +optional
 	LabelExtractors map[string]string `json:"labelExtractors,omitempty"`
 
+	/* The reference to the Log Bucket that owns
+	the Log Metric. Only Log Buckets in projects are supported. The
+	bucket has to be in the same project as the metric. For
+	example:projects/my-project/locations/global/buckets/my-bucket
+	If empty, then the Log Metric is considered a non-Bucket Log Metric.
+	Only `external` field is supported to configure the reference. */
+	// +optional
+	LoggingLogBucketRef *v1alpha1.ResourceRef `json:"loggingLogBucketRef,omitempty"`
+
 	/* Optional. The metric descriptor associated with the logs-based metric. If unspecified, it uses a default metric descriptor with a DELTA metric kind, INT64 value type, with no labels and a unit of "1". Such a metric counts the number of log entries matching the `filter` expression. The `name`, `type`, and `description` fields in the `metric_descriptor` are output only, and is constructed using the `name` and `description` field in the LogMetric. To create a logs-based metric that records a distribution of log values, a DELTA metric kind with a DISTRIBUTION value type must be used along with a `value_extractor` expression in the LogMetric. Each label in the metric descriptor must have a matching label name as the key and an extractor expression as the value in the `label_extractors` map. The `metric_kind` and `value_type` fields in the `metric_descriptor` cannot be updated once initially configured. New labels can be added in the `metric_descriptor`, but existing labels cannot be modified except for their description. */
 	// +optional
 	MetricDescriptor *LogmetricMetricDescriptor `json:"metricDescriptor,omitempty"`

--- a/pkg/clients/generated/apis/logging/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/logging/v1beta1/zz_generated.deepcopy.go
@@ -426,6 +426,11 @@ func (in *LoggingLogMetricSpec) DeepCopyInto(out *LoggingLogMetricSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.LoggingLogBucketRef != nil {
+		in, out := &in.LoggingLogBucketRef, &out.LoggingLogBucketRef
+		*out = new(v1alpha1.ResourceRef)
+		**out = **in
+	}
 	if in.MetricDescriptor != nil {
 		in, out := &in.MetricDescriptor, &out.MetricDescriptor
 		*out = new(LogmetricMetricDescriptor)

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -257,7 +257,7 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 		}
 		// register controllers for tf-based CRDs
 		if val, ok := crd.Labels[crdgeneration.TF2CRDLabel]; !ok || val != "true" {
-			logger.Info("unrecognized CRD; skipping controller registration", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
+			logger.Error(fmt.Errorf("unrecognized CRD: %v", crd.Spec.Names.Kind), "skipping controller registration", "group", gvk.Group, "version", gvk.Version, "kind", gvk.Kind)
 			return nil, nil
 		}
 		su, err := tf.Add(r.mgr, crd, r.provider, r.smLoader, r.defaulters, r.jitterGenerator)

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -223,6 +223,12 @@ func registerDefaultController(r *ReconcileRegistration, config *controller.Conf
 
 	// Depending on which resource it is, we need to register a different controller.
 	switch gvk.Kind {
+	// todo acpana: move direct controllers to the defaut case
+	case "LoggingLogMetric":
+		if err := logging.AddLogMetricController(r.mgr, config, directbase.Deps{JitterGenerator: r.jitterGenerator}); err != nil {
+			return nil, err
+		}
+		return schemaUpdater, nil
 	case "IAMPolicy":
 		if err := policy.Add(r.mgr, &cds); err != nil {
 			return nil, err

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
@@ -99,6 +99,11 @@ disabled: boolean
 filter: string
 labelExtractors:
   string: string
+loggingLogBucketRef:
+  external: string
+  kind: string
+  name: string
+  namespace: string
 metricDescriptor:
   displayName: string
   labels:
@@ -114,6 +119,7 @@ metricDescriptor:
   valueType: string
 projectRef:
   external: string
+  kind: string
   name: string
   namespace: string
 resourceID: string
@@ -289,6 +295,61 @@ valueExtractor: string
     </tr>
     <tr>
         <td>
+            <p><code>loggingLogBucketRef</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">object</code></p>
+            <p>{% verbatim %}The reference to the Log Bucket that owns
+the Log Metric. Only Log Buckets in projects are supported. The
+bucket has to be in the same project as the metric. For
+example:projects/my-project/locations/global/buckets/my-bucket
+If empty, then the Log Metric is considered a non-Bucket Log Metric.
+Only `external` field is supported to configure the reference.{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>loggingLogBucketRef.external</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>{% verbatim %}The external name of the referenced resource{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>loggingLogBucketRef.kind</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>{% verbatim %}Kind of the referent.{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>loggingLogBucketRef.name</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>{% verbatim %}Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>loggingLogBucketRef.namespace</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>{% verbatim %}Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
             <p><code>metricDescriptor</code></p>
             <p><i>Optional</i></p>
         </td>
@@ -444,9 +505,17 @@ valueExtractor: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The resource name of the project in which to create the metric.
-
-Allowed value: The Google Cloud resource name of a `Project` resource (format: `projects/{{name}}`).{% endverbatim %}</p>
+            <p>{% verbatim %}The external name of the referenced resource{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>projectRef.kind</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>{% verbatim %}Kind of the referent.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -525,7 +594,8 @@ updateTime: string
         <td><code>conditions</code></td>
         <td>
             <p><code class="apitype">list (object)</code></p>
-            <p>{% verbatim %}Conditions represent the latest available observation of the resource's current state.{% endverbatim %}</p>
+            <p>{% verbatim %}Conditions represent the latest available observations of the
+LoggingLogMetric's current state.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -553,7 +623,8 @@ updateTime: string
         <td><code>conditions[].reason</code></td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Unique, one-word, CamelCase reason for the condition's last transition.{% endverbatim %}</p>
+            <p>{% verbatim %}Unique, one-word, CamelCase reason for the condition's last
+transition.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/github-actions/tests-e2e-direct.sh
+++ b/scripts/github-actions/tests-e2e-direct.sh
@@ -24,7 +24,14 @@ cd ${REPO_ROOT}/
 echo "Downloading envtest assets..."
 export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
 
-echo "Running e2e tests for LoggingLogMetric direct reconciliation..."
+echo "Running e2e tests samples for LoggingLogMetric direct reconciliation..."
+
+KCC_USE_DIRECT_RECONCILERS=LoggingLogMetric \
+GOLDEN_OBJECT_CHECKS=1 \
+E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock \
+  go test -test.count=1 -timeout 600s -v ./tests/e2e -run 'TestAllInSeries/samples/linear-log-metric|TestAllInSeries/samples/exponential-log-metric|TestAllInSeries/samples/int-log-metric|TestAllInSeries/samples/explicit-log-metric'
+
+echo "Running e2e tests fixtures for LoggingLogMetric direct reconciliation..."
 
 KCC_USE_DIRECT_RECONCILERS=LoggingLogMetric \
 GOLDEN_OBJECT_CHECKS=1 \


### PR DESCRIPTION
Patch introduces a way to generate CRDs from the go structs in `apis`. This is not perfect just yet.

Also adds the bucketName field for our KRM's `LoggingLogMetric` resource