### PR TITLE
Refactor Applier

### DIFF
--- a/experiments/compositions/composition/internal/controller/expander_reconciler.go
+++ b/experiments/compositions/composition/internal/controller/expander_reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/time/rate"
 	compositionv1alpha1 "google.com/composition/api/v1alpha1"
+	"google.com/composition/pkg/applier"
 	"google.com/composition/pkg/containerexecutor/jobcontainerexecutor"
 	pb "google.com/composition/proto"
 	"google.golang.org/grpc"
@@ -141,11 +142,9 @@ func (r *ExpanderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 	}
-	// TODO(barni@): Handle existing jobs for this CR
-
 	// Since applylib doesnt support multiple apply batches we are
 	// tracking all old objects and accumulating them each apply.
-	oldAppliers := []*Applier{}
+	oldAppliers := []*applier.Applier{}
 
 	// Create a new status for comparison later
 	newStatus := compositionv1alpha1.PlanStatus{
@@ -168,14 +167,12 @@ func (r *ExpanderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}()
 
-	expandersProcessed := []string{}
+	// ------------------- EVALUATION SECTION -----------------------
+	stagesEvaluated := []string{}
 	values := map[string]interface{}{}
-	for index, expander := range compositionCR.Spec.Expanders {
-		// -------------------- FETCH VALUES ---------------------------
-		// TODO(barni@): identify dependend variables and path where values need to be read from
-		// Update the CRD_V's status to reflect these values
-
-		// ------------------- EXPANSION SECTION -----------------------
+	planUpdated := false
+	waitRequested := false
+	for _, expander := range compositionCR.Spec.Expanders {
 		logger = loggerCR.WithName(expander.Name).WithName("Expand")
 
 		uri, ev, reason, err := r.getExpanderValue(ctx, expander.Version, expander.Type)
@@ -188,9 +185,6 @@ func (r *ExpanderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		logger.Info("Got valid expander uri", "uri", uri)
 
-		success := false
-		planUpdated := false
-		resultType := pb.ResultType_MANIFESTS
 		if ev.Spec.Type == compositionv1alpha1.ExpanderTypeJob {
 			reason, err := r.runJob(ctx, logger, &inputcr, expander.Name, planNN.Name, uri, ev.Spec.ImageRegistry)
 			if err != nil {
@@ -198,108 +192,144 @@ func (r *ExpanderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 		} else {
-			newValues, updated, reason, rt, err := r.evaluateAndSavePlan(ctx, logger, &inputcr, values, expander, planNN, ev, uri)
+			newValues, updated, reason, err := r.evaluateAndSavePlan(ctx, logger, &inputcr, values, expander, planNN, ev, uri)
 			_, iswaitErr := err.(*EvaluateWaitError)
 			if iswaitErr {
 				newStatus.AppendWaitingCondition(expander.Name, err.Error(), reason)
 				// Subsume the error
-				return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+				waitRequested = true
+				// continue to apply phase
+				break
 			}
-
 			if err != nil {
 				newStatus.AppendErrorCondition(expander.Name, err.Error(), reason)
+				// Skip apply phase and return
 				return ctrl.Result{}, err
 			}
-			resultType = rt
 			planUpdated = updated
 			values = newValues
 		}
-
-		// ------------------- APPLIER SECTION -----------------------
-
-		if resultType == pb.ResultType_MANIFESTS {
-			// Create Applier and wait for the Applier to complete
-			logger = loggerCR.WithName(expander.Name).WithName("Apply")
-
-			oldGeneration := plancr.GetGeneration()
-			// Re-read the Plan CR to load the expanded manifests
-			if err := r.Client.Get(ctx, planNN, &plancr); err != nil {
-				logger.Error(err, "unable to read Plan CR")
-				return ctrl.Result{}, err
-			}
-			if planUpdated && oldGeneration == plancr.GetGeneration() {
-				logger.Error(err, "Did not get the latest planCR. Will retry.")
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-
-			applier := NewApplier(ctx, logger, r, &plancr, &inputcr, &compositionCR, expander.Name)
-
-			err = applier.Load() // Load Manifests
-			if err != nil {
-				r.Recorder.Event(&inputcr, "Warning", "ApplyFailed", fmt.Sprintf("error loading manifests for expander, name: %s", expander.Name))
-				logger.Error(err, "Unable to Load manifests for applying")
-				// Inject plan.ERROR Condition
-				newStatus.AppendErrorCondition(expander.Name, err.Error(), "FailedLoadingManifestsFromPlan")
-				return ctrl.Result{}, err
-			}
-			logger.Info("Successfully loaded manifests for applying")
-			if newStatus.Stages == nil {
-				newStatus.Stages = map[string]compositionv1alpha1.StageStatus{}
-			}
-			newStatus.Stages[expander.Name] = compositionv1alpha1.StageStatus{ResourceCount: applier.Count()}
-
-			prune := false
-			if index == len(compositionCR.Spec.Expanders)-1 {
-				prune = true
-			}
-
-			_, err = applier.Apply(oldAppliers, prune) // Apply Manifests
-			if err != nil {
-				r.Recorder.Event(&inputcr, "Warning", "ApplyFailed", fmt.Sprintf("error applying manifests for expander, name: %s", expander.Name))
-				logger.Error(err, "Unable to apply manifests")
-				// Inject plan.ERROR Condition
-				newStatus.AppendErrorCondition(expander.Name, err.Error(), "FailedApplyingManifests")
-				return ctrl.Result{}, err
-			}
-
-			logger.Info("Successfully applied manifests")
-			r.Recorder.Event(&inputcr, "Normal", "ResourcesApplied", fmt.Sprintf("All expanded resources were applied. name: %s", expander.Name))
-
-			success, err = applier.Wait()
-			if err != nil {
-				r.Recorder.Event(&inputcr, "Warning", "ReconcileFailed", fmt.Sprintf("Failed waiting for resources to be reconciled. name: %s", expander.Name))
-				logger.Error(err, "Failed waiting for applied resources to reconcile")
-				// Inject plan.ERROR Condition
-				newStatus.AppendErrorCondition(expander.Name, err.Error(), "FailedWaitingForAppliedResources")
-				return ctrl.Result{}, err
-			}
-
-			oldAppliers = append(oldAppliers, applier)
-
-			if !success {
-				r.Recorder.Event(&inputcr, "Warning", "ReconcileFailed", fmt.Sprintf("Some resources are not healthy. name: %s", expander.Name))
-				logger.Info("Applied succesfully but some resources did not become healthy")
-				// Inject plan.Waiting Condition
-				newStatus.AppendWaitingCondition(expander.Name, "Not all resources are healthy", "WaitingForAppliedResources")
-				return ctrl.Result{}, fmt.Errorf("Some applied resources are not healthy")
-			}
-			logger.Info("Applied resources successfully.")
-		}
-
-		expandersProcessed = append(expandersProcessed, expander.Name)
-		r.Recorder.Event(&inputcr, "Normal", "ResourcesReconciled", fmt.Sprintf("All applied resources were reconciled. name: %s", expander.Name))
+		stagesEvaluated = append(stagesEvaluated, expander.Name)
 		// Inject plan.Ready Condition with list of expanders
 		newStatus.ClearCondition(compositionv1alpha1.Ready)
-		message := fmt.Sprintf("Processed stages: %s", strings.Join(expandersProcessed, ", "))
+		message := fmt.Sprintf("Evaluated stages: %s", strings.Join(stagesEvaluated, ", "))
+		newStatus.AppendCondition(compositionv1alpha1.Ready, metav1.ConditionFalse, message, "EvaluationPending")
+	}
+
+	// ------------------- APPLIER SECTION -----------------------
+	stagesApplied := []string{}
+
+	// Re-read the Plan CR to load the expanded manifests
+	oldGeneration := plancr.GetGeneration()
+	if err := r.Client.Get(ctx, planNN, &plancr); err != nil {
+		logger.Error(err, "unable to read Plan CR")
+		return ctrl.Result{}, err
+	}
+	if planUpdated && oldGeneration == plancr.GetGeneration() {
+		logger.Info("Did not get the latest Plan CR. Will retry.", "generation", oldGeneration)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	for index, expander := range stagesEvaluated {
+		stage, ok := plancr.Spec.Stages[expander]
+		if !ok {
+			err := fmt.Errorf("plancr.spec.stages[%s] not found !!", stage)
+			logger.Error(err, "error applying stage", "stage", stage)
+			// This is not expected since we just processed the stage above
+			// We dont want to return error. Lets retry again in 20 secs.
+			return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
+		}
+		if stage.Values != "" {
+			// This looks like an Getter stage. skip it
+			continue
+		}
+		if stage.Manifest == "" {
+			err := fmt.Errorf("plancr.spec.stages[%s].manifest is empty !!", stage)
+			logger.Error(err, "error applying stage", "stage", stage)
+			return ctrl.Result{}, err
+		}
+
+		// Create Applier and wait for the Applier to complete
+		logger = loggerCR.WithName(expander).WithName("Apply")
+
+		ac := applier.ApplierClient{
+			Client:     r.Client,
+			Dynamic:    r.Dynamic,
+			RESTMapper: r.RESTMapper,
+		}
+		namespace := ""
+		if compositionCR.Spec.NamespaceMode != compositionv1alpha1.NamespaceModeExplicit {
+			namespace = inputcr.GetNamespace()
+		}
+		applier := applier.NewApplier(ctx, logger, ac, expander, namespace, r.InputGVR.Resource, &plancr)
+		err := applier.Load() // Load Manifests
+		if err != nil {
+			r.Recorder.Event(&inputcr, "Warning", "ApplyFailed", fmt.Sprintf("error loading manifests for expander, name: %s", expander))
+			logger.Error(err, "Unable to Load manifests for applying")
+			// Inject plan.ERROR Condition
+			newStatus.AppendErrorCondition(expander, err.Error(), "FailedLoadingManifestsFromPlan")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Successfully loaded manifests for applying")
+		if newStatus.Stages == nil {
+			newStatus.Stages = map[string]compositionv1alpha1.StageStatus{}
+		}
+		newStatus.Stages[expander] = compositionv1alpha1.StageStatus{ResourceCount: applier.Count()}
+
+		// Prune only for the last expander section
+		prune := false
+		if index == len(compositionCR.Spec.Expanders)-1 {
+			prune = true
+		}
+
+		_, err = applier.Apply(oldAppliers, prune) // Apply Manifests
+		if err != nil {
+			r.Recorder.Event(&inputcr, "Warning", "ApplyFailed", fmt.Sprintf("error applying manifests for expander, name: %s", expander))
+			logger.Error(err, "Unable to apply manifests")
+			// Inject plan.ERROR Condition
+			newStatus.AppendErrorCondition(expander, err.Error(), "FailedApplyingManifests")
+			return ctrl.Result{}, err
+		}
+
+		logger.Info("Successfully applied manifests")
+		r.Recorder.Event(&inputcr, "Normal", "ResourcesApplied", fmt.Sprintf("All expanded resources were applied. name: %s", expander))
+
+		success, err := applier.Wait()
+		if err != nil {
+			r.Recorder.Event(&inputcr, "Warning", "ReconcileFailed", fmt.Sprintf("Failed waiting for resources to be reconciled. name: %s", expander))
+			logger.Error(err, "Failed waiting for applied resources to reconcile")
+			// Inject plan.ERROR Condition
+			newStatus.AppendErrorCondition(expander, err.Error(), "FailedWaitingForAppliedResources")
+			return ctrl.Result{}, err
+		}
+
+		oldAppliers = append(oldAppliers, applier)
+
+		if !success {
+			r.Recorder.Event(&inputcr, "Warning", "ReconcileFailed", fmt.Sprintf("Some resources are not healthy. name: %s", expander))
+			logger.Info("Applied succesfully but some resources did not become healthy")
+			// Inject plan.Waiting Condition
+			newStatus.AppendWaitingCondition(expander, "Not all resources are healthy", "WaitingForAppliedResources")
+			return ctrl.Result{}, fmt.Errorf("Some applied resources are not healthy")
+		}
+		logger.Info("Applied resources successfully.")
+
+		stagesApplied = append(stagesApplied, expander)
+		r.Recorder.Event(&inputcr, "Normal", "ResourcesReconciled", fmt.Sprintf("All applied resources were reconciled. name: %s", expander))
+		// Inject plan.Ready Condition with list of expanders
+		newStatus.ClearCondition(compositionv1alpha1.Ready)
+		message := fmt.Sprintf("Evaluated stages: %s \n Applied stages: %s", strings.Join(stagesEvaluated, ", "), strings.Join(stagesApplied, ", "))
 		newStatus.AppendCondition(compositionv1alpha1.Ready, metav1.ConditionFalse, message, "PendingStages")
 	}
 
 	// Inject plan.Ready Condition with list of expanders
 	newStatus.ClearCondition(compositionv1alpha1.Ready)
-	message := fmt.Sprintf("Processed stages: %s", strings.Join(expandersProcessed, ", "))
+	message := fmt.Sprintf("Evaluated and Applied stages: %s", strings.Join(stagesApplied, ", "))
 	newStatus.AppendCondition(compositionv1alpha1.Ready, metav1.ConditionTrue, message, "ProcessedAllStages")
 	newStatus.InputGeneration = inputcr.GetGeneration()
 	newStatus.Generation = plancr.GetGeneration()
+	if waitRequested {
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -376,15 +406,14 @@ func (r *ExpanderReconciler) runJob(ctx context.Context, logger logr.Logger,
 
 func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger logr.Logger,
 	cr *unstructured.Unstructured, values map[string]interface{}, expander compositionv1alpha1.Expander,
-	planNN types.NamespacedName, ev *compositionv1alpha1.ExpanderVersion, grpcService string) (map[string]interface{}, bool, string, pb.ResultType, error) {
+	planNN types.NamespacedName, ev *compositionv1alpha1.ExpanderVersion, grpcService string) (map[string]interface{}, bool, string, error) {
 	// Set up a connection to the server.
 	updated := false
-	resultType := pb.ResultType_UNKNOWN
 
 	conn, err := grpc.Dial(grpcService, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		logger.Error(err, "grpc dial failed: "+grpcService)
-		return values, updated, "GRPCConnError", resultType, err
+		return values, updated, "GRPCConnError", err
 	}
 
 	// read context in cr.namespace
@@ -393,19 +422,19 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 	contextNN := types.NamespacedName{Namespace: cr.GetNamespace(), Name: "context"}
 	if err := r.Get(ctx, contextNN, &contextcr); err != nil {
 		logger.Error(err, "unable to fetch Context CR", "context", contextNN)
-		return values, updated, "GetContextFailed", resultType, err
+		return values, updated, "GetContextFailed", err
 	}
 	contextBytes, err := json.Marshal(contextcr.Object)
 	if err != nil {
 		logger.Error(err, "failed to marshal Context Object")
-		return values, updated, "MarshallContextFailed", resultType, err
+		return values, updated, "MarshallContextFailed", err
 	}
 
 	// marshall facade cr
 	facadeBytes, err := json.Marshal(cr.Object)
 	if err != nil {
 		logger.Error(err, "failed to marshall Facade Object")
-		return values, updated, "MarshallFacadeFailed", resultType, err
+		return values, updated, "MarshallFacadeFailed", err
 	}
 
 	// marshall expander config
@@ -421,12 +450,12 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 		expanderconfigNN := types.NamespacedName{Namespace: expander.Reference.Namespace, Name: expander.Reference.Name}
 		if err := r.Get(ctx, expanderconfigNN, &expanderconfigcr); err != nil {
 			logger.Error(err, "unable to fetch ExpanderConfig CR", "expander config", expanderconfigNN)
-			return values, updated, "GetExpanderConfigFailed", resultType, err
+			return values, updated, "GetExpanderConfigFailed", err
 		}
 		configBytes, err = json.Marshal(expanderconfigcr.Object)
 		if err != nil {
 			logger.Error(err, "failed to marshal ExpanderConfig Object")
-			return values, updated, "MarshallExpanderConfigFailed", resultType, err
+			return values, updated, "MarshallExpanderConfigFailed", err
 		}
 	} else {
 		// TODO check if json.Marshall is escaping quotes
@@ -436,7 +465,7 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 		configBytes = []byte(expander.Template)
 		if err != nil {
 			logger.Error(err, "failed to marshall Expander template")
-			return values, updated, "MarshallExpanderTemplateFailed", resultType, err
+			return values, updated, "MarshallExpanderTemplateFailed", err
 		}
 	}
 
@@ -444,7 +473,7 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 	valuesBytes, err := json.Marshal(values)
 	if err != nil {
 		logger.Error(err, "failed to marshall Getter Values")
-		return values, updated, "MarshallValuesFailed", resultType, err
+		return values, updated, "MarshallValuesFailed", err
 	}
 
 	expanderClient := pb.NewExpanderClient(conn)
@@ -458,17 +487,17 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 		})
 	if err != nil {
 		logger.Error(err, "expander.Evaluate() Failed", "expander", expander.Name)
-		return values, updated, "EvaluateError", resultType, err
+		return values, updated, "EvaluateError", err
 	}
 	if result.Status == pb.Status_EVALUATE_WAIT {
 		logger.Error(nil, "expander.Evaluate() returned WAIT", "expander", expander.Name, "status", result.Status, "msg", result.Error.Message)
 		err = &EvaluateWaitError{msg: fmt.Sprintf("Expander returned WAIT: %s", result.Error.Message)}
-		return values, updated, "EvaluateStatusWait", resultType, err
+		return values, updated, "EvaluateStatusWait", err
 	}
 	if result.Status != pb.Status_SUCCESS {
 		logger.Error(nil, "expander.Evaluate() Status is not Success", "expander", expander.Name, "status", result.Status)
 		err = fmt.Errorf("Evaluate Failed: %s", result.Error.Message)
-		return values, updated, "EvaluateStatusFailed", resultType, err
+		return values, updated, "EvaluateStatusFailed", err
 	}
 
 	// Write to Plan object
@@ -476,7 +505,7 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 	plancr := compositionv1alpha1.Plan{}
 	if err := r.Client.Get(ctx, planNN, &plancr); err != nil {
 		logger.Error(err, "unable to read Plan CR", "plan", planNN)
-		return values, updated, "GetPlanFailed", resultType, err
+		return values, updated, "GetPlanFailed", err
 	}
 
 	if plancr.Spec.Stages == nil {
@@ -487,14 +516,13 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 		updated = true
 	}
 
-	resultType = result.Type
 	if result.Type == pb.ResultType_MANIFESTS {
 		err = nil
 		//s, err := strconv.Unquote(string(result.Manifests))
 		s := string(result.Manifests)
 		if err != nil {
 			logger.Error(err, "unable to unquote grpc response")
-			return values, updated, "UnquoteResponseFailed", resultType, err
+			return values, updated, "UnquoteResponseFailed", err
 		}
 		if s != plancr.Spec.Stages[expander.Name].Manifest {
 			plancr.Spec.Stages[expander.Name] = compositionv1alpha1.Stage{
@@ -521,14 +549,14 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 		err = json.Unmarshal([]byte(plancr.Spec.Stages[expander.Name].Values), &stageValues)
 		if err != nil {
 			logger.Error(err, "Failed unmarshalling response.Values field")
-			return values, updated, "UnmarshallValuesFailed", resultType, err
+			return values, updated, "UnmarshallValuesFailed", err
 		}
 		for k := range stageValues {
 			_, ok := values[k]
 			if ok {
 				err := fmt.Errorf("values[%s] already exists from one of the previous stages.", k)
 				logger.Error(err, "Duplicate Value Key")
-				return values, updated, "DuplicateValueKey", resultType, err
+				return values, updated, "DuplicateValueKey", err
 			}
 			values[k] = stageValues[k]
 		}
@@ -537,10 +565,10 @@ func (r *ExpanderReconciler) evaluateAndSavePlan(ctx context.Context, logger log
 	err = r.Client.Update(ctx, &plancr)
 	if err != nil {
 		logger.Error(err, "error updating plan", "plan", planNN)
-		return values, updated, "UpdatePlanFailed", resultType, err
+		return values, updated, "UpdatePlanFailed", err
 	}
 
-	return values, updated, "", resultType, nil
+	return values, updated, "", nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/experiments/compositions/composition/tests/scenario/scenario.go
+++ b/experiments/compositions/composition/tests/scenario/scenario.go
@@ -41,7 +41,7 @@ const (
 	// Composition Reconcile - bound on time
 	CompositionReconcileTimeout = 4 * time.Minute
 	// DeleteTimeout time to delete
-	DeleteTimeout = 1 * time.Minute
+	DeleteTimeout = 2 * time.Minute
 	// OutputExistsTimeout - time in which output objects exist after reconcile
 	OutputExistsTimeout = CompositionReconcileTimeout
 )


### PR DESCRIPTION
### Change description

Refactor Applier
- Move applier into pkg/applier, simplify parameters
- Split Evaluate and Apply
  - old: expanders [evaluate + apply]
  - new: expanders [evaluate] , expanders [apply]