### PR TITLE
Make sure we secure pip install/upgrade.

### DIFF
--- a/experiments/compositions/expanders/jinja-expander/Dockerfile
+++ b/experiments/compositions/expanders/jinja-expander/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3.7-slim
 WORKDIR .
 COPY . /
 
-RUN pip install --upgrade pip
-RUN pip install jinja2-cli[yaml,toml,xml,hjson,json5]
+RUN pip install --require-hashes --upgrade pip
+RUN pip install --require-hashes jinja2-cli[yaml,toml,xml,hjson,json5]
 
 ENTRYPOINT ["jinja2"]


### PR DESCRIPTION
Enable the --require-hashes flag for pip usage.

### Change description

Ensure we use the --require-hashes flag when calling pip.

### Tests you have done

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
