### PR TITLE
terraform: fix perm diff on edition field in SQL instance

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/sql/resource_sql_database_instance.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/sql/resource_sql_database_instance.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -161,6 +162,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"edition": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Default:      "ENTERPRISE",
 							ValidateFunc: validation.StringInSlice([]string{"ENTERPRISE", "ENTERPRISE_PLUS"}, false),
 							Description:  `The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.`,
 						},
@@ -1994,7 +1996,7 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 	data := map[string]interface{}{
 		"version":                     settings.SettingsVersion,
 		"tier":                        settings.Tier,
-		"edition":                     settings.Edition,
+		"edition":                     flattenEdition(settings.Edition),
 		"activation_policy":           settings.ActivationPolicy,
 		"availability_type":           settings.AvailabilityType,
 		"collation":                   settings.Collation,
@@ -2320,6 +2322,14 @@ func flattenPasswordValidationPolicy(passwordValidationPolicy *sqladmin.Password
 		"enable_password_policy":      passwordValidationPolicy.EnablePasswordPolicy,
 	}
 	return []map[string]interface{}{data}
+}
+
+func flattenEdition(v interface{}) string {
+	if v == nil || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+		return "ENTERPRISE"
+	}
+
+	return v.(string)
 }
 
 func instanceMutexKey(project, instance_name string) string {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Pick up the fix in https://github.com/GoogleCloudPlatform/magic-modules/pull/9198

Fixes #1802

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

TESTED

1. Create a SQL instance with KCC 1.117.0
```
$ kubectl apply -f create.yaml

$ cat create.yaml 
apiVersion: sql.cnrm.cloud.google.com/v1beta1
kind: SQLInstance
metadata:
  name: sqlinstance-sample-333079656-2
spec:
  region: us-central1
  databaseVersion: MYSQL_5_7
  instanceType: CLOUD_SQL_INSTANCE
  settings:
    tier: db-n1-standard-1
```

2. Update the KCC code to include the patch in this PR. This mimics the case where the users upgrade the KCC to the version with this fix.

3. Setting the "settings.edition" field in the created SQL instance
```
$ kubectl apply -f update.yaml
sqlinstance.sql.cnrm.cloud.google.com/sqlinstance-sample-333079656-2 configured

jingyih@jingyih:~/Project/oncall/b333079656/basic$ cat update.yaml 
apiVersion: sql.cnrm.cloud.google.com/v1beta1
kind: SQLInstance
metadata:
  name: sqlinstance-sample-333079656-2
spec:
  region: us-central1
  databaseVersion: MYSQL_5_7
  instanceType: CLOUD_SQL_INSTANCE
  settings:
    tier: db-n1-standard-1
    edition: ENTERPRISE
``` 

It looks like the originally created SQL instance was defaulted to "ENTERPRISE" edition (according to Pantheon). KCC controller sees no diff when applying the "update.yaml".

4. No update calls in the subsequent KCC reconciliations.
```
{"severity":"info","timestamp":"2024-05-15T01:01:17.380Z","logger":"sqlinstance-controller","msg":"starting reconcile","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"}}
{"severity":"info","timestamp":"2024-05-15T01:01:18.084Z","logger":"sqlinstance-controller","msg":"underlying resource already up to date","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"}}
{"severity":"info","timestamp":"2024-05-15T01:01:18.085Z","logger":"sqlinstance-controller","msg":"successfully finished reconcile","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"},"time to next reconciliation":"13m1.159273067s"}
{"severity":"info","timestamp":"2024-05-15T01:02:03.637Z","logger":"sqlinstance-controller","msg":"starting reconcile","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"}}
{"severity":"info","timestamp":"2024-05-15T01:02:03.849Z","logger":"sqlinstance-controller","msg":"underlying resource already up to date","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"}}
{"severity":"info","timestamp":"2024-05-15T01:02:03.877Z","logger":"sqlinstance-controller","msg":"successfully finished reconcile","resource":{"name":"sqlinstance-sample-333079656-2","namespace":"default"},"time to next reconciliation":"10m3.554834869s"}
```