### PR TITLE
tests: Fix container clusters fixtures test data

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/update.yaml
@@ -35,8 +35,8 @@ spec:
       enabled: true
       topicRef:
         name: pubsubtopic-${uniqueId}
-        loggingConfig:
-  enableComponents:
+  loggingConfig:
+    enableComponents:
       - "SYSTEM_COMPONENTS"
       - "WORKLOADS"
   monitoringConfig:


### PR DESCRIPTION
### Change description

The container clusters e2e test failed because of an error in the test data.
It's concerning that our dynamic test doesn't catch that.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
