### PR TITLE
tests:chore: update for logbucketmetric

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/update.yaml
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+spec:
+  description: "An updated sample log metric"
+  filter: "resource.type=gae_app AND severity>=ERROR"
+  disabled: true
+  metricDescriptor:
+    labels:
+    - key: "mass"
+      valueType: "STRING"
+      description: "amount of matter"
+    - key: "hasMass"
+      valueType: "BOOL"
+      description: "whether the item has a mass"
+    - key: "sku"
+      valueType: "INT64"
+      description: "identifying number for item"
+    metricKind: "DELTA"
+    valueType: "DISTRIBUTION"
+    unit: "s"
+    displayName: "updated-sample-descriptor"
+    metadata:
+      samplePeriod: "3.5s"
+      ingestDelay: "3.5s"
+    launchStage: "PRELAUNCH"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    mass: "EXTRACT(jsonPayload.request)"
+    hasMass: "REGEXP_EXTRACT(jsonPayload.request, \".*([1-9]).*\")"
+    sku: "EXTRACT(jsonPayload.id)"
+  bucketOptions:
+    linearBuckets:
+      numFiniteBuckets: 4
+      width: 2.5
+      offset: 0.5
+  projectRef:
+    external: "projects/${projectId}"
+  loggingLogBucketRef:
+    name: logginglogbucket-dep-${uniqueId}
+    kind: LoggingLogBucket


### PR DESCRIPTION
Path adds update struct  for `logbucketmetric` test.

```bash
$ go test -v -tags=integration ./pkg/controller/dynamic/ -timeout 1600s -test.count=1 -test.run 'TestCreateNoChangeUpdateDelete/logging/basic-logbucketmetric'  2>&1
...
--- PASS: TestCreateNoChangeUpdateDelete (0.12s)
    --- PASS: TestCreateNoChangeUpdateDelete/logging (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/logging/basic-logbucketmetric (79.51s)
PASS
...
ok      github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      89.455s
```