### PR TITLE
Validate format of GoogleServiceAccount in CCC

### DIFF
--- a/operator/pkg/preflight/configconnectorcontextchecker_test.go
+++ b/operator/pkg/preflight/configconnectorcontextchecker_test.go
@@ -169,3 +169,49 @@ func TestConfigConnectorContextChecker(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateGSAFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		gsa  string
+		err  error
+	}{
+		{
+			name: "empty",
+			gsa:  "",
+			err:  nil,
+		},
+		{
+			name: "valid GSA format",
+			gsa:  "foo@abc.gserviceaccount.com",
+			err:  nil,
+		},
+		{
+			name: "valid GSA format",
+			gsa:  "foo@abc.def.gserviceaccount.com",
+			err:  nil,
+		},
+		{
+			name: "valid GSA format",
+			gsa:  "foo@abc.def.ghi.gserviceaccount.com",
+			err:  nil,
+		},
+		{
+			name: "invalid GSA format",
+			gsa:  "abc",
+			err:  fmt.Errorf("invalid GoogleServiceAccount format for %q", "abc"),
+		},
+		{
+			name: "invalid GSA format",
+			gsa:  "foo@bar.com",
+			err:  fmt.Errorf("invalid GoogleServiceAccount format for %q", "foo@bar.com"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateGSAFormat(tc.gsa)
+			asserts.AssertErrorIsExpected(t, err, tc.err)
+		})
+	}
+}


### PR DESCRIPTION
Create a CCC object with invalid GSA.
```
$ cat ~/tmp/ccc.yaml 
apiVersion: core.cnrm.cloud.google.com/v1beta1
kind: ConfigConnectorContext
metadata:
    name: configconnectorcontext.core.cnrm.cloud.google.com
    namespace: config-control
spec:
    googleServiceAccount: foo@bar.com

$ k apply -f ~/tmp/ccc.yaml 
configconnectorcontext.core.cnrm.cloud.google.com/configconnectorcontext.core.cnrm.cloud.google.com created
```

CCC Status:
```
$ k describe -f ~/tmp/ccc.yaml 
(...)
Spec:
  Google Service Account:  foo@bar.com
Status:
  Errors:
    error during reconciliation: invalid GoogleServiceAccount format for "foo@bar.com"
  Healthy:  false
Events:
  Type     Reason        Age                From                               Message
  ----     ------        ----               ----                               -------
  Warning  UpdateFailed  4s (x13 over 24s)  configconnectorcontext-controller  error during reconciliation: invalid GoogleServiceAccount format for "foo@bar.com"
```

KCC operator logs:
```
{"severity":"error","timestamp":"2024-07-13T08:40:57.453Z","msg":"preflight check failed, not reconciling","controller":"configconnectorcontext-controller","controllerGroup":"core.cnrm.cloud.google.com","controllerKind":"ConfigConnectorContext","ConfigConnectorContext":{"name":"configconnectorcontext.core.cnrm.cloud.google.com","namespace":"config-control"},"namespace":"config-control","name":"configconnectorcontext.core.cnrm.cloud.google.com","reconcileID":"7be584f2-b021-4adb-9e3e-14123b343030","error":"invalid GoogleServiceAccount format for \"foo@bar.com\""}
```