### PR TITLE
chore: add golden log for soft-deletion

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/_generated_object_storagebucket.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/_generated_object_storagebucket.golden.yaml
@@ -19,6 +19,9 @@ spec:
   location: US
   publicAccessPrevention: inherited
   resourceID: storagebucket-sample-${uniqueId}
+  softDeletePolicy:
+    effectiveTime: "1970-01-01T00:00:00Z"
+    retentionDurationSeconds: 0
   storageClass: STANDARD
   versioning:
     enabled: true
@@ -30,5 +33,9 @@ status:
     status: "True"
     type: Ready
   observedGeneration: 4
+  observedState:
+    softDeletePolicy:
+      effectiveTime: "1970-01-01T00:00:00Z"
+      retentionDurationSeconds: 0
   selfLink: https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}
   url: gs://storagebucket-sample-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/_http.log
@@ -55,6 +55,9 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
   },
   "location": "US",
   "name": "storagebucket-sample-${uniqueId}",
+  "softDeletePolicy": {
+    "retentionDurationSeconds": "604800"
+  },
   "storageClass": "STANDARD",
   "versioning": {
     "enabled": false
@@ -196,6 +199,9 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
   },
   "lifecycle": {
     "rule": []
+  },
+  "softDeletePolicy": {
+    "retentionDurationSeconds": "0"
   },
   "versioning": {
     "enabled": true
@@ -360,6 +366,192 @@ Vary: X-Origin
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "2",
+  "name": "storagebucket-sample-${uniqueId}",
+  "projectNumber": "${projectNumber}",
+  "rpo": "DEFAULT",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}",
+  "softDeletePolicy": {
+    "effectiveTime": "2024-04-01T12:34:56.123456Z",
+    "retentionDurationSeconds": "604800"
+  },
+  "storageClass": "STANDARD",
+  "timeCreated": "2024-04-01T12:34:56.123456Z",
+  "updated": "2024-04-01T12:34:56.123456Z",
+  "versioning": {
+    "enabled": true
+  }
+}
+
+---
+
+PATCH https://storage.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "softDeletePolicy": {
+    "retentionDurationSeconds": "0"
+  }
+}
+
+200 OK
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Content-Type: application/json; charset=UTF-8
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Pragma: no-cache
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "acl": [
+    {
+      "bucket": "storagebucket-sample-${uniqueId}",
+      "entity": "project-owners-${projectNumber}",
+      "etag": "abcdef0123A",
+      "id": "storagebucket-sample-${uniqueId}/project-owners-${projectNumber}",
+      "kind": "storage#bucketAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "owners"
+      },
+      "role": "OWNER",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}/acl/project-owners-${projectNumber}"
+    },
+    {
+      "bucket": "storagebucket-sample-${uniqueId}",
+      "entity": "project-editors-${projectNumber}",
+      "etag": "abcdef0123A",
+      "id": "storagebucket-sample-${uniqueId}/project-editors-${projectNumber}",
+      "kind": "storage#bucketAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "editors"
+      },
+      "role": "OWNER",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}/acl/project-editors-${projectNumber}"
+    },
+    {
+      "bucket": "storagebucket-sample-${uniqueId}",
+      "entity": "project-viewers-${projectNumber}",
+      "etag": "abcdef0123A",
+      "id": "storagebucket-sample-${uniqueId}/project-viewers-${projectNumber}",
+      "kind": "storage#bucketAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "viewers"
+      },
+      "role": "READER",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}/acl/project-viewers-${projectNumber}"
+    }
+  ],
+  "defaultObjectAcl": [
+    {
+      "entity": "project-owners-${projectNumber}",
+      "etag": "abcdef0123A=",
+      "kind": "storage#objectAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "owners"
+      },
+      "role": "OWNER"
+    },
+    {
+      "entity": "project-editors-${projectNumber}",
+      "etag": "abcdef0123A=",
+      "kind": "storage#objectAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "editors"
+      },
+      "role": "OWNER"
+    },
+    {
+      "entity": "project-viewers-${projectNumber}",
+      "etag": "abcdef0123A=",
+      "kind": "storage#objectAccessControl",
+      "projectTeam": {
+        "projectNumber": "${projectNumber}",
+        "team": "viewers"
+      },
+      "role": "READER"
+    }
+  ],
+  "etag": "abcdef0123A=",
+  "iamConfiguration": {
+    "bucketPolicyOnly": {
+      "enabled": false
+    },
+    "publicAccessPrevention": "inherited",
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "id": "000000000000000000000",
+  "kind": "storage#bucket",
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true",
+    "newkey": "newval"
+  },
+  "location": "US",
+  "locationType": "multi-region",
+  "metageneration": "3",
+  "name": "storagebucket-sample-${uniqueId}",
+  "owner": {
+    "entity": "project-owners-${projectNumber}"
+  },
+  "projectNumber": "${projectNumber}",
+  "rpo": "DEFAULT",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}",
+  "softDeletePolicy": {
+    "effectiveTime": "2024-04-01T12:34:56.123456Z",
+    "retentionDurationSeconds": "604800"
+  },
+  "storageClass": "STANDARD",
+  "timeCreated": "2024-04-01T12:34:56.123456Z",
+  "updated": "2024-04-01T12:34:56.123456Z",
+  "versioning": {
+    "enabled": true
+  }
+}
+
+---
+
+GET https://storage.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private, max-age=0, must-revalidate, no-transform
+Content-Type: application/json; charset=UTF-8
+Expires: {now+0m}
+Server: UploadServer
+Vary: Origin
+Vary: X-Origin
+
+{
+  "etag": "abcdef0123A=",
+  "iamConfiguration": {
+    "bucketPolicyOnly": {
+      "enabled": false
+    },
+    "publicAccessPrevention": "inherited",
+    "uniformBucketLevelAccess": {
+      "enabled": false
+    }
+  },
+  "id": "000000000000000000000",
+  "kind": "storage#bucket",
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true",
+    "newkey": "newval"
+  },
+  "location": "US",
+  "locationType": "multi-region",
+  "metageneration": "3",
   "name": "storagebucket-sample-${uniqueId}",
   "projectNumber": "${projectNumber}",
   "rpo": "DEFAULT",

