### PR TITLE
perf:update expander selection and add validation after expander migration

### DIFF
--- a/experiments/compositions/composition/release/manifest.yaml
+++ b/experiments/compositions/composition/release/manifest.yaml
@@ -1152,3 +1152,14 @@ spec:
         runAsNonRoot: true
       serviceAccountName: composition-controller-manager
       terminationGracePeriodSeconds: 10
+---
+apiVersion: composition.google.com/v1alpha1
+kind: ExpanderVersion
+metadata:
+  name: composition-jinja2
+  namespace: composition-system
+spec:
+  imageRegistry: gcr.io/krmapihosting-release
+  validVersions:
+  - v0.0.1
+  - v0.0.0

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionDeleteFacade/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionDeleteFacade/input.yaml
@@ -106,7 +106,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
@@ -104,20 +104,22 @@ metadata:
   namespace: default
 spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
-  namespaceMode: inherit
   expanders:
-  - type: jinja2
+  - type: fakeExpander
+    version: v1.10.2
     name: common
     template: |
       apiVersion: v1
-      kind: ConfigMap
+      kind: MonfigCap ## should fail
       metadata:
         name: common-config
+        namespace: {{ pconfigs.metadata.namespace }}
         labels:
           createdby: "composition-namespaceconfigmap"
       data:
           key: {{ pconfigs.spec.project }}
-  - type: jinja2
+  - type: fakeExpander
+    version: v1.2.3
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}
@@ -126,28 +128,13 @@ spec:
       kind: ConfigMap
       metadata:
         name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
         labels:
           createdby: "composition-namespaceconfigmap"
       data:
         name: {{ managedProject }}
         billingAccountRef: "010101-ABABCD-BCAB11"
         folderRef: "000000111100"
-  - type: jinja2
-    version: v0.0.1
-    name: clusterscope
-    template: |
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: {{ managedProject }}
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: foobar-foocorp
-      subjects:
-      - kind: ServiceAccount
-        name: foobar
-        namespace: foobar-system
 ---
 apiVersion: v1
 kind: Namespace

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/output.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
@@ -104,20 +104,22 @@ metadata:
   namespace: default
 spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
-  namespaceMode: inherit
   expanders:
   - type: jinja2
+    version: v1.10.2
     name: common
     template: |
       apiVersion: v1
-      kind: ConfigMap
+      kind: MonfigCap ## should fail
       metadata:
         name: common-config
+        namespace: {{ pconfigs.metadata.namespace }}
         labels:
           createdby: "composition-namespaceconfigmap"
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
+    version: v1.2.3
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}
@@ -126,28 +128,13 @@ spec:
       kind: ConfigMap
       metadata:
         name: {{ managedProject }}
+        namespace: {{ pconfigs.metadata.namespace }}
         labels:
           createdby: "composition-namespaceconfigmap"
       data:
         name: {{ managedProject }}
         billingAccountRef: "010101-ABABCD-BCAB11"
         folderRef: "000000111100"
-  - type: jinja2
-    version: v0.0.1
-    name: clusterscope
-    template: |
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: {{ managedProject }}
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: foobar-foocorp
-      subjects:
-      - kind: ServiceAccount
-        name: foobar
-        namespace: foobar-system
 ---
 apiVersion: v1
 kind: Namespace

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/output.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/experiments/compositions/composition/tests/data/TestSimpleFacadeByoSchema/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleFacadeByoSchema/input.yaml
@@ -79,7 +79,7 @@ spec:
   inputAPIGroup: pconfigs.facade.compositions.google.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -92,7 +92,7 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
@@ -107,7 +107,6 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
     name: common
     template: |
       apiVersion: v1
@@ -120,7 +119,6 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}
@@ -137,7 +135,6 @@ spec:
         billingAccountRef: "010101-ABABCD-BCAB11"
         folderRef: "000000111100"
   - type: jinja2
-    version: v0.0.1.alpha
     name: clusterscope
     template: |
       {% set managedProject = pconfigs.spec.project %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/composition_fixed.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/composition_fixed.yaml
@@ -22,7 +22,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -35,7 +35,7 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/input.yaml
@@ -106,7 +106,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -120,7 +120,7 @@ spec:
           # This will cause a jinja expansion failure
           key: {{ unknown.spec.doesNotExist }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/composition_fixed.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/composition_fixed.yaml
@@ -22,7 +22,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -35,7 +35,7 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/input.yaml
@@ -106,7 +106,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -119,7 +119,7 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/composition_fixed.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/composition_fixed.yaml
@@ -22,7 +22,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -35,7 +35,7 @@ spec:
       data:
           key: {{ pconfigs.spec.project }}
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/input.yaml
@@ -106,7 +106,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       ---
@@ -117,7 +117,7 @@ spec:
       stuff: 3
       --- Make sure uncommented content results YAMLSyntaxError
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusWaitingForValues/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusWaitingForValues/input.yaml
@@ -106,7 +106,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: common
     template: |
       apiVersion: v1
@@ -118,7 +118,7 @@ spec:
           createdby: "composition-namespaceconfigmap"
       # No data
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     valuesFrom:
     - name: commondata

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -299,3 +299,23 @@ func TestSimpleFacadeByoSchema(t *testing.T) {
 	// Verify the composition progresses after being unblocked
 	s.VerifyOutputExists()
 }
+
+func TestSimpleExpanderInvalid(t *testing.T) {
+	s := scenario.NewBasic(t)
+	defer s.Cleanup()
+	s.Setup()
+
+	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
+	condition := utils.GetErrorCondition("MissingExpanderCR", "")
+	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+}
+
+func TestSimpleExpanderVersionInvalid(t *testing.T) {
+	s := scenario.NewBasic(t)
+	defer s.Cleanup()
+	s.Setup()
+
+	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
+	condition := utils.GetErrorCondition("InvalidExpanderVersion", "")
+	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+}


### PR DESCRIPTION
### Description

The expander CR has been moved to a different folder https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1775.
- Update the expander version CR name from jinja2 to composition-jinja2
- Add version validation when user selections a specific version
- Add tests for invalid expander/version usecase.

### Tests you have done

`make e2e-test`

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
