### PR TITLE
ConfigConnectorContext should be fetched when 'spec.mode' in ConfigConnector is not set

### DIFF
--- a/operator/pkg/kccstate/kccstate.go
+++ b/operator/pkg/kccstate/kccstate.go
@@ -42,7 +42,8 @@ func FetchLiveKCCState(ctx context.Context, c client.Client, resourceNN types.Na
 		return v1beta1.ConfigConnector{}, v1beta1.ConfigConnectorContext{}, err
 	}
 
-	if cc.Spec.Mode == k8s.NamespacedMode {
+	// Namespaced mode is the default mode for the ConfigConnector object.
+	if cc.Spec.Mode == "" || cc.Spec.Mode == k8s.NamespacedMode {
 		var ccc v1beta1.ConfigConnectorContext
 		if err := c.Get(ctx, types.NamespacedName{
 			Name:      k8s.ConfigConnectorContextAllowedName,


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fetch the ConfigConnectorContext object when the ConfigConnector object exists but `spec.mode` is unset.

Mode in ConfigConnector is defaulted to `namespaced` ([code logic here](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/v1.120.1/operator/pkg/apis/core/v1beta1/configconnector_types.go#L121)) so it's valid to have `spec.mode` unset in it.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
