### PR TITLE
Fix sample docs for CloudSql and AppTeam

### DIFF
--- a/experiments/compositions/samples/AppTeam/README.md
+++ b/experiments/compositions/samples/AppTeam/README.md
@@ -4,7 +4,7 @@ For now this would only work in CC from a specific project.
 
 ## [Platform Admin] Create a Context object
 
-The first step is to create a context object in the namespace where compositions are installed.
+The first step is to create a context object in the namespace where AppTeam will be created.
 
 ```
 kubectl apply -f - <<EOF
@@ -12,7 +12,7 @@ apiVersion: composition.google.com/v1alpha1
 kind: Context
 metadata:
   name: context
-  namespace: default
+  namespace: config-control
 spec:
   project: <Replace with CC project>
 EOF

--- a/experiments/compositions/samples/CloudSQL/README.md
+++ b/experiments/compositions/samples/CloudSQL/README.md
@@ -6,17 +6,32 @@
 kubectl create -f composition/hasql.yaml
 ```
 
-## [clearing Team Admin] Create a CloudSQL `collateral`
+## [Platform Admin] Create a Context object
+
+The first step is to create a context object in the namespace where CloudSQL will be created.
+
+```
+kubectl apply -f - <<EOF
+apiVersion: composition.google.com/v1alpha1
+kind: Context
+metadata:
+  name: context
+  namespace: config-control
+spec:
+  project: <Replace with CC project>
+EOF
+```
+
+## [Team Admin] Create a CloudSQL `collateral`
 
 Please note we are creating this in `config-control` namespace for the sample.
 If KCC is setup in a tenant namespace (say using `AppTeams` composition), then we can use the tenant namespace instead.
 
 ```
 namespace=config-control
-# namespace=clearing-<suffix>
  
 kubectl apply -f - <<EOF
-apiVersion: facade.facade/v1alpha1
+apiVersion: facade.compositions.google.com/v1
 kind: CloudSQL
 metadata:
   name: collateral
@@ -35,10 +50,10 @@ Verify the relevant resources are created succesfully
 ./get_cloudsql.sh ${namespace}
 ```
 
-## [Platform Admin] Cleaning up
+## [Team Admin] Cleaning up
 
 When done with testing, cleanup the resources by deleting the `CloudSQL` CRs.
 
 ```
-kubectl delete cloudsql clearing
+kubectl delete cloudsql collateral
 ```


### PR DESCRIPTION
### Change description
Fix sample docs for CloudSql and AppTeam.
Use correct namespace for `context` objects.
Use correct group for `CloudSQL` facade.
