### PR TITLE
chore: use go-version-file in vcr presubmit

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21.5"
+          go-version-file: 'go.mod'
       - name: "Run vcr tests"
         run: |
           ./scripts/github-actions/tests-e2e-fixtures-vcr.sh


### PR DESCRIPTION
Avoids repeating the go version unnecessarily.
