### PR TITLE
feat: Make the client-side rate limit configurable via flags (Part 1)

### DIFF
--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/ratelimiter"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/clientconfig"
 	dclconversion "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
@@ -96,8 +95,6 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 	// only cache CC and CCC resources
 	nocache.OnlyCacheCCAndCCC(&opts)
 
-	// Set client site rate limiter to optimize the configconnector re-reconciliation performance.
-	ratelimiter.SetMasterRateLimiter(restConfig)
 	mgr, err := manager.New(restConfig, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new manager: %w", err)

--- a/pkg/controller/ratelimiter/ratelimiter.go
+++ b/pkg/controller/ratelimiter/ratelimiter.go
@@ -81,6 +81,6 @@ func RequeueRateLimiter() ratelimiter.RateLimiter {
 //
 // One potential downside of bumping this rate limit is that ConfigConnector could hit GCP service quotes due to the
 // more aggressive GCP requests. For your information, the IAM quota has Read request 6,000 per minute, and Write requests 600 per minute. https://cloud.google.com/iam/quotas
-func SetMasterRateLimiter(restConfig *rest.Config) {
-	restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(80.0, 30)
+func SetMasterRateLimiter(restConfig *rest.Config, qps float32, burst int) {
+	restConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(qps, burst)
 }


### PR DESCRIPTION
We want to allow users to configure the client side rate limit via flags.

follow up PR https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1988