### PR TITLE
chore: Refactor registry to be more reusable

### DIFF
--- a/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
+++ b/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/deepcopy"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/krmtotf"
@@ -49,8 +49,8 @@ func New(tfProvider *schema.Provider, smloader *servicemappingloader.ServiceMapp
 
 func (i *iamClient) SupportsIAM(unstructured *unstructured.Unstructured) (bool, error) {
 	groundKind := unstructured.GroupVersionKind().GroupKind()
-	if direct.IsDirect(groundKind) {
-		return direct.SupportsIAM(groundKind)
+	if registry.IsDirectByGK(groundKind) {
+		return registry.SupportsIAM(groundKind)
 	}
 
 	rc, err := i.smLoader.GetResourceConfig(unstructured)

--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -32,14 +32,15 @@ import (
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/alloydb/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 )
 
 func init() {
-	directbase.ControllerBuilder.RegisterModel(krm.AlloyDBClusterGVK, NewModel)
+	registry.RegisterModel(krm.AlloyDBClusterGVK, NewModel)
 }
 
-func NewModel(config *config.ControllerConfig) directbase.Model {
-	return &clusterModel{config: config}
+func NewModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &clusterModel{config: config}, nil
 }
 
 type clusterModel struct {

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -31,16 +31,17 @@ import (
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/apikeys/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 
 	. "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/mappings" //nolint:revive
 )
 
 func init() {
-	directbase.ControllerBuilder.RegisterModel(krm.APIKeysKeyGVK, newAPIKeysModel)
+	registry.RegisterModel(krm.APIKeysKeyGVK, newAPIKeysModel)
 }
 
-func newAPIKeysModel(config *config.ControllerConfig) directbase.Model {
-	return &model{config: *config}
+func newAPIKeysModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &model{config: *config}, nil
 }
 
 type model struct {

--- a/pkg/controller/direct/gkehub/featuremembership_controller.go
+++ b/pkg/controller/direct/gkehub/featuremembership_controller.go
@@ -30,16 +30,17 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 )
 
 const ctrlName = "gkehubfeaturemembership-controller"
 
 func init() {
-	directbase.ControllerBuilder.RegisterModel(krm.GKEHubFeatureMembershipGVK, GetModel)
+	registry.RegisterModel(krm.GKEHubFeatureMembershipGVK, getGkeHubModel)
 }
 
-func GetModel(config *config.ControllerConfig) directbase.Model {
-	return &gkeHubModel{config: config}
+func getGkeHubModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &gkeHubModel{config: config}, nil
 }
 
 type gkeHubModel struct {

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -31,16 +31,17 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 )
 
 const ctrlName = "logmetric-controller"
 
 func init() {
-	directbase.ControllerBuilder.RegisterModel(krm.LoggingLogMetricGVK, NewLogMetricModel)
+	registry.RegisterModel(krm.LoggingLogMetricGVK, NewLogMetricModel)
 }
 
-func NewLogMetricModel(config *config.ControllerConfig) directbase.Model {
-	return &logMetricModel{config: config}
+func NewLogMetricModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &logMetricModel{config: config}, nil
 }
 
 type logMetricModel struct {

--- a/pkg/controller/direct/registry/registry.go
+++ b/pkg/controller/direct/registry/registry.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var singleton = registry{}
+
+type registry struct {
+	registrations map[schema.GroupKind]*registration
+}
+
+type registration struct {
+	gvk     schema.GroupVersionKind
+	factory ModelFactoryFunc
+	model   directbase.Model
+}
+
+type ModelFactoryFunc func(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error)
+
+func GetModel(gk schema.GroupKind) (directbase.Model, error) {
+	registration := singleton.registrations[gk]
+	if registration == nil {
+		return nil, fmt.Errorf("no model registered for %s", gk)
+	}
+	return registration.model, nil
+}
+
+func PreferredGVK(gk schema.GroupKind) (schema.GroupVersionKind, bool) {
+	registration := singleton.registrations[gk]
+	if registration == nil {
+		return schema.GroupVersionKind{}, false
+	}
+	return registration.gvk, true
+}
+
+func Init(ctx context.Context, config *config.ControllerConfig) error {
+	for _, registration := range singleton.registrations {
+		model, err := registration.factory(ctx, config)
+		if err != nil {
+			return err
+		}
+
+		registration.model = model
+	}
+	return nil
+}
+
+func RegisterModel(gvk schema.GroupVersionKind, modelFn ModelFactoryFunc) {
+	if singleton.registrations == nil {
+		singleton.registrations = make(map[schema.GroupKind]*registration)
+	}
+	singleton.registrations[gvk.GroupKind()] = &registration{
+		gvk:     gvk,
+		factory: modelFn,
+	}
+}
+
+func IsDirectByGK(gk schema.GroupKind) bool {
+	registration := singleton.registrations[gk]
+	return registration != nil
+}
+
+// IsIAMDirect returns true if this resource uses the direct-reconciliation model for IAM.
+func IsIAMDirect(groupKind schema.GroupKind) bool {
+	registration := singleton.registrations[groupKind]
+	if registration == nil {
+		return false
+	}
+
+	// TODO: Move to registration somehow?
+	switch groupKind {
+	case schema.GroupKind{Group: "privateca.cnrm.cloud.google.com", Kind: "PrivateCACAPool"}:
+		return true
+	}
+	return false
+}
+
+// SupportsIAM returns true if this resource supports IAM (not all GCP resources do).
+// An error will be returned if IsDirect(groupKind) is not true.
+func SupportsIAM(groupKind schema.GroupKind) (bool, error) {
+	// TODO: Move to registration somehow?
+	switch groupKind {
+	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
+		return false, nil
+	}
+	return false, fmt.Errorf("groupKind %v is not recognized as a direct kind", groupKind)
+}

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -32,14 +32,15 @@ import (
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 )
 
 func init() {
-	directbase.ControllerBuilder.RegisterModel(krm.TagsTagKeyGVK, newTagKeyModel)
+	registry.RegisterModel(krm.TagsTagKeyGVK, newTagKeyModel)
 }
 
-func newTagKeyModel(config *config.ControllerConfig) directbase.Model {
-	return &tagKeyModel{config: config}
+func newTagKeyModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &tagKeyModel{config: config}, nil
 }
 
 type tagKeyModel struct {

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/ratelimiter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -40,6 +41,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	// Register direct controllers
+	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
 type Config struct {
@@ -142,6 +146,12 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 		HTTPClient:          cfg.HTTPClient,
 		UserAgent:           gcp.KCCUserAgent,
 	}
+
+	// Initialize direct controllers
+	if err := registry.Init(ctx, controllerConfig); err != nil {
+		return nil, err
+	}
+
 	rd := controller.Deps{
 		TfProvider:   provider,
 		TfLoader:     smLoader,

--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -139,9 +139,12 @@ func (rc ResourceContext) Get(ctx context.Context, _ *testing.T, u *unstructured
 	// direct controllers
 	switch u.GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
-		m := logging.NewLogMetricModel(&config.ControllerConfig{
+		m, err := logging.NewLogMetricModel(ctx, &config.ControllerConfig{
 			HTTPClient: httpClient,
 		})
+		if err != nil {
+			return nil, err
+		}
 		a, err := m.AdapterForObject(ctx, c, u)
 		if err != nil {
 			return nil, err
@@ -172,9 +175,12 @@ func (rc ResourceContext) Delete(ctx context.Context, _ *testing.T, u *unstructu
 	// direct controllers
 	switch u.GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
-		m := logging.NewLogMetricModel(&config.ControllerConfig{
+		m, err := logging.NewLogMetricModel(ctx, &config.ControllerConfig{
 			HTTPClient: httpClient,
 		})
+		if err != nil {
+			return err
+		}
 		a, err := m.AdapterForObject(ctx, c, u)
 		if err != nil {
 			return err


### PR DESCRIPTION
We need to move things around to avoid import cycles as we add IAM
support.
