### PR TITLE
Invoke the expander when a composition changes to update resources.

### DIFF
--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -29,6 +29,7 @@ import (
 	pb "google.com/composition/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -48,9 +50,10 @@ var FacadeControllers sync.Map
 // CompositionReconciler reconciles a Composition object
 type CompositionReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	mgr      ctrl.Manager
+	Scheme          *runtime.Scheme
+	Recorder        record.EventRecorder
+	mgr             ctrl.Manager
+	handoffChannels map[schema.GroupVersionKind]chan event.GenericEvent
 }
 
 //+kubebuilder:rbac:groups=composition.google.com,resources=compositions,verbs=get;list;watch;create;update;patch;delete
@@ -332,21 +335,33 @@ func (r *CompositionReconciler) processComposition(
 	logger.Info("Checking if Reconciler already exists for InputAPI CRD")
 	_, loaded := FacadeControllers.LoadOrStore(gvk, true)
 	if loaded {
+		logger.Info("Sending event to handoff channel")
+		r.handoffChannels[gvk] <- event.GenericEvent{
+			Object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      c.Name,
+					Namespace: c.Namespace,
+				},
+			},
+		}
+
 		// Reconciler already exists nothing to be done
 		logger.Info("Reconciler already exists for InputAPI CRD")
 		return nil
 	}
 
 	logger.Info("Starting Reconciler for InputAPI CRD")
