### PR TITLE
test: Use log instead of error when no TestAcquire tests 

### DIFF
--- a/pkg/test/resourcefixture/test_runner.go
+++ b/pkg/test/resourcefixture/test_runner.go
@@ -39,7 +39,7 @@ func RunTests(ctx context.Context, t *testing.T, shouldRun ShouldRunFunc, testCa
 		filtered = append(filtered, tc)
 	}
 	if len(filtered) == 0 {
-		t.Errorf("No test case were run")
+		t.Logf("No test case were run")
 		return
 	}
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

We don't run TestAcquire on ALL dynamic tests, it's expected that there were no tests to run. That should not be an error and make the TestAcquire test to fail.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
