### PR TITLE
perf:remove expander type enum

### DIFF
--- a/experiments/compositions/composition/api/v1alpha1/composition_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/composition_types.go
@@ -68,7 +68,7 @@ type Expander struct {
 	// Type indicates what expander to use
 	//   jinja - jinja2 expander
 	//   none - No expander
-	// +kubebuilder:validation:Enum=jinja2;none
+
 	// +kubebuilder:default=jinja2
 	Type string `json:"type" protobuf:"bytes,2,name=name"`
 	// +kubebuilder:default=latest

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
@@ -64,13 +64,6 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: |-
-                        Type indicates what expander to use
-                          jinja - jinja2 expander
-                          none - No expander
-                      enum:
-                      - jinja2
-                      - none
                       type: string
                     valuesFrom:
                       items:

--- a/experiments/compositions/composition/go.mod
+++ b/experiments/compositions/composition/go.mod
@@ -1,12 +1,11 @@
 module google.com/composition
 
-go 1.22
+go 1.22.0
 
 toolchain go1.22.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v1.4.1
 	github.com/gobuffalo/flect v1.0.2
 	github.com/google/go-cmp v0.6.0

--- a/experiments/compositions/composition/go.sum
+++ b/experiments/compositions/composition/go.sum
@@ -11,7 +11,6 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -29,10 +28,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/experiments/compositions/composition/release/cc/operator.yaml
+++ b/experiments/compositions/composition/release/cc/operator.yaml
@@ -76,13 +76,6 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: |-
-                        Type indicates what expander to use
-                          jinja - jinja2 expander
-                          none - No expander
-                      enum:
-                      - jinja2
-                      - none
                       type: string
                     valuesFrom:
                       items:
@@ -330,6 +323,7 @@ spec:
                   type: string
                 type: array
             required:
+            - imageRegistry
             - validVersions
             type: object
           status:

--- a/experiments/compositions/composition/release/crds.yaml
+++ b/experiments/compositions/composition/release/crds.yaml
@@ -63,13 +63,6 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: |-
-                        Type indicates what expander to use
-                          jinja - jinja2 expander
-                          none - No expander
-                      enum:
-                      - jinja2
-                      - none
                       type: string
                     valuesFrom:
                       items:

--- a/experiments/compositions/composition/release/kind/operator.yaml
+++ b/experiments/compositions/composition/release/kind/operator.yaml
@@ -76,13 +76,6 @@ spec:
                       type: string
                     type:
                       default: jinja2
-                      description: |-
-                        Type indicates what expander to use
-                          jinja - jinja2 expander
-                          none - No expander
-                      enum:
-                      - jinja2
-                      - none
                       type: string
                     valuesFrom:
                       items:


### PR DESCRIPTION
### Change description

Remove the expander type enum to support third party expanders.

### Tests you have done
 `make e2e-test`

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
