### PR TITLE
tests: use generic rule to replace pathIDs that follow normal pattern

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -331,29 +331,17 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 							kind := tokens[n-2]
 							id := tokens[n-1]
 							switch kind {
-							case "tensorboards":
-								pathIDs[id] = "${tensorboardID}"
-							case "tagKeys":
-								pathIDs[id] = "${tagKeyID}"
-							case "tagValues":
-								pathIDs[id] = "${tagValueID}"
-							case "datasets":
-								pathIDs[id] = "${datasetID}"
-							case "networks":
-								pathIDs[id] = "${networkID}"
-							case "subnetworks":
-								pathIDs[id] = "${subnetworkID}"
-							case "notificationChannels":
-								pathIDs[id] = "${notificationChannelID}"
-							case "alertPolicies":
-								pathIDs[id] = "${alertPolicyID}"
-							case "conditions":
-								pathIDs[id] = "${conditionID}"
-							case "uptimeCheckConfigs":
-								pathIDs[id] = "${uptimeCheckConfigId}"
 							case "operations":
 								operationIDs[id] = true
 								pathIDs[id] = "${operationID}"
+
+							default:
+								// e.g. bars/12345 => bars/${barID}
+								if strings.HasSuffix(kind, "ies") {
+									pathIDs[id] = "${" + strings.TrimSuffix(kind, "ies") + "yID}"
+								} else if strings.HasSuffix(kind, "s") {
+									pathIDs[id] = "${" + strings.TrimSuffix(kind, "s") + "ID}"
+								}
 							}
 						}
 					}


### PR DESCRIPTION
If we see a name ending in s, use that to form the replacement value.
Avoids having to hard-code many repetitive rules.
