### PR TITLE
tests: add gcloud exporter for llm

### DIFF
--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export00.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export00.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+createTime: "2024-05-04T02:04:36.418290817Z"
+filter: resource.type=gae_app AND severity<=ERROR
+metricDescriptor:
+  metricKind: DELTA
+  name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  unit: "1"
+  valueType: INT64
+name: logginglogmetric-${uniqueId}
+updateTime: "2024-05-04T02:04:36.418290817Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export01.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export01.yaml
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+createTime: "2024-05-04T02:04:36.418290817Z"
+description: an e2e test
+disabled: true
+filter: resource.type=gae_app AND severity<=INFO
+metricDescriptor:
+  description: an e2e test
+  metricKind: DELTA
+  name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  unit: "1"
+  valueType: INT64
+name: logginglogmetric-${uniqueId}
+updateTime: "2024-05-04T02:04:37.890093544Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export02.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_gcloud_export02.yaml
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+createTime: "2024-05-04T02:04:36.418290817Z"
+description: an e2e test
+disabled: true
+filter: resource.type=gae_app AND severity<=INFO
+metricDescriptor:
+  description: an e2e test
+  metricKind: DELTA
+  name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  unit: "1"
+  valueType: INT64
+name: logginglogmetric-${uniqueId}
+updateTime: "2024-05-04T02:04:37.890093544Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http00.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http00.log
@@ -6,6 +6,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=57
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -16,14 +17,13 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "errors": [
+    "details": [
       {
-        "domain": "global",
-        "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
-        "reason": "notFound"
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: Metric logginglogmetric-${uniqueId} does not exist. [google.rpc.error_details_ext] { message: \"Metric logginglogmetric-${uniqueId} does not exist.\" }"
       }
     ],
-    "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
     "status": "NOT_FOUND"
   }
 }
@@ -38,6 +38,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=54
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -48,14 +49,13 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "errors": [
+    "details": [
       {
-        "domain": "global",
-        "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
-        "reason": "notFound"
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: Metric logginglogmetric-${uniqueId} does not exist. [google.rpc.error_details_ext] { message: \"Metric logginglogmetric-${uniqueId} does not exist.\" }"
       }
     ],
-    "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
     "status": "NOT_FOUND"
   }
 }
@@ -70,6 +70,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=63
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -80,14 +81,13 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "errors": [
+    "details": [
       {
-        "domain": "global",
-        "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
-        "reason": "notFound"
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: Metric logginglogmetric-${uniqueId} does not exist. [google.rpc.error_details_ext] { message: \"Metric logginglogmetric-${uniqueId} does not exist.\" }"
       }
     ],
-    "message": "logMetric \"projects/${projectId}/metrics/logginglogmetric-${uniqueId}\" not found",
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
     "status": "NOT_FOUND"
   }
 }
@@ -107,6 +107,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=756
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -117,6 +118,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -131,6 +139,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=67
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -141,6 +150,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -155,6 +171,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=55
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -165,6 +182,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -179,6 +203,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=56
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -189,6 +214,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -203,6 +235,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=48
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -213,6 +246,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -227,6 +267,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=53
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -237,6 +278,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http01.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http01.log
@@ -6,6 +6,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=58
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -16,6 +17,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -30,6 +38,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=31
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -40,6 +49,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -54,6 +70,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=37
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -64,6 +81,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -78,6 +102,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=52
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -88,6 +113,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -101,13 +133,20 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 {
   "description": "an e2e test",
   "disabled": true,
-  "filter": "resource.type=gae_app AND severity\u003c=INFO"
+  "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "labels": [],
+    "metricKind": "DELTA",
+    "unit": "1",
+    "valueType": "INT64"
+  }
 }
 
 200 OK
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=594
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -120,6 +159,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -134,6 +181,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=53
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -146,6 +194,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http02.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_http02.log
@@ -6,6 +6,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=43
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -18,6 +19,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -32,6 +41,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=52
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -44,6 +54,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -58,6 +76,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Server: ESF
+Server-Timing: gfet4t7; dur=64
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
@@ -70,6 +89,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object00.yaml
@@ -17,7 +17,6 @@ kind: LoggingLogMetric
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -39,5 +38,8 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object01.yaml
@@ -17,7 +17,6 @@ kind: LoggingLogMetric
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -41,5 +40,9 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: an e2e test
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 3
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/_object02.yaml
@@ -17,7 +17,6 @@ kind: LoggingLogMetric
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -39,5 +38,9 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: an e2e test
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 4
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/script.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_set_unset/basic/script.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # creation "empty"
+EXPORTER: GCLOUD-CLI
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:
@@ -25,6 +26,7 @@ spec:
     external: "projects/${projectId}"
 ---
 # setting settable fields
+EXPORTER: GCLOUD-CLI
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:
@@ -39,6 +41,7 @@ spec:
     external: "projects/${projectId}"
 ---
 # unsetting settable fields
+EXPORTER: GCLOUD-CLI
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:


### PR DESCRIPTION
A bit of a hacky way to use gcloud for the field tests (for dcl resources). Set, unmanage and unset.

The exports are captured against `real` gcp:

```bash
$ WRITE_GOLDEN_OUTPUT=1 GOLDEN_REQUEST_CHECKS=1 \
E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=real RUN_E2E=1  \
  go test -test.count=1 -timeout 360s -v ./tests/e2e -run TestE2EScript/scenarios/direct/llm_set_unset/basic 2>&1
```

#### PR todos
* [ ] document the `EXPORTER` control for the scenario based testing
* [ ] more hacking on the normalizer to replace timestamps