### PR TITLE
chore: don't try to install protoc if already available

### DIFF
--- a/dev/tools/proto-to-mapper/Makefile
+++ b/dev/tools/proto-to-mapper/Makefile
@@ -16,7 +16,7 @@ generate-pb: install-protoc-linux
 	go run . -apis ../../../apis/ --api-packages github.com/GoogleCloudPlatform/apis
 
 install-protoc-linux:
-	sudo apt install -y protobuf-compiler
+	which protoc || sudo apt install -y protobuf-compiler
 
 install-protoc-mac:
 	sudo brew install protobuf


### PR DESCRIPTION
This avoids requiring sudo every invocation of make.
