### PR TITLE
feat: honor reconcile period anon in direct controller

### DIFF
--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -234,7 +234,7 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 		}
 		if k8s.HasFinalizer(u, k8s.DeletionDefenderFinalizerName) {
 			// deletion defender has not yet finalized; requeuing
-			logger.Info("deletion defender has not yet been finalized; requeuing", "resource", k8s.GetNamespacedName(u))
+			logger.Info("deletion defender has not yet finalized; requeuing", "resource", k8s.GetNamespacedName(u))
 			return true, nil
 		}
 		if !k8s.HasAbandonAnnotation(u) {

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -171,6 +171,16 @@ func (r *DirectReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		gvk:            r.gvk,
 		NamespacedName: request.NamespacedName,
 	}
+
+	skip, err := resourceactuation.ShouldSkip(obj)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if skip {
+		logger.Info("Skipping reconcile as nothing has changed and 0 reconcile period is set", "resource", request.NamespacedName)
+		return reconcile.Result{}, nil
+	}
+
 	requeue, err := runCtx.doReconcile(ctx, obj)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -223,7 +233,7 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 			return false, nil
 		}
 		if k8s.HasFinalizer(u, k8s.DeletionDefenderFinalizerName) {
-			// deletion defender has not yet been finalized; requeuing
+			// deletion defender has not yet finalized; requeuing
 			logger.Info("deletion defender has not yet been finalized; requeuing", "resource", k8s.GetNamespacedName(u))
 			return true, nil
 		}


### PR DESCRIPTION
We already honor the `reconcile-period` annotation when generating a jittered value for re-enqueuing but we are not honoring it when it's 0.