### PR TITLE
tests:refactor: fatal if e2e_gcp_target set

### DIFF
--- a/pkg/test/main/testmain.go
+++ b/pkg/test/main/testmain.go
@@ -15,7 +15,7 @@
 package testmain
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -34,10 +34,14 @@ import (
 )
 
 func ForIntegrationTests(m *testing.M, mgr *manager.Manager) {
+	if os.Getenv("E2E_GCP_TARGET") != "" {
+		log.Fatalf("dynamic integration tests do not support variable E2E_GCP_TARGET")
+	}
+
 	// Since Terraform logging defers to the Go standard logger,
 	// here we discard everything logged onto the Go standard logger to
 	// disable logging from Terraform Google provider in integration tests.
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	TestMain(m, test.IntegrationTestType, nil, mgr)
 }
 


### PR DESCRIPTION
One liner to quit if we are attempting to use a mock gcp with the dynamic controller integration tests.

Why? Should the dynamic integration tests work with mock gcp? 

That is a good question but we already have a place where the fixtures are called in TestAll under e2e. We can continue that discussion. I just want this papercut to be a bit more evident when I forget I can't use the dynamic controller with a mock gcp backend 😛 .

In practice:

```bash
$ E2E_GCP_TARGET=mock go test -v -tags=integration ./pkg/controller/dynamic/ -timeout 2600s -test.count=1 -test.run 'TestCreateNoChangeUpdateDelete/ids/basic-idsendpoint'  2>&1

2024/06/04 20:15:14 dynamic integration tests do not support variable E2E_GCP_TARGET
FAIL    github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      0.159s
FAIL
```