### PR TITLE
fix: add TODO to the mockgcp TagKey resourceID

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyorgbasic/_generated_object_tagkeyorgbasic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyorgbasic/_generated_object_tagkeyorgbasic.golden.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   description: For keyname resources.
   parent: organizations/123450001
-  resourceID: "1718837800003546533"
+  resourceID: ${uniqueId}
   shortName: keyname${uniqueId}
 status:
   conditions:
@@ -25,7 +25,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  name: "1718837800003546533"
+  name: ${uniqueId}
   namespacedName: 123450001/keyname${uniqueId}
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyprojectbasic/_generated_object_tagkeyprojectbasic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyprojectbasic/_generated_object_tagkeyprojectbasic.golden.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   description: For keyname resources.
   parent: projects/${projectId}
-  resourceID: "1718837823777494893"
+  resourceID: ${uniqueId}
   shortName: keyname${uniqueId}
 status:
   conditions:
@@ -25,7 +25,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  name: "1718837823777494893"
+  name: ${uniqueId}
   namespacedName: ${projectId}/keyname${uniqueId}
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_generated_object_tagvaluebasic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvaluebasic/_generated_object_tagvaluebasic.golden.yaml
@@ -16,7 +16,7 @@ spec:
   description: For valuename resources.
   parentRef:
     name: tagstagkey-${uniqueId}
-  resourceID: "1718837846427802079"
+  resourceID: ${uniqueId}
   shortName: valuename
 status:
   conditions:
@@ -26,6 +26,6 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  name: "1718837846427802079"
+  name: ${uniqueId}
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_generated_object_tagvalueproject.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueproject/_generated_object_tagvalueproject.golden.yaml
@@ -16,7 +16,7 @@ spec:
   description: For valuename resources.
   parentRef:
     name: tagstagkey-${uniqueId}
-  resourceID: "1718837870725566645"
+  resourceID: ${uniqueId}
   shortName: valuename
 status:
   conditions:
@@ -26,7 +26,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  name: "1718837870725566645"
+  name: ${uniqueId}
   namespacedName: ${projectId}/keyname${uniqueId}/valuename
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -115,6 +115,16 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 			name, _, _ = unstructured.NestedString(u.Object, "status", "name")
 		}
 		tokens := strings.Split(name, "/")
+		if len(tokens) == 1 {
+			switch u.GetKind() {
+			case "TagsTagKey", "TagsTagValue":
+				// TODO: The mock TagKey server returns the correct format `tagKeys/{number}`, but the golden object `status.name`
+				// only has {number}. Need to triage the tf/dcl controller.
+				visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+					return strings.ReplaceAll(s, name, "${uniqueId}")
+				})
+			}
+		}
 		if len(tokens) > 2 {
 			typeName := tokens[len(tokens)-2]
 			id := tokens[len(tokens)-1]


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.