### PR TITLE
chore: Handle list of enum during mapper generation

### DIFF
--- a/dev/tools/proto-to-mapper/Makefile
+++ b/dev/tools/proto-to-mapper/Makefile
@@ -17,7 +17,6 @@ generate-pb: install-protoc-linux
 		./third_party/googleapis/google/monitoring/v3/*.proto \
 		./third_party/googleapis/google/monitoring/dashboard/v1/*.proto \
 		./third_party/googleapis/google/devtools/cloudbuild/*/*.proto \
-		./third_party/googleapis/google/cloud/dataform/*/*.proto \
 		-o build/googleapis.pb
 
 install-protoc-linux:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

1. Fix error in `make  generate-code`:
```
F0712 20:24:29.727911 1320557 main.go:411] unhandled kind "enum" for repeated field FieldDescriptor{Syntax: proto3, FullName: google.cloud.kms.v1.KeyAccessJustificationsPolicy.allowed_access_reasons, Number: 1, Cardinality: repeated, Kind: enum, HasJSONName: true, JSONName: "allowedAccessReasons", IsPacked: true, IsList: true, Enum: google.cloud.kms.v1.AccessReason}
exit status 255
make: *** [Makefile:3: generate-code] Error 1
```
2. Handle a List of enum during mapper generation([allowed access reasons](https://github.com/googleapis/googleapis/blob/4472b64f1c110e8e951a0ffaa08842d485ca1cc8/google/cloud/kms/v1/resources.proto#L1014) is a list of enum type)

Before:
```
func KeyAccessJustificationsPolicy_FromProto(mapCtx *MapContext, in *pb.KeyAccessJustificationsPolicy) *krm.KeyAccessJustificationsPolicy {
	if in == nil {
		return nil
	}
	out := &krm.KeyAccessJustificationsPolicy{}
	out.AllowedAccessReasons = in.AllowedAccessReasons
	return out
}

func KeyAccessJustificationsPolicy_ToProto(mapCtx *MapContext, in *krm.KeyAccessJustificationsPolicy) *pb.KeyAccessJustificationsPolicy {
	if in == nil {
		return nil
	}
	out := &pb.KeyAccessJustificationsPolicy{}
	out.AllowedAccessReasons = in.AllowedAccessReasons
	return out
}
```
After: 
```
func KeyAccessJustificationsPolicy_FromProto(mapCtx *MapContext, in *pb.KeyAccessJustificationsPolicy) *krm.KeyAccessJustificationsPolicy {
	if in == nil {
		return nil
	}
	out := &krm.KeyAccessJustificationsPolicy{}
	out.AllowedAccessReasons = Slice_FromProto(mapCtx, in.AllowedAccessReasons, Enum_FromProto(mapCtx, in.AllowedAccessReasons))
	return out
}

func KeyAccessJustificationsPolicy_ToProto(mapCtx *MapContext, in *krm.KeyAccessJustificationsPolicy) *pb.KeyAccessJustificationsPolicy {
	if in == nil {
		return nil
	}
	out := &pb.KeyAccessJustificationsPolicy{}
	out.AllowedAccessReasons = Slice_ToProto(mapCtx, in.AllowedAccessReasons, Enum_ToProto[pb.AccessReason](mapCtx, in.AllowedAccessReasons))
	return out
}
```
3. Remove `./third_party/googleapis/google/cloud/dataform/*/*.proto \` , since `./third_party/googleapis/google/cloud/*/*/*.proto \` already exists.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
