### PR TITLE
chore: stop setting GOPATH in github actions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -33,20 +33,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # This is introduced to make sure 'go generate' works properly
-          path: "src/k8s-config-connector"
           # This is to get all the commits in order to validate them
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'src/k8s-config-connector/go.mod'
+          go-version-file: 'go.mod'
       - name: "Run validations"
         run: |
-          cd ./src/k8s-config-connector
           ./scripts/github-actions/ga-validation.sh
         env:
-          # This is introduced to make sure 'go generate' works properly
-          GOPATH: /home/runner/work/k8s-config-connector/k8s-config-connector
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_HEAD: ${{ github.event.pull_request.head.sha }}
           COMMIT_CNT: ${{ github.event.pull_request.commits }}
@@ -63,8 +58,6 @@ jobs:
       - name: "Run unit tests"
         run: |
           ./scripts/github-actions/ga-unit-test.sh
-        env:
-          GOPATH: /home/runner/go
       - name: "Upload test result"
         uses: actions/upload-artifact@v4
         if: '!cancelled()'
@@ -84,7 +77,6 @@ jobs:
         run: |
           ./scripts/github-actions/tests-e2e-samples
         env:
-          GOPATH: /home/runner/go
           ARTIFACTS: /tmp/artifacts
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
@@ -103,7 +95,6 @@ jobs:
         run: |
           ./scripts/github-actions/tests-e2e-fixtures
         env:
-          GOPATH: /home/runner/go
           ARTIFACTS: /tmp/artifacts
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
@@ -121,8 +112,6 @@ jobs:
       - name: "Run pause tests"
         run: |
           ./scripts/github-actions/ga-pause-test.sh
-        env:
-          GOPATH: /home/runner/go
   direct-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -133,9 +122,7 @@ jobs:
           go-version-file: 'go.mod'
       - name: "run tests-e2e-direct"
         run: |
-          ./scripts/github-actions//tests-e2e-direct.sh
-        env:
-          GOPATH: /home/runner/go
+          ./scripts/github-actions/tests-e2e-direct.sh
   tests-e2e-fixtures-vcr:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -147,8 +134,6 @@ jobs:
       - name: "Run vcr tests"
         run: |
           ./scripts/github-actions/tests-e2e-fixtures-vcr.sh
-        env:
-          GOPATH: /home/runner/go
   build-images:
     runs-on: ubuntu-22.04
     timeout-minutes: 60


### PR DESCRIPTION
We shouldn't need it, and if we do need it, we should set it in the
script, for reproducibility.
