### PR TITLE
Fixes to make the latest GCP samples work with GRPC based expanders

### DIFF
--- a/experiments/compositions/composition/Makefile
+++ b/experiments/compositions/composition/Makefile
@@ -185,13 +185,18 @@ deploy-kind: release-test-kind-manifests docker-build docker-build-inline docker
 	sleep 5
 	kubectl --context kind-${KIND_CLUSTER} get pods -A
 
+
+.PHONY: run-test
+run-test: release-test-kind-manifests docker-build docker-build-inline docker-build-expander-jinja2 docker-build-expander-getter fmt #docker-push docker-push-inline docker-push-expander-jinja2 docker-push-expander-getter
+	cd tests/testcases/ && go test -v -timeout 3600s -run "^${TESTCASE}" --images=${IMG},${INLINE_IMG},${JINJA_IMG},${GETTER_IMG}
+
 .PHONY: e2e-test
 e2e-test: release-test-kind-manifests docker-build docker-build-inline docker-build-expander-jinja2 docker-build-expander-getter fmt #docker-push docker-push-inline docker-push-expander-jinja2 docker-push-expander-getter
 	cd tests/testcases/ && go test -v -timeout 3600s -run ./... --images=${IMG},${INLINE_IMG},${JINJA_IMG},${GETTER_IMG}
 
 .PHONY: kcc-test
 kcc-test: release-test-cc-manifests docker-build docker-build-inline docker-build-expander-jinja2 docker-build-expander-getter fmt docker-push docker-push-inline docker-push-expander-jinja2 docker-push-expander-getter
-	cd tests/testcases/ && go test -v -timeout 3600s -run "^TestKCCSampleAppTeam" --use-cc=true --images=${IMG},${INLINE_IMG},${JINJA_IMG},${GETTER_IMG}
+	cd tests/testcases/ && go test -v -timeout 3600s -run "^TestKCCSampleCloudSQL" --use-cc=true --images=${IMG},${INLINE_IMG},${JINJA_IMG},${GETTER_IMG}
 
 ##@ Deployment
 

