### PR TITLE
WIP: feature: implement "watch" for GCP objects

### DIFF
--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -247,6 +247,7 @@ func (m *mockRoundTripper) modifyUpdateMask(s string) (string, error) {
 // These are implemented on most resources, and rather than mock them
 // per-resource, we implement them once here.
 func (m *mockRoundTripper) roundTripIAMPolicy(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
 	requestPath := req.URL.Path
 
 	lastColon := strings.LastIndex(requestPath, ":")
@@ -254,11 +255,17 @@ func (m *mockRoundTripper) roundTripIAMPolicy(req *http.Request) (*http.Response
 
 	requestPath = strings.TrimSuffix(requestPath, ":"+verb)
 
+	requestPath = strings.TrimPrefix(requestPath, "/v1/")
+	requestPath = strings.TrimPrefix(requestPath, "/v2/")
+	requestPath = strings.TrimPrefix(requestPath, "/v3/")
+
+	requestPath = "/" + strings.TrimPrefix(requestPath, "/")
+
 	switch verb {
 	case "getIamPolicy":
 		if req.Method == "GET" || req.Method == "POST" {
 			resourcePath := req.URL.Host + requestPath
-			return m.iamPolicies.serveGetIAMPolicy(resourcePath)
+			return m.iamPolicies.serveGetIAMPolicy(ctx, resourcePath)
 		} else {
 			response := &http.Response{
 				StatusCode: http.StatusMethodNotAllowed,
@@ -271,7 +278,7 @@ func (m *mockRoundTripper) roundTripIAMPolicy(req *http.Request) (*http.Response
 	case "setIamPolicy":
 		if req.Method == "POST" {
 			resourcePath := req.URL.Host + requestPath
-			return m.iamPolicies.serveSetIAMPolicy(resourcePath, req)
+			return m.iamPolicies.serveSetIAMPolicy(ctx, resourcePath, req)
 		} else {
 			response := &http.Response{
 				StatusCode: http.StatusMethodNotAllowed,

--- a/pkg/cli/stream/url_to_unstructured_resource_stream.go
+++ b/pkg/cli/stream/url_to_unstructured_resource_stream.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/gcpclient"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/resourceskeleton"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
@@ -56,7 +56,7 @@ func (s *URLToUnstructuredResourceStream) Next(ctx context.Context) (*unstructur
 	}
 
 	// First check if this resource uses our direct-reconciliation model
-	exported, err := direct.Export(ctx, s.url, &controller.Config{
+	exported, err := direct.Export(ctx, s.url, &config.ControllerConfig{
 		HTTPClient: s.httpClient,
 	})
 	if err != nil {

--- a/pkg/config/controllerconfig.go
+++ b/pkg/config/controllerconfig.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "net/http"
+
+type ControllerConfig struct {
+	UserAgent string
+
+	// UserProjectOverride provides the option to use the resource project for preconditions, quota, and billing,
+	// instead of the project the credentials belong to; false by default
+	UserProjectOverride bool
+
+	// BillingProject is the project used by the TF provider and DCL client to determine preconditions,
+	// quota, and billing if UserProjectOverride is set to true. If this field is empty,
+	// but UserProjectOverride is set to true, resource project will be used.
+	BillingProject string
+
+	// HTTPClient allows us to specify the HTTP client to use with DCL.
+	// This is particularly useful in mocks/tests.
+	HTTPClient *http.Client
+}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -15,32 +15,14 @@
 package controller
 
 import (
-	"net/http"
-
 	"github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcpwatch"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-type Config struct {
-	UserAgent string
-
-	// UserProjectOverride provides the option to use the resource project for preconditions, quota, and billing,
-	// instead of the project the credentials belong to; false by default
-	UserProjectOverride bool
-
-	// BillingProject is the project used by the TF provider and DCL client to determine preconditions,
-	// quota, and billing if UserProjectOverride is set to true. If this field is empty,
-	// but UserProjectOverride is set to true, resource project will be used.
-	BillingProject string
-
-	// HTTPClient allows us to specify the HTTP client to use with DCL.
-	// This is particularly useful in mocks/tests.
-	HTTPClient *http.Client
-}
 
 // Common controller dependencies.
 type Deps struct {
@@ -50,4 +32,6 @@ type Deps struct {
 	DclConverter *conversion.Converter
 	Defaulters   []k8s.Defaulter
 	JitterGen    jitter.Generator
+
+	DependencyTracker *gcpwatch.DependencyTracker
 }

--- a/pkg/controller/direct/alloydb/client.go
+++ b/pkg/controller/direct/alloydb/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	api "google.golang.org/api/alloydb/v1beta"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/alloydb/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 )
 
@@ -38,13 +38,13 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.AlloyDBClusterGVK, NewModel)
 }
 
-func NewModel(config *controller.Config) directbase.Model {
+func NewModel(config *config.ControllerConfig) directbase.Model {
 	return &clusterModel{config: config}
 }
 
 type clusterModel struct {
 	// *gcpClient
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/apikeys/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 
 	. "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/mappings" //nolint:revive
@@ -39,12 +39,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.APIKeysKeyGVK, newAPIKeysModel)
 }
 
-func newAPIKeysModel(config *controller.Config) directbase.Model {
+func newAPIKeysModel(config *config.ControllerConfig) directbase.Model {
 	return &model{config: *config}
 }
 
 type model struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/gkehub/client.go
+++ b/pkg/controller/direct/gkehub/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	featureapi "google.golang.org/api/gkehub/v1beta"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(config *controller.Config) (*gcpClient, error) {
+func newGCPClient(config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/gkehub/featuremembership_controller.go
+++ b/pkg/controller/direct/gkehub/featuremembership_controller.go
@@ -27,7 +27,7 @@ import (
 
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/gkehub/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
 )
@@ -38,12 +38,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.GKEHubFeatureMembershipGVK, GetModel)
 }
 
-func GetModel(config *controller.Config) directbase.Model {
+func GetModel(config *config.ControllerConfig) directbase.Model {
 	return &gkeHubModel{config: config}
 }
 
 type gkeHubModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/logging/client.go
+++ b/pkg/controller/direct/logging/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	api "google.golang.org/api/logging/v2"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -28,7 +28,7 @@ import (
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/resources/logging/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
 )
@@ -39,12 +39,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.LoggingLogMetricGVK, NewLogMetricModel)
 }
 
-func NewLogMetricModel(config *controller.Config) directbase.Model {
+func NewLogMetricModel(config *config.ControllerConfig) directbase.Model {
 	return &logMetricModel{config: config}
 }
 
 type logMetricModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/registry.go
+++ b/pkg/controller/direct/registry.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/logging"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,7 +48,7 @@ func SupportsIAM(groupKind schema.GroupKind) (bool, error) {
 // Export attempts to export the resource specified by url.
 // The url format should match the Cloud-Asset-Inventory format: https://cloud.google.com/asset-inventory/docs/resource-name-format
 // If url is not recognized or not implemented by a direct controller, this returns (nil, nil)
-func Export(ctx context.Context, url string, config *controller.Config) (*unstructured.Unstructured, error) {
+func Export(ctx context.Context, url string, config *config.ControllerConfig) (*unstructured.Unstructured, error) {
 	if strings.HasPrefix(url, "//logging.googleapis.com/") {
 		tokens := strings.Split(strings.TrimPrefix(url, "//logging.googleapis.com/"), "/")
 		if len(tokens) == 4 && tokens[0] == "projects" && tokens[2] == "metrics" {

--- a/pkg/controller/direct/resourcemanager/client.go
+++ b/pkg/controller/direct/resourcemanager/client.go
@@ -19,15 +19,15 @@ import (
 	"fmt"
 
 	api "cloud.google.com/go/resourcemanager/apiv3"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 )
 
@@ -38,12 +38,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.TagsTagKeyGVK, newTagKeyModel)
 }
 
-func newTagKeyModel(config *controller.Config) directbase.Model {
+func newTagKeyModel(config *config.ControllerConfig) directbase.Model {
 	return &tagKeyModel{config: config}
 }
 
 type tagKeyModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/execution"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcpwatch"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util"
@@ -80,7 +81,7 @@ func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
-	reconciler, err := NewReconciler(mgr, deps.TfProvider, deps.TfLoader, deps.DclConverter, deps.DclConfig, immediateReconcileRequests, resourceWatcherRoutines, deps.Defaulters, deps.JitterGen)
+	reconciler, err := NewReconciler(mgr, deps.TfProvider, deps.TfLoader, deps.DclConverter, deps.DclConfig, immediateReconcileRequests, resourceWatcherRoutines, deps.Defaulters, deps.JitterGen, deps.DependencyTracker)
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 }
 
 // NewReconciler returns a new reconcile.Reconciler.
-func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jg jitter.Generator) (*ReconcileIAMPartialPolicy, error) {
+func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jg jitter.Generator, dependencyTracker *gcpwatch.DependencyTracker) (*ReconcileIAMPartialPolicy, error) {
 	r := ReconcileIAMPartialPolicy{
 		LifecycleHandler: lifecyclehandler.NewLifecycleHandler(
 			mgr.GetClient(),
@@ -106,6 +107,10 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 		},
 		requeueRateLimiter: kccratelimiter.RequeueRateLimiter(),
 		jitterGen:          jg,
+	}
+
+	if r.immediateReconcileRequests != nil && dependencyTracker != nil {
+		r.driftTracker = dependencyTracker.RegisterController("IAMPartialPolicy", r.immediateReconcileRequests)
 	}
 	return &r, nil
 }
@@ -144,15 +149,21 @@ type ReconcileIAMPartialPolicy struct {
 	// rate limit requeues (periodic re-reconciliation), so we don't use the whole rate limit on re-reconciles
 	requeueRateLimiter ratelimiter.RateLimiter
 	jitterGen          jitter.Generator
+
+	driftTracker *gcpwatch.ControllerRegistration
 }
 
 type reconcileContext struct {
 	Reconciler     *ReconcileIAMPartialPolicy
 	Ctx            context.Context
 	NamespacedName types.NamespacedName
+
+	gcpObjects []*iamv1beta1.IAMPolicy
 }
 
 func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
+	log := klog.FromContext(ctx)
+
 	logger.Info("Running reconcile", "resource", request.NamespacedName)
 	startTime := time.Now()
 	ctx, cancel := context.WithTimeout(ctx, k8s.ReconcileDeadline)
@@ -189,6 +200,12 @@ func (r *ReconcileIAMPartialPolicy) Reconcile(ctx context.Context, request recon
 	if requeue {
 		return reconcile.Result{Requeue: true}, nil
 	}
+
+	if len(runCtx.gcpObjects) == 1 && r.driftTracker.Add(ctx, policy, runCtx.gcpObjects[0].Spec.Etag) {
+		log.Info("using gcp watcher instead of periodic requeue")
+		return reconcile.Result{}, nil
+	}
+
 	jitteredPeriod, err := r.jitterGen.JitteredReenqueue(iamv1beta1.IAMPolicyGVK, policy)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -244,6 +261,8 @@ func (r *reconcileContext) doReconcile(pp *iamv1beta1.IAMPartialPolicy) (requeue
 		}
 		return false, r.handleUpdateFailed(pp, err)
 	}
+	r.gcpObjects = append(r.gcpObjects, iamPolicy.DeepCopy())
+
 	k8s.EnsureFinalizers(pp, k8s.ControllerFinalizerName, k8s.DeletionDefenderFinalizerName)
 
 	resolver := IAMMemberIdentityResolver{Iamclient: r.Reconciler.iamClient, Ctx: r.Ctx}

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	operatorv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -29,6 +31,7 @@ import (
 	dclmetadata "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/schema/dclschemaloader"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcpwatch"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 	tfprovider "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/tf/provider"
@@ -77,8 +80,8 @@ type Config struct {
 //
 // This serves as the entry point for the in-cluster main and the Borg service main. Any changes made should be done
 // with care.
-func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.Manager, error) {
-	opts := config.ManagerOptions
+func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Manager, error) {
+	opts := cfg.ManagerOptions
 	if opts.Scheme == nil {
 		// By default, controller-runtime uses the Kubernetes client-go scheme, this can create concurrency bugs as the
 		// the calls to AddToScheme(..) will modify the internal maps
@@ -100,9 +103,9 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 
 	// Bootstrap the Google Terraform provider
 	tfCfg := tfprovider.NewConfig()
-	tfCfg.UserProjectOverride = config.UserProjectOverride
-	tfCfg.BillingProject = config.BillingProject
-	tfCfg.GCPAccessToken = config.GCPAccessToken
+	tfCfg.UserProjectOverride = cfg.UserProjectOverride
+	tfCfg.BillingProject = cfg.BillingProject
+	tfCfg.GCPAccessToken = cfg.GCPAccessToken
 
 	provider, err := tfprovider.New(ctx, tfCfg)
 	if err != nil {
@@ -121,9 +124,9 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	dclConverter := dclconversion.New(dclSchemaLoader, serviceMetadataLoader)
 
 	dclOptions := clientconfig.Options{}
-	dclOptions.UserProjectOverride = config.UserProjectOverride
-	dclOptions.BillingProject = config.BillingProject
-	dclOptions.HTTPClient = config.HTTPClient
+	dclOptions.UserProjectOverride = cfg.UserProjectOverride
+	dclOptions.BillingProject = cfg.BillingProject
+	dclOptions.HTTPClient = cfg.HTTPClient
 	dclOptions.UserAgent = gcp.KCCUserAgent
 
 	dclConfig, err := clientconfig.New(ctx, dclOptions)
@@ -132,23 +135,34 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	}
 
 	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
-	controllerConfig := &controller.Config{
-		UserProjectOverride: config.UserProjectOverride,
-		BillingProject:      config.BillingProject,
-		HTTPClient:          config.HTTPClient,
+	controllerConfig := &config.ControllerConfig{
+		UserProjectOverride: cfg.UserProjectOverride,
+		BillingProject:      cfg.BillingProject,
+		HTTPClient:          cfg.HTTPClient,
 		UserAgent:           gcp.KCCUserAgent,
 	}
-	rd := controller.Deps{
+	rd := &controller.Deps{
 		TfProvider:   provider,
 		TfLoader:     smLoader,
 		DclConfig:    dclConfig,
 		DclConverter: dclConverter,
 		Defaulters:   []k8s.Defaulter{stateIntoSpecDefaulter},
 	}
+
+	fetcher, err := gcpwatch.NewIAMFetcher(ctx, controllerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating resource fetcher: %v", err)
+	}
+	rd.DependencyTracker = gcpwatch.NewDependencyTracker(fetcher)
+
+	go func() {
+		rd.DependencyTracker.PollForever(ctx, time.Second, time.Second)
+	}()
+
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.Add(mgr, &rd,
-		registration.RegisterDefaultController(controllerConfig)); err != nil {
+	if err := registration.Add(mgr, rd,
+		registration.RegisterDefaultController(rd, controllerConfig)); err != nil {
 		return nil, fmt.Errorf("error adding registration controller: %w", err)
 	}
 	return mgr, nil

--- a/pkg/dcl/clientconfig/config.go
+++ b/pkg/dcl/clientconfig/config.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/logger"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
@@ -37,7 +37,7 @@ import (
 var nonretryable = dcl.Retryability{Retryable: false}
 
 type Options struct {
-	controller.Config
+	config.ControllerConfig
 }
 
 func newConfigAndClient(ctx context.Context, opt Options) (*dcl.Config, *http.Client, error) {

--- a/pkg/gcpwatch/fetcher.go
+++ b/pkg/gcpwatch/fetcher.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpwatch
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/iam/apiv1/iampb"
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"google.golang.org/api/option"
+	"k8s.io/klog/v2"
+)
+
+type IAMFetcher struct {
+	crmClient *resourcemanager.ProjectsClient
+}
+
+var _ Fetcher = &IAMFetcher{}
+
+func NewIAMFetcher(ctx context.Context, config *config.ControllerConfig) (*IAMFetcher, error) {
+	opts, err := options(config)
+	if err != nil {
+		return nil, err
+	}
+	crmClient, err := resourcemanager.NewProjectsRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building projects client: %w", err)
+	}
+	return &IAMFetcher{
+		crmClient: crmClient,
+	}, nil
+}
+
+func options(config *config.ControllerConfig) ([]option.ClientOption, error) {
+	var opts []option.ClientOption
+	if config.UserAgent != "" {
+		opts = append(opts, option.WithUserAgent(config.UserAgent))
+	}
+	if config.HTTPClient != nil {
+		// TODO: Set UserAgent in this scenario (error is: WithHTTPClient is incompatible with gRPC dial options)
+		opts = append(opts, option.WithHTTPClient(config.HTTPClient))
+	}
+	if config.UserProjectOverride && config.BillingProject != "" {
+		opts = append(opts, option.WithQuotaProject(config.BillingProject))
+	}
+
+	// TODO: support endpoints?
+	// if m.config.Endpoint != "" {
+	// 	opts = append(opts, option.WithEndpoint(m.config.Endpoint))
+	// }
+
+	return opts, nil
+}
+
+func (f *IAMFetcher) IsSupported(kind string, external string) bool {
+	tokens := strings.Split(external, "/")
+	switch kind {
+	case "Project":
+		return len(tokens) == 2 && tokens[0] == "projects"
+	}
+
+	return false
+}
+
+func (f *IAMFetcher) Fetch(ctx context.Context, kind string, external string) (*ResourceInfo, error) {
+	tokens := strings.Split(external, "/")
+	switch kind {
+	case "Project":
+		if len(tokens) == 2 && tokens[0] == "projects" {
+			return f.fetchProject(ctx, tokens[1])
+		}
+	}
+
+	return nil, fmt.Errorf("%s/%s is not supported by fetcher", kind, external)
+}
+
+func (f *IAMFetcher) fetchProject(ctx context.Context, projectID string) (*ResourceInfo, error) {
+	log := klog.FromContext(ctx)
+
+	req := &iampb.GetIamPolicyRequest{
+		Resource: fmt.Sprintf("projects/%s", projectID),
+	}
+
+	policy, err := f.crmClient.GetIamPolicy(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching iam policy for %q: %w", req.Resource, err)
+	}
+	log.Info("got iam policy for project", "policy", policy, "projectID", projectID)
+	etag := base64.StdEncoding.EncodeToString(policy.Etag)
+	return &ResourceInfo{
+		Etag: etag,
+	}, nil
+}

--- a/pkg/gcpwatch/tracker.go
+++ b/pkg/gcpwatch/tracker.go
@@ -1,0 +1,237 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpwatch
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+type DependencyTracker struct {
+	fetcher Fetcher
+
+	mutex        sync.Mutex
+	gcpResources map[gcpResouceKey]*dependenciesByResource
+
+	controllers map[string]*ControllerRegistration
+}
+
+type ControllerRegistration struct {
+	tracker       *DependencyTracker
+	controllerKey string
+	queue         chan event.GenericEvent
+}
+
+func (t *DependencyTracker) RegisterController(key string, queue chan event.GenericEvent) *ControllerRegistration {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	if _, exists := t.controllers[key]; exists {
+		klog.Fatalf("multiple controllers with key %q", key)
+	}
+
+	registration := &ControllerRegistration{
+		controllerKey: key,
+		queue:         queue,
+		tracker:       t,
+	}
+
+	t.controllers[key] = registration
+
+	return registration
+}
+
+type gcpResouceKey struct {
+	Kind     string
+	External string
+}
+
+type dependenciesByResource struct {
+	mutex        sync.Mutex
+	etag         string
+	dependencies []dependency
+}
+
+type dependency struct {
+	controller *ControllerRegistration
+	namespace  string
+	name       string
+}
+
+type Fetcher interface {
+	IsSupported(kind string, external string) bool
+	Fetch(ctx context.Context, kind string, external string) (*ResourceInfo, error)
+}
+
+type ResourceInfo struct {
+	Etag string
+}
+
+func NewDependencyTracker(fetcher Fetcher) *DependencyTracker {
+	tracker := &DependencyTracker{
+		fetcher:      fetcher,
+		controllers:  make(map[string]*ControllerRegistration),
+		gcpResources: make(map[gcpResouceKey]*dependenciesByResource),
+	}
+	return tracker
+}
+
+func (t *DependencyTracker) PollForever(ctx context.Context, initialDelay time.Duration, minInterval time.Duration) {
+	nextPoll := time.Now().Add(initialDelay)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		time.Sleep(1 * time.Second)
+
+		if time.Now().Before(nextPoll) {
+			continue
+		}
+
+		nextPoll = time.Now().Add(minInterval)
+
+		if err := t.pollOnce(ctx); err != nil {
+			klog.Warningf("error during drift-correction polling: %v", err)
+		}
+	}
+}
+
+func (t *DependencyTracker) pollOnce(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	var keys []gcpResouceKey
+	t.mutex.Lock()
+	for key := range t.gcpResources {
+		keys = append(keys, key)
+	}
+	t.mutex.Unlock()
+
+	for _, key := range keys {
+		t.mutex.Lock()
+		gcpResource := t.gcpResources[key]
+		t.mutex.Unlock()
+
+		if gcpResource == nil {
+			continue
+		}
+
+		latest, err := t.fetcher.Fetch(ctx, key.Kind, key.External)
+		if err != nil {
+			// TODO: Remove if not found?
+			log.Error(err, "error fetching iam", "kind", key.Kind, "external", key.External)
+			continue
+		}
+
+		gcpResource.mutex.Lock()
+		log.Info("got iam etag", "newEtag", latest.Etag, "kind", key.Kind, "external", key.External, "oldEtag", gcpResource.etag)
+		if latest.Etag != gcpResource.etag {
+			gcpResource.etag = latest.Etag
+
+			for _, dep := range gcpResource.dependencies {
+				log.Info("triggering notification", "controller", dep.controller.controllerKey, "namespace", dep.namespace, "name", dep.name)
+				genEvent := event.GenericEvent{}
+				genEvent.Object = &unstructured.Unstructured{}
+				genEvent.Object.SetNamespace(dep.namespace)
+				genEvent.Object.SetName(dep.name)
+				dep.controller.queue <- genEvent
+			}
+		}
+		gcpResource.mutex.Unlock()
+	}
+
+	return nil
+}
+
+func (r *ControllerRegistration) Add(ctx context.Context, policy *v1beta1.IAMPartialPolicy, etag string) bool {
+	log := klog.FromContext(ctx)
+
+	if etag == "" {
+		return false
+	}
+
+	if r == nil {
+		return false
+	}
+
+	// TODO: Resolve Name -> External
+
+	t := r.tracker
+	kind := policy.Spec.ResourceReference.Kind
+	if kind == "" {
+		return false
+	}
+
+	external := policy.Spec.ResourceReference.External
+	if external == "" {
+		return false
+	}
+
+	if !t.fetcher.IsSupported(kind, external) {
+		return false
+	}
+
+	log.Info("adding watch on policy", "policy", policy, "kind", kind, "external", external)
+
+	t.add(kind, external, r, policy.GetNamespace(), policy.GetName(), etag)
+	return true
+}
+
+func (t *DependencyTracker) add(kind string, external string, controller *ControllerRegistration, namespace string, name string, etag string) {
+	target := t.getTarget(kind, external)
+
+	target.mutex.Lock()
+	defer target.mutex.Unlock()
+
+	if target.etag == "" {
+		target.etag = etag
+		// TODO: Trigger now?
+	}
+
+	for i := range target.dependencies {
+		dep := &target.dependencies[i]
+		if dep.controller == controller && dep.namespace == namespace && dep.name == name {
+			return
+		}
+	}
+	target.dependencies = append(target.dependencies, dependency{
+		controller: controller,
+		namespace:  namespace,
+		name:       name,
+	})
+}
+
+func (t *DependencyTracker) getTarget(kind string, external string) *dependenciesByResource {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	key := gcpResouceKey{
+		Kind:     kind,
+		External: external,
+	}
+
+	target := t.gcpResources[key]
+	if target == nil {
+		target = &dependenciesByResource{}
+		t.gcpResources[key] = target
+	}
+	return target
+}


### PR DESCRIPTION
We can't actually watch, but we can instead track dependencies and
poll them.  By doing this we are able to reduce the number of GCP
requests when multiple KCC resources share a GCP resource and we save
a few kube requests in the common (unchanged) case.  We may also be
able to implement a list optimization in future.

This is really a PoC, it only implements a narrow sliver of
functionality.
