### PR TITLE
Find the hubfeaturemembership resource when doing the Delete

### DIFF
--- a/pkg/controller/direct/gkehub/featuremembership_controller.go
+++ b/pkg/controller/direct/gkehub/featuremembership_controller.go
@@ -121,6 +121,14 @@ func (a *gkeHubAdapter) Find(ctx context.Context) (bool, error) {
 
 // Delete implements the Adapter interface.
 func (a *gkeHubAdapter) Delete(ctx context.Context) (bool, error) {
+	exist, err := a.Find(ctx)
+	if err != nil {
+		return false, fmt.Errorf("finding feature for %s:%w", a.featureID, err)
+	}
+	if !exist {
+		// return (false, nil) if the object was not found but should be presumed deleted.
+		return false, nil
+	}
 	// emptying the membershipspec is sufficient
 	a.desired = &featureapi.MembershipFeatureSpec{}
 	if _, err := a.patchMembershipSpec(ctx); err != nil {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
For the resource, the controller needs to do a get before `delete` because the `delete` only cleans up a field for the Gkehub feature resource. Otherwise , `adapter.actual` is not initialized in Delete in the base controller

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
