### PR TITLE
proto-to-mapper: log missing objects at V(2)

### DIFF
--- a/dev/tools/proto-to-mapper/main.go
+++ b/dev/tools/proto-to-mapper/main.go
@@ -208,7 +208,7 @@ func (v *visitor) findKRMStructsForProto(msg protoreflect.MessageDescriptor) map
 		}
 	}
 	if len(matches) == 0 {
-		klog.Infof("did not find mapping for %q", msg.FullName())
+		klog.V(2).Infof("did not find mapping for %q", msg.FullName())
 	}
 	return matches
 }
@@ -635,7 +635,7 @@ func (v *visitor) visitMessage(msg protoreflect.MessageDescriptor) {
 	goTypes := v.findKRMStructsForProto(msg)
 
 	if len(goTypes) == 0 {
-		klog.Infof("no krm for %v", msg.FullName())
+		klog.V(2).Infof("no krm for %v", msg.FullName())
 		return
 	}
 	for _, goType := range goTypes {


### PR DESCRIPTION
These are not unexpected now we're processing (almost) all GCP APIs;
we don't expect go types for the whole API (yet).

Logging hides any important messages and also slows down the process.
