### PR TITLE
enh: check failed updates in conditions 

### DIFF
--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -304,13 +304,13 @@ func (a *logMetricAdapter) hasChanges(ctx context.Context, u *unstructured.Unstr
 	log := klog.FromContext(ctx)
 
 	if u.GetGeneration() != getObservedGeneration(u) {
-		log.Info("generation does not match", "generation", u.GetGeneration(), "observedGeneration", getObservedGeneration(u))
+		log.V(2).Info("generation does not match", "generation", u.GetGeneration(), "observedGeneration", getObservedGeneration(u))
 		return true
 	}
 
 	gcpUpdateTime := a.actual.UpdateTime
 	if gcpUpdateTime == "" {
-		log.Info("updateTime is not set in GCP")
+		log.V(2).Info("updateTime is not set in GCP")
 		return true
 	}
 	gcpUpdateTimestamp, err := convertToMicrotime(gcpUpdateTime)
@@ -325,7 +325,7 @@ func (a *logMetricAdapter) hasChanges(ctx context.Context, u *unstructured.Unstr
 		return true
 	}
 	if obj.Status.UpdateTime == nil {
-		log.Info("status.updateTime is not set")
+		log.V(2).Info("status.updateTime is not set")
 		return true
 	}
 
@@ -334,18 +334,18 @@ func (a *logMetricAdapter) hasChanges(ctx context.Context, u *unstructured.Unstr
 		// the update a chance to heal or keep marking it as failed
 		for _, cd := range obj.Status.Conditions {
 			if cd.Reason == k8s.UpdateFailed {
-				log.Info("status.Conditions contains a failed update")
+				log.V(2).Info("status.Conditions contains a failed update")
 				return true
 			}
 		}
 	}
 
 	if gcpUpdateTimestamp.Equal(obj.Status.UpdateTime) {
-		log.Info("status.updateTime matches gcp updateTime", "status.updateTime", obj.Status.UpdateTime.UTC(), "gcpUpdateTime", gcpUpdateTimestamp.UTC())
+		log.V(2).Info("status.updateTime matches gcp updateTime", "status.updateTime", obj.Status.UpdateTime.UTC(), "gcpUpdateTime", gcpUpdateTimestamp.UTC())
 		return false
 	}
 
-	log.Info("status.updateTime does not match gcp updateTime", "status.updateTime", obj.Status.UpdateTime.UTC(), "gcpUpdateTime", gcpUpdateTimestamp.UTC())
+	log.V(2).Info("status.updateTime does not match gcp updateTime", "status.updateTime", obj.Status.UpdateTime.UTC(), "gcpUpdateTime", gcpUpdateTimestamp.UTC())
 	return true
 }
 


### PR DESCRIPTION
There can be a situation where the a failed update gets marked afterwards as `UpToDate` .

Big shout out to @gemmahou for catching this.