### PR TITLE
fix: replace targetId with id marker

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1alpha1/cloudbuildworkerpool/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1alpha1/cloudbuildworkerpool/_http.log
@@ -113,7 +113,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "7780111738275460050",
+  "targetId": "${networkID}",
   "targetLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/networks/computenetwork-${uniqueId}",
   "user": "user@example.com"
 }
@@ -1023,7 +1023,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "7780111738275460050",
+  "targetId": "${networkID}",
   "targetLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/networks/computenetwork-${uniqueId}",
   "user": "user@example.com"
 }

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_http.log
@@ -64,7 +64,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "7780111738275460050",
+  "targetId": "1719033726205916358",
   "targetLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/sslCertificates/computemanagedsslcertificate-${uniqueId}",
   "user": "user@example.com"
 }
@@ -127,7 +127,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "7780111738275460050",
+  "targetId": "1719033726205916358",
   "targetLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/sslCertificates/computemanagedsslcertificate-${uniqueId}",
   "user": "user@example.com"
 }

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computemanagedsslcertificate/managedsslcertificate/_http.log
@@ -64,7 +64,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "1719033726205916358",
+  "targetId": "${sslCertificatesId}",
   "targetLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/sslCertificates/computemanagedsslcertificate-${uniqueId}",
   "user": "user@example.com"
 }
@@ -127,7 +127,7 @@ X-Xss-Protection: 0
   "selfLink": "https://www.googleapis.com/compute/beta/projects/${projectId}/global/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
   "status": "RUNNING",
-  "targetId": "1719033726205916358",
+  "targetId": "${sslCertificatesId}",
   "targetLink": "https://compute.googleapis.com/compute/v1/projects/${projectId}/global/sslCertificates/computemanagedsslcertificate-${uniqueId}",
   "user": "user@example.com"
 }

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -429,6 +429,8 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 								switch kind {
 								case "subnetworks":
 									pathIDs[targetId] = "${subnetworkNumber}"
+								case "sslCertificates":
+									pathIDs[targetId] = "${sslCertificatesId}"
 								}
 							}
 						}
@@ -546,7 +548,6 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					addReplacement("insertTime", "2024-04-01T12:34:56.123456Z")
 					addReplacement("startTime", "2024-04-01T12:34:56.123456Z")
 					addReplacement("user", "user@example.com")
-					addReplacement("targetId", "7780111738275460050")
 
 					// Specific to vertexai
 					addReplacement("blobStoragePathPrefix", "cloud-ai-platform-00000000-1111-2222-3333-444444444444")


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.

More context: many golden http log uses targetId (see https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061/files#diff-45e74dc3e22d6fbc3f979edfe4959d40c702bf51bea40854de4e4ab393bb5330). Override the targetId may be a little bit too aggressive. 

cc @acpana 