### PR TITLE
chore: Don't require headers on generated testdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ fmt:
 	-ignore "operator/config/gke-addon/image_configmap.yaml" \
 	-ignore "operator/config/rbac/cnrm_viewer_role.yaml" \
 	-ignore "operator/vendor/**" \
+	-ignore "**/testdata/**/_*" \
 	./
 
 .PHONY: lint


### PR DESCRIPTION
This doesn't seem to add anything, and it causes a lot of friction.
