### PR TITLE
Make TestStateIntoSpecDefaulter_ApplyDefaults test cases run in series

### DIFF
--- a/pkg/k8s/stateintospecdefaulter_test.go
+++ b/pkg/k8s/stateintospecdefaulter_test.go
@@ -231,7 +231,6 @@ func TestStateIntoSpecDefaulter_ApplyDefaults(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			ctx := context.Background()
 			mgr, stop := testmain.StartTestManagerFromNewTestEnv()
 			defer stop()


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes b/339701967

TestStateIntoSpecDefaulter_ApplyDefaults is extremely flaky in the integration test suite due to the following error:

```
{"severity":"error","timestamp":"2024-05-12T10:04:24.605Z","logger":"controller-runtime.test-env","msg":"unable to start the controlplane","tries":0,"error":"timeout waiting for process etcd to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)"}
```

It kept retrying for 5 times and then timed out.

I suspected that the issue is caused by parallelism because it will try to start 8 test manager in parallel. I updated the test workflow to make test cases run in series and verified the issue disappeared for 3 consecutive integration test runs.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
