### PR TITLE
Support observed state validation via GitHub action

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -145,6 +145,17 @@ jobs:
       - name: "Run scenarios tests for powertool"
         run: |
           ./scripts/github-actions/powertool-test.sh
+  observed-state-tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run validation tests for observed state"
+        run: |
+          ./scripts/github-actions/observedstate-test.sh
   build-images:
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -770,7 +770,9 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 		case "sourcereporepository":
 		case "spannerdatabase":
 		case "sqluser":
-
+		case "storagebucketbasic":
+		case "storagebucketzero":
+		case "storagebucketsoftdelete":
 		case "computenodegroup":
 		case "computenodetemplate":
 		case "privatecacapool":

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/dcl.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/dcl.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/oauth.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/oauth.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/tf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketbasic/_vcr_cassettes/tf.yaml
@@ -1,0 +1,499 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: fake error message
+        headers:
+            Content-Length:
+                - "171"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NpxmtXxJ3iipK_yWPq4Vv2qipiqoDbuawUwoffJ9JCS-8D4uGaqVuPj-JtTKFK6BrxCLdMRzN3oEA
+        status: 404 Not Found
+        code: 404
+        duration: 122.313317ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 395
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"iamConfiguration":{"uniformBucketLevelAccess":{"enabled":false}},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true"},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"location":"US","name":"storagebucket-sample-3nrz25ociqd9p","softDeletePolicy":{"retentionDurationSeconds":"604800"},"storageClass":"STANDARD","versioning":{"enabled":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=example-project
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:04.261Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-27T00:16:04.261Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NrlVLyx3o1rGO2iFlN681FXVUgsg8SaELJ1aiHh9iN3XUu9avELRjgjfy9w5QOkMhQfGmc
+        status: 200 OK
+        code: 200
+        duration: 707.418886ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:04.261Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"cnrm-test":"true","managed-by-cnrm":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-27T00:16:04.261Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:05 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NpGL31_0P7fPhtvVIEIgrv7YlP61uhFyXdp1lJK6EXkc788rwxUg-8FvMXW4baqH6OExQyp6d2-lg
+        status: 200 OK
+        code: 200
+        duration: 113.883861ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:04.261Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"cnrm-test":"true","managed-by-cnrm":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-27T00:16:04.261Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:05 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Npmos4UsKK23LOLbgdYUoW9vZJ2JSixLGXDMX-IOeZsJWyYQ8as1vTr9DSkuMOVElRgzrYj6Bnq6g
+        status: 200 OK
+        code: 200
+        duration: 93.12134ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:04.261Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","managed-by-cnrm":"true","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-27T00:16:04.261Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:05 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nrtp3jfiqTuBcUVx2f7G-xlG0RMGW41R0MvJY7GeYWoG83Eei13hBG-J2Ie2bNsXB-nM36e-Qah1g
+        status: 200 OK
+        code: 200
+        duration: 175.241075ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 855
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:04.261Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","managed-by-cnrm":"true","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-27T00:16:04.261Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "855"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:06 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NqU9AFcWRwgmlVIasCTEBh3-lJ73QRE4-LsK89O6bAQLa5MbUR-X8Zv-CN4Zt5LQRkpZAisQuud-g
+        status: 200 OK
+        code: 200
+        duration: 123.050627ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 205
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true","newkey":"newval"},"lifecycle":{"rule":[]},"softDeletePolicy":{"retentionDurationSeconds":"0"},"versioning":{"enabled":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2570
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:07.074Z","acl":[{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-3nrz25ociqd9p/project-owners-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p/acl/project-owners-123456789","bucket":"storagebucket-sample-3nrz25ociqd9p","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-3nrz25ociqd9p/project-editors-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p/acl/project-editors-123456789","bucket":"storagebucket-sample-3nrz25ociqd9p","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-3nrz25ociqd9p/project-viewers-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p/acl/project-viewers-123456789","bucket":"storagebucket-sample-3nrz25ociqd9p","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"defaultObjectAcl":[{"kind":"storage#objectAccessControl","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#objectAccessControl","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#objectAccessControl","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"owner":{"entity":"project-owners-123456789"},"versioning":{"enabled":true},"labels":{"managed-by-cnrm":"true","label-one":"value-one","newkey":"newval","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"0"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "2570"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NpX-nqywCy29aZj-Y4sAKa1iU22iy5jf1rl34yTcJBhKJUxsDwujmuDboMq4e4t9IGuV7RruX_O4A
+        status: 200 OK
+        code: 200
+        duration: 462.248563ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 750
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:07.074Z","versioning":{"enabled":true},"labels":{"managed-by-cnrm":"true","newkey":"newval","label-one":"value-one","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"0"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "750"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:07 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nrsu7qchdW4zrxiYXzHwhZ19efbEbOYX23dub8yvy4usZxbQAoarT9EOjLceBEBg7wNmsEnmkIOnA
+        status: 200 OK
+        code: 200
+        duration: 129.176264ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 750
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:07.074Z","versioning":{"enabled":true},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true","newkey":"newval"},"softDeletePolicy":{"retentionDurationSeconds":"0"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "750"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:08 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NpMO9mUABoDIX3OpDQbYcb39ja3ydW4v8kFiGmAaGfvdedwN6Hp5CYQKVVf8m8gz5bZJ1LUx9dGnQ
+        status: 200 OK
+        code: 200
+        duration: 146.015797ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 750
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p","id":"storagebucket-sample-3nrz25ociqd9p","name":"storagebucket-sample-3nrz25ociqd9p","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-27T00:16:04.261Z","updated":"2024-06-27T00:16:07.074Z","versioning":{"enabled":true},"labels":{"newkey":"newval","managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"0"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "750"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:08 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NrZFj78Uun_bhalUC5GfZQBmCBk3C08kZVECFPI9HoBaCF7RoS2ITy9KjG5QGfBkuTP38tbY2KMhA
+        status: 200 OK
+        code: 200
+        duration: 73.670759ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p/o?alt=json&prettyPrint=false&versions=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 26
+        uncompressed: false
+        body: '{"kind":"storage#objects"}'
+        headers:
+            Content-Length:
+                - "26"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Thu, 27 Jun 2024 00:16:08 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NoL275w6Ne70648yFmTp3EdF6BBRd8KYTArrTjD-4OuNPsnSQ1hstcoaz9FuMdaCVECfnifLt9k_Q
+        status: 200 OK
+        code: 200
+        duration: 124.226177ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-3nrz25ociqd9p?alt=json&prettyPrint=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/json
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NrNBtdIJ0RxUM2xoZRBS_m2ZZfrD4V6g3bbmsktvs6mYONobyBjHb98KRcnTlCp8mImLx28sM7sBg
+        status: 204 No Content
+        code: 204
+        duration: 627.691333ms

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/dcl.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/dcl.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/oauth.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/oauth.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/tf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketsoftdelete/_vcr_cassettes/tf.yaml
@@ -1,0 +1,460 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: fake error message
+        headers:
+            Content-Length:
+                - "171"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0Np2mqlWwMAYyGONepED_4JF0b_7QjP-x6lQG6cEX4ZR2UoHSwN6TnMJADcQu9WOs27kptHwUphdKA
+        status: 404 Not Found
+        code: 404
+        duration: 291.299129ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 394
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"iamConfiguration":{"uniformBucketLevelAccess":{"enabled":false}},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true"},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"location":"US","name":"storagebucket-sample-2lmkzyeoibk3u","softDeletePolicy":{"retentionDurationSeconds":"604800"},"storageClass":"STANDARD","versioning":{"enabled":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=example-project
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 854
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:14.291Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "854"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0Nrp1uhyA_hBq5htKXsGjyNEMpxoemGUUmelLXlKGsZEmzbDCFjkRULwmIZpHQvb-tFHDI9S0Yq1jQ
+        status: 200 OK
+        code: 200
+        duration: 848.320458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 854
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:14.291Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","label-one":"value-one","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "854"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:15 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NqTfYnP6s95A04FZ0RhVV1QlGBUDnTe_SNaZntCgSQ6jS8Fjs_zSITwlZidy_uMIEYuBP0
+        status: 200 OK
+        code: 200
+        duration: 119.879216ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 854
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:14.291Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "854"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:15 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nq55kxJpsc-tt9wDXq8HG03wowoZrQUr_2Qto1Q7vXoGWQgQBgpjnOA3AOUmW2JmN9CxDd7ACj5sg
+        status: 200 OK
+        code: 200
+        duration: 180.050593ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 854
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:14.291Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","cnrm-test":"true","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "854"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:15 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nr_V9yrNADtx2dTlOD4fZNPJ7hUbZlGNPyVPCdmtTVzam5n0LsWCbxO9SsjJt9WFkTQ_5HH_dAU1Q
+        status: 200 OK
+        code: 200
+        duration: 95.038856ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 854
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:14.291Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","label-one":"value-one","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "854"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:16 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nrtm9_qn5-pmSP4tpOs5qxLs_lE7Y6XeZlvk7bJ68KrqwdX3G5ENpz8xrTaJ_lhJW49R-nrjDCF8w
+        status: 200 OK
+        code: 200
+        duration: 181.622153ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 130
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true","newkey":"newval"},"versioning":{"enabled":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2693
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:17.423Z","acl":[{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-2lmkzyeoibk3u/project-owners-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u/acl/project-owners-123456789","bucket":"storagebucket-sample-2lmkzyeoibk3u","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-2lmkzyeoibk3u/project-editors-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u/acl/project-editors-123456789","bucket":"storagebucket-sample-2lmkzyeoibk3u","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-2lmkzyeoibk3u/project-viewers-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u/acl/project-viewers-123456789","bucket":"storagebucket-sample-2lmkzyeoibk3u","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"defaultObjectAcl":[{"kind":"storage#objectAccessControl","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#objectAccessControl","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#objectAccessControl","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"owner":{"entity":"project-owners-123456789"},"versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"cnrm-test":"true","label-one":"value-one","newkey":"newval","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "2693"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NpwZHnhcuz6ZQuf4VUXggyMG8VqQLMHv3M3S8Zazqumtb_RNF-z6pfPMzA0v6zVYZq4vHSFjS5PZw
+        status: 200 OK
+        code: 200
+        duration: 424.800854ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 873
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:17.423Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"newkey":"newval","label-one":"value-one","managed-by-cnrm":"true","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "873"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:18 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NrhZtdygMzByY8E5l6ApbUaVBVs45piKeDLvlCOcE97T5SfD3V4XQtIoaDDLgm4PDGeKQVjlgoJAA
+        status: 200 OK
+        code: 200
+        duration: 135.981124ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 873
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u","id":"storagebucket-sample-2lmkzyeoibk3u","name":"storagebucket-sample-2lmkzyeoibk3u","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:14.291Z","updated":"2024-06-26T23:32:17.423Z","versioning":{"enabled":false},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","managed-by-cnrm":"true","cnrm-test":"true","newkey":"newval"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:14.291Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "873"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:18 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NpUWxLA4kgYYeMW6iQAYJZW0h6BBCLh_72zuB6ypso3h6zFes_QoiKYnb1CcOI-CjwTCXqVsWnS5g
+        status: 200 OK
+        code: 200
+        duration: 124.983205ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u/o?alt=json&prettyPrint=false&versions=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 26
+        uncompressed: false
+        body: '{"kind":"storage#objects"}'
+        headers:
+            Content-Length:
+                - "26"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:19 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NogfPGzTmnuhdUHV_MuBETjYdTTrtQxL_Da2kUgd0LE6X8-0-m03qEUXVOGxERLziXB9sscJPvh8g
+        status: 200 OK
+        code: 200
+        duration: 168.858233ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-2lmkzyeoibk3u?alt=json&prettyPrint=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/json
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NrryNLK55dbNOk9t-erFHFRrRVnOmO3sdNVKbsmv39pFxQsPTFY-Hj9XfhWhpGjvCDk-gQ05U4o8Q
+        status: 204 No Content
+        code: 204
+        duration: 787.037321ms

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/dcl.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/dcl.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/oauth.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/oauth.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions: []

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/tf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketzero/_vcr_cassettes/tf.yaml
@@ -1,0 +1,499 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: fake error message
+        headers:
+            Content-Length:
+                - "171"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NrejjwuJPEQfYi92D2ot2T9kGM7bGMJRhdySaQ09-xhSnRM4eIALXv2_8-l8idR8g63lTkQZJPrtQ
+        status: 404 Not Found
+        code: 404
+        duration: 107.444996ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 393
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"iamConfiguration":{"uniformBucketLevelAccess":{"enabled":false}},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true"},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"location":"US","name":"storagebucket-sample-odr58ey9af8z","softDeletePolicy":{"retentionDurationSeconds":"604800"},"storageClass":"STANDARD","versioning":{"enabled":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b?alt=json&prettyPrint=false&project=example-project
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 851
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:48.943Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "851"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NqLaMvQvn2VVTQtAjq_yEndxFpn7zjnipndeMbPNtAni6VRPlSegCA0Geshkgb-4aBzxW1i4wGwFA
+        status: 200 OK
+        code: 200
+        duration: 699.972843ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 851
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:48.943Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "851"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:49 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nqrj7WxzStInXQ5jjAiu8DSf96JUQL7VKILmtNmputQHuAPdc8mKViBCdPJZEIjUQqYl6aJT4uqnw
+        status: 200 OK
+        code: 200
+        duration: 138.693585ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 851
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:48.943Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","cnrm-test":"true","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "851"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:50 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NrDsrVY5KsWgpttYu6b8Wy_QYohJLcoYsY81313GATqj-7jrsuoicLHWAFqoNHCJaBBW1l7xG27QA
+        status: 200 OK
+        code: 200
+        duration: 160.890684ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 851
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:48.943Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "851"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:50 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NrEYF1trXX6cz0uaVurxtJhagHejW19qzj1nPFON61BQ6FeN3fouRRoaVv5bC1w-A_InzBcg5vcxA
+        status: 200 OK
+        code: 200
+        duration: 106.547496ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 851
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"1","location":"US","storageClass":"STANDARD","etag":"CAE=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:48.943Z","versioning":{"enabled":true},"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":7}}]},"labels":{"label-one":"value-one","cnrm-test":"true","managed-by-cnrm":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "851"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:51 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NpJRoiL6qw5rsf7ouEE-hQyZg9nK0NuHv-BLQlFk7I6oLAiIa5g1qNd8woXbHBuEOSNtvpApJ75HQ
+        status: 200 OK
+        code: 200
+        duration: 164.009893ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 154
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true","newkey":"newval"},"lifecycle":{"rule":[]},"versioning":{"enabled":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2607
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:52.239Z","acl":[{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-odr58ey9af8z/project-owners-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z/acl/project-owners-123456789","bucket":"storagebucket-sample-odr58ey9af8z","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-odr58ey9af8z/project-editors-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z/acl/project-editors-123456789","bucket":"storagebucket-sample-odr58ey9af8z","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#bucketAccessControl","id":"storagebucket-sample-odr58ey9af8z/project-viewers-123456789","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z/acl/project-viewers-123456789","bucket":"storagebucket-sample-odr58ey9af8z","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"defaultObjectAcl":[{"kind":"storage#objectAccessControl","entity":"project-owners-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"owners"}},{"kind":"storage#objectAccessControl","entity":"project-editors-123456789","role":"OWNER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"editors"}},{"kind":"storage#objectAccessControl","entity":"project-viewers-123456789","role":"READER","etag":"CAI=","projectTeam":{"projectNumber":"123456789","team":"viewers"}}],"owner":{"entity":"project-owners-123456789"},"versioning":{"enabled":false},"labels":{"managed-by-cnrm":"true","cnrm-test":"true","label-one":"value-one","newkey":"newval"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "2607"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0NpAFPQyBNu6VWEwp7n372G2vM6rVy6mtbkcR6XIXOCzmQRtbUu4ryt8qcVh9mjABFwEWxJeggUMgg
+        status: 200 OK
+        code: 200
+        duration: 470.157922ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 796
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:52.239Z","versioning":{"enabled":false},"labels":{"cnrm-test":"true","label-one":"value-one","managed-by-cnrm":"true","newkey":"newval"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "796"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:52 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NqXZ_ANTq665hMH_7IHZQY-HNSgecyLhcAmjzVBawR3wfTpCkH0lB7BnsacAK0RzRET4EG-WreglQ
+        status: 200 OK
+        code: 200
+        duration: 171.986324ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 796
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:52.239Z","versioning":{"enabled":false},"labels":{"newkey":"newval","label-one":"value-one","managed-by-cnrm":"true","cnrm-test":"true"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "796"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:53 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NqSgBirWe34f1qCjEaDc1X5Ar8YhOPooZa_8NQaBb_n0X3MUhMBaazXN0hV1jg1U_N5oVDTotRNMg
+        status: 200 OK
+        code: 200
+        duration: 105.996466ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 796
+        uncompressed: false
+        body: '{"kind":"storage#bucket","selfLink":"https://www.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z","id":"storagebucket-sample-odr58ey9af8z","name":"storagebucket-sample-odr58ey9af8z","projectNumber":"123456789","metageneration":"2","location":"US","storageClass":"STANDARD","etag":"CAI=","timeCreated":"2024-06-26T23:32:48.943Z","updated":"2024-06-26T23:32:52.239Z","versioning":{"enabled":false},"labels":{"managed-by-cnrm":"true","label-one":"value-one","cnrm-test":"true","newkey":"newval"},"softDeletePolicy":{"retentionDurationSeconds":"604800","effectiveTime":"2024-06-26T23:32:48.943Z"},"iamConfiguration":{"bucketPolicyOnly":{"enabled":false},"uniformBucketLevelAccess":{"enabled":false},"publicAccessPrevention":"inherited"},"locationType":"multi-region","rpo":"DEFAULT"}'
+        headers:
+            Content-Length:
+                - "796"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:53 GMT
+            X-Guploader-Uploadid:
+                - ACJd0NrP0jGy4Vrqe3v3v0h8YsjkFTS7GKeaCxJrzha7trDyteIm-Rhqczm7b9p-IeMomPt-rCIWbrhbow
+        status: 200 OK
+        code: 200
+        duration: 117.876786ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z/o?alt=json&prettyPrint=false&versions=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 26
+        uncompressed: false
+        body: '{"kind":"storage#objects"}'
+        headers:
+            Content-Length:
+                - "26"
+            Content-Type:
+                - application/json; charset=UTF-8
+            Expires:
+                - Wed, 26 Jun 2024 23:32:53 GMT
+            X-Guploader-Uploadid:
+                - ACJd0Nrod0mRcmNlAZt3J64o2oSN9tI_XNvf40j8yJDJGaKL906GCNiaiJpt-wUd4lZMlA9gXDguz5wCiw
+        status: 200 OK
+        code: 200
+        duration: 122.728364ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: storage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            X-Goog-Api-Client:
+                - gl-go/1.22.4 gdcl/0.185.0
+        url: https://storage.googleapis.com/storage/v1/b/storagebucket-sample-odr58ey9af8z?alt=json&prettyPrint=false
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Length:
+                - "0"
+            Content-Type:
+                - application/json
+            Expires:
+                - Mon, 01 Jan 1990 00:00:00 GMT
+            Pragma:
+                - no-cache
+            X-Guploader-Uploadid:
+                - ACJd0Np5FYCbQmVC_Gd5gdFxqc8THUIbs0hm4OaRjUveuhzvAXrMQ5-k6evU0jbvsPPtM2SgOoSgyvfi5A
+        status: 204 No Content
+        code: 204
+        duration: 671.012443ms

--- a/scripts/github-actions/observedstate-test.sh
+++ b/scripts/github-actions/observedstate-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source ${REPO_ROOT}/scripts/shared-vars-public.sh
+cd ${REPO_ROOT}
+source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
+	fetch_tools && \
+	setup_envs
+
+cd ${REPO_ROOT}/
+echo "Running e2e fixtures test with vcr replay mode..."
+
+E2E_KUBE_TARGET=envtest RUN_E2E=1 \
+  E2E_GCP_TARGET=vcr VCR_MODE=replay GOLDEN_OBJECT_CHECKS=1 \
+  go test -timeout 3600s -v ./tests/e2e \
+  -run 'TestAllInSeries/fixtures/storagebucketbasic|TestAllInSeries/fixtures/storagebucketzero|TestAllInSeries/fixtures/storagebucketsoftdelete'


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Leveraged the VCR testing and the golden object comparison to verify that observed state fields are populated properly after a successful reconciliation.

Added the observed state test into the presubmit test.

Added instructions about how to generate observed state test data.



### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
