### PR TITLE
fix: Trigger updates for mysqlinstance + sqlserverinstance mockgcp tests

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/_generated_object_mysqlinstance.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/_generated_object_mysqlinstance.golden.yaml
@@ -10,11 +10,10 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 2
+  generation: 3
   labels:
     cnrm-test: "true"
     label-one: value-one
-    newkey: newval
   name: sqlinstance-sample-${uniqueId}
   namespace: ${uniqueId}
 spec:
@@ -33,9 +32,9 @@ spec:
       startTime: "21:00"
       transactionLogRetentionDays: 7
     connectorEnforcement: NOT_REQUIRED
-    diskAutoresize: true
+    diskAutoresize: false
     diskAutoresizeLimit: 0
-    diskSize: 10
+    diskSize: 20
     diskType: PD_SSD
     edition: ENTERPRISE
     ipConfiguration:
@@ -55,7 +54,7 @@ status:
   firstIpAddress: 10.10.10.10
   instanceType: CLOUD_SQL_INSTANCE
   ipAddress: 10.1.2.3
-  observedGeneration: 2
+  observedGeneration: 3
   publicIpAddress: 10.10.10.10
   selfLink: https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}
   serverCaCert:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/_http.log
@@ -24,10 +24,11 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
   "settings": {
     "activationPolicy": "ALWAYS",
     "availabilityType": "ZONAL",
+    "dataDiskSizeGb": "10",
     "dataDiskType": "PD_SSD",
     "edition": "ENTERPRISE",
     "pricingPlan": "PER_USE",
-    "storageAutoResize": true,
+    "storageAutoResize": false,
     "tier": "db-n1-standard-1",
     "userLabels": {
       "cnrm-test": "true",
@@ -238,7 +239,204 @@ Grpc-Metadata-Content-Type: application/grpc
     "replicationType": "SYNCHRONOUS",
     "settingsVersion": "1",
     "sqlServerAuditConfig": null,
-    "storageAutoResize": true,
+    "storageAutoResize": false,
+    "storageAutoResizeLimit": "0",
+    "tier": "db-n1-standard-1",
+    "timeZone": "",
+    "userLabels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    }
+  },
+  "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
+  "state": "RUNNABLE",
+  "suspensionReason": []
+}
+
+---
+
+PUT https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "availabilityType": "ZONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 7,
+        "retentionUnit": "COUNT"
+      },
+      "binaryLogEnabled": false,
+      "enabled": false,
+      "pointInTimeRecoveryEnabled": false,
+      "startTime": "21:00",
+      "transactionLogRetentionDays": 7
+    },
+    "connectorEnforcement": "NOT_REQUIRED",
+    "dataDiskSizeGb": "20",
+    "dataDiskType": "PD_SSD",
+    "edition": "ENTERPRISE",
+    "ipConfiguration": {
+      "enablePrivatePathForGoogleCloudServices": false,
+      "ipv4Enabled": true,
+      "requireSsl": false
+    },
+    "locationPreference": {
+      "zone": "us-central1-c"
+    },
+    "pricingPlan": "PER_USE",
+    "settingsVersion": "1",
+    "storageAutoResize": false,
+    "tier": "db-n1-standard-1",
+    "userLabels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "apiWarning": null,
+  "backupContext": null,
+  "endTime": null,
+  "error": null,
+  "exportContext": null,
+  "importContext": null,
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "UPDATE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "PENDING",
+  "targetId": "sqlinstance-sample-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "availableMaintenanceVersions": [],
+  "backendType": "SECOND_GEN",
+  "connectionName": "${projectId}:us-central1:sqlinstance-sample-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentDiskSize": null,
+  "databaseInstalledVersion": "MYSQL_5_7_44",
+  "databaseVersion": "MYSQL_5_7",
+  "diskEncryptionConfiguration": null,
+  "diskEncryptionStatus": null,
+  "etag": "abcdef0123A=",
+  "failoverReplica": null,
+  "gceZone": "us-central1-c",
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "ipAddresses": [
+    {
+      "ipAddress": "10.10.10.10",
+      "timeToRetire": null,
+      "type": "PRIMARY"
+    }
+  ],
+  "ipv6Address": "",
+  "kind": "sql#instance",
+  "maintenanceVersion": "MYSQL_5_7_44.R20231105.01_03",
+  "masterInstanceName": "",
+  "maxDiskSize": null,
+  "name": "sqlinstance-sample-${uniqueId}",
+  "onPremisesConfiguration": null,
+  "project": "${projectId}",
+  "region": "us-central1",
+  "replicaConfiguration": null,
+  "replicaNames": [],
+  "rootPassword": "",
+  "satisfiesPzs": null,
+  "scheduledMaintenance": null,
+  "secondaryGceZone": "",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}",
+  "serverCaCert": {
+    "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+    "certSerialNumber": "0",
+    "commonName": "common-name",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "expirationTime": "2024-04-01T12:34:56.123456Z",
+    "instance": "sqlinstance-sample-${uniqueId}",
+    "kind": "sql#sslCert",
+    "selfLink": "",
+    "sha1Fingerprint": "12345678"
+  },
+  "serviceAccountEmailAddress": "p${projectNumber}-abcdef@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "activeDirectoryConfig": null,
+    "advancedMachineFeatures": null,
+    "authorizedGaeApplications": [],
+    "availabilityType": "ZONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 7,
+        "retentionUnit": "COUNT"
+      },
+      "binaryLogEnabled": false,
+      "enabled": false,
+      "kind": "sql#backupConfiguration",
+      "location": "",
+      "pointInTimeRecoveryEnabled": false,
+      "replicationLogArchivingEnabled": null,
+      "startTime": "21:00",
+      "transactionLogRetentionDays": 7
+    },
+    "collation": "",
+    "connectorEnforcement": "NOT_REQUIRED",
+    "crashSafeReplicationEnabled": null,
+    "dataCacheConfig": null,
+    "dataDiskSizeGb": "20",
+    "dataDiskType": "PD_SSD",
+    "databaseFlags": [],
+    "databaseReplicationEnabled": null,
+    "deletionProtectionEnabled": false,
+    "denyMaintenancePeriods": [],
+    "edition": "ENTERPRISE",
+    "insightsConfig": null,
+    "ipConfiguration": {
+      "allocatedIpRange": "",
+      "authorizedNetworks": [],
+      "enablePrivatePathForGoogleCloudServices": false,
+      "ipv4Enabled": true,
+      "privateNetwork": "",
+      "requireSsl": false,
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+    },
+    "kind": "sql#settings",
+    "locationPreference": {
+      "followGaeApplication": "",
+      "kind": "sql#locationPreference",
+      "secondaryZone": "",
+      "zone": "us-central1-c"
+    },
+    "maintenanceWindow": null,
+    "passwordValidationPolicy": null,
+    "pricingPlan": "PER_USE",
+    "replicationType": "SYNCHRONOUS",
+    "settingsVersion": "2",
+    "sqlServerAuditConfig": null,
+    "storageAutoResize": false,
     "storageAutoResizeLimit": "0",
     "tier": "db-n1-standard-1",
     "timeZone": "",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/create.yaml
