### PR TITLE
fix: Prevent expansion of $PATH shell variable in setup script

### DIFF
--- a/scripts/environment-setup/golang-setup.sh
+++ b/scripts/environment-setup/golang-setup.sh
@@ -25,7 +25,7 @@ wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
 sudo tar -xvzf go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local
 rm go${GO_VERSION}.linux-amd64.tar.gz
 
-echo PATH=/usr/local/go/bin:$PATH >> ~/.profile
+echo 'PATH=/usr/local/go/bin:$PATH' >> ~/.profile
 source ~/.profile
 go version
 


### PR DESCRIPTION
### Change description

Populate the ~/.profile with the $PATH variable name, not its contents.

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
