### PR TITLE
ci:chore: update upgrade-dcl probe

### DIFF
--- a/.github/workflows/dcl-upgrade-probe.yaml
+++ b/.github/workflows/dcl-upgrade-probe.yaml
@@ -31,13 +31,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: upgrade dcl
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: upgrade dcl probe
         run: make upgrade-dcl && make ready-pr

--- a/.github/workflows/dcl-upgrade-probe.yaml
+++ b/.github/workflows/dcl-upgrade-probe.yaml
@@ -40,4 +40,5 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: upgrade dcl probe
-        run: make upgrade-dcl && make ready-pr
+        run: |
+          ./scripts/github-actions/ga-upgrade-dcl-probe.sh

--- a/scripts/github-actions/ga-upgrade-dcl-probe.sh
+++ b/scripts/github-actions/ga-upgrade-dcl-probe.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -o errexit
+set -o nounset
+set -o pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source ${REPO_ROOT}/scripts/shared-vars-public.sh
+cd ${REPO_ROOT}
+source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
+	fetch_tools && \
+	setup_envs
+
+echo "Running upgrade-dcl probe..."
+make upgrade-dcl ready-pr


### PR DESCRIPTION
Patch
* reorders GH actions steps
* wraps the probe func to prep env