### PR TITLE
Add pscInstanceConfig fields for AlloyDB instance Update

### DIFF
--- a/mockgcp/mockalloydb/instance.go
+++ b/mockgcp/mockalloydb/instance.go
@@ -124,6 +124,8 @@ func (s *AlloyDBAdminV1) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 			obj.ReadPoolConfig = req.Instance.GetReadPoolConfig()
 		case "machineConfig":
 			obj.MachineConfig = req.Instance.GetMachineConfig()
+		case "pscInstanceConfig":
+			obj.PscInstanceConfig = req.Instance.GetPscInstanceConfig()
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
 		}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Support mock pscInstanceConfig field for alloydb instance in PR 1903
### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
