### PR TITLE
Update composition controller RBAC

### DIFF
--- a/experiments/compositions/composition/config/rbac/role.yaml
+++ b/experiments/compositions/composition/config/rbac/role.yaml
@@ -36,10 +36,17 @@ rules:
   - list
   - patch
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  - create
   - get
   - list
   - watch
@@ -57,6 +64,11 @@ rules:
   - composition.google.com
   resources:
   - compositions
+  - contexts
+  - expanderversions
+  - facades
+  - getterconfigurations
+  - plans
   verbs:
   - create
   - delete
@@ -208,6 +220,25 @@ rules:
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - facade.compositions.google.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - facade.compositions.google.com
+  resources:
+  - '*/status'
+  verbs:
+  - get
   - update
 - apiGroups:
   - facade.facade

--- a/experiments/compositions/composition/internal/controller/composition_controller.go
+++ b/experiments/compositions/composition/internal/controller/composition_controller.go
@@ -56,16 +56,20 @@ type CompositionReconciler struct {
 	handoffChannels map[schema.GroupVersionKind]chan event.GenericEvent
 }
 
-//+kubebuilder:rbac:groups=composition.google.com,resources=compositions,verbs=get;list;watch;create;update;patch;delete
+// TODO: To simplify preview for customers, grant superuser to the composition controller. This should be revisited going forward.
+//+kubebuilder:rbac:groups=*,resources=*,verbs=*
+//+kubebuilder:rbac:groups=composition.google.com,resources=compositions;contexts;expanderversions;facades;getterconfigurations;plans,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=composition.google.com,resources=compositions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=composition.google.com,resources=compositions/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=facade.facade,resources=*,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;create;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;create;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;patch;list;delete
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;get;patch;list;delete
+//+kubebuilder:rbac:groups=facade.compositions.google.com,resources=*,verbs=get;list;patch;update;watch;create;delete
+//+kubebuilder:rbac:groups=facade.compositions.google.com,resources=*/status,verbs=get;update
 
 // /
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -361,7 +365,7 @@ func (r *CompositionReconciler) processComposition(
 		InputGVR:                  gvk.GroupVersion().WithResource(crd.Spec.Names.Plural),
 		RESTMapper:                r.mgr.GetRESTMapper(),
 		Config:                    r.mgr.GetConfig(),
-		ComopsitionChangedWatcher: r.handoffChannels[gvk],
+		CompositionChangedWatcher: r.handoffChannels[gvk],
 	}
 
 	if err := expanderController.SetupWithManager(r.mgr, cr); err != nil {

--- a/experiments/compositions/composition/internal/controller/expander_reconciler.go
+++ b/experiments/compositions/composition/internal/controller/expander_reconciler.go
@@ -62,7 +62,7 @@ type ExpanderReconciler struct {
 	InputGVK                  schema.GroupVersionKind
 	InputGVR                  schema.GroupVersionResource
 	Composition               types.NamespacedName
-	ComopsitionChangedWatcher chan event.GenericEvent
+	CompositionChangedWatcher chan event.GenericEvent
 }
 
 type EvaluateWaitError struct {
@@ -660,7 +660,7 @@ func (r *ExpanderReconciler) SetupWithManager(mgr ctrl.Manager, cr *unstructured
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(cr).
-		WatchesRawSource(&source.Channel{Source: r.ComopsitionChangedWatcher}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllFromGVK)).
+		WatchesRawSource(&source.Channel{Source: r.CompositionChangedWatcher}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllFromGVK)).
 		WithOptions(controller.Options{RateLimiter: ratelimiter}).
 		Complete(r)
 }

--- a/experiments/compositions/composition/release/crds.yaml
+++ b/experiments/compositions/composition/release/crds.yaml
@@ -184,6 +184,21 @@ spec:
                   - type
                   type: object
                 type: array
+              generation:
+                format: int64
+                type: integer
+              stages:
+                additionalProperties:
+                  description: StageStatus captures the status of a stage
+                  properties:
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    validationStatus:
+                      type: string
+                  type: object
+                type: object
             type: object
         type: object
     served: true
