### PR TITLE
chore: don't apply formatting from root into experiments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ manifests: generate
 fmt:
 	mockgcp/dev/fix-gofmt
 	make -C operator fmt
-	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg cmd scripts tests config/tests experiments
+	go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg cmd scripts tests config/tests
 	# 04bfe4ee9ca5764577b029acc6a1957fd1997153 includes fix to not log "Skipped" for each skipped file
 	GOFLAGS= go run github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153 -c "Google LLC" -l apache \
 	-ignore ".build/**" -ignore "vendor/**" -ignore "third_party/**" \


### PR DESCRIPTION
We want to keep these separated (experiments has its own build/CI scripts)
