### PR TITLE
chore: normalize status.observedState.etag in golden tests

### DIFF
--- a/mockgcp/mockcloudbuild/workerpool.go
+++ b/mockgcp/mockcloudbuild/workerpool.go
@@ -78,7 +78,7 @@ func (s *CloudBuildV1) CreateWorkerPool(ctx context.Context, req *pb.CreateWorke
 		result.CreateTime = now
 		result.UpdateTime = now
 		result.State = pb.WorkerPool_RUNNING
-		result.Etag = fields.ComputeEtag(result)
+		result.Etag = fields.ComputeWeakEtag(result)
 		return result, nil
 	})
 }
@@ -124,7 +124,7 @@ func (s *CloudBuildV1) UpdateWorkerPool(ctx context.Context, req *pb.UpdateWorke
 		result := proto.Clone(obj).(*pb.WorkerPool)
 		result.UpdateTime = now
 		result.State = pb.WorkerPool_RUNNING
-		result.Etag = fields.ComputeEtag(result)
+		result.Etag = fields.ComputeWeakEtag(result)
 		return result, nil
 	})
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1alpha1/cloudbuildworkerpool/_generated_object_cloudbuildworkerpool.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1alpha1/cloudbuildworkerpool/_generated_object_cloudbuildworkerpool.golden.yaml
@@ -34,7 +34,7 @@ status:
   observedGeneration: 2
   observedState:
     createTime: "1970-01-01T00:00:00Z"
-    etag: W/"pwzCjvRptOAz64ZilGUmgNZjYVh0LzD3Oh+zEbMPULw="
+    etag: abcdef123456
     networkConfig:
       egressOption: NO_PUBLIC_EGRESS
       peeredNetwork: projects/${projectId}/global/networks/computenetwork-${uniqueId}

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -59,6 +59,7 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	visitor.replacePaths[".status.updateTime"] = "1970-01-01T00:00:00Z"
 	visitor.replacePaths[".status.lastModifiedTime"] = "1970-01-01T00:00:00Z"
 	visitor.replacePaths[".status.etag"] = "abcdef123456"
+	visitor.replacePaths[".status.observedState.etag"] = "abcdef123456"
 
 	// Specific to AlloyDB
 	visitor.replacePaths[".status.continuousBackupInfo[].enabledTime"] = "1970-01-01T00:00:00Z"


### PR DESCRIPTION
Also simplify etag computation, as we don't rely on the value itself
any more.
