### PR TITLE
Compositions: Replace boolean for ResourceStatus.isHealthy with string enum.

### DIFF
--- a/experiments/compositions/composition/api/v1alpha1/plan_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/plan_types.go
@@ -34,14 +34,21 @@ type PlanSpec struct {
 	Stages map[string]Stage `json:"stages,omitempty"`
 }
 
+type HealthType string
+
+const (
+	HEALTHY   HealthType = "Healthy"
+	UNHEALTHY            = "Unhealthy"
+)
+
 type ResourceStatus struct {
-	Group     string `json:"group,omitempty"`
-	Version   string `json:"version,omitempty"`
-	Kind      string `json:"kind"`
-	Namespace string `json:"namespace,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Status    string `json:"status,omitempty"`
-	IsHealthy bool   `json:"isHealthy"`
+	Group     string     `json:"group,omitempty"`
+	Version   string     `json:"version,omitempty"`
+	Kind      string     `json:"kind"`
+	Namespace string     `json:"namespace,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Status    string     `json:"status,omitempty"`
+	Health    HealthType `json:"health"`
 }
 
 // StageStatus captures the status of a stage

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_plans.yaml
@@ -155,8 +155,8 @@ spec:
                   properties:
                     group:
                       type: string
-                    isHealthy:
-                      type: boolean
+                    health:
+                      type: string
                     kind:
                       type: string
                     name:
@@ -168,7 +168,7 @@ spec:
                     version:
                       type: string
                   required:
-                  - isHealthy
+                  - health
                   - kind
                   type: object
                 type: array
@@ -183,8 +183,8 @@ spec:
                         properties:
                           group:
                             type: string
-                          isHealthy:
-                            type: boolean
+                          health:
+                            type: string
                           kind:
                             type: string
                           name:
@@ -196,7 +196,7 @@ spec:
                           version:
                             type: string
                         required:
-                        - isHealthy
+                        - health
                         - kind
                         type: object
                       type: array

--- a/experiments/compositions/composition/pkg/applier/applier.go
+++ b/experiments/compositions/composition/pkg/applier/applier.go
@@ -82,7 +82,7 @@ func (a *Applier) UpdatePruneStatus(status *compositionv1alpha1.PlanStatus) {
 			Namespace: resultObj.NameNamespace.Namespace,
 			Name:      resultObj.NameNamespace.Name,
 			Status:    "Pruned",
-			IsHealthy: true, // Is it ?
+			Health:    compositionv1alpha1.HEALTHY, // Is it ?
 		}
 		if resultObj.Error != nil {
 			rs.Status = fmt.Sprintf("Prune Error: %s", resultObj.Error)
@@ -114,7 +114,7 @@ func (a *Applier) UpdateStageStatus(status *compositionv1alpha1.PlanStatus) {
 				Namespace: resultObj.NameNamespace.Namespace,
 				Name:      resultObj.NameNamespace.Name,
 				Status:    "",
-				IsHealthy: false,
+				Health:    compositionv1alpha1.UNHEALTHY,
 			}
 			if resultObj.IsPruned {
 				rs.Status = "Unexpected Prune"
@@ -125,7 +125,9 @@ func (a *Applier) UpdateStageStatus(status *compositionv1alpha1.PlanStatus) {
 					applyCount++
 					rs.Status = resultObj.Message
 				}
-				rs.IsHealthy = resultObj.IsHealthy
+				if resultObj.IsHealthy {
+					rs.Health = compositionv1alpha1.HEALTHY
+				}
 			}
 			if status.Stages[a.stageName] == nil {
 				status.Stages[a.stageName] = &compositionv1alpha1.StageStatus{


### PR DESCRIPTION
### Change description

Replace boolean for ResourceStatus.isHealthy with string enum per request on PR #2017. The currently supported values are "Healthy" and "Unhealthy".

### Tests you have done

Deployed to a KIND cluster and applied a test composition (`experiments/compositions/composition/tests/data/TestSimpleDeleteFacade/input.yaml`). Described the composition to see the status:
```
Status:
  Composition Generation:  1
  Composition UID:         f8fa482a-4e35-48b1-b28d-934a5bb7f489
  Conditions:
    Last Transition Time:  2024-06-17T17:51:42Z
    Message:               Evaluated and Applied stages: project
    Reason:                ProcessedAllStages
    Status:                True
    Type:                  Ready
  Generation:              2
  Input Generation:        1
  Stages:
    Project:
      Applied Count:  1
      Last Applied:
        Health:        Healthy
        Kind:          ConfigMap
        Name:          proj-a
        Namespace:     team-a
        Status:        Resource is always ready
        Version:       v1
      Resource Count:  1
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