+	r.handoffChannels[gvk] = make(chan event.GenericEvent)
 	expanderController := &ExpanderReconciler{
-		Client:      r.Client,
-		Recorder:    r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
-		Scheme:      r.Scheme,
-		InputGVK:    gvk,
-		Composition: types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
-		InputGVR:    gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
-		RESTMapper:  r.mgr.GetRESTMapper(),
-		Config:      r.mgr.GetConfig(),
+		Client:            r.Client,
+		Recorder:          r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
+		Scheme:            r.Scheme,
+		InputGVK:          gvk,
+		Composition:       types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
+		InputGVR:          gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
+		RESTMapper:        r.mgr.GetRESTMapper(),
+		Config:            r.mgr.GetConfig(),
+		CRDChangedWatcher: r.handoffChannels[gvk],
 	}
 
 	if err := expanderController.SetupWithManager(r.mgr, cr); err != nil {
@@ -369,6 +384,7 @@ func (r *CompositionReconciler) processComposition(
 // SetupWithManager sets up the controller with the Manager.
 func (r *CompositionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.mgr = mgr
+	r.handoffChannels = make(map[schema.GroupVersionKind]chan event.GenericEvent)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&compositionv1alpha1.Composition{}).
 		Complete(r)

--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -353,15 +353,15 @@ func (r *CompositionReconciler) processComposition(
 	logger.Info("Starting Reconciler for InputAPI CRD")
 	r.handoffChannels[gvk] = make(chan event.GenericEvent)
 	expanderController := &ExpanderReconciler{
-		Client:            r.Client,
-		Recorder:          r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
-		Scheme:            r.Scheme,
-		InputGVK:          gvk,
-		Composition:       types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
-		InputGVR:          gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
-		RESTMapper:        r.mgr.GetRESTMapper(),
-		Config:            r.mgr.GetConfig(),
-		CRDChangedWatcher: r.handoffChannels[gvk],
+		Client:                    r.Client,
+		Recorder:                  r.mgr.GetEventRecorderFor(crd.Spec.Names.Plural + "-expander"),
+		Scheme:                    r.Scheme,
+		InputGVK:                  gvk,
+		Composition:               types.NamespacedName{Name: c.Name, Namespace: c.Namespace},
+		InputGVR:                  gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
+		RESTMapper:                r.mgr.GetRESTMapper(),
+		Config:                    r.mgr.GetConfig(),
+		ComopsitionChangedWatcher: r.handoffChannels[gvk],
 	}
 
 	if err := expanderController.SetupWithManager(r.mgr, cr); err != nil {

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/input.yaml
@@ -1,0 +1,231 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pconfigs.facade.updatetest.com
+spec:
+  group: facade.updatetest.com
+  names:
+    kind: PConfig
+    listKind: PConfigList
+    plural: pconfigs
+    singular: pconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the pconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PConfig spec
+            properties:
+              projects:
+                items:
+                  type: string
+                type: array
+            required:
+            - projects
+            type: object
+          status:
+            description: PConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sconfigs.facade.updatetest.com
+spec:
+  group: facade.updatetest.com
+  names:
+    kind: SConfig
+    listKind: SConfigList
+    plural: sconfigs
+    singular: sconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schema for the sconfig
+        properties:
+          apiVersion:
+            description: api-version of api
+            type: string
+          kind:
+            description: gvk Kind
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SConfig spec
+            properties:
+              projects:
+                items:
+                  type: string
+                type: array
+            required:
+            - projects
+            type: object
+          status:
+            description: SConfig status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: composition-facade-updatetest
+rules:
+- apiGroups:
+  - facade.updatetest.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - facade.updatetest.com
+  resources:
+  - "*/status"
+  verbs:
+  - get
+  - update
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: composition-facade-updatetest
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: composition-facade-updatetest
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Composition
+metadata:
+  name: pprojectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.updatetest.com
+  expanders:
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% for project in pconfigs.spec.projects %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: p-{{ project }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ project }}
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+      ---
+      {% endfor %}
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Composition
+metadata:
+  name: sprojectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: sconfigs.facade.updatetest.com
+  expanders:
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% for project in sconfigs.spec.projects %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: s-{{ project }}
+        namespace: {{ sconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ project }}
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+      ---
+      {% endfor %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+---
+apiVersion: composition.google.com/v1alpha1
+kind: Context
+metadata:
+  name: context
+  namespace: team-a
+spec:
+  project: proj-a
+---
+apiVersion: facade.updatetest.com/v1alpha1
+kind: PConfig
+metadata:
+  name: team-a-config
+  namespace: team-a
+spec:
+  projects:
+  - proj-a
+  - proj-b
+---
+apiVersion: facade.updatetest.com/v1alpha1
+kind: SConfig
+metadata:
+  name: team-a-config
+  namespace: team-a
+spec:
+  projects:
+  - proj-a
+  - proj-b

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/modified_composition.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/modified_composition.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: composition.google.com/v1alpha1
+kind: Composition
+metadata:
+  name: pprojectconfigmap
+  namespace: default
+spec:
+  inputAPIGroup: pconfigs.facade.updatetest.com
+  expanders:
+  - type: jinja2
+    name: project
+    template: |
+      {% set hostProject = 'compositions-foobar' %}
+      {% for project in pconfigs.spec.projects %}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: p-{{ project }}
+        namespace: {{ pconfigs.metadata.namespace }}
+        labels:
+          createdby: "composition-namespaceconfigmap"
+      data:
+        name: {{ project }}-updated
+        billingAccountRef: "010101-ABABCD-BCAB11"
+        folderRef: "000000111100"
+      ---
+      {% endfor %}

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/output.yaml
@@ -1,0 +1,85 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-a-updated
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: p-proj-a
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: pconfigs-team-a-config
+---
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-b-updated
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: p-proj-b
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: pconfigs-team-a-config
+---
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-a
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: s-proj-a
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: sconfigs-team-a-config
+---
+apiVersion: v1
+data:
+  billingAccountRef: 010101-ABABCD-BCAB11
+  folderRef: "000000111100"
+  name: proj-b
+kind: ConfigMap
+metadata:
+  labels:
+    createdby: composition-namespaceconfigmap
+  name: s-proj-b
+  namespace: team-a
+  ownerReferences:
+  - apiVersion: composition.google.com/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Plan
+    name: sconfigs-team-a-config

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -50,6 +50,27 @@ func TestSimpleExpansionGrpc(t *testing.T) {
 	s.VerifyOutputSpecMatches()
 }
 
+func TestSimpleCompositionUpdate(t *testing.T) {
+	s := scenario.NewBasic(t)
+	defer s.Cleanup()
+	s.Setup()
+
+	// Make sure the pre-update CRs have been created to ensure the coming update triggers a new reconcile.
+	cmNames := []string{"p-proj-a", "p-proj-b", "s-proj-a", "s-proj-b"}
+	cms := make([]*unstructured.Unstructured, 0)
+	for _, cmName := range cmNames {
+		cms = append(cms, utils.GetConfigMapObj("team-a", cmName))
+	}
+	s.C.MustExist(cms, scenario.ExistTimeout)
+
+	// Apply the modified Composition
+	s.ApplyManifests("modified composition", "modified_composition.yaml")
+
+	// Changing the composition should trigger the expander to re-reconcile all objects.
+	s.VerifyOutputExists()
+	s.VerifyOutputSpecMatches()
+}
+
 func TestSimpleDeleteFacade(t *testing.T) {
 	//t.Parallel()
 	s := scenario.NewBasic(t)


### PR DESCRIPTION
### Change description

When the composition controller reconciles a change in a composition, the desired outcome is that affected resources be re-processed to reflect the changes.
Set up a side-channel to the expander and send events on it when compositions change. The expander will then enqueue the necessary events for all relevant resources.

### Tests you have done
Added `TestSimpleCompositionUpdate` to e2e tests and ran the scenario manually. The test exercises updating multiple CRs and ensures CRs for a different GVK aren't affected.
