### PR TITLE
tests: simplify monitoringdashboard test case, add to tests-e2e-direct

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_generated_object_monitoringdashboardrefs.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_generated_object_monitoringdashboardrefs.golden.yaml
@@ -52,7 +52,7 @@ spec:
           filter: metric.type="agent.googleapis.com/nginx/connections/accepted_count"
           resourceNames: []
         title: Widget 4
-  displayName: monitoringdashboard-${uniqueId}
+  displayName: monitoringdashboard updated
   projectRef:
     name: otherproject
   resourceID: monitoringdashboard-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_http.log
@@ -524,9 +524,9 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
       }
     ]
   },
-  "displayName": "monitoringdashboard-${uniqueId}",
+  "displayName": "monitoringdashboard updated",
   "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/dashboards/monitoringdashboard-${uniqueId}"
+  "name": "projects/projects/other${uniqueId}/dashboards/monitoringdashboard-${uniqueId}"
 }
 
 200 OK
@@ -613,7 +613,7 @@ X-Xss-Protection: 0
       }
     ]
   },
-  "displayName": "monitoringdashboard-${uniqueId}",
+  "displayName": "monitoringdashboard updated",
   "etag": "abcdef0123A=",
   "name": "projects/${projectNumber}/dashboards/monitoringdashboard-${uniqueId}"
 }
@@ -708,7 +708,7 @@ X-Xss-Protection: 0
       }
     ]
   },
-  "displayName": "monitoringdashboard-${uniqueId}",
+  "displayName": "monitoringdashboard updated",
   "etag": "abcdef0123A=",
   "name": "projects/${projectNumber}/dashboards/monitoringdashboard-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/update.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   projectRef:
     name: otherproject
-  displayName: "monitoringdashboard-${uniqueId}"
+  displayName: "monitoringdashboard updated"
   columnLayout:
     columns:
     - weight: 2

--- a/scripts/github-actions/tests-e2e-direct.sh
+++ b/scripts/github-actions/tests-e2e-direct.sh
@@ -38,7 +38,7 @@ echo "Running e2e tests fixtures for LoggingLogMetric direct reconciliation..."
 GOLDEN_OBJECT_CHECKS=1 \
 GOLDEN_REQUEST_CHECKS=1 \
 E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock \
-  go test -test.count=1 -timeout 600s -v ./tests/e2e -run 'TestAllInSeries/fixtures/explicitlogmetric|TestAllInSeries/fixtures/exponentiallogmetric|TestAllInSeries/fixtures/linearlogmetric|TestAllInSeries/fixtures/logbucketmetric'
+  go test -test.count=1 -timeout 600s -v ./tests/e2e -run 'TestAllInSeries/fixtures/explicitlogmetric|TestAllInSeries/fixtures/exponentiallogmetric|TestAllInSeries/fixtures/linearlogmetric|TestAllInSeries/fixtures/logbucketmetric|TestAllInSeries/fixtures/monitoringdashboard'
 
 echo "Running scenarios tests for LoggingLogMetric direct reconciliation..."
 


### PR DESCRIPTION
Changing to a random display name is not very intuitive (and doesn't
get us much).
    
Also add this to tests-e2e-direct, so we verify the golden output