### PR TITLE
Add update logic to handle unmanage and unset behaviour the same as t…

### DIFF
--- a/pkg/controller/direct/gkehub/acmconversion.go
+++ b/pkg/controller/direct/gkehub/acmconversion.go
@@ -49,6 +49,24 @@ func convertKRMtoAPI_ConfigManagement(r *krm.FeaturemembershipConfigmanagement) 
 
 }
 
+func convertAPItoKRM_ConfigManagement(r *featureapi.ConfigManagementMembershipSpec) *krm.FeaturemembershipConfigmanagement {
+	krmObj := krm.FeaturemembershipConfigmanagement{}
+	if r.Binauthz != nil {
+		krmObj.Binauthz = convertAPItoKRM_Binauthz(r.Binauthz)
+	}
+	if r.ConfigSync != nil {
+		krmObj.ConfigSync = convertAPItoKRM_ConfigSync(r.ConfigSync)
+	}
+	if r.HierarchyController != nil {
+		krmObj.HierarchyController = convertAPItoKRM_HierachyController(r.HierarchyController)
+	}
+	if r.PolicyController != nil {
+		krmObj.PolicyController = convertAPItoKRM_ConfigManagementPolicyController(r.PolicyController)
+	}
+	krmObj.Version = LazyPtr(r.Version)
+	return &krmObj
+}
+
 func convertKRMtoAPI_ConfigManagementPolicyController(r *krm.FeaturemembershipPolicyController) (*featureapi.ConfigManagementPolicyController, error) {
 	apiObj := featureapi.ConfigManagementPolicyController{}
 	if r.AuditIntervalSeconds != nil {
@@ -82,12 +100,39 @@ func convertKRMtoAPI_ConfigManagementPolicyController(r *krm.FeaturemembershipPo
 	return &apiObj, nil
 }
 
+func convertAPItoKRM_ConfigManagementPolicyController(r *featureapi.ConfigManagementPolicyController) *krm.FeaturemembershipPolicyController {
+	krmObj := krm.FeaturemembershipPolicyController{}
+	if r.AuditIntervalSeconds != 0 {
+		krmObj.AuditIntervalSeconds = PtrTo(convertInt64toString(r.AuditIntervalSeconds))
+	}
+	krmObj.Enabled = LazyPtr(r.Enabled)
+	if r.ExemptableNamespaces != nil {
+		krmObj.ExemptableNamespaces = r.ExemptableNamespaces
+	}
+	krmObj.LogDeniesEnabled = LazyPtr(r.LogDeniesEnabled)
+	if r.Monitoring != nil {
+		krmObj.Monitoring = convertAPItoKRM_Monitoring(r.Monitoring)
+	}
+	krmObj.MutationEnabled = LazyPtr(r.MutationEnabled)
+	krmObj.ReferentialRulesEnabled = LazyPtr(r.ReferentialRulesEnabled)
+	krmObj.TemplateLibraryInstalled = LazyPtr(r.TemplateLibraryInstalled)
+	return &krmObj
+}
+
 func convertKRMtoAPI_Monitoring(r *krm.FeaturemembershipMonitoring) *featureapi.ConfigManagementPolicyControllerMonitoring {
 	apiObj := featureapi.ConfigManagementPolicyControllerMonitoring{}
 	if r.Backends != nil {
 		apiObj.Backends = r.Backends
 	}
 	return &apiObj
+}
+
+func convertAPItoKRM_Monitoring(r *featureapi.ConfigManagementPolicyControllerMonitoring) *krm.FeaturemembershipMonitoring {
+	krmObj := krm.FeaturemembershipMonitoring{}
+	if r.Backends != nil {
+		krmObj.Backends = r.Backends
+	}
+	return &krmObj
 }
 
 func convertKRMtoAPI_HierachyController(r *krm.FeaturemembershipHierarchyController) *featureapi.ConfigManagementHierarchyControllerConfig {
@@ -104,12 +149,26 @@ func convertKRMtoAPI_HierachyController(r *krm.FeaturemembershipHierarchyControl
 	return &apiObj
 }
 
+func convertAPItoKRM_HierachyController(r *featureapi.ConfigManagementHierarchyControllerConfig) *krm.FeaturemembershipHierarchyController {
+	krmObj := krm.FeaturemembershipHierarchyController{}
+	krmObj.EnableHierarchicalResourceQuota = LazyPtr(r.EnableHierarchicalResourceQuota)
+	krmObj.EnablePodTreeLabels = LazyPtr(r.EnablePodTreeLabels)
+	krmObj.Enabled = LazyPtr(r.Enabled)
+	return &krmObj
+}
+
 func convertKRMtoAPI_Binauthz(r *krm.FeaturemembershipBinauthz) *featureapi.ConfigManagementBinauthzConfig {
 	apiObj := featureapi.ConfigManagementBinauthzConfig{}
 	if r.Enabled != nil {
 		apiObj.Enabled = *r.Enabled
 	}
 	return &apiObj
+}
+
+func convertAPItoKRM_Binauthz(r *featureapi.ConfigManagementBinauthzConfig) *krm.FeaturemembershipBinauthz {
+	krmObj := krm.FeaturemembershipBinauthz{}
+	krmObj.Enabled = LazyPtr(r.Enabled)
+	return &krmObj
 }
 
 func convertKRMtoAPI_ConfigSync(r *krm.FeaturemembershipConfigSync) (*featureapi.ConfigManagementConfigSync, error) {
@@ -120,6 +179,9 @@ func convertKRMtoAPI_ConfigSync(r *krm.FeaturemembershipConfigSync) (*featureapi
 			return nil, err
 		}
 		apiObj.Git = val
+	}
+	if r.MetricsGcpServiceAccountRef != nil {
+		apiObj.MetricsGcpServiceAccountEmail = r.MetricsGcpServiceAccountRef.External
 	}
 	if r.Oci != nil {
 		val, err := convertKRMtoAPI_Oci(r.Oci)
@@ -137,8 +199,29 @@ func convertKRMtoAPI_ConfigSync(r *krm.FeaturemembershipConfigSync) (*featureapi
 	return &apiObj, nil
 }
 
+func convertAPItoKRM_ConfigSync(r *featureapi.ConfigManagementConfigSync) *krm.FeaturemembershipConfigSync {
+	krmObj := krm.FeaturemembershipConfigSync{}
+	if r.Git != nil {
+		krmObj.Git = convertAPItoKRM_Git(r.Git)
+	}
+	if r.MetricsGcpServiceAccountEmail != "" {
+		krmObj.MetricsGcpServiceAccountRef.External = r.MetricsGcpServiceAccountEmail
+	}
+	if r.Oci != nil {
+		krmObj.Oci = convertAPItoKRM_Oci(r.Oci)
+	}
+	krmObj.PreventDrift = LazyPtr(r.PreventDrift)
+	if r.SourceFormat != "" {
+		krmObj.SourceFormat = &r.SourceFormat
+	}
+	return &krmObj
+}
+
 func convertKRMtoAPI_Git(r *krm.FeaturemembershipGit) (*featureapi.ConfigManagementGitConfig, error) {
 	apiObj := featureapi.ConfigManagementGitConfig{}
+	if r.GcpServiceAccountRef != nil {
+		apiObj.GcpServiceAccountEmail = r.GcpServiceAccountRef.External
+	}
 	if r.HttpsProxy != nil {
 		apiObj.HttpsProxy = *r.HttpsProxy
 	}
@@ -167,8 +250,29 @@ func convertKRMtoAPI_Git(r *krm.FeaturemembershipGit) (*featureapi.ConfigManagem
 	return &apiObj, nil
 }
 
+func convertAPItoKRM_Git(r *featureapi.ConfigManagementGitConfig) *krm.FeaturemembershipGit {
+	krmObj := krm.FeaturemembershipGit{}
+	if r.GcpServiceAccountEmail != "" {
+		krmObj.GcpServiceAccountRef.External = r.GcpServiceAccountEmail
+	}
+	krmObj.HttpsProxy = LazyPtr(r.HttpsProxy)
+	krmObj.PolicyDir = LazyPtr(r.PolicyDir)
+	krmObj.SecretType = LazyPtr(r.SecretType)
+	krmObj.SyncBranch = LazyPtr(r.SyncBranch)
+	krmObj.SyncRepo = LazyPtr(r.SyncRepo)
+	krmObj.SyncRev = LazyPtr(r.SyncRev)
+	// treat as unset if the value is 0
+	if r.SyncWaitSecs != 0 {
+		krmObj.SyncWaitSecs = PtrTo(convertInt64toString(r.SyncWaitSecs))
+	}
+	return &krmObj
+}
+
 func convertKRMtoAPI_Oci(r *krm.FeaturemembershipOci) (*featureapi.ConfigManagementOciConfig, error) {
 	apiObj := featureapi.ConfigManagementOciConfig{}
+	if r.GcpServiceAccountRef != nil {
+		apiObj.GcpServiceAccountEmail = r.GcpServiceAccountRef.External
+	}
 	if r.PolicyDir != nil {
 		apiObj.PolicyDir = *r.PolicyDir
 	}
@@ -186,4 +290,19 @@ func convertKRMtoAPI_Oci(r *krm.FeaturemembershipOci) (*featureapi.ConfigManagem
 		apiObj.SyncWaitSecs = val
 	}
 	return &apiObj, nil
+}
+
+func convertAPItoKRM_Oci(r *featureapi.ConfigManagementOciConfig) *krm.FeaturemembershipOci {
+	krmObj := krm.FeaturemembershipOci{}
+	if r.GcpServiceAccountEmail != "" {
+		krmObj.GcpServiceAccountRef.External = r.GcpServiceAccountEmail
+	}
+	krmObj.PolicyDir = LazyPtr(r.PolicyDir)
+	krmObj.SecretType = LazyPtr(r.SecretType)
+	krmObj.SyncRepo = LazyPtr(r.SyncRepo)
+
+	if r.SyncWaitSecs != 0 {
+		krmObj.SyncWaitSecs = PtrTo(convertInt64toString(r.SyncWaitSecs))
+	}
+	return &krmObj
 }

--- a/pkg/controller/direct/gkehub/diffs.go
+++ b/pkg/controller/direct/gkehub/diffs.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gkehub
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/gkehub/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type diff struct {
+	path       string
+	desiredVal any
+}
+
+// objectDiffWalker walks through two objects and record any fields diffs and errors.
+type objectDiffWalker struct {
+	errs  []error
+	diffs []diff
+}
+
+// records the left value as the desired value.
+func (o *objectDiffWalker) recordDiff(lV any, path string) {
+	o.diffs = append(o.diffs, diff{path: path, desiredVal: lV})
+}
+
+// To follow the "unmanage and unset" behaviour, the visitAny function does the following:
+// lV is the desired state and rV is the actual state.
+// * Fields both present in lV and rV, but have different values, record the diff.
+// * Fields only present in lV but not in rV, record the diff.
+// * Fields not present in lV but in rV, do not record the diff.
+func (o *objectDiffWalker) visitAny(lV, rV any, path string) {
+	if lV == nil {
+		return
+	}
+	if rV == nil {
+		o.recordDiff(lV, path)
+	}
+	switch lV := lV.(type) {
+	case map[string]any:
+		m, ok := rV.(map[string]any)
+		if !ok {
+			o.errs = append(o.errs, fmt.Errorf("unhandled type at path %q: %T", path, rV))
+		} else {
+			o.visitMap(lV, m, path)
+		}
+	case []any:
+		m, ok := rV.([]any)
+		// For the gkehub API, slices only contain primitive types.
+		if !ok {
+			o.errs = append(o.errs, fmt.Errorf("unhandled type at path %q: %T", path, rV))
+		} else {
+			if !reflect.DeepEqual(lV, m) {
+				o.recordDiff(lV, path)
+			}
+		}
+	case int64, float64, bool, string:
+		if !reflect.DeepEqual(lV, rV) {
+			o.recordDiff(lV, path)
+		}
+	default:
+		o.errs = append(o.errs, fmt.Errorf("unhandled type at path %q: %T", path, lV))
+	}
+}
+
+func (o *objectDiffWalker) visitMap(l, r map[string]any, path string) {
+	var childPath string
+	for k, lV := range l {
+		if len(path) == 0 {
+			childPath = k
+		} else {
+			childPath = path + "." + k
+		}
+		rV, found := r[k]
+		if !found {
+			o.recordDiff(lV, childPath)
+			continue
+		}
+		o.visitAny(lV, rV, childPath)
+	}
+}
+
+// ListFieldDiffs assuems the l and r has similar structure after converting to unstructed. otherwise, throw an error.
+func ListFieldDiffs(l any, r any) ([]diff, error) {
+	lObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&l)
+	if err != nil {
+		return nil, fmt.Errorf("converting %T to unstructured: %w", l, err)
+	}
+	rObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&r)
+	if err != nil {
+		return nil, fmt.Errorf("converting %T to unstructured: %w", r, err)
+	}
+	o := &objectDiffWalker{}
+	o.visitMap(lObj, rObj, "")
+	return o.diffs, errors.Join(o.errs...)
+}
+
+func SetObjWithDiffs(obj *map[string]interface{}, diffs []diff) error {
+	for _, diff := range diffs {
+		switch val := diff.desiredVal.(type) {
+		case map[string]interface{}:
+			if err := unstructured.SetNestedField(*obj, val, strings.Split(diff.path, ".")...); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := unstructured.SetNestedSlice(*obj, val, strings.Split(diff.path, ".")...); err != nil {
+				return err
+			}
+		case int64, float64, bool, string:
+			if err := unstructured.SetNestedField(*obj, val, strings.Split(diff.path, ".")...); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unhandled type at path %q: %T", diff.path, val)
+		}
+	}
+	return nil
+}
+
+// newFeatureMembershipKRMWithDiffs creates a GKEHubFeatureMembershipSpec struct from a GKEHubFeatureMembershipSpec struct with the diffs set.
+func newFeatureMembershipKRMWithDiffs(r *krm.GKEHubFeatureMembershipSpec, diffs []diff) (*krm.GKEHubFeatureMembershipSpec, error) {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
+	if err != nil {
+		return nil, fmt.Errorf("converting %T to unstructured: %w", r, err)
+	}
+	if err := SetObjWithDiffs(&u, diffs); err != nil {
+		return nil, err
+	}
+	obj := &krm.GKEHubFeatureMembershipSpec{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+	return obj, nil
+}

--- a/pkg/controller/direct/gkehub/diffs_test.go
+++ b/pkg/controller/direct/gkehub/diffs_test.go
@@ -1,0 +1,394 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gkehub
+
+import (
+	"reflect"
+	"testing"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/gkehub/v1beta1"
+)
+
+var (
+	dummyString1 = "fakeString1"
+	dummyString2 = "fakeString2"
+	dummyBool1   = true
+	dummyBool2   = false
+)
+
+func Test_ListFieldDiffs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		left          krm.GKEHubFeatureMembershipSpec
+		right         krm.GKEHubFeatureMembershipSpec
+		expectedDiffs []diff
+		expectedError bool
+	}{
+		{
+			name: "left is a subset of right, no diff",
+			left: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString1,
+							SyncRev:    &dummyString1,
+						},
+						PreventDrift: &dummyBool1,
+					},
+					Version: &dummyString1,
+				},
+			},
+			right: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString1,
+							SyncRev:    &dummyString1,
+							SecretType: &dummyString1,
+							SyncBranch: &dummyString1,
+						},
+						PreventDrift: &dummyBool1,
+						SourceFormat: &dummyString1,
+					},
+					Version: &dummyString1,
+				},
+			},
+		},
+		{
+			name: "left has some fields with their values different from right, diff exists",
+			left: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString1,
+							SyncRev:    &dummyString1,
+						},
+						PreventDrift: &dummyBool1,
+					},
+					Version: &dummyString1,
+				},
+			},
+			right: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString2,
+							SyncRev:    &dummyString1,
+							SecretType: &dummyString1,
+							SyncBranch: &dummyString1,
+						},
+						PreventDrift: &dummyBool2,
+						SourceFormat: &dummyString1,
+					},
+					Version: &dummyString2,
+				},
+			},
+			expectedDiffs: []diff{
+				{
+					path:       "configmanagement.configSync.git.httpsProxy",
+					desiredVal: dummyString1,
+				},
+				{
+					path:       "configmanagement.version",
+					desiredVal: dummyString1,
+				},
+				{
+					path:       "configmanagement.configSync.preventDrift",
+					desiredVal: dummyBool1,
+				},
+			},
+		},
+		{
+			name: "left has some fields that right doesn't have, diff exists",
+			left: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString1,
+							SyncRev:    &dummyString1,
+							SecretType: &dummyString1,
+							SyncBranch: &dummyString1,
+						},
+						PreventDrift: &dummyBool1,
+						SourceFormat: &dummyString1,
+					},
+					Version: &dummyString1,
+				},
+			},
+			right: krm.GKEHubFeatureMembershipSpec{
+				Configmanagement: &krm.FeaturemembershipConfigmanagement{
+					ConfigSync: &krm.FeaturemembershipConfigSync{
+						Git: &krm.FeaturemembershipGit{
+							HttpsProxy: &dummyString1,
+							SecretType: &dummyString1,
+						},
+						PreventDrift: &dummyBool1,
+					},
+					Version: &dummyString1,
+				},
+			},
+			expectedDiffs: []diff{
+				{
+					path:       "configmanagement.configSync.git.syncRev",
+					desiredVal: dummyString1,
+				}, {
+					path:       "configmanagement.configSync.git.syncBranch",
+					desiredVal: dummyString1,
+				},
+				{
+					path:       "configmanagement.configSync.sourceFormat",
+					desiredVal: dummyString1,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs, err := ListFieldDiffs(tc.left, &tc.right)
+			if err != nil != tc.expectedError {
+				t.Errorf("ListFieldDiffs returns error %v; expected %t", err, tc.expectedError)
+			}
+			if !diffsEqual(diffs, tc.expectedDiffs) {
+				t.Errorf("ListFieldDiffs returns diffs %+v; expected %+v", diffs, tc.expectedDiffs)
+			}
+		})
+	}
+}
+
+func diffsEqual(l, r []diff) bool {
+	if l == nil && r == nil {
+		return true
+	} else if l == nil || r == nil {
+		return false
+	}
+	if len(l) != len(r) {
+		return false
+	}
+	checkedTimes := 0
+	for _, lDiff := range l {
+		for _, rDiff := range r {
+			if !reflect.DeepEqual(lDiff, rDiff) {
+				continue
+			}
+			checkedTimes++
+			break
+		}
+	}
+	return checkedTimes == len(l)
+}
+
+func Test_SetObjWithDiffs(t *testing.T) {
+	testCases := []struct {
+		name             string
+		resource         map[string]interface{}
+		diffs            []diff
+		expectedResource map[string]interface{}
+		expectedError    bool
+	}{
+		{
+			name: "two equal objects with no diff",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+							},
+							"preventDrift": dummyBool1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+			expectedResource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+							},
+							"preventDrift": dummyBool1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+		},
+		{
+			name: "unrecognized field type",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+							},
+							"preventDrift": dummyBool1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+			diffs: []diff{
+				{
+					path: "spec.configmanagement.configSync.fieldWithUnexpectedType",
+					desiredVal: map[int]interface{}{
+						1: 1,
+						2: 2,
+					},
+				},
+			},
+			expectedError: true,
+			expectedResource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+							},
+							"preventDrift": dummyBool1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+		},
+		{
+			name: "set some null fields",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"preventDrift": dummyBool1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+			diffs: []diff{
+				{
+					path: "spec.configmanagement.configSync.git",
+					desiredVal: map[string]interface{}{
+						"httpsProxy": dummyString1,
+						"syncRev":    dummyString1,
+						"secretType": dummyString1,
+						"syncBranch": dummyString1,
+					},
+				},
+				{
+					path:       "spec.configmanagement.configSync.sourceFormat",
+					desiredVal: dummyString1,
+				},
+				{
+					path: "spec.configmanagement.policyController.exemptableNamespaces",
+					desiredVal: []interface{}{
+						dummyString1,
+					},
+				},
+			},
+
+			expectedResource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+								"secretType": dummyString1,
+								"syncBranch": dummyString1,
+							},
+							"preventDrift": dummyBool1,
+							"sourceFormat": dummyString1,
+						},
+						"policyController": map[string]interface{}{
+							"exemptableNamespaces": []interface{}{
+								dummyString1,
+							},
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+		},
+		{
+			name: "overrride field values",
+			resource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString1,
+								"syncRev":    dummyString1,
+								"secretType": dummyString1,
+								"syncBranch": dummyString1,
+							},
+							"preventDrift": dummyBool1,
+							"sourceFormat": dummyString1,
+						},
+						"version": dummyString1,
+					},
+				},
+			},
+			expectedResource: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configmanagement": map[string]interface{}{
+						"configSync": map[string]interface{}{
+							"git": map[string]interface{}{
+								"httpsProxy": dummyString2,
+								"syncRev":    dummyString1,
+								"secretType": dummyString1,
+								"syncBranch": dummyString1,
+							},
+							"preventDrift": dummyBool2,
+							"sourceFormat": dummyString1,
+						},
+						"version": dummyString2,
+					},
+				},
+			},
+			diffs: []diff{
+				{
+					path:       "spec.configmanagement.configSync.git.httpsProxy",
+					desiredVal: dummyString2,
+				},
+				{
+					path:       "spec.configmanagement.version",
+					desiredVal: dummyString2,
+				},
+				{
+					path:       "spec.configmanagement.configSync.preventDrift",
+					desiredVal: dummyBool2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetObjWithDiffs(&tc.resource, tc.diffs)
+			if err != nil != tc.expectedError {
+				t.Errorf("setFeatureMembershipKRMWithDiffs returns error %v; expected %t", err, tc.expectedError)
+			}
+			if !reflect.DeepEqual(tc.resource, tc.expectedResource) {
+				t.Errorf("setFeatureMembershipKRMWithDiffs sets obj as %+v, expected: %+v", tc.resource, tc.expectedResource)
+			}
+		})
+	}
+}

