### PR TITLE
Switch jinja2 to grpc based expansion

### DIFF
--- a/experiments/compositions/composition/api/v1alpha1/expanderversion_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/expanderversion_types.go
@@ -38,11 +38,11 @@ const (
 
 // ExpanderVersionSpec defines the desired state of ExpanderVersion
 type ExpanderVersionSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// ImageRegistry is the designated registry for where to pull the named expander image
 	ImageRegistry string `json:"imageRegistry,omitempty"`
+
+	// Image if different from removePrefix(expanderversion.name , "composition-")
+	Image string `json:"image,omitempty"`
 
 	// ValidVersions is a list of valid versions of the named expander
 	ValidVersions []string `json:"validVersions"`

--- a/experiments/compositions/composition/api/v1alpha1/plan_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/plan_types.go
@@ -40,6 +40,10 @@ type StageStatus struct {
 
 // PlanStatus defines the observed state of Plan
 type PlanStatus struct {
+	// Facade's generation last we successfully reconciled
+	InputGeneration int64 `json:"inputGeneration,omitempty"`
+	// Plan generation we last successfully reconciled
+	Generation int64                  `json:"generation,omitempty"`
 	Conditions []metav1.Condition     `json:"conditions,omitempty"`
 	Stages     map[string]StageStatus `json:"stages,omitempty"`
 }

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_expanderversions.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_expanderversions.yaml
@@ -53,6 +53,10 @@ spec:
           spec:
             description: ExpanderVersionSpec defines the desired state of ExpanderVersion
             properties:
+              image:
+                description: Image if different from removePrefix(expanderversion.name
+                  , "composition-")
+                type: string
               imageRegistry:
                 description: ImageRegistry is the designated registry for where to
                   pull the named expander image

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
@@ -135,6 +135,14 @@ spec:
                   - type
                   type: object
                 type: array
+              generation:
+                description: Plan generation we last successfully reconciled
+                format: int64
+                type: integer
+              inputGeneration:
+                description: Facade's generation last we successfully reconciled
+                format: int64
+                type: integer
               stages:
                 additionalProperties:
                   description: StageStatus captures the status of a stage

--- a/experiments/compositions/composition/config/expanders/expander_versions.yaml
+++ b/experiments/compositions/composition/config/expanders/expander_versions.yaml
@@ -15,11 +15,12 @@
 apiVersion: composition.google.com/v1alpha1
 kind: ExpanderVersion
 metadata:
-  name: jinja2
+  name: jinja2-job
   namespace: system
 spec:
   type: job
   imageRegistry: gcr.io/krmapihosting-release
+  image: expander-jinja2
   validVersions:
   # current golang semver package only support version comparison
   # in the format of `v{num}.{num}.{num}-{alphabet}`, `v{num}.{num}.{num}` and `{num}.{num}.{num}`.
@@ -30,7 +31,7 @@ spec:
 apiVersion: composition.google.com/v1alpha1
 kind: ExpanderVersion
 metadata:
-  name: gjinja2
+  name: jinja2
   namespace: system
 spec:
   type: grpc

--- a/experiments/compositions/composition/config/expanders/jinja2-v0.0.1.yaml
+++ b/experiments/compositions/composition/config/expanders/jinja2-v0.0.1.yaml
@@ -101,7 +101,7 @@ metadata:
     app.kubernetes.io/part-of: composition
     app.kubernetes.io/instance: jinja2-v0.0.1
     app.kubernetes.io/component: expanders
-  name: gjinja2-v0-0-1
+  name: jinja2-v0-0-1
   namespace: system
 spec:
   # type: LoadBalancer

--- a/experiments/compositions/composition/expanders.mk
+++ b/experiments/compositions/composition/expanders.mk
@@ -59,8 +59,8 @@ docker-run-expander-jinja2: docker-build-expander-jinja2
 
 .PHONY: unit-test-expander-jinja2
 unit-test-expander-jinja2: deploy-kind
-	kubectl patch service -n composition-system composition-gjinja2-v0-0-1 -p '{"spec":{"type":"LoadBalancer"}}'
+	kubectl patch service -n composition-system composition-jinja2-v0-0-1 -p '{"spec":{"type":"LoadBalancer"}}'
 	nodeip=$$(kubectl get nodes -o json  | jq '.items[0].status.addresses[0].address' | xargs echo );\
-	nodeport=$$(kubectl get service -n composition-system composition-gjinja2-v0-0-1 -o json | jq ".spec.ports[0].nodePort");\
+	nodeport=$$(kubectl get service -n composition-system composition-jinja2-v0-0-1 -o json | jq ".spec.ports[0].nodePort");\
 	echo $$nodeip:$$nodeport; \
 	cd expanders/jinja2 && go test -v --addr=$$nodeip:$$nodeport

--- a/experiments/compositions/composition/internal/controller/expanderversion_controller.go
+++ b/experiments/compositions/composition/internal/controller/expanderversion_controller.go
@@ -116,6 +116,10 @@ func (r *ExpanderVersionReconciler) processExpanderVersion(
 	}
 
 	expander := strings.TrimPrefix(ev.Name, "composition-")
+	image := ev.Spec.Image
+	if image == "" {
+		image = fmt.Sprintf("expander-%s", expander)
+	}
 	semVerVersions := []*semver.Version{}
 	for _, r := range ev.Spec.ValidVersions {
 		v, err := semver.NewVersion(r)
@@ -129,7 +133,7 @@ func (r *ExpanderVersionReconciler) processExpanderVersion(
 		value := ""
 
 		if ev.Spec.Type == compositionv1alpha1.ExpanderTypeJob {
-			value = fmt.Sprintf("%s/expander-%s:%s", ev.Spec.ImageRegistry, expander, key)
+			value = fmt.Sprintf("%s/%s:%s", ev.Spec.ImageRegistry, image, key)
 		} else {
 			svcVersion := strings.Replace(key, ".", "-", -1)
 			value = fmt.Sprintf("composition-%s-%s:8443", expander, svcVersion)

--- a/experiments/compositions/composition/release/manifest.yaml
+++ b/experiments/compositions/composition/release/manifest.yaml
@@ -1234,7 +1234,7 @@ spec:
 apiVersion: composition.google.com/v1alpha1
 kind: ExpanderVersion
 metadata:
-  name: composition-gjinja2
+  name: composition-jinja2
   namespace: composition-system
 spec:
   type: grpc

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionExpansionGrpc/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionExpansionGrpc/input.yaml
@@ -105,7 +105,7 @@ metadata:
 spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
-  - type: gjinja2
+  - type: jinja2
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionExpansionJob/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionExpansionJob/input.yaml
@@ -105,7 +105,7 @@ metadata:
 spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
-  - type: jinja2
+  - type: jinja2-job
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/scenario/scenario.go
+++ b/experiments/compositions/composition/tests/scenario/scenario.go
@@ -76,6 +76,11 @@ func NewBasic(t *testing.T) *Scenario {
 	// TODO (barney-s) parameterize or make it global
 	logRoot := "../../"
 
+	t.Logf("------------------------------------------------------------------")
+	t.Logf("%s", name)
+	t.Logf("------------------------------------------------------------------")
+	time.Sleep(2 * time.Second)
+
 	ctx := context.Background()
 	clusterUser := cluster.ReserveCluster(t)
 	config := clusterUser.Config()

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -92,7 +92,7 @@ func TestSimpleCompositionAddFacadeField(t *testing.T) {
 
 	// Check if additional ConfigMap is created
 	cm := utils.GetConfigMapObj("team-a", "proj-b")
-	s.C.MustExist([]*unstructured.Unstructured{cm}, scenario.ExistTimeout)
+	s.C.MustExist([]*unstructured.Unstructured{cm}, scenario.CompositionReconcileTimeout)
 }
 
 // Test removing config that results in removal of some expanded resource
@@ -127,7 +127,7 @@ func TestSimpleCompositionStatusValidation(t *testing.T) {
 	// Verify there is a Validation failure status condition in compositions
 	composition := utils.GetCompositionObj("default", "projectconfigmap")
 	condition := utils.GetValidationFailedCondition("ExpanderValidationFailed", "")
-	s.C.MustHaveCondition(composition, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
 
 	// Apply the fixed Composition
 	s.ApplyManifests("composition without validation error", "fixed_composition.yaml")
@@ -135,7 +135,7 @@ func TestSimpleCompositionStatusValidation(t *testing.T) {
 	// Check if Validation failure condition is cleared
 	composition = utils.GetCompositionObj("default", "projectconfigmap")
 	condition = utils.GetValidationFailedCondition("ExpanderValidationFailed", "")
-	s.C.MustNotHaveCondition(composition, condition, scenario.ExistTimeout)
+	s.C.MustNotHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimpleCompositionStatusFacadeCRDMissing(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSimpleCompositionStatusFacadeCRDMissing(t *testing.T) {
 	// Verify there is a Error status condition in compositions
 	composition := utils.GetCompositionObj("default", "projectconfigmap")
 	condition := utils.GetErrorCondition("MissingFacadeCRD", "")
-	s.C.MustHaveCondition(composition, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
 
 	// Apply the fixed Composition
 	s.ApplyManifests("Facade CRD", "facade_crd.yaml")
@@ -155,7 +155,7 @@ func TestSimpleCompositionStatusFacadeCRDMissing(t *testing.T) {
 	// Check if Validation failure condition is cleared
 	composition = utils.GetCompositionObj("default", "projectconfigmap")
 	condition = utils.GetErrorCondition("MissingFacadeCRD", "")
-	s.C.MustNotHaveCondition(composition, condition, scenario.ExistTimeout)
+	s.C.MustNotHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimplePlanStatusWaitingForValues(t *testing.T) {
@@ -167,7 +167,7 @@ func TestSimplePlanStatusWaitingForValues(t *testing.T) {
 	// Verify there is a Waiting failure status condition in plan
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetWaitingCondition("FetchValuesFromFailed", "")
-	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 
 	// Apply Configmap with data present
 	s.ApplyManifests("Fixed Configmap", "configmap_with_data.yaml")
@@ -189,7 +189,7 @@ func TestSimplePlanStatusErrorExpansionFailed(t *testing.T) {
 
 	// Verify there is a Waiting failure status condition in plan
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
-	condition := utils.GetErrorCondition("ExpansionFailed", "")
+	condition := utils.GetErrorCondition("EvaluateStatusFailed", "")
 	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 
 	// Apply Configmap with data present
@@ -197,7 +197,7 @@ func TestSimplePlanStatusErrorExpansionFailed(t *testing.T) {
 
 	// Check if Waiting failure condition is cleared
 	plan = utils.GetPlanObj("team-a", "pconfigs-team-a-config")
-	condition = utils.GetErrorCondition("ExpansionFailed", "")
+	condition = utils.GetErrorCondition("EvaluateStatusFailed", "")
 	s.C.MustNotHaveCondition(plan, condition, 2*scenario.CompositionReconcileTimeout)
 
 	// Verify the composition progresses after being unblocked
@@ -213,7 +213,7 @@ func TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan(t *testing.T) {
 	// Verify there is a Waiting failure status condition in plan
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetErrorCondition("FailedLoadingManifestsFromPlan", "")
-	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 
 	// Apply Configmap with data present
 	s.ApplyManifests("Composition without yaml error", "composition_fixed.yaml")
@@ -262,7 +262,7 @@ func TestSimpleNamespaceInherit(t *testing.T) {
 	// Verify presence of an error because one of the manifests is cluster scoped
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetErrorCondition("FailedApplyingManifests", "")
-	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimpleNamespaceExplicit(t *testing.T) {
@@ -317,7 +317,7 @@ func TestSimpleExpanderInvalid(t *testing.T) {
 
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetErrorCondition("MissingExpanderCR", "")
-	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimpleExpanderVersionInvalid(t *testing.T) {
@@ -327,5 +327,5 @@ func TestSimpleExpanderVersionInvalid(t *testing.T) {
 
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetErrorCondition("VersionNotFound", "")
-	s.C.MustHaveCondition(plan, condition, scenario.ExistTimeout)
+	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 }


### PR DESCRIPTION
### Change description

Switch jinja2 to grpc based expansion:
- rename gjinjg2 -> jinja2 (making jinja2 grpc based)
- rename existing pod based jinja2 -> pjinja2
- Add `image` field to ExpanderVersion
  - allow specifying an image that doesnt follow the
    removePrefix(expanderversion.name , "composition-") pattern.
  - provides more flexibility
  - In our case the type is pjinja and the image is expander-jinja
- Add a custom ratelimiter for the facade reconciler
  - Due to a bug, the reconciler is not restarted across tests.
  - Old failures add to rate limiting causing random failures
  - make ratelimiter max backoff 120s
- Add a small sleep b/w tests
- Move all ExistTimeout to CompositionReconcileTimeout
- Check if a plan was updated and if so check if the applier sees the
  latest plan object. If not retry again.
- Add InputGeneration and Generation to plan status