--- a/experiments/compositions/composition/internal/controller/expander_reconciler.go
+++ b/experiments/compositions/composition/internal/controller/expander_reconciler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -430,7 +429,11 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 			return values, updated, "MarshallExpanderConfigFailed", resultType, err
 		}
 	} else {
-		configBytes, err = json.Marshal(expander.Template)
+		// TODO check if json.Marshall is escaping quotes
+		// Also causes > to be replaced unicode 'if loop.index \u003e 1'
+		err = nil
+		//configBytes, err = json.Marshal(expander.Template)
+		configBytes = []byte(expander.Template)
 		if err != nil {
 			logger.Error(err, "failed to marshall Expander template")
 			return values, updated, "MarshallExpanderTemplateFailed", resultType, err
@@ -486,7 +489,9 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 
 	resultType = result.Type
 	if result.Type == pb.ResultType_MANIFESTS {
-		s, err := strconv.Unquote(string(result.Manifests))
+		err = nil
+		//s, err := strconv.Unquote(string(result.Manifests))
+		s := string(result.Manifests)
 		if err != nil {
 			logger.Error(err, "unable to unquote grpc response")
 			return values, updated, "UnquoteResponseFailed", resultType, err

--- a/experiments/compositions/composition/tests/cluster/kind/cluster.go
+++ b/experiments/compositions/composition/tests/cluster/kind/cluster.go
@@ -96,22 +96,22 @@ func VerifyKindIsInstalled() error {
 func (c *kindCluster) create() error {
 	err := c.Delete()
 	if err != nil {
-		return err
+		return fmt.Errorf("Delete existing cluster if present. err: %v", err)
 	}
 	clusterConfig, err := c.kindClusterDefinition()
 	if err != nil {
-		return err
+		return fmt.Errorf("kindClusterDefinition failed. err: %v", err)
 	}
 	defer os.Remove(clusterConfig)
 
 	c.config, err = c.createCluster(clusterConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("createCluster() failed. err: %v", err)
 	}
 
 	c.Client, err = client.New(c.Config(), client.Options{Scheme: scheme})
 	if err != nil {
-		return err
+		return fmt.Errorf("getting client for kind cluster failed. err: %v", err)
 	}
 
 	return nil
@@ -294,7 +294,7 @@ func (c *kindCluster) Exists() (bool, error) {
 func (c *kindCluster) kindClusterDefinition() (string, error) {
 	ipAddress, err := c.getHostIPAddress()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("getHostIPAddress failed. err: %v", err)
 	}
 	clusterConfigFile, err := os.CreateTemp("", "kind-cluster.yaml")
 	if err != nil {
@@ -312,9 +312,9 @@ networking:
 }
 
 func (c *kindCluster) createCluster(clusterConfig string) (*rest.Config, error) {
-	_, err := exec.Command("kind", "create", "cluster", "--name", c.name, "--config", clusterConfig).CombinedOutput()
+	op, err := exec.Command("kind", "create", "cluster", "--name", c.name, "--config", clusterConfig, "--retain").CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("kind create cluster command failed: %v\n output: %s", err, op)
 	}
 
 	kubeConfigFile, err := os.CreateTemp("", "kubeconfig.yaml")

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusFacadeCRDMissing/input.yaml
@@ -21,7 +21,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/fixed_composition.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionStatusValidation/fixed_composition.yaml
@@ -22,7 +22,7 @@ spec:
   inputAPIGroup: pconfigs.facade.foocorp.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/input.yaml
@@ -56,6 +56,47 @@ spec:
     subresources:
       status: {}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: composition-facade-foocorp
+rules:
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - "*/status"
+  verbs:
+  - get
+  - update
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: composition-facade-foocorp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
 apiVersion: composition.google.com/v1alpha1
 kind: Composition
 metadata:
@@ -66,6 +107,28 @@ spec:
   expanders:
   - type: jinja2
     version: v0.0.1
+    name: common
+    # Using single and double quotes in jinja for loop
+    # had issue when we used json.Marshall():
+    #  - double quotes were escaped
+    #  - > was replaced with unicode string
+    # so removed json.Marshall(template)
+    template: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: common-config
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+          {% set services=[ "cloudkms.googleapis.com", 'iam.googleapis.com', "serviceusage.googleapis.com", 'sqladmin.googleapis.com' ] %}
+          {% for service in services %}
+          key{{loop.index}}: {{service}}
+          {% endfor %}
+  - type: jinja2
+    version: v0.0.1
+    name: project
     template: |
       {% set hostProject = 'compositions-foobar' %}
       {% set managedProject = pconfigs.spec.project %}
@@ -78,7 +141,26 @@ spec:
           createdby: "composition-namespaceconfigmap"
       data:
         name: {{ managedProject }}
-        billingAccountRef:
-          external: "010101-ABABCD-BCAB11"
-        folderRef:
-          external: "000000111100"
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Context
+metadata:
+  name: context
+  namespace: team-a
+spec:
+  project: proj-a
+---
+apiVersion: facade.foocorp.com/v1alpha1
+kind: PConfig
+metadata:
+  name: team-a-config
+  namespace: team-a
+spec:
+  project: proj-a

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/output.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-a
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: proj-a
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: pconfigs-team-a-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-config
+  namespace: team-a
+  labels:
+   createdby: "composition-namespaceconfigmap"
+data:
+  key1: cloudkms.googleapis.com
+  key2: iam.googleapis.com
+  key3: serviceusage.googleapis.com
+  key4: sqladmin.googleapis.com

--- a/experiments/compositions/composition/tests/testcases/kcc_samples_test.go
+++ b/experiments/compositions/composition/tests/testcases/kcc_samples_test.go
@@ -39,7 +39,7 @@ func getAppTeamObj(project string) []*unstructured.Unstructured {
 				"apiVersion": "facade.facade/v1alpha1",
 				"kind":       "AppTeam",
 				"metadata": map[string]interface{}{
-					"name":      "clearing",
+					"name":      project,
 					"namespace": "config-control",
 				},
 				"spec": map[string]interface{}{
@@ -80,7 +80,7 @@ func getAppTeamOutputObjects(project string) []*unstructured.Unstructured {
 
 func TestKCCSampleAppTeam(t *testing.T) {
 	//t.Parallel()
-	s := scenario.NewKCCSample(t, "AppTeam", "appteam.yaml")
+	s := scenario.NewKCCSample(t, scenario.Sample{Name: "AppTeam", Composition: "appteam.yaml"}, nil)
 	defer s.Cleanup()
 	s.Setup()
 
@@ -164,25 +164,46 @@ func getCloudSQLOutputObjects(namespace, name string) []*unstructured.Unstructur
 
 func TestKCCSampleCloudSQL(t *testing.T) {
 	//t.Parallel()
-	s := scenario.NewKCCSample(t, "CloudSQL", "hasql.yaml")
+
+	// Create a project
+	s := scenario.NewKCCSample(t,
+		scenario.Sample{Name: "CloudSQL", Composition: "hasql.yaml"},
+		[]scenario.Sample{
+			{Name: "AppTeam", Composition: "appteam.yaml"},
+		},
+	)
 	defer s.Cleanup()
 	s.Setup()
 
-	// Wait for Pconfig CRD to be established.
 	// TODO: better wait
 	time.Sleep(time.Second * 10)
-	// Apply cloudsql facade
-	namespace := "config-control"
-	name := "collateral"
-	s.Apply("appteam-object", getCloudSqlObj(namespace, name))
+
+	// ---- Setup App Team for cloudsql user --------
+	// Apply clearing team facade
+	project := fmt.Sprintf("clearing-%s", strings.ToLower(rand.String(8)))
+	s.Apply("appteam-object", getAppTeamObj(project))
 
 	// Check plan object has no error
-	plan := utils.GetPlanObj("config-control", "cloudsqls-collateral")
+	planName := fmt.Sprintf("appteams-%s", project)
+	plan := utils.GetPlanObj("config-control", planName)
 	condition := utils.GetReadyCondition("ProcessedAllStages", "")
 	s.C.MustHaveCondition(plan, condition, 5*scenario.CompositionReconcileTimeout)
 
 	// Since the Plan says it has processed all stages we should validate KCC resources.
-	s.Verify("kcc-objects", false, getCloudSQLOutputObjects(namespace, name))
+	s.Verify("appteam-kcc-objects", false, getAppTeamOutputObjects(project))
 
+	// ---- Test CloudSQL -----------------------------
+	// Apply cloudsql facade
+	namespace := project
+	name := "collateral"
+	s.Apply("appteam-object", getCloudSqlObj(namespace, name))
+
+	// Check plan object has no error
+	cloudsqlPlan := utils.GetPlanObj(namespace, "cloudsqls-collateral")
+	condition = utils.GetReadyCondition("ProcessedAllStages", "")
+	s.C.MustHaveCondition(cloudsqlPlan, condition, 5*scenario.CompositionReconcileTimeout)
+
+	// Since the Plan says it has processed all stages we should validate KCC resources.
+	s.Verify("kcc-objects", false, getCloudSQLOutputObjects(namespace, name))
 	// Verify KCC object status ?
 }

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -187,7 +187,7 @@ func TestSimplePlanStatusErrorExpansionFailed(t *testing.T) {
 	defer s.Cleanup()
 	s.Setup()
 
-	// Verify there is a Waiting failure status condition in plan
+	// Verify there is a Error failure status condition in plan
 	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition := utils.GetErrorCondition("EvaluateStatusFailed", "")
 	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
@@ -195,9 +195,24 @@ func TestSimplePlanStatusErrorExpansionFailed(t *testing.T) {
 	// Apply Configmap with data present
 	s.ApplyManifests("Composition without jinja error", "composition_fixed.yaml")
 
-	// Check if Waiting failure condition is cleared
+	// Check if Error failure condition is cleared
 	plan = utils.GetPlanObj("team-a", "pconfigs-team-a-config")
 	condition = utils.GetErrorCondition("EvaluateStatusFailed", "")
+	s.C.MustNotHaveCondition(plan, condition, 2*scenario.CompositionReconcileTimeout)
+
+	// Verify the composition progresses after being unblocked
+	s.VerifyOutputExists()
+}
+
+func TestSimpleExpanderJinjaWithQuotes(t *testing.T) {
+	//t.Parallel()
+	s := scenario.NewBasic(t)
+	defer s.Cleanup()
+	s.Setup()
+
+	// Verify there is a Error failure status condition in plan
+	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
+	condition := utils.GetErrorCondition("EvaluateStatusFailed", "")
 	s.C.MustNotHaveCondition(plan, condition, 2*scenario.CompositionReconcileTimeout)
 
 	// Verify the composition progresses after being unblocked

--- a/experiments/compositions/samples/AppTeam/composition/appteam.yaml
+++ b/experiments/compositions/samples/AppTeam/composition/appteam.yaml
@@ -22,7 +22,7 @@ spec:
   namespaceMode: explicit
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: project
     template: |
       {% set hostProject = 'allotrope-barni' %}
@@ -45,7 +45,7 @@ spec:
           external: "722947980017"
   - type: jinja2
     name: namespace
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       {% set hostProject = 'allotrope-barni' %}
       {% set managedProject = appteams.spec.project %}
@@ -59,7 +59,7 @@ spec:
           cnrm.cloud.google.com/project-id: {{ managedProject }}
   - type: jinja2
     name: setup-kcc
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       {% set hostProject = 'allotrope-barni' %}
       {% set managedProject = appteams.spec.project %}
@@ -102,7 +102,7 @@ spec:
               - member: serviceAccount:{{ hostProject }}.svc.id.goog[cnrm-system/cnrm-controller-manager-{{ managedProject }}]
   - type: jinja2
     name: project-owner
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       {% set hostProject = 'allotrope-barni' %}
       {% set managedProject = appteams.spec.project %}
@@ -128,7 +128,7 @@ spec:
               - member: user:barni@google.com
   - type: jinja2
     name: bucket
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       {% set managedProject = appteams.spec.project %}
       {% set namespace = appteams.spec.project %}
@@ -147,7 +147,7 @@ spec:
           enabled: false
   - type: jinja2
     name: compositions-context
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       {% set managedProject = appteams.spec.project %}
       {% set namespace = appteams.spec.project %}

--- a/experiments/compositions/samples/CloudSQL/README.md
+++ b/experiments/compositions/samples/CloudSQL/README.md
@@ -29,6 +29,7 @@ If KCC is setup in a tenant namespace (say using `AppTeams` composition), then w
 
 ```
 namespace=config-control
+#namespace=<app-team's namespace>
  
 kubectl apply -f - <<EOF
 apiVersion: facade.compositions.google.com/v1

--- a/experiments/compositions/samples/CloudSQL/composition/hasql.yaml
+++ b/experiments/compositions/samples/CloudSQL/composition/hasql.yaml
@@ -34,6 +34,24 @@ spec:
     type: object
 ---
 apiVersion: composition.google.com/v1alpha1
+kind: GetterConfiguration
+metadata:
+  name: sql-siemail
+  namespace: default
+spec:
+  valuesFrom:
+  - name: identity
+    resourceRef:
+      group: serviceusage.cnrm.cloud.google.com
+      version: v1beta1
+      kind: ServiceIdentity
+      resource: serviceidentities
+      name: sqladmin.googleapis.com
+    fieldRef:
+    - path: ".status.email"
+      as: email
+---
+apiVersion: composition.google.com/v1alpha1
 kind: Composition
 metadata:
   name: sqlha
@@ -42,10 +60,10 @@ spec:
   inputAPIGroup: cloudsqls.facade.compositions.google.com
   expanders:
   - type: jinja2
-    version: v0.0.1.alpha
+    version: v0.0.1
     name: enable-services
     template: |
-      {% set services=[ "cloudkms.googleapis.com", "iam.googleapis.com", "serviceusage.googleapis.com", "sqladmin.googleapis.com" ] %}
+      {% set services=[ 'cloudkms.googleapis.com', 'iam.googleapis.com', 'serviceusage.googleapis.com', 'sqladmin.googleapis.com' ] %}
       {% for service in services %}
       ---
       apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
@@ -61,7 +79,7 @@ spec:
       {% endfor %}
   - type: jinja2
     name: block2
-    version: v0.0.1.alpha
+    version: v0.0.1
     template: |
       apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
       kind: ServiceIdentity
@@ -71,20 +89,16 @@ spec:
       spec:
         projectRef:
           external: {{ context.spec.project }}
+  - type: getter
+    version: v0.0.1
+    name: get-serviceidentity
+    template: ""
+    configref:
+      name: sql-siemail
+      namespace: default
   - type: jinja2
     name: block3
-    version: v0.0.1.alpha
-    valuesFrom:
-    - name: identity
-      resourceRef:
-        group: serviceusage.cnrm.cloud.google.com
-        version: v1beta1
-        kind: ServiceIdentity
-        esource: serviceidentities
-        name: sqladmin.googleapis.com
-      fieldRef:
-      - path: ".status.email"
-        as: email
+    version: v0.0.1
     template: |
       {% for region in cloudsqls.spec.regions %}
       ---


### PR DESCRIPTION
### Change description

Fixes to make the latest GCP samples work.
- KCC Sample Test changes
  - In CloudSQL test, Create an AppTeam and in the new project create CloudSQL (testing user , demo flow)
- Samples changes
  - Remove alpha from expander names (grpc ones)
  - In hasql composition,
    - Use new grpc getter, GetterConfiguration
- Test infra changes
  - Add support for dependent samples for KCC Scenario (CloudSQL on AppTeam)
- Makefile changes
  - add run-test target to run a single testcase
  - make CloudSQL the default kcc-test
- Reconciler changes
  - dont json.Marshall() the expander template
  - conversely no need to unquote the result
  - json.Marshall() was escaping double quotes, and converting '>' to
    uni-code
- e2e Test changes
  - Add new test case to verify roundtripping template is not broken
    - TestSimpleExpanderJinjaWithQuotes
  - Add more logs to debug kind cluster create failures
  - Fix sample expander versions