### PR TITLE
chore: enable ids service

### DIFF
--- a/scripts/shared-vars-public.sh
+++ b/scripts/shared-vars-public.sh
@@ -73,6 +73,7 @@ SUPPORTED_SERVICES=(
   iap.googleapis.com
   iam.googleapis.com
   identitytoolkit.googleapis.com
+  ids.googleapis.com
   krmapihosting.googleapis.com
   logging.googleapis.com
   monitoring.googleapis.com


### PR DESCRIPTION
For our post submits to run the `cloudidsendpoint`, we need to enable the `ids.googleapis.com` service.