### PR TITLE
refactor: mock_http_roundtrip

### DIFF
--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -309,7 +308,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		w := &bufferedResponseWriter{body: &body, header: make(http.Header)}
 		mux.ServeHTTP(w, req)
 		response := &http.Response{}
-		response.Body = ioutil.NopCloser(&body)
+		response.Body = io.NopCloser(&body)
 		response.Header = w.header
 		if w.statusCode == 0 {
 			w.statusCode = 200
@@ -343,7 +342,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 		log.Printf("response: %d %s", response.StatusCode, string(j))
 
-		response.Body = ioutil.NopCloser(bytes.NewReader(j))
+		response.Body = io.NopCloser(bytes.NewReader(j))
 	} else {
 		log.Printf("response: %d %s", response.StatusCode, "-")
 	}

--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -335,7 +335,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			"Please verify the ExpectedHost in service.go and retry.", req.Host)
 	}
 
-	if body != nil {
+	if len(body) != 0 {
 		j, err := json.Marshal(body)
 		if err != nil {
 			panic("json.Marshal failed")


### PR DESCRIPTION
Some small refactors on the mock_http_roundtrip; should be pretty low risk.