### PR TITLE
mockgcp: support enum-encoding=int alt specifier

### DIFF
--- a/mockgcp/common/httpmux/mux.go
+++ b/mockgcp/common/httpmux/mux.go
@@ -33,7 +33,7 @@ type Options struct {
 }
 
 type ServeMux struct {
-	*runtime.ServeMux
+	ServeMux *runtime.ServeMux
 
 	// RewriteError allows us to customize the error we return.
 	// Error can be changed in-place.
@@ -51,6 +51,20 @@ func NewServeMux(ctx context.Context, conn *grpc.ClientConn, opt Options, handle
 		Marshaler: &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
 				EmitUnpopulated: opt.EmitUnpopulated,
+				Resolver:        resolver,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+				Resolver:       resolver,
+			},
+		},
+	}
+
+	marshalerWithEnumNumbers := &runtime.HTTPBodyMarshaler{
+		Marshaler: &runtime.JSONPb{
+			MarshalOptions: protojson.MarshalOptions{
+				EmitUnpopulated: opt.EmitUnpopulated,
+				UseEnumNumbers:  true,
 				Resolver:        resolver,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{
@@ -78,6 +92,7 @@ func NewServeMux(ctx context.Context, conn *grpc.ClientConn, opt Options, handle
 
 	mux := runtime.NewServeMux(
 		runtime.WithErrorHandler(m.customErrorHandler),
+		runtime.WithMarshalerOption("application/json;enum-encoding=int", marshalerWithEnumNumbers),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, marshaler),
 		runtime.WithOutgoingHeaderMatcher(outgoingHeaderMatcher),
 		runtime.WithForwardResponseOption(m.addGCPHeaders),
@@ -110,4 +125,20 @@ func (m *ServeMux) addGCPHeaders(ctx context.Context, w http.ResponseWriter, res
 	}
 
 	return nil
+}
+
+func (m *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	handler := m.ServeMux.ServeHTTP
+
+	for k, values := range r.URL.Query() {
+		if k == "$alt" {
+			for _, v := range values {
+				if v == "json;enum-encoding=int" {
+					klog.Infof("found %q=%q, will convert to Accept header", k, v)
+					r.Header.Set("Accept", "application/json;enum-encoding=int")
+				}
+			}
+		}
+	}
+	handler(w, r)
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
@@ -633,7 +633,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
   "privatePoolV1Config": {
     "networkConfig": {
-      "egressOption": "NO_PUBLIC_EGRESS",
+      "egressOption": 1,
       "peeredNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
       "peeredNetworkIpRange": "/29"
     },
@@ -756,7 +756,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
   "privatePoolV1Config": {
     "networkConfig": {
-      "egressOption": "NO_PUBLIC_EGRESS",
+      "egressOption": 1,
       "peeredNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
       "peeredNetworkIpRange": "/29"
     },

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_http.log
@@ -128,12 +128,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -144,14 +144,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "100s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -160,12 +160,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -176,7 +176,7 @@ X-Xss-Protection: 0
               "timeshiftDuration": "60s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -227,12 +227,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -243,14 +243,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "100s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -259,12 +259,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -275,7 +275,7 @@ X-Xss-Protection: 0
               "timeshiftDuration": "60s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -403,12 +403,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -419,14 +419,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "100s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -435,12 +435,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -451,7 +451,7 @@ X-Xss-Protection: 0
               "timeshiftDuration": "60s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -502,12 +502,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -518,14 +518,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "100s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -534,12 +534,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -550,7 +550,7 @@ X-Xss-Protection: 0
               "timeshiftDuration": "60s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -674,12 +674,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -690,14 +690,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -706,12 +706,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -721,7 +721,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -769,12 +769,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -785,14 +785,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -801,12 +801,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -816,7 +816,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_http.log
@@ -451,12 +451,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y2",
+                  "plotType": 1,
+                  "targetAxis": 2,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -467,26 +467,26 @@ X-Xss-Protection: 0
               "timeshiftDuration": "600.500s",
               "y2Axis": {
                 "label": "y2Axis",
-                "scale": "LOG10"
+                "scale": 2
               },
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {
                 "backgroundColor": "#000",
-                "fontSize": "FS_LARGE",
-                "horizontalAlignment": "H_CENTER",
-                "padding": "P_MEDIUM",
-                "pointerLocation": "PL_TOP_LEFT",
+                "fontSize": 4,
+                "horizontalAlignment": 2,
+                "padding": 3,
+                "pointerLocation": 5,
                 "textColor": "#fff",
-                "verticalAlignment": "V_CENTER"
+                "verticalAlignment": 2
               }
             }
           },
@@ -496,12 +496,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -512,13 +512,13 @@ X-Xss-Protection: 0
               "thresholds": [
                 {
                   "label": "Important",
-                  "targetAxis": "Y1",
+                  "targetAxis": 1,
                   "value": 1.2
                 }
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -561,7 +561,7 @@ X-Xss-Protection: 0
           },
           {
             "pieChart": {
-              "chartType": "DONUT",
+              "chartType": 2,
               "dataSets": [
                 {
                   "minAlignmentPeriod": "60s",
@@ -570,12 +570,12 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\"",
                       "secondaryAggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
+                        "perSeriesAligner": 12
                       }
                     }
                   }
@@ -619,14 +619,14 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\""
                     }
                   }
                 }
               ],
-              "metricVisualization": "NUMBER"
+              "metricVisualization": 1
             },
             "title": "TimeSeriesTable Widget"
           },
