### PR TITLE
chore: client-generator should visit objects in maps

### DIFF
--- a/scripts/generate-go-crd-clients/generate-types-file.go
+++ b/scripts/generate-go-crd-clients/generate-types-file.go
@@ -562,5 +562,8 @@ func flattenChildrenDescription(result []fielddesc.FieldDescription, fd fielddes
 	for _, child := range fd.Children {
 		result = flattenChildrenDescription(result, child)
 	}
+	for _, child := range fd.AdditionalProperties {
+		result = flattenChildrenDescription(result, child)
+	}
 	return result
 }


### PR DESCRIPTION
Some APIs may include objects in maps, we want to output those objects
also.