@@ -23,4 +23,6 @@ spec:
   databaseVersion: MYSQL_5_7
   instanceType: CLOUD_SQL_INSTANCE
   settings:
+    diskAutoresize: false
+    diskSize: 10
     tier: db-n1-standard-1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/mysqlinstance/update.yaml
@@ -17,12 +17,12 @@ kind: SQLInstance
 metadata:
   labels:
     label-one: "value-one"
-    newkey: "newval"
   name: sqlinstance-sample-${uniqueId}
 spec:
   region: us-central1
   databaseVersion: MYSQL_5_7
   instanceType: CLOUD_SQL_INSTANCE
   settings:
+    diskAutoresize: false
+    diskSize: 20
     tier: db-n1-standard-1
-    edition: ENTERPRISE

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_generated_object_sqlserverinstance.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_generated_object_sqlserverinstance.golden.yaml
@@ -10,11 +10,10 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 2
+  generation: 3
   labels:
     cnrm-test: "true"
     label-one: value-one
-    newkey: newval
   name: sqlinstance-sample-${uniqueId}
   namespace: ${uniqueId}
 spec:
@@ -35,9 +34,9 @@ spec:
       startTime: "21:00"
       transactionLogRetentionDays: 7
     connectorEnforcement: NOT_REQUIRED
