### PR TITLE
feat: Support immutability checks for llm

### DIFF
--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -243,7 +243,11 @@ func (a *logMetricAdapter) Update(ctx context.Context, u *unstructured.Unstructu
 				update.Filter = a.actual.Filter
 			}
 		}
+
 		if !compareMetricDescriptors(a.desired.Spec.MetricDescriptor, a.actual.MetricDescriptor) {
+			if err := validateImmutableFieldsUpdated(a.desired.Spec.MetricDescriptor, a.actual.MetricDescriptor); err != nil {
+				return fmt.Errorf("logMetric update failed: %w", err)
+			}
 			update.MetricDescriptor = convertKCCtoAPIForMetricDescriptor(a.desired.Spec.MetricDescriptor)
 		}
 

--- a/pkg/webhook/immutable_fields_validator.go
+++ b/pkg/webhook/immutable_fields_validator.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl"
 	dclextension "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/extension"
@@ -36,7 +38,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/pathslice"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/typeutil"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 	"github.com/nasa9084/go-openapi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -55,7 +57,7 @@ var (
 
 type immutableFieldsValidatorHandler struct {
 	smLoader              *servicemappingloader.ServiceMappingLoader
-	tfResourceMap         map[string]*schema.Resource
+	tfResourceMap         map[string]*tfschema.Resource
 	dclSchemaLoader       dclschemaloader.DCLSchemaLoader
 	serviceMetadataLoader dclmetadata.ServiceMetadataLoader
 }
