### PR TITLE
Update Attached samples to use CRD instead of Facade.

### DIFF
--- a/experiments/compositions/samples/AttachedAKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedAKS/01-composition.yaml
@@ -12,31 +12,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: composition.google.com/v1alpha1
-kind: Facade
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: attachedaks
-  namespace: default
+  name: attachedakses.idp.mycompany.com
 spec:
-  facadeKind: AttachedAKS
-  openAPIV3Schema:
-    description: AttachedAKS defines the parameters for attaching ASK cluster to GCP.
-    properties:
-      adminUsers:
-        items:
-          type: string
-        type: array
-      attachedPlatformVersion:
-        type: string
-      azureRegion:
-        type: string
-      gcpProjectNumber:
-        type: string
-      gcpRegion:
-        type: string
-      kubernetesVersion:
-        type: string
-    type: object
+  conversion:
+    strategy: None
+  group: idp.mycompany.com
+  names:
+    categories:
+    - facade
+    - facades
+    kind: AttachedAKS
+    listKind: AttachedAKSList
+    plural: attachedakses
+    singular: attachedaks
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TODO
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AttachedAKS defines the parameters for attaching ASK cluster
+              to GCP.
+            properties:
+              adminUsers:
+                items:
+                  type: string
+                type: array
+              attachedPlatformVersion:
+                type: string
+              azureRegion:
+                type: string
+              gcpProjectNumber:
+                type: string
+              gcpRegion:
+                type: string
+              kubernetesVersion:
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      description: human readable message
+                      maxLength: 1024
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 256
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: composition.google.com/v1alpha1
 kind: GetterConfiguration
@@ -61,7 +133,7 @@ kind: Composition
 metadata:
   name: compo-aks-1
 spec:
-  inputAPIGroup: attachedakses.facade.compositions.google.com
+  inputAPIGroup: attachedakses.idp.mycompany.com
   expanders:
   - type: jinja2
     version: v0.0.1

--- a/experiments/compositions/samples/AttachedAKS/03-attached-1.yaml
+++ b/experiments/compositions/samples/AttachedAKS/03-attached-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: facade.compositions.google.com/v1
+apiVersion: idp.mycompany.com/v1
 kind: AttachedAKS
 metadata:
   name: test-composition-aks-1

--- a/experiments/compositions/samples/AttachedEKS/01-composition.yaml
+++ b/experiments/compositions/samples/AttachedEKS/01-composition.yaml
@@ -12,44 +12,116 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: composition.google.com/v1alpha1
-kind: Facade
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: attachedeks
-  namespace: default
+  name: attachedekses.idp.mycompany.com
 spec:
-  facadeKind: AttachedEKS
-  openAPIV3Schema:
-    description: AttachedEKS defines the parameters for attaching EKS cluster to GCP.
-    properties:
-      adminUsers:
-        items:
-          type: string
-        type: array
-      attachedPlatformVersion:
-        type: string
-      awsAvailabilityZones:
-        items:
-          properties:
-            privateSubnet:
-              type: string
-            publicSubnet:
-              type: string
-            zoneNameSuffix:
-              type: string
-          type: object
-        type: array
-      awsRegion:
-        type: string
-      awsAccessIdentity:
-        type: string
-      gcpProjectNumber:
-        type: string
-      gcpRegion:
-        type: string
-      kubernetesVersion:
-        type: string
-    type: object
+  conversion:
+    strategy: None
+  group: idp.mycompany.com
+  names:
+    categories:
+    - facade
+    - facades
+    kind: AttachedEKS
+    listKind: AttachedEKSList
+    plural: attachedekses
+    singular: attachedeks
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TODO
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AttachedEKS defines the parameters for attaching EKS cluster
+              to GCP.
+            properties:
+              adminUsers:
+                items:
+                  type: string
+                type: array
+              attachedPlatformVersion:
+                type: string
+              awsAccessIdentity:
+                type: string
+              awsAvailabilityZones:
+                items:
+                  properties:
+                    privateSubnet:
+                      type: string
+                    publicSubnet:
+                      type: string
+                    zoneNameSuffix:
+                      type: string
+                  type: object
+                type: array
+              awsRegion:
+                type: string
+              gcpProjectNumber:
+                type: string
+              gcpRegion:
+                type: string
+              kubernetesVersion:
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      description: human readable message
+                      maxLength: 1024
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 256
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: composition.google.com/v1alpha1
 kind: GetterConfiguration
@@ -93,7 +165,7 @@ metadata:
   name: compo-eks-1
   namespace: default
 spec:
-  inputAPIGroup: attachedekses.facade.compositions.google.com
+  inputAPIGroup: attachedekses.idp.mycompany.com
   expanders:
   - type: jinja2
     version: v0.0.1

--- a/experiments/compositions/samples/AttachedEKS/03-attached-1.yaml
+++ b/experiments/compositions/samples/AttachedEKS/03-attached-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: facade.compositions.google.com/v1
+apiVersion: idp.mycompany.com/v1
 kind: AttachedEKS
 metadata:
   name: test-composition-eks-1


### PR DESCRIPTION
### Change description

- Grabbed the CRD from the cluster after applying the Facade and replaced the contents in the yaml.
- Renamed the group something more generic to better demonstrate the definition is something users own.
- Tested both AKS and EKS flows.
