### PR TITLE
fix: endpointIp -> endpointIP

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudidsendpoints.cloudids.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudidsendpoints.cloudids.cnrm.cloud.google.com.yaml
@@ -189,7 +189,7 @@ spec:
                     description: URL of the endpoint's network address to which traffic
                       is to be sent by Packet Mirroring.
                     type: string
-                  endpointIp:
+                  endpointIP:
                     description: Internal IP address of the endpoint's network entry
                       point.
                     type: string
@@ -370,7 +370,7 @@ spec:
                     description: URL of the endpoint's network address to which traffic
                       is to be sent by Packet Mirroring.
                     type: string
-                  endpointIp:
+                  endpointIP:
                     description: Internal IP address of the endpoint's network entry
                       point.
                     type: string

--- a/pkg/clients/generated/apis/cloudids/v1beta1/cloudidsendpoint_types.go
+++ b/pkg/clients/generated/apis/cloudids/v1beta1/cloudidsendpoint_types.go
@@ -74,7 +74,7 @@ type EndpointObservedStateStatus struct {
 
 	/* Internal IP address of the endpoint's network entry point. */
 	// +optional
-	EndpointIp *string `json:"endpointIp,omitempty"`
+	EndpointIP *string `json:"endpointIP,omitempty"`
 
 	/* Last update timestamp in RFC 3339 text format. */
 	// +optional

--- a/pkg/clients/generated/apis/cloudids/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/cloudids/v1beta1/zz_generated.deepcopy.go
@@ -167,8 +167,8 @@ func (in *EndpointObservedStateStatus) DeepCopyInto(out *EndpointObservedStateSt
 		*out = new(string)
 		**out = **in
 	}
-	if in.EndpointIp != nil {
-		in, out := &in.EndpointIp, &out.EndpointIp
+	if in.EndpointIP != nil {
+		in, out := &in.EndpointIP, &out.EndpointIP
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/resourceoverrides/cloudids_overrides.go
+++ b/pkg/resourceoverrides/cloudids_overrides.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceoverrides
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func GetCloudIDSEndpointResourceOverrides() ResourceOverrides {
+	return ResourceOverrides{
+		Kind: "CloudIDSEndpoint",
+		Overrides: []ResourceOverride{
+			mapEndpointIpToEndpointIP(),
+		},
+	}
+}
+
+func mapEndpointIpToEndpointIP() ResourceOverride {
+	return ResourceOverride{
+		CRDDecorate: func(crd *apiextensions.CustomResourceDefinition) error {
+			for _, version := range crd.Spec.Versions {
+				schema := version.Schema.OpenAPIV3Schema
+				status, ok := schema.Properties["status"]
+				if !ok {
+					return fmt.Errorf("status field not found for version %s", version.Name)
+				}
+				observedState, ok := status.Properties["observedState"]
+				if !ok {
+					return fmt.Errorf("observedState field not found for version %s", version.Name)
+				}
+				endpointIp, ok := observedState.Properties["endpointIp"]
+				if !ok {
+					return fmt.Errorf("endpointIp field not found for version %s", version.Name)
+				}
+
+				// Rename endpointIp to endpointIP
+				observedState.Properties["endpointIP"] = endpointIp
+				delete(observedState.Properties, "endpointIp")
+			}
+
+			return nil
+		},
+		PostActuationTransform: func(original, reconciled *k8s.Resource, tfState *terraform.InstanceState, dclState *unstructured.Unstructured) error {
+			endpointIp, ok := reconciled.Status["endpointIp"]
+			if !ok {
+				return fmt.Errorf("endpointIp field was not populated")
+			}
+			reconciled.Status["endpointIP"] = endpointIp
+			delete(reconciled.Status, "endpointIp")
+
+			return nil
+		},
+	}
+}

--- a/pkg/resourceoverrides/overrides.go
+++ b/pkg/resourceoverrides/overrides.go
@@ -236,4 +236,6 @@ func init() {
 
 	// IAM
 	Handler.Register(GetIAMCustomRoleResourceOverrides())
+
+	Handler.Register(GetCloudIDSEndpointResourceOverrides())
 }

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudids/cloudidsendpoint.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudids/cloudidsendpoint.md
@@ -254,7 +254,7 @@ observedGeneration: integer
 observedState:
   createTime: string
   endpointForwardingRule: string
-  endpointIp: string
+  endpointIP: string
   updateTime: string
 ```
 
@@ -343,7 +343,7 @@ observedState:
         </td>
     </tr>
     <tr>
-        <td><code>observedState.endpointIp</code></td>
+        <td><code>observedState.endpointIP</code></td>
         <td>
             <p><code class="apitype">string</code></p>
             <p>{% verbatim %}Internal IP address of the endpoint's network entry point.{% endverbatim %}</p>

--- a/tests/apichecks/testdata/exceptions/acronyms.txt
+++ b/tests/apichecks/testdata/exceptions/acronyms.txt
@@ -77,8 +77,6 @@
 [acronyms] crd=cloudfunctionsfunctions.cloudfunctions.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceArchiveUrl" should be ".spec.sourceArchiveURL"
 [acronyms] crd=cloudfunctionsfunctions.cloudfunctions.cnrm.cloud.google.com version=v1beta1: field ".status.sourceRepository.deployedUrl" should be ".status.sourceRepository.deployedURL"
 [acronyms] crd=cloudfunctionsfunctions.cloudfunctions.cnrm.cloud.google.com version=v1beta1: field ".status.versionId" should be ".status.versionID"
-[acronyms] crd=cloudidsendpoints.cloudids.cnrm.cloud.google.com version=v1alpha1: field ".status.observedState.endpointIp" should be ".status.observedState.endpointIP"
-[acronyms] crd=cloudidsendpoints.cloudids.cnrm.cloud.google.com version=v1beta1: field ".status.observedState.endpointIp" should be ".status.observedState.endpointIP"
 [acronyms] crd=cloudiotdevices.cloudiot.cnrm.cloud.google.com version=v1alpha1: field ".spec.gatewayConfig.lastAccessedGatewayId" should be ".spec.gatewayConfig.lastAccessedGatewayID"
 [acronyms] crd=cloudiotdevices.cloudiot.cnrm.cloud.google.com version=v1alpha1: field ".status.numId" should be ".status.numID"
 [acronyms] crd=cloudschedulerjobs.cloudscheduler.cnrm.cloud.google.com version=v1beta1: field ".spec.appEngineHttpTarget" should be ".spec.appEngineHTTPTarget"


### PR DESCRIPTION
Adds resource overrides for `CloudIDSEndpoint` to rename the output only field `endpointIp` to `endpointIP`.