### PR TITLE
monitoringdashboard: round trip tests

### DIFF
--- a/dev/tasks/find-missing-fields
+++ b/dev/tasks/find-missing-fields
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+# TODO: We need to figure out how to find all the fuzz tests, or maybe we should have one fuzz test
+# that we register all the types with.
+go test -v ./pkg/controller/direct/monitoring/ -fuzz=FuzzMonitoringDashboardSpec -fuzztime 60s
+go test -v ./pkg/controller/direct/securesourcemanager/ -fuzz=FuzzSecureSourceManagerInstanceSpec -fuzztime 60s
+go test -v ./pkg/controller/direct/securesourcemanager/ -fuzz=FuzzSecureSourceManagerInstanceObservedState -fuzztime 60s

--- a/docs/releasenotes/release-1.120.md
+++ b/docs/releasenotes/release-1.120.md
@@ -35,6 +35,7 @@ output fields from GCP APIs are in `status.observedState.*`
   * Added `pieChart` widgets.
   * Added `sectionHeader` widgets.
   * Added `singleViewGroup` widgets.
+  * Added `timeSeriesTable` widgets.
 
   * Added `dataSets.targetAxis` and `y2Axis` fields to `xyChart` widgets.
   * Added `id` field to all widgets.

--- a/pkg/controller/direct/monitoring/maputils.go
+++ b/pkg/controller/direct/monitoring/maputils.go
@@ -142,8 +142,16 @@ func Duration_FromProto(mapCtx *MapContext, in *durationpb.Duration) *string {
 		return nil
 	}
 
-	d := in.AsDuration()
-	s := fmt.Sprintf("%vs", d.Seconds())
+	// We want to report the duration without truncation (do don't want to map via float64)
+	s := strconv.FormatInt(in.Seconds, 10)
+	if in.Nanos != 0 {
+		nanos := strconv.FormatInt(int64(in.Nanos), 10)
+		pad := 9 - len(nanos)
+		nanos = strings.Repeat("0", pad) + nanos
+		nanos = strings.TrimRight(nanos, "0")
+		s += "." + nanos
+	}
+	s += "s"
 	return &s
 }
 

--- a/pkg/controller/direct/monitoring/roundtrip_test.go
+++ b/pkg/controller/direct/monitoring/roundtrip_test.go
@@ -47,7 +47,6 @@ func FuzzMonitoringDashboardSpec(f *testing.F) {
 		unimplementedFields := sets.New(
 			".name",
 			".labels",
-			".dashboard_filters",
 		)
 
 		// Widgets are under a few paths
@@ -58,33 +57,17 @@ func FuzzMonitoringDashboardSpec(f *testing.F) {
 			".row_layout.rows[].widgets[]",
 		}
 		for _, widgetPath := range widgetPaths {
-			unimplementedFields.Insert(widgetPath + ".xy_chart.data_sets[].target_axis")
-			unimplementedFields.Insert(widgetPath + ".xy_chart.data_sets[].time_series_query.prometheus_query")
-			unimplementedFields.Insert(widgetPath + ".xy_chart.y2_axis")
-			unimplementedFields.Insert(widgetPath + ".xy_chart.timeshift_duration")
-			unimplementedFields.Insert(widgetPath + ".xy_chart.thresholds[].target_axis")
-
-			// This one might be a bug?
-			unimplementedFields.Insert(widgetPath + ".xy_chart.data_sets[].min_alignment_period.nanos")
-
-			unimplementedFields.Insert(widgetPath + ".scorecard.thresholds[].target_axis")
 			unimplementedFields.Insert(widgetPath + ".scorecard.blank_view")
 
-			unimplementedFields.Insert(widgetPath + ".alert_chart")
+			unimplementedFields.Insert(widgetPath + ".pie_chart.data_sets[].time_series_query.time_series_filter.statistical_time_series_filter")
+			unimplementedFields.Insert(widgetPath + ".pie_chart.data_sets[].time_series_query.time_series_filter.pick_time_series_filter.interval")
+			unimplementedFields.Insert(widgetPath + ".pie_chart.data_sets[].time_series_query.time_series_filter_ratio.statistical_time_series_filter")
+			unimplementedFields.Insert(widgetPath + ".pie_chart.data_sets[].time_series_query.time_series_filter_ratio.pick_time_series_filter.interval")
 
-			unimplementedFields.Insert(widgetPath + ".time_series_table")
-
-			unimplementedFields.Insert(widgetPath + ".pie_chart")
-
-			unimplementedFields.Insert(widgetPath + ".single_view_group")
-
-			unimplementedFields.Insert(widgetPath + ".time_series_table")
-
-			unimplementedFields.Insert(widgetPath + ".error_reporting_panel")
-
-			unimplementedFields.Insert(widgetPath + ".incident_list")
-
-			unimplementedFields.Insert(widgetPath + ".id")
+			unimplementedFields.Insert(widgetPath + ".time_series_table.data_sets[].time_series_query.time_series_filter.statistical_time_series_filter")
+			unimplementedFields.Insert(widgetPath + ".time_series_table.data_sets[].time_series_query.time_series_filter.pick_time_series_filter.interval")
+			unimplementedFields.Insert(widgetPath + ".time_series_table.data_sets[].time_series_query.time_series_filter_ratio.statistical_time_series_filter")
+			unimplementedFields.Insert(widgetPath + ".time_series_table.data_sets[].time_series_query.time_series_filter_ratio.pick_time_series_filter.interval")
 		}
 
 		// Remove any output only or known-unimplemented fields
@@ -96,8 +79,17 @@ func FuzzMonitoringDashboardSpec(f *testing.F) {
 		// Force resource_names to be valid
 		r := &ReplaceFields{}
 		r.Func = func(path string, val protoreflect.Value) (protoreflect.Value, bool) {
+			// resource_names should be valid projects
 			if strings.HasSuffix(path, ".resource_names[]") {
 				return protoreflect.ValueOfString("projects/" + val.String()), true
+			}
+			// alignment_period only supports seconds
+			if strings.HasSuffix(path, ".alignment_period.nanos") {
+				return protoreflect.ValueOfInt32(0), true
+			}
+			// min_alignment_period only supports seconds
+			if strings.HasSuffix(path, ".min_alignment_period.nanos") {
+				return protoreflect.ValueOfInt32(0), true
 			}
 			return protoreflect.Value{}, false
 		}


### PR DESCRIPTION
Create a script to run our round-trip tests, also stop excluding some fields we
have added support for, and normalize more values to be valid
(e.g. alignment_period only supports whole seconds)