### PR TITLE
chore: gitignore generated

### DIFF
--- a/dev/tools/proto-to-mapper/.gitignore
+++ b/dev/tools/proto-to-mapper/.gitignore
@@ -1,2 +1,3 @@
 build/
 third_party/
+generated/


### PR DESCRIPTION
This is to help with cleanup when running `make generate-pb` as the artifacts probably don't need to live in the tree at `dev/tools/proto-to-mapper` .