### PR TITLE
tests: add logbucketmetric to direct tests

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_generated_export_logbucketmetric.golden
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_generated_export_logbucketmetric.golden
@@ -1,0 +1,38 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+spec:
+  bucketOptions:
+    linearBuckets:
+      numFiniteBuckets: 4
+      offset: 0.5
+      width: 2.5
+  description: An updated sample log metric
+  disabled: true
+  filter: resource.type=gae_app AND severity>=ERROR
+  labelExtractors:
+    hasMass: REGEXP_EXTRACT(jsonPayload.request, ".*([1-9]).*")
+    mass: EXTRACT(jsonPayload.request)
+    sku: EXTRACT(jsonPayload.id)
+  loggingLogBucketRef:
+    external: projects/${projectId}/locations/global/buckets/my-bucket-${uniqueId}
+  metricDescriptor:
+    displayName: updated-sample-descriptor
+    labels:
+    - description: whether the item has a mass
+      key: hasMass
+      valueType: BOOL
+    - description: amount of matter
+      key: mass
+      valueType: STRING
+    - description: identifying number for item
+      key: sku
+      valueType: INT64
+    launchStage: ""
+    metricKind: DELTA
+    unit: s
+    valueType: DISTRIBUTION
+  projectRef:
+    external: ${projectId}
+  valueExtractor: EXTRACT(jsonPayload.response)

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logbucketmetric/_http.log
@@ -544,6 +544,71 @@ X-Xss-Protection: 0
 
 ---
 
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5
+X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "projects/${projectId}/locations/global/buckets/my-bucket-${uniqueId}",
+  "bucketOptions": {
+    "linearBuckets": {
+      "numFiniteBuckets": 4,
+      "offset": 0.5,
+      "width": 2.5
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "An updated sample log metric",
+  "disabled": true,
+  "filter": "resource.type=gae_app AND severity\u003e=ERROR",
+  "labelExtractors": {
+    "hasMass": "REGEXP_EXTRACT(jsonPayload.request, \".*([1-9]).*\")",
+    "mass": "EXTRACT(jsonPayload.request)",
+    "sku": "EXTRACT(jsonPayload.id)"
+  },
+  "metricDescriptor": {
+    "description": "An updated sample log metric",
+    "displayName": "updated-sample-descriptor",
+    "labels": [
+      {
+        "description": "amount of matter",
+        "key": "mass"
+      },
+      {
+        "description": "whether the item has a mass",
+        "key": "hasMass",
+        "valueType": "BOOL"
+      },
+      {
+        "description": "identifying number for item",
+        "key": "sku",
+        "valueType": "INT64"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "s",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
 DELETE https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5
 X-Goog-Api-Client: gl-go/1.22.3 gdcl/0.177.0

--- a/scripts/github-actions/tests-e2e-direct.sh
+++ b/scripts/github-actions/tests-e2e-direct.sh
@@ -38,7 +38,7 @@ KCC_USE_DIRECT_RECONCILERS=LoggingLogMetric \
 GOLDEN_OBJECT_CHECKS=1 \
 GOLDEN_REQUEST_CHECKS=1 \
 E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock \
-  go test -test.count=1 -timeout 600s -v ./tests/e2e -run 'TestAllInSeries/fixtures/explicitlogmetric|TestAllInSeries/fixtures/exponentiallogmetric|TestAllInSeries/fixtures/linearlogmetric'
+  go test -test.count=1 -timeout 600s -v ./tests/e2e -run 'TestAllInSeries/fixtures/explicitlogmetric|TestAllInSeries/fixtures/exponentiallogmetric|TestAllInSeries/fixtures/linearlogmetric|TestAllInSeries/fixtures/logbucketmetric'
 
 echo "Running scenarios tests for LoggingLogMetric direct reconciliation..."
 


### PR DESCRIPTION
Run the logbucketmetric in the direct tests. ~Note, I am not convinced we need it since the postsubmits hit the direct controller now but~ it's probably good practice to add it for now until we can better target all of the tests under a GVK.