### PR TITLE
Enable anthos api for gkehubfeaturemembership tests

### DIFF
--- a/mockgcp/mockserviceusage/knownservices.go
+++ b/mockgcp/mockserviceusage/knownservices.go
@@ -21,6 +21,7 @@ var allServices = []string{
 	"runtimeconfig.googleapis.com",
 	"storage.googleapis.com",
 	"gkehub.googleapis.com",
+	"anthos.googleapis.com",
 	"anthosconfigmanagement.googleapis.com",
 	"multiclusteringress.googleapis.com",
 	"multiclusterservicediscovery.googleapis.com",

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
@@ -577,6 +577,51 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
+POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/anthos.googleapis.com:enable?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "done": true,
+  "metadata": null,
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://serviceusage.googleapis.com/v1/projects/example-project-01/services?alt=json&fields=services%2Fname%2CnextPageToken&filter=state%3AENABLED&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "nextPageToken": "",
+  "services": [
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/container.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    }
+  ]
+}
+
+---
+
 POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/gkehub.googleapis.com:enable?alt=json&prettyPrint=false
 Content-Type: application/json
 User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
@@ -608,6 +653,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },
@@ -653,6 +704,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/dependencies.yaml
@@ -51,6 +51,14 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: anthos.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
     # Abandon the resource to unblock cleanup; Otherwise it fails with error message
     # "Error waiting for api to disable ... ensure there are no more resources managed
     # by this service." Likely there is some delay in GKEHub resources clean up.

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
@@ -577,6 +577,51 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
+POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/anthos.googleapis.com:enable?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "done": true,
+  "metadata": null,
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://serviceusage.googleapis.com/v1/projects/example-project-01/services?alt=json&fields=services%2Fname%2CnextPageToken&filter=state%3AENABLED&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "nextPageToken": "",
+  "services": [
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/container.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    }
+  ]
+}
+
+---
+
 POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/gkehub.googleapis.com:enable?alt=json&prettyPrint=false
 Content-Type: application/json
 User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
@@ -608,6 +653,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },
@@ -653,6 +704,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/dependencies.yaml
@@ -51,6 +51,14 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: anthos.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
     # Abandon the resource to unblock cleanup; Otherwise it fails with error message
     # "Error waiting for api to disable ... ensure there are no more resources managed
     # by this service." Likely there is some delay in GKEHub resources clean up.

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
@@ -577,6 +577,51 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
+POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/anthos.googleapis.com:enable?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{}
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "done": true,
+  "metadata": null,
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://serviceusage.googleapis.com/v1/projects/example-project-01/services?alt=json&fields=services%2Fname%2CnextPageToken&filter=state%3AENABLED&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Content-Type: application/json
+Grpc-Metadata-Content-Type: application/grpc
+
+{
+  "nextPageToken": "",
+  "services": [
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/container.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    }
+  ]
+}
+
+---
+
 POST https://serviceusage.googleapis.com/v1/projects/example-project-01/services/gkehub.googleapis.com:enable?alt=json&prettyPrint=false
 Content-Type: application/json
 User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
@@ -608,6 +653,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },
@@ -653,6 +704,12 @@ Grpc-Metadata-Content-Type: application/grpc
     {
       "config": null,
       "name": "projects/${projectNumber}/services/gkehub.googleapis.com",
+      "parent": "projects/${projectNumber}",
+      "state": "ENABLED"
+    },
+    {
+      "config": null,
+      "name": "projects/${projectNumber}/services/anthos.googleapis.com",
       "parent": "projects/${projectNumber}",
       "state": "ENABLED"
     },

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/dependencies.yaml
@@ -51,6 +51,14 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+  name: anthos.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
     # Abandon the resource to unblock cleanup; Otherwise it fails with error message
     # "Error waiting for api to disable ... ensure there are no more resources managed
     # by this service." Likely there is some delay in GKEHub resources clean up.


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
I think it recently becomes a requirement to enable anthos API(may be related to GKEE).
```
reconcile.go:193: error was not considered transient; chain is [[*fmt.wrapError: Update call failed: error applying desired state: operation received error: error code "9", message: configmanagement feature requires enablement of anthos.googleapis.com, details: []
         details: map[]] [*fmt.wrapError: error applying desired state: operation received error: error code "9", message: configmanagement feature requires enablement of anthos.googleapis.com, details: []
```
### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
