### PR TITLE
fix: sort mockgcp string slice fields

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containernodepool/_generated_object_containernodepool.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containernodepool/_generated_object_containernodepool.golden.yaml
@@ -35,12 +35,12 @@ spec:
     metadata:
       disable-legacy-endpoints: "true"
     oauthScopes:
+    - https://www.googleapis.com/auth/devstorage.read_only
+    - https://www.googleapis.com/auth/logging.write
     - https://www.googleapis.com/auth/monitoring
     - https://www.googleapis.com/auth/service.management.readonly
     - https://www.googleapis.com/auth/servicecontrol
     - https://www.googleapis.com/auth/trace.append
-    - https://www.googleapis.com/auth/devstorage.read_only
-    - https://www.googleapis.com/auth/logging.write
     serviceAccountRef:
       external: default
     shieldedInstanceConfig:

--- a/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_generated_object_removedefaultnodepool.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_generated_object_removedefaultnodepool.golden.yaml
@@ -53,12 +53,12 @@ spec:
   nodeConfig:
     loggingVariant: DEFAULT
     oauthScopes:
-    - https://www.googleapis.com/auth/trace.append
     - https://www.googleapis.com/auth/devstorage.read_only
     - https://www.googleapis.com/auth/logging.write
     - https://www.googleapis.com/auth/monitoring
     - https://www.googleapis.com/auth/service.management.readonly
     - https://www.googleapis.com/auth/servicecontrol
+    - https://www.googleapis.com/auth/trace.append
   nodeLocations:
   - us-central1-a
   nodeVersion: ""

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -91,6 +91,7 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	visitor.sortSlices = sets.New[string]()
 	// TODO: This should not be needed, we want to avoid churning the kube objects
 	visitor.sortSlices.Insert(".spec.access")
+	visitor.sortSlices.Insert(".spec.nodeConfig.oauthScopes")
 
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, project.ProjectID, "${projectId}")


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.