### PR TITLE
bigquery table require_partition_filter.patch

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerytables.bigquery.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerytables.bigquery.cnrm.cloud.google.com.yaml
@@ -375,6 +375,10 @@ spec:
                 - field
                 - range
                 type: object
+              requirePartitionFilter:
+                description: If set to true, queries over this table require a partition
+                  filter that can be used for partition elimination to be specified.
+                type: boolean
               resourceID:
                 description: Immutable. Optional. The tableId of the resource. Used
                   for creation and acquisition. When unset, the value of `metadata.name`
@@ -466,9 +470,10 @@ spec:
                       time.
                     type: string
                   requirePartitionFilter:
-                    description: If set to true, queries over this table require a
-                      partition filter that can be used for partition elimination
-                      to be specified.
+                    description: DEPRECATED. This field is deprecated; please use
+                      the top level field with the same name instead. If set to true,
+                      queries over this table require a partition filter that can
+                      be used for partition elimination to be specified.
                     type: boolean
                   type:
                     description: The supported types are DAY, HOUR, MONTH, and YEAR,

--- a/config/samples/resources/bigquerytable/bigquery_v1beta1_bigquerytable.yaml
+++ b/config/samples/resources/bigquerytable/bigquery_v1beta1_bigquerytable.yaml
@@ -23,6 +23,7 @@ spec:
   description: "BigQuery Sample Table"
   datasetRef:
     name: bigquerytabledep
+  requirePartitionFilter: true
   friendlyName: bigquerytable-sample
   externalDataConfiguration:
     autodetect: true

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -743,8 +743,9 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 		// case "fullalloydbcluster":
 		case "apikeyskeybasic":
 		case "artifactregistryrepository":
-		case "bigqueryjob":
 		case "bigqueryconnectionconnection":
+		case "bigqueryjob":
+		case "bigquerytable":
 		case "custombudget":
 		case "certificatemanagercertificatemapentry":
 		case "httpsfunction":