@@ -655,13 +655,13 @@ X-Xss-Protection: 0
   },
   "dashboardFilters": [
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "instance_id",
       "stringValue": "3133577226154888113",
       "templateVariable": "iid"
     },
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "zone"
     }
   ],
@@ -704,12 +704,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y2",
+                  "plotType": 1,
+                  "targetAxis": 2,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -720,26 +720,26 @@ X-Xss-Protection: 0
               "timeshiftDuration": "600.500s",
               "y2Axis": {
                 "label": "y2Axis",
-                "scale": "LOG10"
+                "scale": 2
               },
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {
                 "backgroundColor": "#000",
-                "fontSize": "FS_LARGE",
-                "horizontalAlignment": "H_CENTER",
-                "padding": "P_MEDIUM",
-                "pointerLocation": "PL_TOP_LEFT",
+                "fontSize": 4,
+                "horizontalAlignment": 2,
+                "padding": 3,
+                "pointerLocation": 5,
                 "textColor": "#fff",
-                "verticalAlignment": "V_CENTER"
+                "verticalAlignment": 2
               }
             }
           },
@@ -749,12 +749,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -765,13 +765,13 @@ X-Xss-Protection: 0
               "thresholds": [
                 {
                   "label": "Important",
-                  "targetAxis": "Y1",
+                  "targetAxis": 1,
                   "value": 1.2
                 }
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -814,7 +814,7 @@ X-Xss-Protection: 0
           },
           {
             "pieChart": {
-              "chartType": "DONUT",
+              "chartType": 2,
               "dataSets": [
                 {
                   "minAlignmentPeriod": "60s",
@@ -823,12 +823,12 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\"",
                       "secondaryAggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
+                        "perSeriesAligner": 12
                       }
                     }
                   }
@@ -872,14 +872,14 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\""
                     }
                   }
                 }
               ],
-              "metricVisualization": "NUMBER"
+              "metricVisualization": 1
             },
             "title": "TimeSeriesTable Widget"
           },
@@ -908,13 +908,13 @@ X-Xss-Protection: 0
   },
   "dashboardFilters": [
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "instance_id",
       "stringValue": "3133577226154888113",
       "templateVariable": "iid"
     },
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "zone"
     }
   ],
@@ -1190,12 +1190,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y2",
+                  "plotType": 1,
+                  "targetAxis": 2,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -1206,26 +1206,26 @@ X-Xss-Protection: 0
               "timeshiftDuration": "600.500s",
               "y2Axis": {
                 "label": "y2Axis",
-                "scale": "LOG10"
+                "scale": 2
               },
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {
                 "backgroundColor": "#000",
-                "fontSize": "FS_LARGE",
-                "horizontalAlignment": "H_CENTER",
-                "padding": "P_MEDIUM",
-                "pointerLocation": "PL_TOP_LEFT",
+                "fontSize": 4,
+                "horizontalAlignment": 2,
+                "padding": 3,
+                "pointerLocation": 5,
                 "textColor": "#fff",
-                "verticalAlignment": "V_CENTER"
+                "verticalAlignment": 2
               }
             }
           },
@@ -1235,12 +1235,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -1251,13 +1251,13 @@ X-Xss-Protection: 0
               "thresholds": [
                 {
                   "label": "Important",
-                  "targetAxis": "Y1",
+                  "targetAxis": 1,
                   "value": 1.2
                 }
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -1300,7 +1300,7 @@ X-Xss-Protection: 0
           },
           {
             "pieChart": {
-              "chartType": "DONUT",
+              "chartType": 2,
               "dataSets": [
                 {
                   "minAlignmentPeriod": "60s",
@@ -1309,12 +1309,12 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\"",
                       "secondaryAggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
+                        "perSeriesAligner": 12
                       }
                     }
                   }
@@ -1358,14 +1358,14 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\""
                     }
                   }
                 }
               ],
