### PR TITLE
Golden output for LoggingLogMetric & test/mock fixes

### DIFF
--- a/mockgcp/mocklogging/logmetric.go
+++ b/mockgcp/mocklogging/logmetric.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/genproto/googleapis/api"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -45,10 +46,23 @@ func (s *metricsService) GetLogMetric(ctx context.Context, req *pb.GetLogMetricR
 
 	obj := &pb.LogMetric{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Metric %s does not exist.", name.MetricName)
+		}
 		return nil, err
 	}
 
-	return obj, nil
+	return redactForReturn(obj), nil
+}
+
+func redactForReturn(obj *pb.LogMetric) *pb.LogMetric {
+	redacted := proto.Clone(obj).(*pb.LogMetric)
+	if redacted.MetricDescriptor != nil {
+		redacted.MetricDescriptor.Metadata = nil
+		redacted.MetricDescriptor.LaunchStage = api.LaunchStage_LAUNCH_STAGE_UNSPECIFIED
+	}
+
+	return redacted
 }
 
 func (s *metricsService) CreateLogMetric(ctx context.Context, req *pb.CreateLogMetricRequest) (*pb.LogMetric, error) {
@@ -67,13 +81,17 @@ func (s *metricsService) CreateLogMetric(ctx context.Context, req *pb.CreateLogM
 	obj.CreateTime = timestamppb.New(now)
 	obj.UpdateTime = timestamppb.New(now)
 
+	if obj.MetricDescriptor != nil {
+		obj.MetricDescriptor.Description = obj.Description
+	}
+
 	s.populateDefaultsForLogMetric(name, obj)
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
 
-	return obj, nil
+	return redactForReturn(obj), nil
 }
 
 func (s *metricsService) populateDefaultsForLogMetric(name *logMetricName, obj *pb.LogMetric) {
@@ -100,17 +118,22 @@ func (s *metricsService) UpdateLogMetric(ctx context.Context, req *pb.UpdateLogM
 
 	now := time.Now()
 
-	updated := req.GetMetric()
+	updated := proto.Clone(req.GetMetric()).(*pb.LogMetric)
 	updated.Name = name.MetricName
 	updated.CreateTime = existing.CreateTime
 	updated.UpdateTime = timestamppb.New(now)
-
+	if updated.MetricDescriptor == nil {
+		updated.MetricDescriptor = existing.MetricDescriptor
+	}
+	if updated.MetricDescriptor != nil {
+		updated.MetricDescriptor.Description = updated.Description
+	}
 	s.populateDefaultsForLogMetric(name, updated)
 
 	if err := s.storage.Update(ctx, fqn, updated); err != nil {
 		return nil, err
 	}
-	return updated, nil
+	return redactForReturn(updated), nil
 }
 
 func (s *metricsService) DeleteLogMetric(ctx context.Context, req *pb.DeleteLogMetricRequest) (*empty.Empty, error) {

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_generated_object_logbucketmetric.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_generated_object_logbucketmetric.golden.yaml
@@ -1,0 +1,75 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: logginglogmetric-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  bucketOptions:
+    linearBuckets:
+      numFiniteBuckets: 3
+      offset: 1.5
+      width: 3.5
+  description: A sample log metric
+  disabled: false
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    mass: EXTRACT(jsonPayload.request)
+    sku: EXTRACT(jsonPayload.id)
+  loggingLogBucketRef:
+    external: projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}
+  metricDescriptor:
+    displayName: sample-descriptor
+    labels:
+    - description: amount of matter
+      key: mass
+      valueType: STRING
+    - description: identifying number for item
+      key: sku
+      valueType: INT64
+    launchStage: UNIMPLEMENTED
+    metadata:
+      ingestDelay: 2s
+      samplePeriod: 5s
+    metricKind: DELTA
+    unit: bit
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.request)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: A sample log metric
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_http.log
@@ -1,0 +1,434 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Bucket `logginglogbucket-dep-${uniqueId}` does not exist",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://logging.googleapis.com/v2/projects/${projectId}/locations/global/buckets?alt=json&bucketId=logginglogbucket-dep-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "description": "A sample log bucket",
+  "locked": false,
+  "name": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "retentionDays": 30
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log bucket",
+  "lifecycleState": "ACTIVE",
+  "name": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "retentionDays": 30,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log bucket",
+  "lifecycleState": "ACTIVE",
+  "name": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "retentionDays": 30,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 3,
+      "offset": 1.5,
+      "width": 3.5
+    }
+  },
+  "description": "A sample log metric",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "displayName": "sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass",
+        "valueType": "STRING"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "launchStage": "UNIMPLEMENTED",
+    "metadata": {
+      "ingestDelay": "2s",
+      "samplePeriod": "5s"
+    },
+    "metricKind": "DELTA",
+    "name": "sample-descriptor",
+    "unit": "bit",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "valueExtractor": "EXTRACT(jsonPayload.request)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 3,
+      "offset": 1.5,
+      "width": 3.5
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log metric",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "description": "A sample log metric",
+    "displayName": "sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "bit",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.request)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 3,
+      "offset": 1.5,
+      "width": 3.5
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log metric",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "description": "A sample log metric",
+    "displayName": "sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "bit",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.request)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 3,
+      "offset": 1.5,
+      "width": 3.5
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log metric",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "displayName": "sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass",
+        "valueType": "STRING"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "launchStage": "UNIMPLEMENTED",
+    "metadata": {
+      "ingestDelay": "2s",
+      "samplePeriod": "5s"
+    },
+    "metricKind": "DELTA",
+    "name": "sample-descriptor",
+    "unit": "bit",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.request)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 3,
+      "offset": 1.5,
+      "width": 3.5
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log metric",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "description": "A sample log metric",
+    "displayName": "sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "bit",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.request)"
+}
+
+---
+
+DELETE https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "A sample log bucket",
+  "lifecycleState": "ACTIVE",
+  "name": "projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}",
+  "retentionDays": 30,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://logging.googleapis.com/v2/projects/${projectId}/locations/global/buckets/logginglogbucket-dep-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -579,23 +579,6 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 						}
 					}
 