@@ -112,6 +114,12 @@ func (a *immutableFieldsValidatorHandler) Handle(_ context.Context, req admissio
 
 	if err := validateImmutableStateIntoSpecAnnotation(obj, oldObj); err != nil {
 		return admission.Errored(http.StatusForbidden, err)
+	}
+
+	gk := oldObj.GroupVersionKind().GroupKind()
+	switch gk {
+	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
+		return validateImmutableFieldsForLoggingLogMetricResource(oldSpec, spec)
 	}
 
 	if dclmetadata.IsDCLBasedResourceKind(obj.GroupVersionKind(), a.serviceMetadataLoader) {
@@ -278,7 +286,7 @@ func getQualifiedFieldName(prefix string, fieldName string) string {
 	return qualifiedName
 }
 
-func validateImmutableFieldsForTFBasedResource(obj, oldObj *unstructured.Unstructured, spec, oldSpec map[string]interface{}, smLoader *servicemappingloader.ServiceMappingLoader, tfResourceMap map[string]*schema.Resource) admission.Response {
+func validateImmutableFieldsForTFBasedResource(obj, oldObj *unstructured.Unstructured, spec, oldSpec map[string]interface{}, smLoader *servicemappingloader.ServiceMappingLoader, tfResourceMap map[string]*tfschema.Resource) admission.Response {
 	rc, err := smLoader.GetResourceConfig(obj)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest,
@@ -317,6 +325,41 @@ func validateImmutableFieldsForTFBasedResource(obj, oldObj *unstructured.Unstruc
 			k8s.NewImmutableFieldsMutationError(res))
 	}
 
+	return allowedResponse
+}
+
+func validateImmutableFieldsForLoggingLogMetricResource(oldSpec, spec map[string]interface{}) admission.Response {
+	if isResourceIDModified(oldSpec, spec) {
+		return admission.Errored(http.StatusForbidden,
+			k8s.NewImmutableFieldsMutationError([]string{k8s.ResourceIDFieldPath}))
+	}
+
+	isImmutableFieldsModified := func(oldSpec, newSpec map[string]interface{}, field string) bool {
+		tokens := strings.Split(field, ".")
+		oldVal, ok1, err1 := unstructured.NestedFieldCopy(oldSpec, tokens...)
+		newVal, ok2, err2 := unstructured.NestedFieldCopy(newSpec, tokens...)
+		if oldVal == nil && newVal == nil {
+			return false
+		}
+		if !ok1 || err1 != nil {
+			return true
+		}
+		if !ok2 || err2 != nil {
+			return true
+		}
+		return !reflect.DeepEqual(oldVal, newVal)
+	}
+	ImmutableFields := []string{"metricDescriptor.metricKind", "metricDescriptor.valueType", "projectRef"}
+	var res []string
+	for _, field := range ImmutableFields {
+		if isImmutableFieldsModified(oldSpec, spec, field) {
+			res = append(res, field)
+		}
+	}
+	if len(res) != 0 {
+		return admission.Errored(http.StatusForbidden,
+			k8s.NewImmutableFieldsMutationError(res))
+	}
 	return allowedResponse
 }
 
@@ -457,7 +500,7 @@ func findChangesOnImmutableLocationField(obj map[string]interface{}, oldObj map[
 }
 
 // TODO: get rid of list.List by changing the function to return a []string recursively
-func compareAndFindChangesOnImmutableFields(obj map[string]interface{}, oldObj map[string]interface{}, schemaMap map[string]*schema.Schema, prefix string, resourceConfig *corekccv1alpha1.ResourceConfig, ignoredFields map[string]bool, fields *list.List) {
+func compareAndFindChangesOnImmutableFields(obj map[string]interface{}, oldObj map[string]interface{}, schemaMap map[string]*tfschema.Schema, prefix string, resourceConfig *corekccv1alpha1.ResourceConfig, ignoredFields map[string]bool, fields *list.List) {
 	for k, s := range schemaMap {
 		qualifiedName := getQualifiedFieldName(prefix, k)
 		if ignoredFields[qualifiedName] {
@@ -490,21 +533,21 @@ func compareAndFindChangesOnImmutableFields(obj map[string]interface{}, oldObj m
 		switch s.Type {
 		// TODO: terraform schema doc says that TypeMap only support Elem to be a *Schema with a Type that is one of the primitives
 		// Is there any edge cases to handle?
-		case schema.TypeBool, schema.TypeFloat, schema.TypeString, schema.TypeInt, schema.TypeMap:
+		case tfschema.TypeBool, tfschema.TypeFloat, tfschema.TypeString, tfschema.TypeInt, tfschema.TypeMap:
 			if s.ForceNew && !reflect.DeepEqual(v1, v2) {
 				fields.PushBack(qualifiedName)
 			}
-		case schema.TypeList, schema.TypeSet:
+		case tfschema.TypeList, tfschema.TypeSet:
 			switch s.Elem.(type) {
-			case *schema.Schema:
+			case *tfschema.Schema:
 				// it's a list of primitives
 				if s.ForceNew && !reflect.DeepEqual(v1, v2) {
 					fields.PushBack(qualifiedName)
 				}
-			case *schema.Resource:
+			case *tfschema.Resource:
 				if s.MaxItems == 1 {
 					// A list with MaxItems == 1 is actually a nested object due to limitations with TF schemas.
-					tfObjSchemaMap := s.Elem.(*schema.Resource).Schema
+					tfObjSchemaMap := s.Elem.(*tfschema.Resource).Schema
 					var o1 map[string]interface{}
 					var o2 map[string]interface{}
 					if v1 != nil {

--- a/pkg/webhook/immutable_fields_validator_test.go
+++ b/pkg/webhook/immutable_fields_validator_test.go
@@ -2394,3 +2394,88 @@ func getSpecFromUnstructed(t *testing.T, u *unstructured.Unstructured) map[strin
 	}
 	return spec
 }
+
+func TestUpdateLogLoggingMetric(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     map[string]interface{}
+		oldSpec  map[string]interface{}
+		response admission.Response
+	}{
+		{
+			name: "change on a mutable field",
+			spec: map[string]interface{}{
+				"description": "An updated sample log metric",
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project",
+				},
+			},
+			oldSpec: map[string]interface{}{
+				"description": "A sample log metric",
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project",
+				},
+			},
+			response: allowedResponse,
+		},
+		{
+			name: "changes on a mutable field and an immutable field",
+			spec: map[string]interface{}{
+				"description": "An updated sample log metric",
+				"metricDescriptor": map[string]interface{}{
+					"metricKind": "DELTA",
+					"valueType":  "DISTRIBUTION",
+				},
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project",
+				},
+			},
+			oldSpec: map[string]interface{}{
+				"description": "A sample log metric",
+				"metricDescriptor": map[string]interface{}{
+					"metricKind": "CUMULATIVE",
+					"valueType":  "DISTRIBUTION",
+				},
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project",
+				},
+			},
+			response: admission.Errored(http.StatusForbidden,
+				k8s.NewImmutableFieldsMutationError([]string{"metricDescriptor.metricKind"})),
+		},
+		{
+			name: "changes on multiple immutable fields",
+			spec: map[string]interface{}{
+				"description": "An updated sample log metric",
+				"metricDescriptor": map[string]interface{}{
+					"metricKind": "DELTA",
+					"valueType":  "INT64",
+				},
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project-update",
+				},
+			},
+			oldSpec: map[string]interface{}{
+				"description": "A sample log metric",
+				"metricDescriptor": map[string]interface{}{
+					"metricKind": "CUMULATIVE",
+					"valueType":  "DISTRIBUTION",
+				},
+				"projectRef": map[string]interface{}{
+					"external": "projects/test-project",
+				},
+			},
+			response: admission.Errored(http.StatusForbidden,
+				k8s.NewImmutableFieldsMutationError([]string{"metricDescriptor.metricKind", "metricDescriptor.valueType", "projectRef"})),
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual := validateImmutableFieldsForLoggingLogMetricResource(tc.oldSpec, tc.spec)
+			if !testutil.Equals(t, actual, tc.response) {
+				t.Fatalf("got: %v, but want: %v", actual, tc.response)
+			}
+		})
+	}
+}

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -118,8 +118,10 @@ func TestE2EScript(t *testing.T) {
 					case "APPLY":
 						applyObject(h, obj)
 						create.WaitForReady(h, obj)
-
 						appliedObjects[k] = obj
+					case "APPLY-10-SEC":
+						applyObject(h, obj)
+						time.Sleep(10 * time.Second)
 					case "APPLY-NO-WAIT":
 						applyObject(h, obj)
 						appliedObjects[k] = obj

--- a/tests/e2e/testdata/scenarios/README.md
+++ b/tests/e2e/testdata/scenarios/README.md
@@ -7,18 +7,23 @@ The `script.yaml` file contains a set of kube objects, which are applied
 in turn.  After each object is applied, we run some golden checks:
 
 * We export the GCP object and we golden-compare to _exportNN.yaml
-* We read the KRM object from the kuberneters cluster, and we golden-compare to _objectNN.yaml
+* We read the KRM object from the kubernetes cluster, and we golden-compare to _objectNN.yaml
 
 
 We also support a few "special actions", which are triggered by setting
 a top-level field `TEST` on the object:
 
-* Setting TEST: APPLY is a no op as this is the default value for the TEST field.
+* Setting `TEST: APPLY` is a no op as this is the default value for the TEST field.
 
-* Setting TEST: APPLY-NO-WAIT will apply the object without waiting for the object
-  to be makred as ready. We will also not export the object.
+* Setting `TEST: APPLY-NO-WAIT` will apply the object without waiting for the object
+  to be marked as ready. We will also not export the object.
 
-* Setting `TEST: DELETE` will delete the KCC object and wait for the deltion
+* Setting `TEST: APPLY-10-SEC` will apply an object that we know is going to fail. 
+  i.e. immutable field is modified. Instead of keeping query the error resource, 
+  we stop the test after 10s and capture the error log. This action can be used to 
+  test the expected error state.
+
+* Setting `TEST: DELETE` will delete the KCC object and wait for the deletion
   to complete; it will automatically skip
   the GCP export and the kube export.  It suffices to set
   apiVersion / kind / namespace / name.

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/SCENARIO_README.MD
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/SCENARIO_README.MD
@@ -1,0 +1,3 @@
+Step1: Create a logginglogmetric resource, operation succeeds
+Step2: Update spec.metricDescriptor.labels.valueType field for the resource, operation fails. We'll see no PUT request
+in _http01 and resource has UpdateFailed message in _object01.

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_http00.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_http00.log
@@ -1,0 +1,232 @@
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=1606
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=77
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=962
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_http01.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_http01.log
@@ -1,0 +1,393 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=89
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "INT64"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+400 Bad Request
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=360
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \"Cannot change value type of label: testkey\" }"
+      }
+    ],
+    "errors": [
+      {
+        "debugInfo": "detail: \"[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \\\"Cannot change value type of label: testkey\\\" }\"\n",
+        "domain": "global",
+        "message": "Cannot change value type of label: testkey",
+        "reason": "badRequest"
+      }
+    ],
+    "message": "Cannot change value type of label: testkey",
+    "status": "INVALID_ARGUMENT"
+  }
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=73
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "INT64"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+400 Bad Request
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=322
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \"Cannot change value type of label: testkey\" }"
+      }
+    ],
+    "errors": [
+      {
+        "debugInfo": "detail: \"[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \\\"Cannot change value type of label: testkey\\\" }\"\n",
+        "domain": "global",
+        "message": "Cannot change value type of label: testkey",
+        "reason": "badRequest"
+      }
+    ],
+    "message": "Cannot change value type of label: testkey",
+    "status": "INVALID_ARGUMENT"
+  }
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=89
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "INT64"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+400 Bad Request
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=375
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \"Cannot change value type of label: testkey\" }"
+      }
+    ],
+    "errors": [
+      {
+        "debugInfo": "detail: \"[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \\\"Cannot change value type of label: testkey\\\" }\"\n",
+        "domain": "global",
+        "message": "Cannot change value type of label: testkey",
+        "reason": "badRequest"
+      }
+    ],
+    "message": "Cannot change value type of label: testkey",
+    "status": "INVALID_ARGUMENT"
+  }
+}

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_object00.yaml
@@ -1,0 +1,67 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  description: a description
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: STRING
+    launchStage: EARLY_ACCESS
+    metadata:
+      ingestDelay: 1s
+      samplePeriod: 1s
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: a description
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/_object01.yaml
@@ -1,0 +1,62 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  description: an updated description
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: INT64
+    launchStage: EARLY_ACCESS
+    metadata:
+      ingestDelay: 1s
+      samplePeriod: 1s
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: |-
+      Update call failed: error updating: logMetric update failed: googleapi: Error 400: Cannot change value type of label: testkey
+      Details:
+      [
+        {
+          "@type": "type.googleapis.com/google.rpc.DebugInfo",
+          "detail": "[ORIGINAL ERROR] generic::invalid_argument: Cannot change value type of label: testkey [google.rpc.error_details_ext] { message: \"Cannot change value type of label: testkey\" }"
+        }
+      ]
+      , badRequest
+    reason: UpdateFailed
+    status: "False"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: a description
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/script.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/labels_value_type/script.yaml
@@ -1,0 +1,78 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  description: "a description"
+  filter: "resource.type=gae_app AND severity<=ERROR"
+  metricDescriptor:
+    displayName: "a concise name"
+    launchStage: "EARLY_ACCESS"
+    metadata:
+      ingestDelay: "1s"
+      samplePeriod: "1s"
+    labels:
+    - description: "a label description"
+      key: "testkey"
+      valueType: "STRING"
+    metricKind: "DELTA"
+    valueType: "DISTRIBUTION"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)"
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  projectRef:
+    external: "projects/${projectId}"
+---
+TEST: APPLY-10-SEC
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  description: "a description"
+  filter: "resource.type=gae_app AND severity<=ERROR"
+  metricDescriptor:
+    displayName: "a concise name"
+    launchStage: "EARLY_ACCESS"
+    metadata:
+      ingestDelay: "1s"
+      samplePeriod: "1s"
+    labels:
+    - description: "a label description"
+      key: "testkey"
+      valueType: "INT64"
+    metricKind: "DELTA"
+    valueType: "DISTRIBUTION"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)"
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+        - 1.5
+        - 4.5
+  projectRef:
+    external: "projects/${projectId}"

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/SCENARIO_README.MD
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/SCENARIO_README.MD
@@ -1,0 +1,3 @@
+Step1: Create a logginglogmetric resource, operation succeeds
+Step2: Update spec.metricDescriptor.metricKind and valueType fields for the resource, operation fails. We'll see no PUT request
+in _http01 and resource has UpdateFailed message in _object01.

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_http00.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_http00.log
@@ -1,0 +1,232 @@
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=1514
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=95
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "name": "a concise name",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=1088
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_http01.log
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_http01.log
@@ -1,0 +1,156 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=90
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=77
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.1 gdcl/0.160.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Server-Timing: gfet4t7; dur=83
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "a description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "a description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_object00.yaml
@@ -1,0 +1,67 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  description: a description
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: STRING
+    launchStage: EARLY_ACCESS
+    metadata:
+      ingestDelay: 1s
+      samplePeriod: 1s
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: a description
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/_object01.yaml
@@ -1,0 +1,54 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  description: an updated description
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: STRING
+    launchStage: EARLY_ACCESS
+    metadata:
+      ingestDelay: 1s
+      samplePeriod: 1s
+    metricKind: CUMULATIVE
+    valueType: INT64
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: 'Update call failed: error updating: logMetric update failed: cannot
+      make changes to immutable field(s): [metricDescriptor.MetricKind metricDescriptor.ValueType]'
+    reason: UpdateFailed
+    status: "False"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: a description
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/script.yaml
+++ b/tests/e2e/testdata/scenarios/direct/llm_immutable_field/metric_kind_and_value_type/script.yaml
@@ -1,0 +1,78 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  description: "a description"
+  filter: "resource.type=gae_app AND severity<=ERROR"
+  metricDescriptor:
+    displayName: "a concise name"
+    launchStage: "EARLY_ACCESS"
+    metadata:
+      ingestDelay: "1s"
+      samplePeriod: "1s"
+    labels:
+    - description: "a label description"
+      key: "testkey"
+      valueType: "STRING"
+    metricKind: "DELTA"
+    valueType: "DISTRIBUTION"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)"
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  projectRef:
+    external: "projects/${projectId}"
+---
+TEST: APPLY-10-SEC
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  description: "an updated description"
+  filter: "resource.type=gae_app AND severity<=ERROR"
+  metricDescriptor:
+    displayName: "a concise name"
+    launchStage: "EARLY_ACCESS"
+    metadata:
+      ingestDelay: "1s"
+      samplePeriod: "1s"
+    labels:
+    - description: "a label description"
+      key: "testkey"
+      valueType: "STRING"
+    metricKind: "CUMULATIVE"
+    valueType: "INT64"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)"
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+        - 1.5
+        - 4.5
+  projectRef:
+    external: "projects/${projectId}"


### PR DESCRIPTION
### Change description

Fixes b/339129197

Add immutability checks in webhook and llm controller.

Golden log captured using:
GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=real RUN_E2E=1 KCC_USE_DIRECT_RECONCILERS=LoggingLogMetric   go test -test.count=1 -timeout 360s -v ./tests/e2e -run TestE2EScript/scenarios/direct/immutable_field

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
