### PR TITLE
fix: replace mockresourcemanager generated Project number

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
@@ -25,5 +25,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "2727742225"
+  number: "518915279"
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
@@ -25,5 +25,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "518915279"
+  number: ${projectNumber}
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinorg/_generated_object_projectinorg.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinorg/_generated_object_projectinorg.golden.yaml
@@ -25,5 +25,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "2713651918"
+  number: "518915279"
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinorg/_generated_object_projectinorg.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinorg/_generated_object_projectinorg.golden.yaml
@@ -25,5 +25,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "518915279"
+  number: ${projectNumber}
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectmovedfoldertofolder/_generated_object_projectmovedfoldertofolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectmovedfoldertofolder/_generated_object_projectmovedfoldertofolder.golden.yaml
@@ -24,5 +24,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "518915279"
+  number: ${projectNumber}
   observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectmovedfoldertofolder/_generated_object_projectmovedfoldertofolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectmovedfoldertofolder/_generated_object_projectmovedfoldertofolder.golden.yaml
@@ -24,5 +24,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  number: "2589592254"
+  number: "518915279"
   observedGeneration: 3

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -95,9 +95,18 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, project.ProjectID, "${projectId}")
 	})
+
+	// Update the project number with variable marker.
+	if u.GetKind() == "Project" {
+		// The ProjectNumber is ProjectID based. For those tests relying on the Mock Resource Manager server,
+		// the ProjectID is dynamic, different from the default mock test Project "mock-project",
+		// so the number is different as well.
+		visitor.replacePaths[".status.number"] = fmt.Sprintf("%d", project.ProjectNumber)
+	}
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}")
 	})
+
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, uniqueID, "${uniqueId}")
 	})

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -92,17 +92,16 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	// TODO: This should not be needed, we want to avoid churning the kube objects
 	visitor.sortSlices.Insert(".spec.access")
 
+	if u.GetKind() == "Project" {
+		// For some tests that talk to the Mock Resource Manager, the Project object's ProjectID and ProjectNumber are dynamcially generated.
+		// We do not want to overrride this with the default mocked Project "mock-project".
+		visitor.replacePaths[".status.number"] = "${projectNumber}"
+	}
+
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, project.ProjectID, "${projectId}")
 	})
 
-	// Update the project number with variable marker.
-	if u.GetKind() == "Project" {
-		// The ProjectNumber is ProjectID based. For those tests relying on the Mock Resource Manager server,
-		// the ProjectID is dynamic, different from the default mock test Project "mock-project",
-		// so the number is different as well.
-		visitor.replacePaths[".status.number"] = fmt.Sprintf("%d", project.ProjectNumber)
-	}
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 		return strings.ReplaceAll(s, fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}")
 	})


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.