### PR TITLE
enh: check if not supported

### DIFF
--- a/pkg/controller/direct/export.go
+++ b/pkg/controller/direct/export.go
@@ -17,6 +17,7 @@ package direct
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
@@ -29,6 +30,10 @@ import (
 func Export(ctx context.Context, url string, config *config.ControllerConfig) (*unstructured.Unstructured, error) {
 	adapter, err := registry.AdapterForURL(ctx, url)
 	if err != nil {
+		if strings.Contains(err.Error(), "not supported") {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 	if adapter != nil {
@@ -42,6 +47,9 @@ func Export(ctx context.Context, url string, config *config.ControllerConfig) (*
 
 		u, err := adapter.Export(ctx)
 		if err != nil {
+			if strings.Contains(err.Error(), "not supported") {
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Goes with https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2294 . If the Export is not supported yet in the controller package return nil.