-              "metricVisualization": "NUMBER"
+              "metricVisualization": 1
             },
             "title": "TimeSeriesTable Widget"
           },
@@ -1394,13 +1394,13 @@ X-Xss-Protection: 0
   },
   "dashboardFilters": [
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "instance_id",
       "stringValue": "3133577226154888113",
       "templateVariable": "iid"
     },
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "zone"
     }
   ],
@@ -1443,12 +1443,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y2",
+                  "plotType": 1,
+                  "targetAxis": 2,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -1459,26 +1459,26 @@ X-Xss-Protection: 0
               "timeshiftDuration": "600.500s",
               "y2Axis": {
                 "label": "y2Axis",
-                "scale": "LOG10"
+                "scale": 2
               },
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {
                 "backgroundColor": "#000",
-                "fontSize": "FS_LARGE",
-                "horizontalAlignment": "H_CENTER",
-                "padding": "P_MEDIUM",
-                "pointerLocation": "PL_TOP_LEFT",
+                "fontSize": 4,
+                "horizontalAlignment": 2,
+                "padding": 3,
+                "pointerLocation": 5,
                 "textColor": "#fff",
-                "verticalAlignment": "V_CENTER"
+                "verticalAlignment": 2
               }
             }
           },
@@ -1488,12 +1488,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -1504,13 +1504,13 @@ X-Xss-Protection: 0
               "thresholds": [
                 {
                   "label": "Important",
-                  "targetAxis": "Y1",
+                  "targetAxis": 1,
                   "value": 1.2
                 }
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -1553,7 +1553,7 @@ X-Xss-Protection: 0
           },
           {
             "pieChart": {
-              "chartType": "DONUT",
+              "chartType": 2,
               "dataSets": [
                 {
                   "minAlignmentPeriod": "60s",
@@ -1562,12 +1562,12 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\"",
                       "secondaryAggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
+                        "perSeriesAligner": 12
                       }
                     }
                   }
@@ -1611,14 +1611,14 @@ X-Xss-Protection: 0
                     "timeSeriesFilter": {
                       "aggregation": {
                         "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"compute.googleapis.com/instance/disk/read_bytes_count\" resource.type=\"gce_instance\""
                     }
                   }
                 }
               ],
-              "metricVisualization": "NUMBER"
+              "metricVisualization": 1
             },
             "title": "TimeSeriesTable Widget"
           },
@@ -1647,13 +1647,13 @@ X-Xss-Protection: 0
   },
   "dashboardFilters": [
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "instance_id",
       "stringValue": "3133577226154888113",
       "templateVariable": "iid"
     },
     {
-      "filterType": "RESOURCE_LABEL",
+      "filterType": 1,
       "labelKey": "zone"
     }
   ],

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardrefs/_http.log
@@ -279,12 +279,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -295,14 +295,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -311,12 +311,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -326,7 +326,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -377,12 +377,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -393,14 +393,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -409,12 +409,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -424,7 +424,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -551,12 +551,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -567,14 +567,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -583,12 +583,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -598,7 +598,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -649,12 +649,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -665,14 +665,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -681,12 +681,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -696,7 +696,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -820,12 +820,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -836,14 +836,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -852,12 +852,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -867,7 +867,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
@@ -915,12 +915,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
+                  "plotType": 1,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -931,14 +931,14 @@ X-Xss-Protection: 0
               "timeshiftDuration": "0s",
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },
           {
             "text": {
               "content": "Widget 2",
-              "format": "MARKDOWN",
+              "format": 1,
               "style": {}
             }
           },
@@ -947,12 +947,12 @@ X-Xss-Protection: 0
             "xyChart": {
               "dataSets": [
                 {
-                  "plotType": "STACKED_BAR",
-                  "targetAxis": "Y1",
+                  "plotType": 3,
+                  "targetAxis": 1,
                   "timeSeriesQuery": {
                     "timeSeriesFilter": {
                       "aggregation": {
-                        "perSeriesAligner": "ALIGN_RATE"
+                        "perSeriesAligner": 2
                       },
                       "filter": "metric.type=\"agent.googleapis.com/nginx/connections/accepted_count\""
                     },
@@ -962,7 +962,7 @@ X-Xss-Protection: 0
               ],
               "yAxis": {
                 "label": "y1Axis",
-                "scale": "LINEAR"
+                "scale": 1
               }
             }
           },


### PR DESCRIPTION
Clients can specify a query parameter of $alt=json;enum-encoding=int
(with some escaping) to get integer encoded values from protos.

We support this for more fidelity with mockgcp (though it does make
things a bit harder to read - ideally the clients would not do this,
but if we use the default clients we don't have full control here)
