### PR TITLE
Revert "enh: return nil for unimplemented"

### DIFF
--- a/dev/tools/controllerbuilder/template/controller.go
+++ b/dev/tools/controllerbuilder/template/controller.go
@@ -129,7 +129,7 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 
 func (m *model) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
 	// TODO: Support URLs
-	return nil, fmt.Errorf("AdapterForURL not supported for {{.Kind}} yet")
+	return nil, nil
 }
 
 type Adapter struct {
@@ -247,7 +247,7 @@ func (a *Adapter) Update(ctx context.Context, u *unstructured.Unstructured) erro
 
 func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
 	// TODO(kcc) 
-	return nil, fmt.Errorf("Export not supported for {{.Kind}} yet")
+	return nil, nil
 }
 
 // Delete implements the Adapter interface.


### PR DESCRIPTION
Per conversations w Justin, we want to stick with the `nil, nil` over `nil, ErrNotImplemented` for now. Maybe in the future we will add a `nil, not_implemented_bool, nil`. Reverting this so it doesn't confuse devs.