### PR TITLE
fix: override mockgcp vertexai pathPrefix

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/vertexai/v1alpha1/vertexaitensorboard/_generated_object_vertexaitensorboard.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vertexai/v1alpha1/vertexaitensorboard/_generated_object_vertexaitensorboard.golden.yaml
@@ -20,7 +20,7 @@ spec:
   region: us-central1
   resourceID: projects/${projectNumber}/locations/us-central1/tensorboards/${tensorboardId}
 status:
-  blobStoragePathPrefix: cloud-ai-platform-4c7152f6-07a9-47d6-8f51-4299e2fdff92
+  blobStoragePathPrefix: cloud-ai-platform-00000000-1111-2222-3333-444444444444
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"
     message: The resource is up to date

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -74,6 +74,9 @@ func normalizeKRMObject(u *unstructured.Unstructured, project testgcp.GCPProject
 	visitor.replacePaths[".status.serverCaCert.createTime"] = "1970-01-01T00:00:00Z"
 	visitor.replacePaths[".status.serverCaCert.expirationTime"] = "1970-01-01T00:00:00Z"
 
+	// Specific to VertexAI
+	visitor.replacePaths[".status.blobStoragePathPrefix"] = "cloud-ai-platform-00000000-1111-2222-3333-444444444444"
+
 	// Specific to Monitoring
 	visitor.replacePaths[".status.creationRecord[].mutateTime"] = "1970-01-01T00:00:00Z"
 	visitor.replacePaths[".status.creationRecord[].mutatedBy"] = "user@google.com"


### PR DESCRIPTION
This is a follow up PR to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1934 and blocks https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2061

We need to fix the existing golden log to turn on the stricter PRESUBMIT check.