### PR TITLE
chore: postsubmits should also install jq if missing

### DIFF
--- a/dev/tasks/install-tools
+++ b/dev/tasks/install-tools
@@ -30,3 +30,8 @@ EOF
   ln -sf /usr/local/go/bin/go /usr/bin/go
   rm /tmp/go.tar.gz
 fi
+
+if ! command -v jq; then
+  echo "Must install jq; assuming we are running in a container"
+  apt-get install --yes jq
+fi


### PR DESCRIPTION
We may be running in a container / build environment that does not
have jq.  Try to install it using apt.
