### PR TITLE
Fix resource skeleton for BigQueryConnectionConnection

### DIFF
--- a/pkg/resourceskeleton/testdata/uri-skeleton.yaml
+++ b/pkg/resourceskeleton/testdata/uri-skeleton.yaml
@@ -762,15 +762,7 @@
         external: bigquerydatasetsamplehnf4t2squ1g1ghnendt0
   ResourceConfigId: BigQueryTable
   URI: "https://bigquery.googleapis.com/bigquery/v2/projects/kcc-test/datasets/bigquerydatasetsamplehnf4t2squ1g1ghnendt0/tables/bigquerytablesamplehnf4t2squ1g1ghnendt0"
-- ExpectedSkeleton:
-    apiVersion: bigqueryconnection.cnrm.cloud.google.com/v1alpha1
-    kind: BigQueryConnectionConnection
-    metadata:
-      name: cloudresource-connection
-    spec:
-      projectRef:
-        external: kcc-test
-      location: us-central1
+- ExpectedSkeleton: null
   ResourceConfigId: BigQueryConnectionConnection
   URI: "https://bigqueryconnection.googleapis.com/v1/projects/kcc-test/locations/us-central1/connections/my-connection"
 - ExpectedSkeleton:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fix resource skeleton for BigQueryConnectionConnection so that TestNewFromURI() passes.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
