### PR TITLE
differentiate aks/eks oidc issuer name in composition samples

### DIFF
--- a/experiments/compositions/samples/AttachedAKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedAKS/01-composition.yaml
@@ -51,7 +51,7 @@ spec:
       version: v1
       kind: ConfigMap
       resource: configmaps
-      nameSuffix: "-issuer"
+      nameSuffix: "-aks-issuer"
     fieldRef:
     - path: ".data.oidc"
       as: url
@@ -102,14 +102,14 @@ spec:
         operatorSpec:
           configMaps:
             oidcIssuerProfile:
-              name: {{ attachedakses.metadata.name }}-issuer
+              name: {{ attachedakses.metadata.name }}-aks-issuer
               key: oidc
           secrets:
             adminCredentials:
-              name: {{ attachedakses.metadata.name }}-admin 
+              name: {{ attachedakses.metadata.name }}-admin
               key: adminCredentials
             userCredentials:
-              name: {{ attachedakses.metadata.name }}-user 
+              name: {{ attachedakses.metadata.name }}-user
               key: userCredentials
   - type: getter
     version: v0.0.1

--- a/experiments/compositions/samples/AttachedEKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedEKS/01-composition.yaml
@@ -64,7 +64,7 @@ spec:
       version: v1
       kind: ConfigMap
       resource: configmaps
-      nameSuffix: "-issuer"
+      nameSuffix: "-eks-issuer"
     fieldRef:
     - path: ".data.oidc"
       as: url
@@ -391,7 +391,7 @@ spec:
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: {{ attachedekses.metadata.name }}-issuer
+        name: {{ attachedekses.metadata.name }}-eks-issuer
         namespace: {{ attachedekses.metadata.namespace }}
       data: {}
       ---
@@ -415,7 +415,7 @@ spec:
         to:
           key: oidc
           kind: configmap
-          name: {{ attachedekses.metadata.name }}-issuer
+          name: {{ attachedekses.metadata.name }}-eks-issuer
           namespace: {{ attachedekses.metadata.namespace }}
       ---
   - type: getter


### PR DESCRIPTION
use different suffix for aks/eks oidc issuer configmap to avoid conflict if customer is using the same name for different type of clusters

### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
use different suffix for aks/eks oidc issuer configmap to avoid conflict if customer is using the same name for different type of clusters

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [*] Run `make ready-pr` to ensure this PR is ready for review.
- [*] Perform necessary E2E testing for changed resources.
