### PR TITLE
Add validator to return a warning when `state-into-spec` is set to `merge`

### DIFF
--- a/pkg/webhook/register.go
+++ b/pkg/webhook/register.go
@@ -180,6 +180,18 @@ func GetCommonWebhookConfigs() ([]Config, error) {
 			),
 			SideEffects: admissionregistration.SideEffectClassNone,
 		},
+		{
+			Name:          "state-into-spec-validation.cnrm.cloud.google.com",
+			Path:          "/state-into-spec-validation",
+			Type:          Validating,
+			HandlerFunc:   NewRequestLoggingHandler(NewStateIntoSpecAnnotationValidatorHandler(), "state-into-spec validation"),
+			FailurePolicy: admissionregistration.Fail,
+			Rules: getRulesForOperationTypes(allResourcesRules,
+				admissionregistration.Create,
+				admissionregistration.Update,
+			),
+			SideEffects: admissionregistration.SideEffectClassNone,
+		},
 	}
 	return whCfgs, nil
 }

--- a/pkg/webhook/state_into_spec_annotation_validator.go
+++ b/pkg/webhook/state_into_spec_annotation_validator.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type stateIntoSpecAnnotationValidator struct {
+	client client.Client
+}
+
+func NewStateIntoSpecAnnotationValidatorHandler() HandlerFunc {
+	return func(mgr manager.Manager) admission.Handler {
+		return &stateIntoSpecAnnotationValidator{client: mgr.GetClient()}
+	}
+}
+
+func (a *stateIntoSpecAnnotationValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	deserializer := codecs.UniversalDeserializer()
+	obj := &unstructured.Unstructured{}
+	if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err != nil {
+		klog.Error(err)
+		return admission.Errored(http.StatusBadRequest,
+			fmt.Errorf("error decoding object: %w", err))
+	}
+
+	value, ok := k8s.GetAnnotation(k8s.StateIntoSpecAnnotation, obj)
+	if ok && value == k8s.StateMergeIntoSpec {
+		return allowedResponse.WithWarnings(
+			fmt.Sprintf("'%v: %v' is unsupported for CRDs added in "+
+				"1.114.0 and later. Use '%v' instead. More details can be "+
+				"found at https://cloud.google.com/config-connector/docs/concepts/ignore-unspecified-fields.",
+				k8s.StateIntoSpecAnnotation, k8s.StateMergeIntoSpec, k8s.StateAbsentInSpec))
+	}
+	// TODO: Verify if the state-into-spec annotation will be defaulted to 'merge'.
+	return allowedResponse
+}

--- a/pkg/webhook/state_into_spec_annotation_validator.go
+++ b/pkg/webhook/state_into_spec_annotation_validator.go
@@ -32,6 +32,9 @@ type stateIntoSpecAnnotationValidator struct {
 	client client.Client
 }
 
+// NewStateIntoSpecAnnotationValidatorHandler creates an instance of
+// stateIntoSpecAnnotationValidator to handle state-into-spec annotation
+// validation.
 func NewStateIntoSpecAnnotationValidatorHandler() HandlerFunc {
 	return func(mgr manager.Manager) admission.Handler {
 		return &stateIntoSpecAnnotationValidator{client: mgr.GetClient()}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Added a validating webhook that checks whether the `state-into-spec` annotation is explicitly set to `merge` and returns a warning if so.

Further improvement would be validating whether the `state-into-spec` annotation will be defaulted to `merge` for a resource, and/or validating whether `stateIntoSpec` field is set to `Merge` for CC or CCC.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Ran `make docker-build docker-push deploy` to install a locally built version, and verified that the warning is returned when `cnrm.cloud.google.com/state-into-spec: merge` is set:

```
$ kubectl apply -f pubsubtopic-merge.yaml 
Warning: 'cnrm.cloud.google.com/state-into-spec: merge' is unsupported for CRDs added in 1.114.0 and later. Use 'absent' instead. More details can be found at https://cloud.google.com/config-connector/docs/concepts/ignore-unspecified-fields.
pubsubtopic.pubsub.cnrm.cloud.google.com/pubsubtopic-sample-2 created
```