-    diskAutoresize: true
+    diskAutoresize: false
     diskAutoresizeLimit: 0
-    diskSize: 10
+    diskSize: 20
     diskType: PD_SSD
     edition: ENTERPRISE
     ipConfiguration:
@@ -60,7 +59,7 @@ status:
   firstIpAddress: 10.10.10.10
   instanceType: SQL_INSTANCE_TYPE_UNSPECIFIED
   ipAddress: 10.1.2.3
-  observedGeneration: 2
+  observedGeneration: 3
   publicIpAddress: 10.10.10.10
   selfLink: https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}
   serverCaCert:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_http.log
@@ -165,13 +165,14 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
   "settings": {
     "activationPolicy": "ALWAYS",
     "availabilityType": "ZONAL",
+    "dataDiskSizeGb": "10",
     "dataDiskType": "PD_SSD",
     "edition": "ENTERPRISE",
     "pricingPlan": "PER_USE",
     "sqlServerAuditConfig": {
       "bucket": "gs://storagebucket-${uniqueId}"
     },
-    "storageAutoResize": true,
+    "storageAutoResize": false,
     "tier": "db-custom-1-3840",
     "userLabels": {
       "cnrm-test": "true",
@@ -412,7 +413,211 @@ Grpc-Metadata-Content-Type: application/grpc
       "retentionInterval": null,
       "uploadInterval": null
     },
-    "storageAutoResize": true,
+    "storageAutoResize": false,
+    "storageAutoResizeLimit": "0",
+    "tier": "db-custom-1-3840",
+    "timeZone": "",
+    "userLabels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    }
+  },
+  "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
+  "state": "RUNNABLE",
+  "suspensionReason": []
+}
+
+---
+
+PUT https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "instanceType": "SQL_INSTANCE_TYPE_UNSPECIFIED",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "availabilityType": "ZONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 7,
+        "retentionUnit": "COUNT"
+      },
+      "binaryLogEnabled": false,
+      "enabled": false,
+      "pointInTimeRecoveryEnabled": false,
+      "startTime": "21:00",
+      "transactionLogRetentionDays": 7
+    },
+    "connectorEnforcement": "NOT_REQUIRED",
+    "dataDiskSizeGb": "20",
+    "dataDiskType": "PD_SSD",
+    "edition": "ENTERPRISE",
+    "ipConfiguration": {
+      "ipv4Enabled": true,
+      "requireSsl": false
+    },
+    "locationPreference": {
+      "zone": "us-central1-c"
+    },
+    "pricingPlan": "PER_USE",
+    "settingsVersion": "1",
+    "sqlServerAuditConfig": {
+      "bucket": "gs://storagebucket-${uniqueId}"
+    },
+    "storageAutoResize": false,
+    "tier": "db-custom-1-3840",
+    "userLabels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "apiWarning": null,
+  "backupContext": null,
+  "endTime": null,
+  "error": null,
+  "exportContext": null,
+  "importContext": null,
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "UPDATE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "PENDING",
+  "targetId": "sqlinstance-sample-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "availableMaintenanceVersions": [],
+  "backendType": "SECOND_GEN",
+  "connectionName": "${projectId}:us-central1:sqlinstance-sample-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentDiskSize": null,
+  "databaseInstalledVersion": "SQLSERVER_2017_EXPRESS_CU31_GDR",
+  "databaseVersion": "SQLSERVER_2017_EXPRESS",
+  "diskEncryptionConfiguration": null,
+  "diskEncryptionStatus": null,
+  "etag": "abcdef0123A=",
+  "failoverReplica": null,
+  "gceZone": "us-central1-c",
+  "instanceType": "SQL_INSTANCE_TYPE_UNSPECIFIED",
+  "ipAddresses": [
+    {
+      "ipAddress": "10.10.10.10",
+      "timeToRetire": null,
+      "type": "PRIMARY"
+    }
+  ],
+  "ipv6Address": "",
+  "kind": "sql#instance",
+  "maintenanceVersion": "SQLSERVER_2017_EXPRESS_CU31_GDR.R20231029.00_02",
+  "masterInstanceName": "",
+  "maxDiskSize": null,
+  "name": "sqlinstance-sample-${uniqueId}",
+  "onPremisesConfiguration": null,
+  "project": "${projectId}",
+  "region": "us-central1",
+  "replicaConfiguration": null,
+  "replicaNames": [],
+  "rootPassword": "",
+  "satisfiesPzs": null,
+  "scheduledMaintenance": null,
+  "secondaryGceZone": "",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}",
+  "serverCaCert": {
+    "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+    "certSerialNumber": "0",
+    "commonName": "common-name",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "expirationTime": "2024-04-01T12:34:56.123456Z",
+    "instance": "sqlinstance-sample-${uniqueId}",
+    "kind": "sql#sslCert",
+    "selfLink": "",
+    "sha1Fingerprint": "12345678"
+  },
+  "serviceAccountEmailAddress": "p${projectNumber}-abcdef@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "activeDirectoryConfig": null,
+    "advancedMachineFeatures": null,
+    "authorizedGaeApplications": [],
+    "availabilityType": "ZONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 7,
+        "retentionUnit": "COUNT"
+      },
+      "binaryLogEnabled": false,
+      "enabled": false,
+      "kind": "sql#backupConfiguration",
+      "location": "",
+      "pointInTimeRecoveryEnabled": false,
+      "replicationLogArchivingEnabled": null,
+      "startTime": "21:00",
+      "transactionLogRetentionDays": 7
+    },
+    "collation": "",
+    "connectorEnforcement": "NOT_REQUIRED",
+    "crashSafeReplicationEnabled": null,
+    "dataCacheConfig": null,
+    "dataDiskSizeGb": "20",
+    "dataDiskType": "PD_SSD",
+    "databaseFlags": [],
+    "databaseReplicationEnabled": null,
+    "deletionProtectionEnabled": false,
+    "denyMaintenancePeriods": [],
+    "edition": "ENTERPRISE",
+    "insightsConfig": null,
+    "ipConfiguration": {
+      "allocatedIpRange": "",
+      "authorizedNetworks": [],
+      "enablePrivatePathForGoogleCloudServices": null,
+      "ipv4Enabled": true,
+      "privateNetwork": "",
+      "requireSsl": false,
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+    },
+    "kind": "sql#settings",
+    "locationPreference": {
+      "followGaeApplication": "",
+      "kind": "sql#locationPreference",
+      "secondaryZone": "",
+      "zone": "us-central1-c"
+    },
+    "maintenanceWindow": null,
+    "passwordValidationPolicy": null,
+    "pricingPlan": "PER_USE",
+    "replicationType": "SYNCHRONOUS",
+    "settingsVersion": "2",
+    "sqlServerAuditConfig": {
+      "bucket": "gs://storagebucket-${uniqueId}",
+      "kind": "",
+      "retentionInterval": null,
+      "uploadInterval": null
+    },
+    "storageAutoResize": false,
     "storageAutoResizeLimit": "0",
     "tier": "db-custom-1-3840",
     "timeZone": "",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/create.yaml
@@ -22,6 +22,8 @@ spec:
   region: us-central1
   databaseVersion: SQLSERVER_2017_EXPRESS
   settings:
+    diskAutoresize: false
+    diskSize: 10
     tier: db-custom-1-3840
     sqlServerAuditConfig:
       bucketRef:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/update.yaml
@@ -17,12 +17,13 @@ kind: SQLInstance
 metadata:
   labels:
     label-one: "value-one"
-    newkey: "newval"
   name: sqlinstance-sample-${uniqueId}
 spec:
   region: us-central1
   databaseVersion: SQLSERVER_2017_EXPRESS
   settings:
+    diskAutoresize: false
+    diskSize: 20
     tier: db-custom-1-3840
     sqlServerAuditConfig:
       bucketRef:


### PR DESCRIPTION
### Change description

Seems that the existing `metadata.labels` changes do not incur updates to the resources. So that we exercise the mockgcp update path, made some changes to `spec.settings.diskSize` for these resources.