### PR TITLE
feat: use resource mapper to generate g3doc for direct resource

### DIFF
--- a/pkg/apis/core/v1alpha1/servicemapping_types.go
+++ b/pkg/apis/core/v1alpha1/servicemapping_types.go
@@ -54,6 +54,11 @@ type ResourceConfig struct {
 	// If unset, the default API version of the service mapping will be used.
 	Version *string `json:"version"`
 
+	// Direct tells if the ResourceConfig is for ConfigConnector directly managed resources.
+	// Directly managed resource does not use Terraform or DCL controller, and do not rely on any TF specified fields like `SkipImport`
+	// A direct ResourceConfig is used to generate g3doc.
+	Direct bool `json:"direct"`
+
 	// SkipImport skips the import step when fetching the live state of the underlying
 	// resource. If specified, IDTemplate must also be specified, and its expanded
 	// form will be used as the TF resource's `id` field.

--- a/scripts/generate-crds/main.go
+++ b/scripts/generate-crds/main.go
@@ -122,12 +122,21 @@ func generateTFBasedCRDs() []*apiextensions.CustomResourceDefinition {
 				log.Fatal(err)
 			}
 			crds := make([]*apiextensions.CustomResourceDefinition, 0)
+			directCount := 0
 			for _, rc := range rcs {
+				if rc.Direct {
+					fmt.Printf("skip generate TF-based CRD for direct resource %s\n", rc.Kind)
+					directCount += 1
+					continue
+				}
 				crd, err := crdgeneration.GenerateTF2CRD(&sm, rc)
 				if err != nil {
 					log.Fatalf("error generating CRD for %v: %v", rc.Name, err)
 				}
 				crds = append(crds, crd)
+			}
+			if directCount == len(rcs) {
+				continue
 			}
 			crd, err := mergeCRDs(crds)
 			if err != nil {


### PR DESCRIPTION
Verified this in CBWP via `make ready-pr`