### PR TITLE
[cleanup] Remove image-registry parameter from the composition controller

### DIFF
--- a/experiments/compositions/composition/Makefile
+++ b/experiments/compositions/composition/Makefile
@@ -100,7 +100,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go --image-registry gcr.io/$(GCP_PROJECT_ID)
+	go run ./cmd/main.go
 
 .PHONY: debug
 debug: generate fmt vet manifests
@@ -150,12 +150,10 @@ release-manifests: manifests kustomize
 .PHONY: release-test-cc-manifests
 release-test-cc-manifests: common-test-manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	cd config/default && $(KUSTOMIZE) edit add patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/args/-\", \"value\": \"--image-registry=gcr.io/$(GCP_PROJECT_ID)\"}]"
 	cd config/default && $(KUSTOMIZE) edit add patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/imagePullPolicy\", \"value\": \"Always\"}]"
 	cd config/expanders && $(KUSTOMIZE) edit set image expander-jinja2=${JINJA_IMG}
 	$(KUSTOMIZE) build config/default -o release/test/cc-operator.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=composition:latest
-	cd config/default && $(KUSTOMIZE) edit remove patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/args/-\", \"value\": \"--image-registry=gcr.io/$(GCP_PROJECT_ID)\"}]"
 	cd config/default && $(KUSTOMIZE) edit remove patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/imagePullPolicy\", \"value\": \"Always\"}]"
 	cd config/expanders && $(KUSTOMIZE) edit set image expander-jinja2=expander-jinja2:latest
 
@@ -163,11 +161,9 @@ release-test-cc-manifests: common-test-manifests
 release-test-kind-manifests: common-test-manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	cd config/expanders && $(KUSTOMIZE) edit set image expander-jinja2=${JINJA_IMG}
-	cd config/default && $(KUSTOMIZE) edit add patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/args/-\", \"value\": \"--image-registry=gcr.io/$(GCP_PROJECT_ID)\"}]"
 	$(KUSTOMIZE) build config/default -o release/test/kind-operator.yaml
 	cd config/manager && $(KUSTOMIZE) edit set image controller=composition:latest
 	cd config/expanders && $(KUSTOMIZE) edit set image expander-jinja2=expander-jinja2:latest
-	cd config/default && $(KUSTOMIZE) edit remove patch --namespace system --name controller-manager --kind Deployment --patch "[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/1/args/-\", \"value\": \"--image-registry=gcr.io/$(GCP_PROJECT_ID)\"}]"
 
 .PHONY: deploy-kind
 deploy-kind: release-test-kind-manifests docker-build docker-build-inline docker-build-expander-jinja2

--- a/experiments/compositions/composition/cmd/main.go
+++ b/experiments/compositions/composition/cmd/main.go
@@ -59,8 +59,6 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var imageRegistry string
-	flag.StringVar(&imageRegistry, "image-registry", "gcr.io/krmapihosting-release", "docker image registry.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -98,10 +96,9 @@ func main() {
 	}
 
 	if err = (&controller.CompositionReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		ImageRegistry: imageRegistry,
-		Recorder:      mgr.GetEventRecorderFor("composition"),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("composition"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Composition")
 		os.Exit(1)

--- a/experiments/compositions/composition/config/release/kustomization.yaml
+++ b/experiments/compositions/composition/config/release/kustomization.yaml
@@ -157,12 +157,6 @@ resources:
 
 patches:
 - path: manager_auth_proxy_patch.yaml
-- patch: '[{"op": "add", "path": "/spec/template/spec/containers/1/args/-", "value":
-    "--image-registry=gcr.io/krmapihosting-release"}]'
-  target:
-    kind: Deployment
-    name: controller-manager
-    namespace: system
 - patch: '[{"op": "add", "path": "/spec/template/spec/containers/1/imagePullPolicy",
     "value": "Always"}]'
   target:

--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -43,10 +43,9 @@ var FacadeControllers sync.Map
 // CompositionReconciler reconciles a Composition object
 type CompositionReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Recorder      record.EventRecorder
-	mgr           ctrl.Manager
-	ImageRegistry string
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	mgr      ctrl.Manager
 }
 
 //+kubebuilder:rbac:groups=composition.google.com,resources=compositions,verbs=get;list;watch;create;update;patch;delete
@@ -169,15 +168,14 @@ func (r *CompositionReconciler) processComposition(
 
 	logger.Info("Starting Reconciler for InputAPI CRD")
 	expanderController := &ExpanderReconciler{
-		Client:        r.Client,
-		Recorder:      r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
-		Scheme:        r.Scheme,
-		InputGVK:      gvk,
-		ImageRegistry: r.ImageRegistry,
-		Composition:   types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
-		InputGVR:      gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
-		RESTMapper:    r.mgr.GetRESTMapper(),
-		Config:        r.mgr.GetConfig(),
+		Client:      r.Client,
+		Recorder:    r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
+		Scheme:      r.Scheme,
+		InputGVK:    gvk,
+		Composition: types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
+		InputGVR:    gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
+		RESTMapper:  r.mgr.GetRESTMapper(),
+		Config:      r.mgr.GetConfig(),
 	}
 
 	if err := expanderController.SetupWithManager(r.mgr, cr); err != nil {

--- a/experiments/compositions/composition/internal/controller/expander_reconciler.go
+++ b/experiments/compositions/composition/internal/controller/expander_reconciler.go
@@ -46,15 +46,14 @@ import (
 // ExpanderReconciler reconciles a expander object
 type ExpanderReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	Recorder      record.EventRecorder
-	RESTMapper    meta.RESTMapper
-	Config        *rest.Config
-	ImageRegistry string
-	Dynamic       *dynamic.DynamicClient
-	InputGVK      schema.GroupVersionKind
-	InputGVR      schema.GroupVersionResource
-	Composition   types.NamespacedName
+	Scheme      *runtime.Scheme
+	Recorder    record.EventRecorder
+	RESTMapper  meta.RESTMapper
+	Config      *rest.Config
+	Dynamic     *dynamic.DynamicClient
+	InputGVK    schema.GroupVersionKind
+	InputGVR    schema.GroupVersionResource
+	Composition types.NamespacedName
 }
 
 var planGVK schema.GroupVersionKind = schema.GroupVersionKind{

--- a/experiments/compositions/composition/release/manifest.yaml
+++ b/experiments/compositions/composition/release/manifest.yaml
@@ -1151,7 +1151,6 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --image-registry=gcr.io/krmapihosting-release
         command:
         - /manager
         image: gcr.io/krmapihosting-release/composition:v0.0.1.alpha

--- a/experiments/compositions/composition/tests/utils/utils.go
+++ b/experiments/compositions/composition/tests/utils/utils.go
@@ -39,7 +39,7 @@ func init() {
 	utilruntime.Must(compositionv1alpha1.AddToScheme(scheme))
 }
 
-func StartLocalController(config *rest.Config, imageRegistry string) error {
+func StartLocalController(config *rest.Config) error {
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:         scheme,
 		LeaderElection: false,
@@ -50,9 +50,8 @@ func StartLocalController(config *rest.Config, imageRegistry string) error {
 	}
 
 	if err = (&controller.CompositionReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		ImageRegistry: imageRegistry,
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create Composition controller: %w", err)
 	}


### PR DESCRIPTION
### Change description

Remove image-registry parameter from the composition controller

- Was added initially when we hardcoded the image in the job template
- ExpanderVersion removes the need for this parameter