--- a/pkg/controller/direct/gkehub/mappings.go
+++ b/pkg/controller/direct/gkehub/mappings.go
@@ -44,3 +44,17 @@ func featureMembershipSpecKRMtoMembershipFeatureSpecAPI(r *krm.GKEHubFeatureMemb
 		Mesh:             mesh,
 	}, nil
 }
+
+func membershipFeatureSpecAPItoFeatureMembershipSpecKRM(r *api.MembershipFeatureSpec) *krm.GKEHubFeatureMembershipSpec {
+	featureMembershipSpec := &krm.GKEHubFeatureMembershipSpec{}
+	if r.Configmanagement != nil {
+		featureMembershipSpec.Configmanagement = convertAPItoKRM_ConfigManagement(r.Configmanagement)
+	}
+	if r.Mesh != nil {
+		featureMembershipSpec.Mesh = convertAPItoKRM_ServiceMesh(r.Mesh)
+	}
+	if r.Policycontroller != nil {
+		featureMembershipSpec.Policycontroller = convertAPItoKRM_Policycontroller(r.Policycontroller)
+	}
+	return featureMembershipSpec
+}

--- a/pkg/controller/direct/gkehub/meshconversion.go
+++ b/pkg/controller/direct/gkehub/meshconversion.go
@@ -29,3 +29,10 @@ func convertKRMtoAPI_ServiceMesh(r *krm.FeaturemembershipMesh) *featureapi.Servi
 	}
 	return apiObj
 }
