### PR TITLE
fix: replace mockgcp dynamic resourceID to id marker

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringnotificationchannel/_generated_object_monitoringnotificationchannel.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringnotificationchannel/_generated_object_monitoringnotificationchannel.golden.yaml
@@ -26,7 +26,7 @@ spec:
   labels:
     url: http://hooks.example.com/notification
     username: user
-  resourceID: "1718837116591979324"
+  resourceID: ${notificationChannelID}
   sensitiveLabels:
     password:
       valueFrom:
@@ -41,5 +41,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  name: projects/${projectId}/notificationChannels/1718837116591979324
+  name: projects/${projectId}/notificationChannels/${notificationChannelID}
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/vertexai/v1alpha1/vertexaitensorboard/_generated_object_vertexaitensorboard.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vertexai/v1alpha1/vertexaitensorboard/_generated_object_vertexaitensorboard.golden.yaml
@@ -18,7 +18,7 @@ spec:
   projectRef:
     external: ${projectId}
   region: us-central1
-  resourceID: projects/${projectNumber}/locations/us-central1/tensorboards/1718837895702041590
+  resourceID: projects/${projectNumber}/locations/us-central1/tensorboards/${tensorboardId}
 status:
   blobStoragePathPrefix: cloud-ai-platform-4c7152f6-07a9-47d6-8f51-4299e2fdff92
   conditions:
@@ -28,6 +28,6 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  name: projects/${projectNumber}/locations/us-central1/tensorboards/1718837895702041590
+  name: projects/${projectNumber}/locations/us-central1/tensorboards/${tensorboardId}
   observedGeneration: 3
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -128,6 +128,16 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 					return strings.ReplaceAll(s, id, "${alertPolicyId}")
 				})
 			}
+			if typeName == "tensorboards" {
+				visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+					return strings.ReplaceAll(s, id, "${tensorboardId}")
+				})
+			}
+			if typeName == "notificationChannels" {
+				visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+					return strings.ReplaceAll(s, id, "${notificationChannelID}")
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.