### PR TITLE
Use service identity to generate P4SA in samples and tests for Vertex AI resources

### DIFF
--- a/config/samples/resources/vertexaidataset/vertexai-dataset-encryptionkey/iam_v1beta1_iampolicymember.yaml
+++ b/config/samples/resources/vertexaidataset/vertexai-dataset-encryptionkey/iam_v1beta1_iampolicymember.yaml
@@ -19,7 +19,9 @@ kind: IAMPolicyMember
 metadata:
   name: vertexaidataset-dep-encryptionkey
 spec:
-  member: serviceAccount:service-${PROJECT_NUMBER?}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: vertexaidataset-dep-encryptionkey
   role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/config/samples/resources/vertexaidataset/vertexai-dataset-encryptionkey/serviceusage_v1beta1_serviceidentity.yaml
+++ b/config/samples/resources/vertexaidataset/vertexai-dataset-encryptionkey/serviceusage_v1beta1_serviceidentity.yaml
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Replace ${PROJECT_ID?} and ${PROJECT_NUMBER?} below with your desired project
-# ID and project number.
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
 metadata:
-  name: vertexaiendpoint-dep-encryptionkey
+  name: vertexaidataset-dep-encryptionkey
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
 spec:
-  memberFrom:
-    serviceIdentityRef:
-      name: vertexaiendpoint-dep-encryptionkey
-  role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: projects/${PROJECT_ID?}
+  projectRef:
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
+  resourceID: aiplatform.googleapis.com

--- a/config/samples/resources/vertexaiendpoint/vertexai-endpoint-encryptionkey/serviceusage_v1beta1_serviceidentity.yaml
+++ b/config/samples/resources/vertexaiendpoint/vertexai-endpoint-encryptionkey/serviceusage_v1beta1_serviceidentity.yaml
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Replace ${PROJECT_ID?} and ${PROJECT_NUMBER?} below with your desired project
-# ID and project number.
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
 metadata:
   name: vertexaiendpoint-dep-encryptionkey
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
 spec:
-  memberFrom:
-    serviceIdentityRef:
-      name: vertexaiendpoint-dep-encryptionkey
-  role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
-  resourceRef:
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: projects/${PROJECT_ID?}
+  projectRef:
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
+  resourceID: aiplatform.googleapis.com

--- a/pkg/test/resourcefixture/testdata/basic/vertexai/v1beta1/vertexaidataset/vertexaidatasetencryptionkey/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vertexai/v1beta1/vertexaidataset/vertexaidatasetencryptionkey/dependencies.yaml
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: serviceidentity-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+spec:
+  projectRef:
+    external: ${projectId}
+  resourceID: aiplatform.googleapis.com
+---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: iampolicymember-${uniqueId}
 spec:
-  member: serviceAccount:service-${projectNumber}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: serviceidentity-${uniqueId}
   role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/pkg/test/resourcefixture/testdata/basic/vertexai/v1beta1/vertexaiendpoint/vertexaiendpointencryptionkey/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vertexai/v1beta1/vertexaiendpoint/vertexaiendpointencryptionkey/dependencies.yaml
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: serviceidentity-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+spec:
+  projectRef:
+    external: ${projectId}
+  resourceID: aiplatform.googleapis.com
+---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   name: iampolicymember-${uniqueId}
 spec:
-  member: serviceAccount:service-${projectNumber}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: serviceidentity-${uniqueId}
   role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaidataset.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaidataset.md
@@ -407,7 +407,9 @@ kind: IAMPolicyMember
 metadata:
   name: vertexaidataset-dep-encryptionkey
 spec:
-  member: serviceAccount:service-${PROJECT_NUMBER?}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: vertexaidataset-dep-encryptionkey
   role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
@@ -429,6 +431,18 @@ metadata:
   name: vertexaidataset-dep-encryptionkey
 spec:
   location: us-central1
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: vertexaidataset-dep-encryptionkey
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+spec:
+  projectRef:
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
+  resourceID: aiplatform.googleapis.com
 ```
 
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaiendpoint.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/vertexai/vertexaiendpoint.md
@@ -429,7 +429,9 @@ kind: IAMPolicyMember
 metadata:
   name: vertexaiendpoint-dep-encryptionkey
 spec:
-  member: serviceAccount:service-${PROJECT_NUMBER?}@gcp-sa-aiplatform.iam.gserviceaccount.com
+  memberFrom:
+    serviceIdentityRef:
+      name: vertexaiendpoint-dep-encryptionkey
   role: roles/cloudkms.cryptoKeyEncrypterDecrypter # required by vertex AI service agent to access KMS keys
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
@@ -451,6 +453,18 @@ metadata:
   name: vertexaiendpoint-dep-encryptionkey
 spec:
   location: us-central1
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: vertexaiendpoint-dep-encryptionkey
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+spec:
+  projectRef:
+    # Replace ${PROJECT_ID?} with your project ID.
+    external: ${PROJECT_ID?}
+  resourceID: aiplatform.googleapis.com
 ```
 
 ### Vertexai Endpoint Network


### PR DESCRIPTION
Avoid hard-coding P4SA service account in Vertex AI samples and tests.

TESTED
```
$ go test -v -tags=integration ./config/tests/samples/create/ -run-tests vertexai-dataset-encryptionkey

$ go test -v -tags=integration ./config/tests/samples/create/ -run-tests vertexai-endpoint-encryptionkey

$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests vertexaidatasetencryptionkey

$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests vertexaiendpointencryptionkey
```