### PR TITLE
chore: gen-proto requires gen-api

### DIFF
--- a/mockgcp/Makefile
+++ b/mockgcp/Makefile
@@ -1,5 +1,5 @@
 .PHONY: gen-proto
-gen-proto:
+gen-proto: generate-protos-from-openapi
 	mkdir -p bin/
 	GOBIN=`pwd`/bin/ go install \
 		github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.11.3 \


### PR DESCRIPTION
One liner to have `gen-proto` depend on generating from the gapi api. 

I got bit by this when working on `mockcloudids` and forgot to run `gen-proto`.