@@ -755,6 +770,13 @@ spec:
           status:
             description: PlanStatus defines the observed state of Plan
             properties:
+              compositionGeneration:
+                description: Composition generation last succesfully reconciled
+                format: int64
+                type: integer
+              compositionUID:
+                description: Composition UID
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -829,19 +851,68 @@ spec:
                 format: int64
                 type: integer
               inputGeneration:
-                description: Facade's generation last we successfully reconciled
+                description: Facade's generation last succesfully reconciled
                 format: int64
                 type: integer
+              lastPruned:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    status:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - health
+                  - kind
+                  type: object
+                type: array
               stages:
                 additionalProperties:
                   description: StageStatus captures the status of a stage
                   properties:
+                    appliedCount:
+                      type: integer
+                    lastApplied:
+                      items:
+                        properties:
+                          group:
+                            type: string
+                          health:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          status:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - health
+                        - kind
+                        type: object
+                      type: array
                     resourceCount:
                       type: integer
                   required:
                   - resourceCount
                   type: object
                 type: object
+            required:
+            - compositionGeneration
+            - inputGeneration
             type: object
         type: object
     served: true

--- a/experiments/compositions/composition/release/manifest.yaml
+++ b/experiments/compositions/composition/release/manifest.yaml
@@ -197,6 +197,21 @@ spec:
                   - type
                   type: object
                 type: array
+              generation:
+                format: int64
+                type: integer
+              stages:
+                additionalProperties:
+                  description: StageStatus captures the status of a stage
+                  properties:
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    validationStatus:
+                      type: string
+                  type: object
+                type: object
             type: object
         type: object
     served: true
@@ -768,6 +783,13 @@ spec:
           status:
             description: PlanStatus defines the observed state of Plan
             properties:
+              compositionGeneration:
+                description: Composition generation last succesfully reconciled
+                format: int64
+                type: integer
+              compositionUID:
+                description: Composition UID
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -842,19 +864,68 @@ spec:
                 format: int64
                 type: integer
               inputGeneration:
-                description: Facade's generation last we successfully reconciled
+                description: Facade's generation last succesfully reconciled
                 format: int64
                 type: integer
+              lastPruned:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    status:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - health
+                  - kind
+                  type: object
+                type: array
               stages:
                 additionalProperties:
                   description: StageStatus captures the status of a stage
                   properties:
+                    appliedCount:
+                      type: integer
+                    lastApplied:
+                      items:
+                        properties:
+                          group:
+                            type: string
+                          health:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          status:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - health
+                        - kind
+                        type: object
+                      type: array
                     resourceCount:
                       type: integer
                   required:
                   - resourceCount
                   type: object
                 type: object
+            required:
+            - compositionGeneration
+            - inputGeneration
             type: object
         type: object
     served: true
@@ -1058,10 +1129,17 @@ rules:
   - list
   - patch
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
+  - create
   - get
   - list
   - watch
@@ -1079,6 +1157,11 @@ rules:
   - composition.google.com
   resources:
   - compositions
+  - contexts
+  - expanderversions
+  - facades
+  - getterconfigurations
+  - plans
   verbs:
   - create
   - delete
@@ -1230,6 +1313,25 @@ rules:
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - facade.compositions.google.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - facade.compositions.google.com
+  resources:
+  - '*/status'
+  verbs:
+  - get
   - update
 - apiGroups:
   - facade.facade
@@ -1506,7 +1608,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: gcr.io/krmapihosting-release/composition:v0.0.1.alpha
+        image: gcr.io/krmapihosting-release/composition:v0.0.328
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -1568,7 +1670,7 @@ spec:
         - --port=8443
         command:
         - /expander
-        image: expander-getter:latest
+        image: gcr.io/krmapihosting-release/expander-getter:v0.0.1
         name: getter
         resources:
           limits:
@@ -1666,5 +1768,11 @@ spec:
   imageRegistry: gcr.io/krmapihosting-release
   type: job
   validVersions:
+  - v0.0.115
+  - v0.0.114
+  - v0.0.113
+  - v0.0.112
+  - v0.0.111
+  - v0.0.110
   - v0.0.1
   - v0.0.0

--- a/experiments/compositions/composition/tests/data/TestSimpleAddFacadeField/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleAddFacadeField/input.yaml
@@ -82,9 +82,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -94,6 +91,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleCompositionUpdate/input.yaml
@@ -126,9 +126,11 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs:
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -138,6 +140,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-updatetest
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleDeleteFacade/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleDeleteFacade/input.yaml
@@ -80,9 +80,32 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestSimpleDeleteFacadeField/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleDeleteFacadeField/input.yaml
@@ -82,9 +82,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -94,6 +91,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderJinjaWithQuotes/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestSimpleExpansionGrpc/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpansionGrpc/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleExpansionJob/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpansionJob/input.yaml
@@ -80,9 +80,32 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestSimpleFacadeByoSchema/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleFacadeByoSchema/input.yaml
@@ -37,9 +37,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -49,6 +46,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/input.yaml
@@ -80,9 +80,42 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
 - apiGroups: ["*"]
-  resources: ["*"]
+  resources:
+  - configmaps
   verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -137,19 +170,18 @@ spec:
   - type: jinja2
     name: clusterscope
     template: |
-      {% set managedProject = pconfigs.spec.project %}
       apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
+      kind: ClusterRole
       metadata:
-        name: {{ managedProject }}
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
         name: foobar-foocorp
-      subjects:
-      - kind: ServiceAccount
-        name: foobar
-        namespace: foobar-system
+      rules:
+      - apiGroups:
+        - facade.foocorp.com
+        resources:
+        - "*/status"
+        verbs:
+        - get
+        - update
 ---
 apiVersion: v1
 kind: Namespace

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceExplicit/output.yaml
@@ -41,14 +41,14 @@ data:
   key1: value1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  name: proj-a
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
   name: foobar-foocorp
-subjects:
-- kind: ServiceAccount
-  name: foobar
-  namespace: foobar-system
+rules:
+- apiGroups:
+  - facade.foocorp.com
+  resources:
+  - "*/status"
+  verbs:
+  - get
+  - update

--- a/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleNamespaceInherit/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorExpansionFailed/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedApplyingManifests/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusErrorFailedLoadingManifestsFromPlan/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestSimplePlanStatusWaitingForValues/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimplePlanStatusWaitingForValues/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -92,6 +89,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: composition-facade-foocorp
+subjects:
+- kind: ServiceAccount
+  name: composition-controller-manager
+  namespace: composition-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:serviceaccount:composition-system:composition-controller-manager
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:serviceaccount:composition-system:composition-controller-manager
 subjects:
 - kind: ServiceAccount
   name: composition-controller-manager

--- a/experiments/compositions/composition/tests/data/TestUpdateCompositionCRAddStage/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestUpdateCompositionCRAddStage/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestUpdateCompositionCRRemoveStage/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestUpdateCompositionCRRemoveStage/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/composition/tests/data/TestUpdateCompositionModifyStage/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestUpdateCompositionModifyStage/input.yaml
@@ -80,9 +80,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/samples/AppTeam/composition/appteam.yaml
+++ b/experiments/compositions/samples/AppTeam/composition/appteam.yaml
@@ -183,9 +183,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/experiments/compositions/samples/CloudSQL/composition/hasql.yaml
+++ b/experiments/compositions/samples/CloudSQL/composition/hasql.yaml
@@ -206,9 +206,6 @@ rules:
   verbs:
   - get
   - update
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Change description

Update composition controller RBAC
    
Tests all manually grant superuser permissions to the composition controller for simplicity, but that hid the fact that the controller did not have the right permissions to carry out its tasks.
This change removes the broad permissions from the tests and samples and updates the controller RBAC to cover more of the requirements (while still expecting users to grant any additional permissions as necessary).

As a hack to make preview smoother for customers, globally grant superuser to the controller for the short term.