### PR TITLE
test: test NoChange after Update in dynamic test

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -53,6 +53,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -276,14 +277,31 @@ func validateCreate(ctx context.Context, t *testing.T, testContext testrunner.Te
 	}
 }
 
+func testNoChangeAfterCreate(ctx context.Context, t *testing.T, testContext testrunner.TestContext, systemContext testrunner.SystemContext, resourceContext contexts.ResourceContext) {
+	testNoChange(ctx, t, testContext, systemContext, resourceContext, false)
+}
+
+// testNoChangeAfterUpdate is enabled only on resources allowlisted inside the function.
+func testNoChangeAfterUpdate(ctx context.Context, t *testing.T, testContext testrunner.TestContext, systemContext testrunner.SystemContext, resourceContext contexts.ResourceContext) {
+	switch testContext.ResourceFixture.GVK.GroupKind() {
+	case schema.GroupKind{Group: "sql.cnrm.cloud.google.com", Kind: "SQLInstance"}: // test coverage for https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/1802
+	default:
+		return
+	}
+	testNoChange(ctx, t, testContext, systemContext, resourceContext, true)
+}
+
 // testNoChange verifies that reconciling a resource which has not changed does not result in
 // any meaningful changes.
-func testNoChange(ctx context.Context, t *testing.T, testContext testrunner.TestContext, systemContext testrunner.SystemContext, resourceContext contexts.ResourceContext) {
+func testNoChange(ctx context.Context, t *testing.T, testContext testrunner.TestContext, systemContext testrunner.SystemContext, resourceContext contexts.ResourceContext, useUpdateFixture bool) {
 	if resourceContext.SkipNoChange {
 		return
 	}
 	kubeClient := systemContext.Manager.GetClient()
 	initialUnstruct := testContext.CreateUnstruct.DeepCopy()
+	if useUpdateFixture {
+		initialUnstruct = testContext.UpdateUnstruct.DeepCopy()
+	}
 	if err := kubeClient.Get(ctx, testContext.NamespacedName, initialUnstruct); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
@@ -537,8 +555,9 @@ func testReconcileCreateNoChangeUpdateDelete(ctx context.Context, t *testing.T, 
 	resourceCleanup := systemContext.Reconciler.BuildCleanupFunc(ctx, testContext.CreateUnstruct, getResourceCleanupPolicy())
 	defer resourceCleanup()
 	testCreate(ctx, t, testContext, systemContext, resourceContext)
-	testNoChange(ctx, t, testContext, systemContext, resourceContext)
+	testNoChangeAfterCreate(ctx, t, testContext, systemContext, resourceContext)
 	testUpdate(ctx, t, testContext, systemContext, resourceContext)
+	testNoChangeAfterUpdate(ctx, t, testContext, systemContext, resourceContext)
 	testDriftCorrection(ctx, t, testContext, systemContext, resourceContext)
 	testDelete(ctx, t, testContext, systemContext, resourceContext)
 }

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/update.yaml
@@ -24,4 +24,5 @@ spec:
   databaseVersion: MYSQL_5_7
   instanceType: CLOUD_SQL_INSTANCE
   settings:
-    tier: db-n1-standard-4
+    tier: db-n1-standard-1
+    edition: ENTERPRISE


### PR DESCRIPTION
Make a no-change update after the update test. Ensure there is no unexpected update call.

This test could help catch bugs like #1802.

Without the fix in #1803, the test fails with
```
go test -timeout 1200s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests mysqlinstance
...
k8s.go:84: expected event with reason 'Updating' to not be recorded for SQLInstance epqxuxkxxi5dnnbghdaq/sqlinstance-sample-epqxuxkxxi5dnnbghdaq, but it was
...
--- FAIL: TestCreateNoChangeUpdateDelete (0.16s)
    --- FAIL: TestCreateNoChangeUpdateDelete/sql (0.00s)
        --- FAIL: TestCreateNoChangeUpdateDelete/sql/basic-mysqlinstance (337.22s)
...
```

With the fix in #1803, the test passes
```
go test -timeout 1200s -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests mysqlinstance
...
--- PASS: TestCreateNoChangeUpdateDelete (0.16s)
    --- PASS: TestCreateNoChangeUpdateDelete/sql (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/sql/basic-mysqlinstance (395.45s)
```
