### PR TITLE
Fix cluster version setting in attached compositions.

### DIFF
--- a/experiments/compositions/samples/AttachedAKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedAKS/01-composition.yaml
@@ -98,8 +98,7 @@ spec:
             mode: System
         identity:
           type: SystemAssigned
-        # kubernetesVersion: {{ attachedakses.spec.kubernetesVersion }}
-        kubernetesVersion: "1.28"
+        kubernetesVersion: "{{ attachedakses.spec.kubernetesVersion }}"
         operatorSpec:
           configMaps:
             oidcIssuerProfile:

--- a/experiments/compositions/samples/AttachedEKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedEKS/01-composition.yaml
@@ -338,7 +338,7 @@ spec:
         namespace: {{ attachedekses.metadata.namespace }}
       spec:
         name: {{ attachedekses.metadata.name }}-cluster
-        version: "1.28"
+        version: "{{ attachedekses.spec.kubernetesVersion }}"
         roleRef:
           from:
             name: {{ attachedekses.metadata.name }}-cluster-role
@@ -371,7 +371,7 @@ spec:
           minSize: 1
           maxSize: 2
           desiredSize: 1
-        version: "1.28"
+        version: "{{ attachedekses.spec.kubernetesVersion }}"
       ---
       apiVersion: eks.services.k8s.aws/v1alpha1
       kind: AccessEntry


### PR DESCRIPTION
### Change description

Update the compositions for AKS and EKS to use the defined k8s cluster version instead of the hard-coded 1.28.