### PR TITLE
chore: don't assume "co" git alias for checkout

### DIFF
--- a/dev/codebots/update-golang-version
+++ b/dev/codebots/update-golang-version
@@ -36,4 +36,4 @@ done
 
 # Ignore third_party changes
 cd ${REPO_ROOT}
-git co -- third_party/
+git checkout -- third_party/

--- a/dev/tasks/update-dependency
+++ b/dev/tasks/update-dependency
@@ -32,4 +32,4 @@ done
 
 # Ignore third_party changes
 cd ${REPO_ROOT}
-git co -- third_party/
+git checkout -- third_party/


### PR DESCRIPTION
It is not defined everywhere
