### PR TITLE
chore: only update dependencies in dev scripts if they are in go.mod

### DIFF
--- a/dev/tasks/update-dependency
+++ b/dev/tasks/update-dependency
@@ -16,8 +16,12 @@ cd ${REPO_ROOT}
 for f in $(git ls-files 'go.mod' '**/go.mod' | grep -v third_party | grep -v experiments/composite); do
   cd ${REPO_ROOT}
   cd $(dirname $f)
-  echo "Updating $DEPENDENCY in $f"
-  go get $DEPENDENCY
+  if $(grep -q $DEPENDENCY $f); then
+    echo "Updating $DEPENDENCY in $f"
+    go get $DEPENDENCY
+  else
+    echo "Skipping update of $DEPENDENCY in $f; not in go.mod"
+  fi
 done
 
 # Run go mod tidy


### PR DESCRIPTION
This stops bumping versions for dependencies we aren't using.
