### PR TITLE
fix: Add more new golden http log for managed SSL Certificate

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_generated_object_managedsslcertificate.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_generated_object_managedsslcertificate.golden.yaml
@@ -1,0 +1,32 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeManagedSSLCertificate
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 1
+  labels:
+    cnrm-test: "true"
+  name: computemanagedsslcertificate-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  managed:
+    domains:
+    - sslcert.kcc-test.club.
+  projectRef:
+    external: ${projectId}
+  resourceID: computemanagedsslcertificate-${uniqueId}
+status:
+  certificateId: 1111011111111110000
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  creationTimestamp: "1970-01-01T00:00:00Z"
+  observedGeneration: 1
+  selfLink: https://compute.googleapis.com/compute/v1/projects/${projectId}/global/sslCertificates/computemanagedsslcertificate-${uniqueId}

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -64,9 +64,13 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	// Specific to Sql
 	visitor.replacePaths[".items[].etag"] = "abcdef0123A="
 
+	// Specific to global SSL certificate. This is a server generated id.
+	visitor.replacePaths[".status.certificateId"] = 1111011111111110000
+
 	// Specific to AlloyDB
 	visitor.replacePaths[".status.continuousBackupInfo[].enabledTime"] = "1970-01-01T00:00:00Z"
 	visitor.replacePaths[".status.ipAddress"] = "10.1.2.3"
+
 	// Specific to BigQuery
 	visitor.replacePaths[".spec.access[].userByEmail"] = "user@google.com"
 


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.