### PR TITLE
[WIP] Return a warning when the state-into-spec annotation will be defaulted to 'merge'

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -23,6 +23,7 @@ import (
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 	"time"
 
+	operatorv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp/profiler"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
@@ -119,6 +120,9 @@ func main() {
 	apis.AddToSchemes = append(apis.AddToSchemes, apiextensions.SchemeBuilder.AddToScheme)
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatal(err)
+	}
+	if err := operatorv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatal(fmt.Sprintf("error adding 'operatorv1beta1' resources to the scheme: %v", err))
 	}
 
 	log.Printf("Registering Webhooks.")

--- a/config/installbundle/components/clusterroles/webhook_role.yaml
+++ b/config/installbundle/components/clusterroles/webhook_role.yaml
@@ -43,6 +43,15 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - core.cnrm.cloud.google.com
+    resources:
+      - configconnectors
+      - configconnectorcontexts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - services

--- a/pkg/webhook/state_into_spec_annotation_validator.go
+++ b/pkg/webhook/state_into_spec_annotation_validator.go
@@ -51,7 +51,7 @@ func (a *stateIntoSpecAnnotationValidator) Handle(ctx context.Context, req admis
 	}
 
 	value, ok := k8s.GetAnnotation(k8s.StateIntoSpecAnnotation, obj)
-	klog.Infof("maqiuyu...annotation value %v, ok? %v", value, ok)
+	klog.Infof("maqiuyu...kind %q, obj %q, annotation value %v, ok? %v", obj.GroupVersionKind().Kind, obj.GetName(), value, ok)
 	if ok && value == k8s.StateMergeIntoSpec {
 		return allowedResponse.WithWarnings(
 			fmt.Sprintf("'%v: %v' is unsupported for CRDs added in "+
@@ -60,12 +60,13 @@ func (a *stateIntoSpecAnnotationValidator) Handle(ctx context.Context, req admis
 				k8s.StateIntoSpecAnnotation, k8s.StateMergeIntoSpec, k8s.StateAbsentInSpec))
 	} else if !ok {
 		stateIntoSpecDefaultVal, err := k8s.GetStateIntoSpecDefaultValue(ctx, a.client, obj)
-		klog.Infof("maqiuyu...default value %v, err? %v", stateIntoSpecDefaultVal, err)
+		klog.Infof("maqiuyu...kind %q, obj %q, default value %v, err? %v", obj.GroupVersionKind().Kind, obj.GetName(), stateIntoSpecDefaultVal, err)
 		if err != nil {
 			// Something wrong happened while trying to fetch the default value
 			// 'state-into-spec' annotation. This should not block the request.
 			return allowedResponse
 		}
+		klog.Infof("maqiuyu...kind %q, obj %q, will start comparing the default value", obj.GroupVersionKind().Kind, obj.GetName())
 		if stateIntoSpecDefaultVal == k8s.StateMergeIntoSpec {
 			return allowedResponse.WithWarnings(
 				fmt.Sprintf("'%v: %v' is unsupported for CRDs added in "+


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

This is an experiment PR that checks the default value of `state-into-spec` annotation in the webhook via retrieving the ConfigConnector object and potentially the ConfigConnectorContext object, and returns a warning if the default value is `merge`.

In general, we shouldn't make API calls in the webhook because it has a short timeout (10s), though it should be fairly cheap to do the CC/CCC object retrievals.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Ran `make deploy-controller` locally with basic CCC and CC objects (no `spec.stateIntoSpec` configuration), then applied a PubsubTopic resource (no `state-into-spec` annotation). Got the following warning as expected:

```
kubectl apply -f pubsubtopic.yaml 
Warning: 'cnrm.cloud.google.com/state-into-spec: merge' is unsupported for CRDs added in 1.114.0 and later. Use 'absent' instead. More details can be found at https://cloud.google.com/config-connector/docs/concepts/ignore-unspecified-fields.
pubsubtopic.pubsub.cnrm.cloud.google.com/pubsubtopic-sample-2 created
```