### PR TITLE
feat: resolve resourceID for existing LLM resources

### DIFF
--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -57,7 +57,7 @@ var _ directbase.Model = &logMetricModel{}
 
 type logMetricAdapter struct {
 	resourceID string
-	parentID   string
+	projectID  string
 
 	desired         *krm.LoggingLogMetric
 	actual          *api.LogMetric
@@ -103,7 +103,7 @@ func (m *logMetricModel) AdapterForObject(ctx context.Context, u *unstructured.U
 
 	return &logMetricAdapter{
 		resourceID:      resourceID,
-		parentID:        projectID,
+		projectID:       projectID,
 		desired:         obj,
 		logMetricClient: projectMetricsService,
 	}, nil
@@ -257,7 +257,7 @@ func (a *logMetricAdapter) Update(ctx context.Context, u *unstructured.Unstructu
 }
 
 func (a *logMetricAdapter) fullyQualifiedName() string {
-	return MakeFQN(a.parentID, a.resourceID)
+	return MakeFQN(a.projectID, a.resourceID)
 }
 
 // MakeFQN constructions a fully qualified name for a LogMetric resources

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -78,6 +78,14 @@ func (m *logMetricModel) AdapterForObject(ctx context.Context, u *unstructured.U
 		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
 	}
 
+	resourceID := ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("cannot resolve resource ID")
+	}
+
 	projectID := obj.Spec.ProjectRef.External
 	if projectID == "" {
 		return nil, fmt.Errorf("cannot resolve project")
@@ -94,7 +102,7 @@ func (m *logMetricModel) AdapterForObject(ctx context.Context, u *unstructured.U
 	}
 
 	return &logMetricAdapter{
-		resourceID:      ValueOf(obj.Spec.ResourceID),
+		resourceID:      resourceID,
 		parentID:        projectID,
 		desired:         obj,
 		logMetricClient: projectMetricsService,


### PR DESCRIPTION
Patch adds resolution of existing LoggingLogMetric resources and a rename for parentID->projectID.