### PR TITLE
Fix the error when 'state-into-spec: merge' is configured for handwritten IAM resources

### DIFF
--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -45,7 +45,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -159,10 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	// r.Get() overrides the TypeMeta to empty value, so need to configure it
 	// after r.Get().
-	auditConfig.TypeMeta = metav1.TypeMeta{
-		APIVersion: iamv1beta1.IAMAuditConfigGVK.GroupVersion().String(),
-		Kind:       iamv1beta1.IAMAuditConfigGVK.Kind,
-	}
+	auditConfig.SetGroupVersionKind(iamv1beta1.IAMAuditConfigGVK)
 	if err := r.handleDefaults(ctx, &auditConfig); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(&auditConfig), err)
 	}

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -45,6 +45,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -155,6 +156,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
+	}
+	// r.Get() overrides the TypeMeta to empty value, so need to configure it
+	// after r.Get().
+	auditConfig.TypeMeta = metav1.TypeMeta{
+		APIVersion: iamv1beta1.IAMAuditConfigGVK.GroupVersion().String(),
+		Kind:       iamv1beta1.IAMAuditConfigGVK.Kind,
 	}
 	if err := r.handleDefaults(ctx, &auditConfig); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(&auditConfig), err)

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -173,10 +173,7 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 	}
 	// r.Get() overrides the TypeMeta to empty value, so need to configure it
 	// after r.Get().
-	policy.TypeMeta = metav1.TypeMeta{
-		APIVersion: iamv1beta1.IAMPartialPolicyGVK.GroupVersion().String(),
-		Kind:       iamv1beta1.IAMPartialPolicyGVK.Kind,
-	}
+	policy.SetGroupVersionKind(iamv1beta1.IAMPartialPolicyGVK)
 	if err := r.handleDefaults(ctx, policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM partial policy '%v': %w", k8s.GetNamespacedName(policy), err)
 	}

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -171,6 +171,12 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	// r.Get() overrides the TypeMeta to empty value, so need to configure it
+	// after r.Get().
+	policy.TypeMeta = metav1.TypeMeta{
+		APIVersion: iamv1beta1.IAMPartialPolicyGVK.GroupVersion().String(),
+		Kind:       iamv1beta1.IAMPartialPolicyGVK.Kind,
+	}
 	if err := r.handleDefaults(ctx, policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM partial policy '%v': %w", k8s.GetNamespacedName(policy), err)
 	}

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -45,7 +45,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -169,10 +168,7 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 	}
 	// r.Get() overrides the TypeMeta to empty value, so need to configure it
 	// after r.Get().
-	policy.TypeMeta = metav1.TypeMeta{
-		APIVersion: iamv1beta1.IAMPolicyGVK.GroupVersion().String(),
-		Kind:       iamv1beta1.IAMPolicyGVK.Kind,
-	}
+	policy.SetGroupVersionKind(iamv1beta1.IAMPolicyGVK)
 	if err := r.handleDefaults(ctx, policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(policy), err)
 	}

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -45,6 +45,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -165,6 +166,12 @@ func (r *ReconcileIAMPolicy) Reconcile(ctx context.Context, request reconcile.Re
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
+	}
+	// r.Get() overrides the TypeMeta to empty value, so need to configure it
+	// after r.Get().
+	policy.TypeMeta = metav1.TypeMeta{
+		APIVersion: iamv1beta1.IAMPolicyGVK.GroupVersion().String(),
+		Kind:       iamv1beta1.IAMPolicyGVK.Kind,
 	}
 	if err := r.handleDefaults(ctx, policy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy '%v': %w", k8s.GetNamespacedName(policy), err)

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -45,7 +45,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -167,10 +166,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	// r.Get() overrides the TypeMeta to empty value, so need to configure it
 	// after r.Get().
-	memberPolicy.TypeMeta = metav1.TypeMeta{
-		APIVersion: iamv1beta1.IAMPolicyMemberGVK.GroupVersion().String(),
-		Kind:       iamv1beta1.IAMPolicyMemberGVK.Kind,
-	}
+	memberPolicy.SetGroupVersionKind(iamv1beta1.IAMPolicyMemberGVK)
 	if err := r.handleDefaults(ctx, &memberPolicy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %w", k8s.GetNamespacedName(&memberPolicy), err)
 	}

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -45,6 +45,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,6 +164,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
+	}
+	// r.Get() overrides the TypeMeta to empty value, so need to configure it
+	// after r.Get().
+	memberPolicy.TypeMeta = metav1.TypeMeta{
+		APIVersion: iamv1beta1.IAMPolicyMemberGVK.GroupVersion().String(),
+		Kind:       iamv1beta1.IAMPolicyMemberGVK.Kind,
 	}
 	if err := r.handleDefaults(ctx, &memberPolicy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error handling default values for IAM policy member '%v': %w", k8s.GetNamespacedName(&memberPolicy), err)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes b/338572343.

Issue:
`merge` is considered invalid value for the `state-into-spec` annotation in the handwritten IAM resources.

Root cause:
TypeMeta is missing in the retrieved object in the handwritten IAM controllers. Without type metadata, the kind is `""`, and kind `""` indeed doesn't support `merge`.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
