### PR TITLE
controllerbuilder: use go 1.22

### DIFF
--- a/dev/tools/controllerbuilder/go.mod
+++ b/dev/tools/controllerbuilder/go.mod
@@ -1,6 +1,8 @@
 module github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder
 
-go 1.23
+go 1.22
+
+toolchain go1.22.4
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
go 1.23 is not released yet.