--- a/pkg/clients/generated/apis/bigquery/v1beta1/bigquerytable_types.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/bigquerytable_types.go
@@ -275,7 +275,7 @@ type TableTimePartitioning struct {
 	// +optional
 	Field *string `json:"field,omitempty"`
 
-	/* If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. */
+	/* DEPRECATED. This field is deprecated; please use the top level field with the same name instead. If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. */
 	// +optional
 	RequirePartitionFilter *bool `json:"requirePartitionFilter,omitempty"`
 
@@ -330,6 +330,10 @@ type BigQueryTableSpec struct {
 	/* If specified, configures range-based partitioning for this table. */
 	// +optional
 	RangePartitioning *TableRangePartitioning `json:"rangePartitioning,omitempty"`
+
+	/* If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified. */
+	// +optional
+	RequirePartitionFilter *bool `json:"requirePartitionFilter,omitempty"`
 
 	/* Immutable. Optional. The tableId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional

--- a/pkg/clients/generated/apis/bigquery/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/bigquery/v1beta1/zz_generated.deepcopy.go
@@ -646,6 +646,11 @@ func (in *BigQueryTableSpec) DeepCopyInto(out *BigQueryTableSpec) {
 		*out = new(TableRangePartitioning)
 		**out = **in
 	}
+	if in.RequirePartitionFilter != nil {
+		in, out := &in.RequirePartitionFilter, &out.RequirePartitionFilter
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ResourceID != nil {
 		in, out := &in.ResourceID, &out.ResourceID
 		*out = new(string)

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_generated_object_bigquerytable.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_generated_object_bigquerytable.golden.yaml
@@ -1,0 +1,42 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: bigquerytablesample${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  datasetRef:
+    name: bigquerydatasetsample${uniqueId}
+  externalDataConfiguration:
+    autodetect: true
+    compression: NONE
+    sourceFormat: CSV
+    sourceUris:
+    - gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt
+  friendlyName: bigquerytable-sample-updated
+  requirePartitionFilter: false
+  resourceID: bigquerytablesample${uniqueId}
+  schema: '[{"mode":"NULLABLE","name":"string_field_0","type":"STRING"},{"mode":"NULLABLE","name":"string_field_1","type":"STRING"},{"mode":"NULLABLE","name":"string_field_2","type":"STRING"},{"mode":"NULLABLE","name":"string_field_3","type":"STRING"},{"mode":"NULLABLE","name":"string_field_4","type":"STRING"},{"mode":"NULLABLE","name":"string_field_5","type":"STRING"},{"mode":"NULLABLE","name":"int64_field_6","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_7","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_8","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_9","type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_10","type":"STRING"},{"mode":"NULLABLE","name":"int64_field_11","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_12","type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_13","type":"STRING"}]'
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  creationTime: "1970-01-01T00:00:00Z"
+  etag: abcdef123456
+  lastModifiedTime: "1970-01-01T00:00:00Z"
+  location: US
+  observedGeneration: 3
+  selfLink: https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}
+  type: EXTERNAL

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/dcl.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/dcl.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/oauth.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/oauth.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/tf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_vcr_cassettes/tf.yaml
@@ -1,0 +1,769 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 615.256925ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 142
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"datasetReference":{"datasetId":"bigquerydatasetsamplel7b81f5rgmgk"},"labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"location":"US"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets?alt=json
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "bigquery#dataset",
+              "etag": "pYo/zUITYaROvtieJn/Efg==",
+              "id": "example-project:bigquerydatasetsamplel7b81f5rgmgk",
+              "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk",
+              "datasetReference": {
+                "datasetId": "bigquerydatasetsamplel7b81f5rgmgk",
+                "projectId": "example-project"
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "access": [
+                {
+                  "role": "WRITER",
+                  "specialGroup": "projectWriters"
+                },
+                {
+                  "role": "OWNER",
+                  "specialGroup": "projectOwners"
+                },
+                {
+                  "role": "OWNER",
+                  "userByEmail": "andylu@pisces.joonix.net"
+                },
+                {
+                  "role": "READER",
+                  "specialGroup": "projectReaders"
+                }
+              ],
+              "creationTime": "1720515934342",
+              "lastModifiedTime": "1720515934342",
+              "location": "US",
+              "type": "DEFAULT"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 705.821848ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "bigquery#dataset",
+              "etag": "pYo/zUITYaROvtieJn/Efg==",
+              "id": "example-project:bigquerydatasetsamplel7b81f5rgmgk",
+              "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk",
+              "datasetReference": {
+                "datasetId": "bigquerydatasetsamplel7b81f5rgmgk",
+                "projectId": "example-project"
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "access": [
+                {
+                  "role": "WRITER",
+                  "specialGroup": "projectWriters"
+                },
+                {
+                  "role": "OWNER",
+                  "specialGroup": "projectOwners"
+                },
+                {
+                  "role": "OWNER",
+                  "userByEmail": "andylu@pisces.joonix.net"
+                },
+                {
+                  "role": "READER",
+                  "specialGroup": "projectReaders"
+                }
+              ],
+              "creationTime": "1720515934342",
+              "lastModifiedTime": "1720515934342",
+              "location": "US",
+              "type": "DEFAULT"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 444.121271ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 404 Not Found
+        code: 404
+        duration: 212.578131ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "bigquery#dataset",
+              "etag": "pYo/zUITYaROvtieJn/Efg==",
+              "id": "example-project:bigquerydatasetsamplel7b81f5rgmgk",
+              "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk",
+              "datasetReference": {
+                "datasetId": "bigquerydatasetsamplel7b81f5rgmgk",
+                "projectId": "example-project"
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "access": [
+                {
+                  "role": "WRITER",
+                  "specialGroup": "projectWriters"
+                },
+                {
+                  "role": "OWNER",
+                  "specialGroup": "projectOwners"
+                },
+                {
+                  "role": "OWNER",
+                  "userByEmail": "andylu@pisces.joonix.net"
+                },
+                {
+                  "role": "READER",
+                  "specialGroup": "projectReaders"
+                }
+              ],
+              "creationTime": "1720515934342",
+              "lastModifiedTime": "1720515934342",
+              "location": "US",
+              "type": "DEFAULT"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 419.825033ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 507
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"externalDataConfiguration":{"autodetect":true,"compression":"NONE","sourceFormat":"CSV","sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"]},"friendlyName":"bigquerytable-sample","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"requirePartitionFilter":true,"tableReference":{"datasetId":"bigquerydatasetsamplel7b81f5rgmgk","projectId":"example-project","tableId":"bigquerytablesamplel7b81f5rgmgk"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables?alt=json&prettyPrint=false
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"ZYaCcTJ8PF5Tok2MBL096Q==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515937237","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":true,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 689.112379ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"ZYaCcTJ8PF5Tok2MBL096Q==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515937237","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":true,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 326.434921ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"ZYaCcTJ8PF5Tok2MBL096Q==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515937237","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":true,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 441.704191ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"ZYaCcTJ8PF5Tok2MBL096Q==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515937237","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":true,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 448.04455ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1575
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"externalDataConfiguration":{"autodetect":true,"compression":"NONE","sourceFormat":"CSV","sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"]},"friendlyName":"bigquerytable-sample-updated","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"mode":"NULLABLE","name":"string_field_0","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"string_field_1","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"string_field_2","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"string_field_3","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"string_field_4","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"string_field_5","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"int64_field_6","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_7","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_8","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_9","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_10","policyTags":{},"type":"STRING"},{"mode":"NULLABLE","name":"int64_field_11","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_12","policyTags":{},"type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_13","policyTags":{},"type":"STRING"}]},"tableReference":{"datasetId":"bigquerydatasetsamplel7b81f5rgmgk","projectId":"example-project","tableId":"bigquerytablesamplel7b81f5rgmgk"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"BMni8WOOCXFgFa5BC/jfkg==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample-updated","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515940935","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":false,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 329.29309ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"BMni8WOOCXFgFa5BC/jfkg==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample-updated","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515940935","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":false,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 282.727165ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "bigquery#dataset",
+              "etag": "pYo/zUITYaROvtieJn/Efg==",
+              "id": "example-project:bigquerydatasetsamplel7b81f5rgmgk",
+              "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk",
+              "datasetReference": {
+                "datasetId": "bigquerydatasetsamplel7b81f5rgmgk",
+                "projectId": "example-project"
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "access": [
+                {
+                  "role": "WRITER",
+                  "specialGroup": "projectWriters"
+                },
+                {
+                  "role": "OWNER",
+                  "specialGroup": "projectOwners"
+                },
+                {
+                  "role": "OWNER",
+                  "userByEmail": "andylu@pisces.joonix.net"
+                },
+                {
+                  "role": "READER",
+                  "specialGroup": "projectReaders"
+                }
+              ],
+              "creationTime": "1720515934342",
+              "lastModifiedTime": "1720515934342",
+              "location": "US",
+              "type": "DEFAULT"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 327.354671ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"kind":"bigquery#table","etag":"BMni8WOOCXFgFa5BC/jfkg==","id":"example-project:bigquerydatasetsamplel7b81f5rgmgk.bigquerytablesamplel7b81f5rgmgk","selfLink":"https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk","tableReference":{"projectId":"example-project","datasetId":"bigquerydatasetsamplel7b81f5rgmgk","tableId":"bigquerytablesamplel7b81f5rgmgk"},"friendlyName":"bigquerytable-sample-updated","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"schema":{"fields":[{"name":"string_field_0","type":"STRING","mode":"NULLABLE"},{"name":"string_field_1","type":"STRING","mode":"NULLABLE"},{"name":"string_field_2","type":"STRING","mode":"NULLABLE"},{"name":"string_field_3","type":"STRING","mode":"NULLABLE"},{"name":"string_field_4","type":"STRING","mode":"NULLABLE"},{"name":"string_field_5","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_6","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_7","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_8","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_9","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_10","type":"STRING","mode":"NULLABLE"},{"name":"int64_field_11","type":"INTEGER","mode":"NULLABLE"},{"name":"int64_field_12","type":"INTEGER","mode":"NULLABLE"},{"name":"string_field_13","type":"STRING","mode":"NULLABLE"}]},"numBytes":"0","numLongTermBytes":"0","numRows":"0","creationTime":"1720515936786","lastModifiedTime":"1720515940935","type":"EXTERNAL","externalDataConfiguration":{"sourceUris":["gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"],"sourceFormat":"CSV","autodetect":true,"compression":"NONE"},"location":"US","requirePartitionFilter":false,"numTotalLogicalBytes":"0","numActiveLogicalBytes":"0","numLongTermLogicalBytes":"0"}'
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 371.806487ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json&deleteContents=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: true
+        body: fake error message
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 400 Bad Request
+        code: 400
+        duration: 287.000684ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.5 gdcl/0.187.0
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk/tables/bigquerytablesamplel7b81f5rgmgk?alt=json&prettyPrint=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 204 No Content
+        code: 204
+        duration: 316.441881ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "kind": "bigquery#dataset",
+              "etag": "pYo/zUITYaROvtieJn/Efg==",
+              "id": "example-project:bigquerydatasetsamplel7b81f5rgmgk",
+              "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk",
+              "datasetReference": {
+                "datasetId": "bigquerydatasetsamplel7b81f5rgmgk",
+                "projectId": "example-project"
+              },
+              "labels": {
+                "cnrm-test": "true",
+                "managed-by-cnrm": "true"
+              },
+              "access": [
+                {
+                  "role": "WRITER",
+                  "specialGroup": "projectWriters"
+                },
+                {
+                  "role": "OWNER",
+                  "specialGroup": "projectOwners"
+                },
+                {
+                  "role": "OWNER",
+                  "userByEmail": "andylu@pisces.joonix.net"
+                },
+                {
+                  "role": "READER",
+                  "specialGroup": "projectReaders"
+                }
+              ],
+              "creationTime": "1720515934342",
+              "lastModifiedTime": "1720515934342",
+              "location": "US",
+              "type": "DEFAULT"
+            }
+        headers:
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 200 OK
+        code: 200
+        duration: 436.728931ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: bigquery.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://bigquery.googleapis.com/bigquery/v2/projects/example-project/datasets/bigquerydatasetsamplel7b81f5rgmgk?alt=json&deleteContents=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/json; charset=UTF-8
+        status: 204 No Content
+        code: 204
+        duration: 391.253016ms

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/create.yaml
@@ -22,3 +22,9 @@ spec:
   friendlyName: bigquerytable-sample
   datasetRef:
     name: bigquerydatasetsample${uniqueId}
+  requirePartitionFilter: true
+  externalDataConfiguration:
+    autodetect: true
+    sourceFormat: CSV
+    sourceUris:
+      - "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/update.yaml
@@ -22,3 +22,9 @@ spec:
   friendlyName: bigquerytable-sample-updated
   datasetRef:
     name: bigquerydatasetsample${uniqueId}
+  requirePartitionFilter: false
+  externalDataConfiguration:
+    autodetect: true
+    sourceFormat: CSV
+    sourceUris:
+      - "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
@@ -160,6 +160,7 @@ rangePartitioning:
     end: integer
     interval: integer
     start: integer
+requirePartitionFilter: boolean
 resourceID: string
 schema: string
 tableConstraints:
@@ -814,6 +815,16 @@ view:
     </tr>
     <tr>
         <td>
+            <p><code>requirePartitionFilter</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">boolean</code></p>
+            <p>{% verbatim %}If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.{% endverbatim %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
             <p><code>resourceID</code></p>
             <p><i>Optional</i></p>
         </td>
@@ -1009,7 +1020,7 @@ view:
         </td>
         <td>
             <p><code class="apitype">boolean</code></p>
-            <p>{% verbatim %}If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.{% endverbatim %}</p>
+            <p>{% verbatim %}DEPRECATED. This field is deprecated; please use the top level field with the same name instead. If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1238,6 +1249,7 @@ spec:
   description: "BigQuery Sample Table"
   datasetRef:
     name: bigquerytabledep
+  requirePartitionFilter: true
   friendlyName: bigquerytable-sample
   externalDataConfiguration:
     autodetect: true

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/bigquery/resource_bigquery_table.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/bigquery/resource_bigquery_table.go
@@ -902,9 +902,11 @@ func ResourceBigQueryTable() *schema.Resource {
 						// require a partition filter that can be used for partition elimination to be
 						// specified.
 						"require_partition_filter": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: `If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.`,
+							Type:          schema.TypeBool,
+							Optional:      true,
+							Description:   `If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.`,
+							Deprecated:    `This field is deprecated and will be removed in a future major release; please use the top level field with the same name instead.`,
+							ConflictsWith: []string{"require_partition_filter"},
 						},
 					},
 				},
@@ -961,6 +963,16 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			// RequirePartitionFilter: [Optional] If set to true, queries over this table
+			// require a partition filter that can be used for partition elimination to be
+			// specified.
+			"require_partition_filter": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Description:   `If set to true, queries over this table require a partition filter that can be used for partition elimination to be specified.`,
+				ConflictsWith: []string{"time_partitioning.0.require_partition_filter"},
 			},
 
 			// Clustering: [Optional] Specifies column names to use for data clustering.  Up to four
@@ -1281,6 +1293,10 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		table.RangePartitioning = rangePartitioning
 	}
 
+	if v, ok := d.GetOk("require_partition_filter"); ok {
+		table.RequirePartitionFilter = v.(bool)
+	}
+
 	if v, ok := d.GetOk("clustering"); ok {
 		table.Clustering = &bigquery.Clustering{
 			Fields:          tpgresource.ConvertStringArr(v.([]interface{})),
@@ -1431,6 +1447,14 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting type: %s", err)
 	}
 
+	// determine whether the deprecated require_partition_filter field is used
+	use_old_rpf := false
+	if _, ok := d.GetOk("time_partitioning.0.require_partition_filter"); ok {
+		use_old_rpf = true
+	} else if err := d.Set("require_partition_filter", res.RequirePartitionFilter); err != nil {
+		return fmt.Errorf("Error setting require_partition_filter: %s", err)
+	}
+
 	if res.ExternalDataConfiguration != nil {
 		externalDataConfiguration, err := flattenExternalDataConfiguration(res.ExternalDataConfiguration)
 		if err != nil {
@@ -1461,7 +1485,7 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if res.TimePartitioning != nil {
-		if err := d.Set("time_partitioning", flattenTimePartitioning(res.TimePartitioning)); err != nil {
+		if err := d.Set("time_partitioning", flattenTimePartitioning(res.TimePartitioning, use_old_rpf)); err != nil {
 			return err
 		}
 	}
@@ -2059,7 +2083,7 @@ func flattenEncryptionConfiguration(ec *bigquery.EncryptionConfiguration) []map[
 	return []map[string]interface{}{{"kms_key_name": ec.KmsKeyName, "kms_key_version": ""}}
 }
 
-func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interface{} {
+func flattenTimePartitioning(tp *bigquery.TimePartitioning, use_old_rpf bool) []map[string]interface{} {
 	result := map[string]interface{}{"type": tp.Type}
 
 	if tp.Field != "" {
@@ -2070,7 +2094,7 @@ func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interfa
 		result["expiration_ms"] = tp.ExpirationMs
 	}
 
-	if tp.RequirePartitionFilter {
+	if tp.RequirePartitionFilter && use_old_rpf {
 		result["require_partition_filter"] = tp.RequirePartitionFilter
 	}
 


### PR DESCRIPTION
require_partition_filter.patch

Make require_partition_filter a top level field.
This will replace the same field in the time_partitioning.

Fixes [1654](https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/1654)

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
