### PR TITLE
Update expander versions.

### DIFF
--- a/experiments/compositions/composition/config/expanders/expander_versions.yaml
+++ b/experiments/compositions/composition/config/expanders/expander_versions.yaml
@@ -25,6 +25,12 @@ spec:
   # current golang semver package only support version comparison
   # in the format of `v{num}.{num}.{num}-{alphabet}`, `v{num}.{num}.{num}` and `{num}.{num}.{num}`.
   # Removing the `.alpha` here for now. Will be added back in the test.
+  - v0.0.115
+  - v0.0.114
+  - v0.0.113
+  - v0.0.112
+  - v0.0.111
+  - v0.0.110
   - v0.0.1
   - v0.0.0
 ---

--- a/experiments/compositions/composition/tests/data/TestSimpleExpansionJob/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpansionJob/input.yaml
@@ -107,6 +107,7 @@ spec:
   expanders:
   - type: jinja2-job
     name: project
+    version: v0.0.1
     template: |
       {% set hostProject = 'compositions-foobar' %}
       {% set managedProject = pconfigs.spec.project %}


### PR DESCRIPTION
Update the expander to use the most recent versions
- reference: https://pantheon.corp.google.com/gcr/images/krmapihosting-release/global/expander-jinja2?inv=1&invt=AbTxWw

Updating the version first to update the composition manifest in CC.
