### PR TITLE
fix: guard against nil model

### DIFF
--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -57,6 +57,10 @@ func AddController(mgr manager.Manager, gvk schema.GroupVersionKind, model Model
 	immediateReconcileRequests := make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize)
 	resourceWatcherRoutines := semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines)
 
+	if model == nil {
+		return fmt.Errorf("model is nil for gvk %s", gvk)
+	}
+
 	reconciler, err := NewReconciler(mgr, immediateReconcileRequests, resourceWatcherRoutines, gvk, model, deps.JitterGenerator)
 	if err != nil {
 		return err

--- a/pkg/controller/direct/registry/registry.go
+++ b/pkg/controller/direct/registry/registry.go
@@ -39,7 +39,7 @@ type ModelFactoryFunc func(ctx context.Context, config *config.ControllerConfig)
 
 func GetModel(gk schema.GroupKind) (directbase.Model, error) {
 	registration := singleton.registrations[gk]
-	if registration == nil {
+	if registration == nil || registration.model == nil {
 		return nil, fmt.Errorf("no model registered for %s", gk)
 	}
 	return registration.model, nil

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
@@ -95,6 +96,14 @@ func NewTestReconciler(t *testing.T, mgr manager.Manager, provider *tfschema.Pro
 	}
 	serviceMetaLoader := metadata.New()
 	dclConverter := conversion.New(dclSchemaLoader, serviceMetaLoader)
+
+	// Initialize direct controllers
+	if err := registry.Init(context.TODO(), &config.ControllerConfig{
+		HTTPClient: httpClient,
+	}); err != nil {
+		log.Fatalf("error intializing direct registry: %v", err)
+	}
+
 	return &TestReconciler{
 		mgr:          mgr,
 		t:            t,


### PR DESCRIPTION
The `model`s for the dynamic controller presubmits are nil bc we never `Init` the registry. This also proved to me that we probably want to error out in `AddController` if `model` is nil for a `gvk`. Finally, if the `registration` for a `gk` contains a `nil` model, we probably want to err out to signal to consumers that `Init` was not called.