### PR TITLE
chore: Refactor ControllerConfig into its own package

### DIFF
--- a/pkg/cli/stream/url_to_unstructured_resource_stream.go
+++ b/pkg/cli/stream/url_to_unstructured_resource_stream.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/gcpclient"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/resourceskeleton"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
@@ -56,7 +56,7 @@ func (s *URLToUnstructuredResourceStream) Next(ctx context.Context) (*unstructur
 	}
 
 	// First check if this resource uses our direct-reconciliation model
-	exported, err := direct.Export(ctx, s.url, &controller.Config{
+	exported, err := direct.Export(ctx, s.url, &config.ControllerConfig{
 		HTTPClient: s.httpClient,
 	})
 	if err != nil {

--- a/pkg/config/controllerconfig.go
+++ b/pkg/config/controllerconfig.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "net/http"
+
+type ControllerConfig struct {
+	UserAgent string
+
+	// UserProjectOverride provides the option to use the resource project for preconditions, quota, and billing,
+	// instead of the project the credentials belong to; false by default
+	UserProjectOverride bool
+
+	// BillingProject is the project used by the TF provider and DCL client to determine preconditions,
+	// quota, and billing if UserProjectOverride is set to true. If this field is empty,
+	// but UserProjectOverride is set to true, resource project will be used.
+	BillingProject string
+
+	// HTTPClient allows us to specify the HTTP client to use with DCL.
+	// This is particularly useful in mocks/tests.
+	HTTPClient *http.Client
+}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -15,8 +15,6 @@
 package controller
 
 import (
-	"net/http"
-
 	"github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/jitter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
@@ -24,23 +22,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-type Config struct {
-	UserAgent string
-
-	// UserProjectOverride provides the option to use the resource project for preconditions, quota, and billing,
-	// instead of the project the credentials belong to; false by default
-	UserProjectOverride bool
-
-	// BillingProject is the project used by the TF provider and DCL client to determine preconditions,
-	// quota, and billing if UserProjectOverride is set to true. If this field is empty,
-	// but UserProjectOverride is set to true, resource project will be used.
-	BillingProject string
-
-	// HTTPClient allows us to specify the HTTP client to use with DCL.
-	// This is particularly useful in mocks/tests.
-	HTTPClient *http.Client
-}
 
 // Common controller dependencies.
 type Deps struct {

--- a/pkg/controller/direct/alloydb/client.go
+++ b/pkg/controller/direct/alloydb/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	api "google.golang.org/api/alloydb/v1beta"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/alloydb/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 )
 
@@ -38,13 +38,13 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.AlloyDBClusterGVK, NewModel)
 }
 
-func NewModel(config *controller.Config) directbase.Model {
+func NewModel(config *config.ControllerConfig) directbase.Model {
 	return &clusterModel{config: config}
 }
 
 type clusterModel struct {
 	// *gcpClient
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/apikeys/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 
 	. "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/mappings" //nolint:revive
@@ -39,12 +39,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.APIKeysKeyGVK, newAPIKeysModel)
 }
 
-func newAPIKeysModel(config *controller.Config) directbase.Model {
+func newAPIKeysModel(config *config.ControllerConfig) directbase.Model {
 	return &model{config: *config}
 }
 
 type model struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/gkehub/client.go
+++ b/pkg/controller/direct/gkehub/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	featureapi "google.golang.org/api/gkehub/v1beta"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(config *controller.Config) (*gcpClient, error) {
+func newGCPClient(config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/gkehub/featuremembership_controller.go
+++ b/pkg/controller/direct/gkehub/featuremembership_controller.go
@@ -27,7 +27,7 @@ import (
 
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/gkehub/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
 )
@@ -38,12 +38,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.GKEHubFeatureMembershipGVK, GetModel)
 }
 
-func GetModel(config *controller.Config) directbase.Model {
+func GetModel(config *config.ControllerConfig) directbase.Model {
 	return &gkeHubModel{config: config}
 }
 
 type gkeHubModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/logging/client.go
+++ b/pkg/controller/direct/logging/client.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	api "google.golang.org/api/logging/v2"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -28,7 +28,7 @@ import (
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/resources/logging/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/references"
 )
@@ -39,12 +39,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.LoggingLogMetricGVK, NewLogMetricModel)
 }
 
-func NewLogMetricModel(config *controller.Config) directbase.Model {
+func NewLogMetricModel(config *config.ControllerConfig) directbase.Model {
 	return &logMetricModel{config: config}
 }
 
 type logMetricModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/direct/registry.go
+++ b/pkg/controller/direct/registry.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/logging"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,7 +48,7 @@ func SupportsIAM(groupKind schema.GroupKind) (bool, error) {
 // Export attempts to export the resource specified by url.
 // The url format should match the Cloud-Asset-Inventory format: https://cloud.google.com/asset-inventory/docs/resource-name-format
 // If url is not recognized or not implemented by a direct controller, this returns (nil, nil)
-func Export(ctx context.Context, url string, config *controller.Config) (*unstructured.Unstructured, error) {
+func Export(ctx context.Context, url string, config *config.ControllerConfig) (*unstructured.Unstructured, error) {
 	if strings.HasPrefix(url, "//logging.googleapis.com/") {
 		tokens := strings.Split(strings.TrimPrefix(url, "//logging.googleapis.com/"), "/")
 		if len(tokens) == 4 && tokens[0] == "projects" && tokens[2] == "metrics" {

--- a/pkg/controller/direct/resourcemanager/client.go
+++ b/pkg/controller/direct/resourcemanager/client.go
@@ -19,15 +19,15 @@ import (
 	"fmt"
 
 	api "cloud.google.com/go/resourcemanager/apiv3"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config controller.Config
+	config config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *controller.Config) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 )
 
@@ -38,12 +38,12 @@ func init() {
 	directbase.ControllerBuilder.RegisterModel(krm.TagsTagKeyGVK, newTagKeyModel)
 }
 
-func newTagKeyModel(config *controller.Config) directbase.Model {
+func newTagKeyModel(config *config.ControllerConfig) directbase.Model {
 	return &tagKeyModel{config: config}
 }
 
 type tagKeyModel struct {
-	config *controller.Config
+	config *config.ControllerConfig
 }
 
 // model implements the Model interface.

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -21,6 +21,7 @@ import (
 
 	operatorv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -77,8 +78,8 @@ type Config struct {
 //
 // This serves as the entry point for the in-cluster main and the Borg service main. Any changes made should be done
 // with care.
-func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.Manager, error) {
-	opts := config.ManagerOptions
+func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Manager, error) {
+	opts := cfg.ManagerOptions
 	if opts.Scheme == nil {
 		// By default, controller-runtime uses the Kubernetes client-go scheme, this can create concurrency bugs as the
 		// the calls to AddToScheme(..) will modify the internal maps
@@ -100,9 +101,9 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 
 	// Bootstrap the Google Terraform provider
 	tfCfg := tfprovider.NewConfig()
-	tfCfg.UserProjectOverride = config.UserProjectOverride
-	tfCfg.BillingProject = config.BillingProject
-	tfCfg.GCPAccessToken = config.GCPAccessToken
+	tfCfg.UserProjectOverride = cfg.UserProjectOverride
+	tfCfg.BillingProject = cfg.BillingProject
+	tfCfg.GCPAccessToken = cfg.GCPAccessToken
 
 	provider, err := tfprovider.New(ctx, tfCfg)
 	if err != nil {
@@ -121,9 +122,9 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	dclConverter := dclconversion.New(dclSchemaLoader, serviceMetadataLoader)
 
 	dclOptions := clientconfig.Options{}
-	dclOptions.UserProjectOverride = config.UserProjectOverride
-	dclOptions.BillingProject = config.BillingProject
-	dclOptions.HTTPClient = config.HTTPClient
+	dclOptions.UserProjectOverride = cfg.UserProjectOverride
+	dclOptions.BillingProject = cfg.BillingProject
+	dclOptions.HTTPClient = cfg.HTTPClient
 	dclOptions.UserAgent = gcp.KCCUserAgent
 
 	dclConfig, err := clientconfig.New(ctx, dclOptions)
@@ -132,10 +133,10 @@ func New(ctx context.Context, restConfig *rest.Config, config Config) (manager.M
 	}
 
 	stateIntoSpecDefaulter := k8s.NewStateIntoSpecDefaulter(mgr.GetClient())
-	controllerConfig := &controller.Config{
-		UserProjectOverride: config.UserProjectOverride,
-		BillingProject:      config.BillingProject,
-		HTTPClient:          config.HTTPClient,
+	controllerConfig := &config.ControllerConfig{
+		UserProjectOverride: cfg.UserProjectOverride,
+		BillingProject:      cfg.BillingProject,
+		HTTPClient:          cfg.HTTPClient,
 		UserAgent:           gcp.KCCUserAgent,
 	}
 	rd := controller.Deps{

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/deletiondefender"
@@ -174,13 +175,13 @@ func isServiceAccountKeyCRD(crd *apiextensions.CustomResourceDefinition) bool {
 	return crd.Spec.Group == serviceAccountKeyAPIGroup && crd.Spec.Names.Kind == serviceAccountKeyKind
 }
 
-func RegisterDefaultController(config *controller.Config) registrationFunc { //nolint:revive
+func RegisterDefaultController(config *config.ControllerConfig) registrationFunc { //nolint:revive
 	return func(r *ReconcileRegistration, crd *apiextensions.CustomResourceDefinition, gvk schema.GroupVersionKind) (k8s.SchemaReferenceUpdater, error) {
 		return registerDefaultController(r, config, crd, gvk)
 	}
 }
 
-func registerDefaultController(r *ReconcileRegistration, config *controller.Config, crd *apiextensions.CustomResourceDefinition, gvk schema.GroupVersionKind) (k8s.SchemaReferenceUpdater, error) {
+func registerDefaultController(r *ReconcileRegistration, config *config.ControllerConfig, crd *apiextensions.CustomResourceDefinition, gvk schema.GroupVersionKind) (k8s.SchemaReferenceUpdater, error) {
 	if _, ok := k8s.IgnoredKindList[crd.Spec.Names.Kind]; ok {
 		return nil, nil
 	}

--- a/pkg/dcl/clientconfig/config.go
+++ b/pkg/dcl/clientconfig/config.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/logger"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
@@ -37,7 +37,7 @@ import (
 var nonretryable = dcl.Retryability{Retryable: false}
 
 type Options struct {
-	controller.Config
+	config.ControllerConfig
 }
 
 func newConfigAndClient(ctx context.Context, opt Options) (*dcl.Config, *http.Client, error) {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	kcccontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/auditconfig"
@@ -241,7 +241,7 @@ func (r *TestReconciler) newReconcilerForCRD(crd *apiextensions.CustomResourceDe
 		}
 		gv := schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}
 		if directbase.ControllerBuilder.IsDirectByGK(gv) {
-			return directbase.ControllerBuilder.NewReconciler(r.mgr, &kcccontroller.Config{HTTPClient: r.httpClient}, immediateReconcileRequests, resourceWatcherRoutines, crd, jg)
+			return directbase.ControllerBuilder.NewReconciler(r.mgr, &config.ControllerConfig{HTTPClient: r.httpClient}, immediateReconcileRequests, resourceWatcherRoutines, crd, jg)
 		}
 	}
 	return nil, fmt.Errorf("CRD format not recognized")

--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/logging"
@@ -135,11 +135,11 @@ func (rc ResourceContext) Create(ctx context.Context, _ *testing.T, u *unstructu
 	return terraformCreate(ctx, u, provider, c, smLoader)
 }
 
-func (rc ResourceContext) Get(ctx context.Context, _ *testing.T, u *unstructured.Unstructured, provider *tfschema.Provider, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader, config *mmdcl.Config, dclConverter *dclconversion.Converter, httpClient *http.Client) (*unstructured.Unstructured, error) {
+func (rc ResourceContext) Get(ctx context.Context, _ *testing.T, u *unstructured.Unstructured, provider *tfschema.Provider, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader, cfg *mmdcl.Config, dclConverter *dclconversion.Converter, httpClient *http.Client) (*unstructured.Unstructured, error) {
 	// direct controllers
 	switch u.GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
-		m := logging.NewLogMetricModel(&controller.Config{
+		m := logging.NewLogMetricModel(&config.ControllerConfig{
 			HTTPClient: httpClient,
 		})
 		a, err := m.AdapterForObject(ctx, c, u)
@@ -163,16 +163,16 @@ func (rc ResourceContext) Get(ctx context.Context, _ *testing.T, u *unstructured
 	}
 
 	if rc.DCLBased {
-		return dclGet(ctx, u, config, c, dclConverter, smLoader)
+		return dclGet(ctx, u, cfg, c, dclConverter, smLoader)
 	}
 	return terraformGet(ctx, u, provider, c, smLoader)
 }
 
-func (rc ResourceContext) Delete(ctx context.Context, _ *testing.T, u *unstructured.Unstructured, provider *tfschema.Provider, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader, config *mmdcl.Config, dclConverter *dclconversion.Converter, httpClient *http.Client) error {
+func (rc ResourceContext) Delete(ctx context.Context, _ *testing.T, u *unstructured.Unstructured, provider *tfschema.Provider, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader, cfg *mmdcl.Config, dclConverter *dclconversion.Converter, httpClient *http.Client) error {
 	// direct controllers
 	switch u.GroupVersionKind().GroupKind() {
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
-		m := logging.NewLogMetricModel(&controller.Config{
+		m := logging.NewLogMetricModel(&config.ControllerConfig{
 			HTTPClient: httpClient,
 		})
 		a, err := m.AdapterForObject(ctx, c, u)
@@ -196,7 +196,7 @@ func (rc ResourceContext) Delete(ctx context.Context, _ *testing.T, u *unstructu
 		}
 	}
 	if rc.DCLBased {
-		return dclDelete(ctx, u, config, c, dclConverter, smLoader)
+		return dclDelete(ctx, u, cfg, c, dclConverter, smLoader)
 	}
 	return terraformDelete(ctx, u, provider, c, smLoader)
 }


### PR DESCRIPTION
This makes it more reusable, and means we can likely DRY the
calculation of the client.Options
