### PR TITLE
use service identity to generate P4SA for vertex AI Index

### DIFF
--- a/config/samples/resources/vertexaiindex/iam_v1beta1_iampolicymember.yaml
+++ b/config/samples/resources/vertexaiindex/iam_v1beta1_iampolicymember.yaml
@@ -18,7 +18,9 @@ kind: IAMPolicyMember
 metadata:
   name: vertexaiindex-dep
 spec:
-  member: serviceAccount:service-${PROJECT_NUMBER?}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: vertexaiindex-dep
   role: roles/storage.admin # required by vertex AI service agent to access test data
   resourceRef:
     apiVersion: storage.cnrm.cloud.google.com/v1beta1

--- a/config/samples/resources/vertexaiindex/serviceusage_v1beta1_serviceidentity.yaml
+++ b/config/samples/resources/vertexaiindex/serviceusage_v1beta1_serviceidentity.yaml
@@ -15,24 +15,11 @@
 apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: ServiceIdentity
 metadata:
-  name: serviceidentity-${uniqueId}
+  name: vertexaiindex-dep
   annotations:
     cnrm.cloud.google.com/deletion-policy: "abandon"
 spec:
   projectRef:
-    external: ${projectId}
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
   resourceID: aiplatform.googleapis.com
----
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
-metadata:
-  name: iampolicymember-${uniqueId}
-spec:
-  memberFrom:
-    serviceIdentityRef:
-      name: serviceidentity-${uniqueId}
-  role: roles/storage.admin # required by vertex AI service agent to access test data
-  resourceRef:
-    apiVersion: storage.cnrm.cloud.google.com/v1beta1
-    kind: StorageBucket
-    external: ${KCC_VERTEX_AI_INDEX_TEST_BUCKET}

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaiindex.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaiindex.md
@@ -555,12 +555,26 @@ kind: IAMPolicyMember
 metadata:
   name: vertexaiindex-dep
 spec:
-  member: serviceAccount:service-${PROJECT_NUMBER?}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: vertexaiindex-dep
   role: roles/storage.admin # required by vertex AI service agent to access test data
   resourceRef:
     apiVersion: storage.cnrm.cloud.google.com/v1beta1
     kind: StorageBucket
     external: ${KCC_VERTEX_AI_INDEX_TEST_BUCKET?}
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: vertexaiindex-dep
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+spec:
+  projectRef:
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
+  resourceID: aiplatform.googleapis.com
 ```
 
 


### PR DESCRIPTION
Error message from prow testing:

```
=== NAME  TestCreateNoChangeUpdateDelete/vertexai/basic-vertexaiindex
    testreconciler.go:105: reconcile for IAMPolicyMember:afkqn26w3f7wy3ikjibq/iampolicymember-afkqn26w3f7wy3ikjibq took 1.445401796s, result was ({false 0s}, Update call failed: error setting policy member: error applying changes: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid)
    reconcile.go:193: error was not considered transient; chain is [[*fmt.wrapError: Update call failed: error setting policy member: error applying changes: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid] [*fmt.wrapError: error setting policy member: error applying changes: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid] [*fmt.wrapError: error applying changes: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid] [*errors.errorString: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid]]
    testreconciler.go:105: reconcile returned unexpected error: Update call failed: error setting policy member: error applying changes: summary: Error applying IAM policy for storage bucket "b/kcc-vertex-ai-index-test": Error setting IAM policy for storage bucket "b/kcc-vertex-ai-index-test": googleapi: Error 400: Service account service-65713775505@gcp-sa-aiplatform.iam.gserviceaccount.com does not exist., invalid}
```

It seems that the vertex AI service agent is not created right after the API enablement.