### PR TITLE
LoggingLogMetric: use string instead of metav1.Time

### DIFF
--- a/apis/resources/logging/v1beta1/logmetric_types.go
+++ b/apis/resources/logging/v1beta1/logmetric_types.go
@@ -206,7 +206,7 @@ type LoggingLogMetricStatus struct {
 	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
 	/* Output only. The creation timestamp of the metric. This field may not be present for older metrics. */
 	// +optional
-	CreateTime *metav1.MicroTime `json:"createTime,omitempty"`
+	CreateTime *string `json:"createTime,omitempty"`
 
 	// +optional
 	MetricDescriptor *LogmetricMetricDescriptorStatus `json:"metricDescriptor,omitempty"`
@@ -217,7 +217,7 @@ type LoggingLogMetricStatus struct {
 
 	/* Output only. The last update timestamp of the metric. This field may not be present for older metrics. */
 	// +optional
-	UpdateTime *metav1.MicroTime `json:"updateTime,omitempty"`
+	UpdateTime *string `json:"updateTime,omitempty"`
 }
 
 // +genclient

--- a/apis/resources/logging/v1beta1/zz_generated.deepcopy.go
+++ b/apis/resources/logging/v1beta1/zz_generated.deepcopy.go
@@ -153,7 +153,8 @@ func (in *LoggingLogMetricStatus) DeepCopyInto(out *LoggingLogMetricStatus) {
 	}
 	if in.CreateTime != nil {
 		in, out := &in.CreateTime, &out.CreateTime
-		*out = (*in).DeepCopy()
+		*out = new(string)
+		**out = **in
 	}
 	if in.MetricDescriptor != nil {
 		in, out := &in.MetricDescriptor, &out.MetricDescriptor
@@ -167,7 +168,8 @@ func (in *LoggingLogMetricStatus) DeepCopyInto(out *LoggingLogMetricStatus) {
 	}
 	if in.UpdateTime != nil {
 		in, out := &in.UpdateTime, &out.UpdateTime
-		*out = (*in).DeepCopy()
+		*out = new(string)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/direct/logging/utils.go
+++ b/pkg/controller/direct/logging/utils.go
@@ -40,6 +40,17 @@ func ValueOf[T any](p *T) T {
 	return v
 }
 
+// LazyPtr returns a pointer to v, unless it is the empty value, in which case it returns nil.
+// It is essentially the inverse of ValueOf, though it is lossy
+// because we can't tell nil and empty apart without a pointer.
+func LazyPtr[T comparable](v T) *T {
+	var defaultValue T
+	if v == defaultValue {
+		return nil
+	}
+	return &v
+}
+
 // IsNotFound returns true if the given error is an HTTP 404.
 func IsNotFound(err error) bool {
 	return HasHTTPCode(err, 404)


### PR DESCRIPTION
metav1.Time is overly strict about the input format, and we can't
parse values that were written with nanosecond precision.