+
+func convertAPItoKRM_ServiceMesh(r *featureapi.ServiceMeshMembershipSpec) *krm.FeaturemembershipMesh {
+	krmObj := krm.FeaturemembershipMesh{}
+	krmObj.ControlPlane = LazyPtr(r.ControlPlane)
+	krmObj.Management = LazyPtr(r.Management)
+	return &krmObj
+}

--- a/pkg/controller/direct/gkehub/pococonversion.go
+++ b/pkg/controller/direct/gkehub/pococonversion.go
@@ -29,6 +29,13 @@ func convertKRMtoAPI_Policycontroller(r *krm.FeaturemembershipPolicycontroller) 
 	return apiObj
 }
 
+func convertAPItoKRM_Policycontroller(r *featureapi.PolicyControllerMembershipSpec) *krm.FeaturemembershipPolicycontroller {
+	krmObj := &krm.FeaturemembershipPolicycontroller{}
+	krmObj.PolicyControllerHubConfig = convertAPItoKRM_PolicycontrollerHubConfig(r.PolicyControllerHubConfig)
+	krmObj.Version = LazyPtr(r.Version)
+	return krmObj
+}
+
 func convertKRMtoAPI_PolicycontrollerHubConfig(r krm.FeaturemembershipPolicyControllerHubConfig) *featureapi.PolicyControllerHubConfig {
 	apiObj := &featureapi.PolicyControllerHubConfig{}
 	if r.AuditIntervalSeconds != nil {
@@ -58,7 +65,28 @@ func convertKRMtoAPI_PolicycontrollerHubConfig(r krm.FeaturemembershipPolicyCont
 	if r.ReferentialRulesEnabled != nil {
 		apiObj.ReferentialRulesEnabled = *r.ReferentialRulesEnabled
 	}
-	return nil
+	return apiObj
+}
+
+func convertAPItoKRM_PolicycontrollerHubConfig(r *featureapi.PolicyControllerHubConfig) krm.FeaturemembershipPolicyControllerHubConfig {
+	krmObj := krm.FeaturemembershipPolicyControllerHubConfig{}
+	krmObj.AuditIntervalSeconds = LazyPtr(r.AuditIntervalSeconds)
+	krmObj.ConstraintViolationLimit = LazyPtr(r.ConstraintViolationLimit)
+
+	if r.ExemptableNamespaces != nil {
+		krmObj.ExemptableNamespaces = r.ExemptableNamespaces
+	}
+	krmObj.InstallSpec = LazyPtr(r.InstallSpec)
+	krmObj.LogDeniesEnabled = LazyPtr(r.LogDeniesEnabled)
+	if r.Monitoring != nil {
+		krmObj.Monitoring = convertAPItoKRM_FeaturemembershipMonitoring(r.Monitoring)
+	}
+	krmObj.MutationEnabled = LazyPtr(r.MutationEnabled)
+	if r.PolicyContent != nil {
+		krmObj.PolicyContent = convertAPItoKRM_PolicyContent(r.PolicyContent)
+	}
+	krmObj.ReferentialRulesEnabled = LazyPtr(r.ReferentialRulesEnabled)
+	return krmObj
 }
 
 func convertKRMtoAPI_FeaturemembershipMonitoring(r *krm.FeaturemembershipMonitoring) *featureapi.PolicyControllerMonitoringConfig {
@@ -69,6 +97,14 @@ func convertKRMtoAPI_FeaturemembershipMonitoring(r *krm.FeaturemembershipMonitor
 	return apiObj
 }
 
+func convertAPItoKRM_FeaturemembershipMonitoring(r *featureapi.PolicyControllerMonitoringConfig) *krm.FeaturemembershipMonitoring {
+	krmObj := &krm.FeaturemembershipMonitoring{}
+	if r.Backends != nil {
+		krmObj.Backends = r.Backends
+	}
+	return krmObj
+}
+
 func convertKRMtoAPI_PolicyContent(r *krm.FeaturemembershipPolicyContent) *featureapi.PolicyControllerPolicyContentSpec {
 	apiObj := &featureapi.PolicyControllerPolicyContentSpec{}
 	if r.TemplateLibrary != nil {
@@ -77,10 +113,24 @@ func convertKRMtoAPI_PolicyContent(r *krm.FeaturemembershipPolicyContent) *featu
 	return apiObj
 }
 
+func convertAPItoKRM_PolicyContent(r *featureapi.PolicyControllerPolicyContentSpec) *krm.FeaturemembershipPolicyContent {
+	krmObj := &krm.FeaturemembershipPolicyContent{}
+	if r.TemplateLibrary != nil {
+		krmObj.TemplateLibrary = convertAPItoKRM_TemplateLibrary(r.TemplateLibrary)
+	}
+	return krmObj
+}
+
 func convertKRMtoAPI_TemplateLibrary(r *krm.FeaturemembershipTemplateLibrary) *featureapi.PolicyControllerTemplateLibraryConfig {
 	apiObj := &featureapi.PolicyControllerTemplateLibraryConfig{}
 	if r.Installation != nil {
 		apiObj.Installation = *r.Installation
 	}
 	return apiObj
+}
+
+func convertAPItoKRM_TemplateLibrary(r *featureapi.PolicyControllerTemplateLibraryConfig) *krm.FeaturemembershipTemplateLibrary {
+	krmObj := &krm.FeaturemembershipTemplateLibrary{}
+	krmObj.Installation = LazyPtr(r.Installation)
+	return krmObj
 }

--- a/pkg/controller/direct/gkehub/util.go
+++ b/pkg/controller/direct/gkehub/util.go
@@ -58,3 +58,20 @@ func convertStringToInt64(s string) (int64, error) {
 	}
 	return val, nil
 }
+
+func convertInt64toString(num int64) string {
+	str := strconv.FormatInt(num, 10)
+	return str
+}
+
+func LazyPtr[V comparable](v V) *V {
+	var defaultV V
+	if v == defaultV {
+		return nil
+	}
+	return &v
+}
+
+func PtrTo[T any](t T) *T {
+	return &t
+}


### PR DESCRIPTION
…he existing controller

### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
The change revamps the Update logic. The controllers compares the desired state and current state to detect diffs. 
To align with the existing `unmanage` and `unset` behavior, the controller merges the diffs into the current state and use that to send request to the GCP API.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