-					got := events.FormatHTTP()
-					expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
-					normalizers := []func(string) string{}
-					normalizers = append(normalizers, IgnoreComments)
-					normalizers = append(normalizers, ReplaceString(uniqueID, "${uniqueId}"))
-					normalizers = append(normalizers, ReplaceString(project.ProjectID, "${projectId}"))
-					normalizers = append(normalizers, ReplaceString(fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}"))
-					for k, v := range pathIDs {
-						normalizers = append(normalizers, ReplaceString(k, v))
-					}
-					for k := range operationIDs {
-						normalizers = append(normalizers, ReplaceString(k, "${operationID}"))
-					}
-					for k := range networkIDs {
-						normalizers = append(normalizers, ReplaceString(k, "${networkID}"))
-					}
-
 					// Remove repeated GET requests (after normalization)
 					{
 						var previous *test.LogEntry
@@ -613,6 +596,23 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 							previous = e
 							return keep
 						})
+					}
+
+					got := events.FormatHTTP()
+					expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
+					normalizers := []func(string) string{}
+					normalizers = append(normalizers, IgnoreComments)
+					normalizers = append(normalizers, ReplaceString(uniqueID, "${uniqueId}"))
+					normalizers = append(normalizers, ReplaceString(project.ProjectID, "${projectId}"))
+					normalizers = append(normalizers, ReplaceString(fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}"))
+					for k, v := range pathIDs {
+						normalizers = append(normalizers, ReplaceString(k, v))
+					}
+					for k := range operationIDs {
+						normalizers = append(normalizers, ReplaceString(k, "${operationID}"))
+					}
+					for k := range networkIDs {
+						normalizers = append(normalizers, ReplaceString(k, "${networkID}"))
 					}
 
 					if testPause {


### PR DESCRIPTION
- chore: capture golden output for logbucketmetric test
- mockgcp: Improved fidelity for LoggingLogMetric
- tests: Fix repeated-GET removal
