### PR TITLE
Add explanation for state-into-spec in LoggingLogMetric reference doc

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbinstance.md
@@ -7,7 +7,8 @@
 
 
 
-Note: Secondary instances should only be created once the associated primary instance is ready and up to date
+Note: Secondary instances should only be created once the associated primary
+instance is ready and up to date.
 
 <table>
 <thead>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
@@ -7,6 +7,14 @@
 
 
 
+Caution: After
+[v1.118.1](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.118.1),
+`cnrm.cloud.google.com/state-into-spec` annotation is ignored during
+LoggingLogMetric reconciliation, and [externally-managed
+fields](https://cloud.google.com/config-connector/docs/concepts/managing-fields-externally)
+in the existing LoggingLogMetric resources are considered managed, i.e.
+Kubernetes _is_ the source of truth for these values.
+
 <table>
 <thead>
 <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
@@ -9,7 +9,7 @@
 
 Caution: After
 [v1.118.1](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.118.1),
-`cnrm.cloud.google.com/state-into-spec` annotation is ignored during
+`cnrm.cloud.google.com/state-into-spec` annotation is no longer used during
 LoggingLogMetric reconciliation, and [externally-managed
 fields](https://cloud.google.com/config-connector/docs/concepts/managing-fields-externally)
 in the existing LoggingLogMetric resources are considered managed, i.e.

--- a/scripts/generate-google3-docs/resource-reference/templates/alloydb_alloydbinstance.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/alloydb_alloydbinstance.tmpl
@@ -6,7 +6,8 @@
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
 
-Note: Secondary instances should only be created once the associated primary instance is ready and up to date
+Note: Secondary instances should only be created once the associated primary
+instance is ready and up to date.
 
 <table>
 <thead>

--- a/scripts/generate-google3-docs/resource-reference/templates/logging_logginglogmetric.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/logging_logginglogmetric.tmpl
@@ -8,7 +8,7 @@
 
 Caution: After
 [v1.118.1](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.118.1),
-`cnrm.cloud.google.com/state-into-spec` annotation is ignored during
+`cnrm.cloud.google.com/state-into-spec` annotation is no longer used during
 LoggingLogMetric reconciliation, and [externally-managed
 fields](https://cloud.google.com/config-connector/docs/concepts/managing-fields-externally)
 in the existing LoggingLogMetric resources are considered managed, i.e.

--- a/scripts/generate-google3-docs/resource-reference/templates/logging_logginglogmetric.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/logging_logginglogmetric.tmpl
@@ -6,6 +6,14 @@
 {% block body %}
 {{template "alphadisclaimer.tmpl" .}}
 
+Caution: After
+[v1.118.1](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.118.1),
+`cnrm.cloud.google.com/state-into-spec` annotation is ignored during
+LoggingLogMetric reconciliation, and [externally-managed
+fields](https://cloud.google.com/config-connector/docs/concepts/managing-fields-externally)
+in the existing LoggingLogMetric resources are considered managed, i.e.
+Kubernetes _is_ the source of truth for these values.
+
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Added warning to the reference doc as the behavior for the `state-into-spec` annotation is changed after LoggingLogMetric uses the direct controller.

Also did a small clean up for the note in AlloyDBInstance.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