--- a/pkg/test/resourcefixture/testdata/directives/forcedestroy/_generated_object_forcedestroy.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/directives/forcedestroy/_generated_object_forcedestroy.golden.yaml
@@ -20,6 +20,9 @@ spec:
   location: US
   publicAccessPrevention: inherited
   resourceID: storagebucket-sample-${uniqueId}
+  softDeletePolicy:
+    effectiveTime: "1970-01-01T00:00:00Z"
+    retentionDurationSeconds: 604800
   storageClass: STANDARD
   versioning:
     enabled: true
@@ -31,5 +34,9 @@ status:
     status: "True"
     type: Ready
   observedGeneration: 3
+  observedState:
+    softDeletePolicy:
+      effectiveTime: "1970-01-01T00:00:00Z"
+      retentionDurationSeconds: 604800
   selfLink: https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}
   url: gs://storagebucket-sample-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/reconcileintervalannotations/storagebucket/_generated_object_storagebucket#01.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/reconcileintervalannotations/storagebucket/_generated_object_storagebucket#01.golden.yaml
@@ -18,6 +18,9 @@ spec:
   location: US
   publicAccessPrevention: inherited
   resourceID: storagebucket-sample-${uniqueId}
+  softDeletePolicy:
+    effectiveTime: "1970-01-01T00:00:00Z"
+    retentionDurationSeconds: 604800
   storageClass: STANDARD
   versioning:
     enabled: true
@@ -29,5 +32,9 @@ status:
     status: "True"
     type: Ready
   observedGeneration: 4
+  observedState:
+    softDeletePolicy:
+      effectiveTime: "1970-01-01T00:00:00Z"
+      retentionDurationSeconds: 604800
   selfLink: https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}
   url: gs://storagebucket-sample-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/stateabsentinspec/clusterleveloverride/_generated_object_clusterleveloverride.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/stateabsentinspec/clusterleveloverride/_generated_object_clusterleveloverride.golden.yaml
@@ -29,5 +29,9 @@ status:
     status: "True"
     type: Ready
   observedGeneration: 3
+  observedState:
+    softDeletePolicy:
+      effectiveTime: "1970-01-01T00:00:00Z"
+      retentionDurationSeconds: 604800
   selfLink: https://www.googleapis.com/storage/v1/b/storagebucket-sample-${uniqueId}
   url: gs://storagebucket-sample-${uniqueId}


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.

Note:
The golden object shows some output-only spec fields. We shall have them fixed (and have the golden logs updated correspondingly) before next launch.

cc @maqiuyujoyce @600lyy @justinsb 