### PR TITLE
minor fix: Remove tests from skipCRUDTests list

### DIFF
--- a/pkg/test/constants/presubmitconstants.go
+++ b/pkg/test/constants/presubmitconstants.go
@@ -52,6 +52,7 @@ var (
 		"dataproc":             {"dataproccluster"},
 		"dlp":                  {"cloudstoragepathstoredinfotype"},
 		"dns":                  {"dnsrecordset"},
+		"edgecontainer":        {"edgecontainercluster"},
 		"eventarc":             {"eventarctrigger"},
 		"filestore":            {"filestorebackup"},
 		"gkehub":               {"gkehubfeaturemembership"},
@@ -84,7 +85,6 @@ var (
 		"storage":              {"storagenotification"},
 		"storagetransfer":      {"storagetransferjob"},
 		"vpcaccess":            {"subnetconnector"},
-		"edgecontainer":        {"edgecontainercluster"},
 		"vertexai":             {"vertexaidatasetbasic"},
 	}
 	longRunningCRUDTests = []string{
@@ -114,10 +114,8 @@ var (
 	}
 	// Services with special testing requirements that should be skipped in presubmit
 	skipCRUDTests = map[string]bool{
-		"containerattached":          true,
-		"edgenetwork":                true,
-		"edgecontainervpnconnection": true,
-		"edgecontainernodepool":      true,
+		"containerattached": true,
+		"edgenetwork":       true,
 	}
 	DynamicTestPackagePath = "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic/..."
 )


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Remove tests from the GoB presubmit skipCRUDTest list, they won't be triggered in GoB presubmit, so no longer need to include them.

Since we switch to OSS, the GoB presubmit constants may not be used anymore, but I just want to keep things updated to avoid confusions.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
