### PR TITLE
Add a deprecation note that Policy Controller should be configured through the policycontroller feature instead.

### DIFF
--- a/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
+++ b/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
@@ -74,7 +74,7 @@ type FeaturemembershipConfigmanagement struct {
 	// +optional
 	HierarchyController *FeaturemembershipHierarchyController `json:"hierarchyController,omitempty"`
 
-	/* Policy Controller configuration for the cluster. */
+	/* **DEPRECATED** Configuring Policy Controller through the configmanagement feature is no longer recommended. Use the policycontroller feature instead. */
 	// +optional
 	PolicyController *FeaturemembershipPolicyController `json:"policyController,omitempty"`
 

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_gkehubfeaturememberships.gkehub.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_gkehubfeaturememberships.gkehub.cnrm.cloud.google.com.yaml
@@ -248,7 +248,9 @@ spec:
                         type: boolean
                     type: object
                   policyController:
-                    description: Policy Controller configuration for the cluster.
+                    description: '**DEPRECATED** Configuring Policy Controller through
+                      the configmanagement feature is no longer recommended. Use the
+                      policycontroller feature instead.'
                     properties:
                       auditIntervalSeconds:
                         description: Sets the interval for Policy Controller Audit

--- a/mockgcp/generated/mockgcp/cloud/gkehub/v1beta/configmanagement/configmanagement.pb.go
+++ b/mockgcp/generated/mockgcp/cloud/gkehub/v1beta/configmanagement/configmanagement.pb.go
@@ -284,7 +284,7 @@ type MembershipSpec struct {
 
 	// Config Sync configuration for the cluster.
 	ConfigSync *ConfigSync `protobuf:"bytes,1,opt,name=config_sync,json=configSync,proto3" json:"config_sync,omitempty"`
-	// Policy Controller configuration for the cluster.
+	// **DEPRECATED** Configuring Policy Controller through the configmanagement feature is no longer recommended. Use the policycontroller feature instead.
 	PolicyController *PolicyController `protobuf:"bytes,2,opt,name=policy_controller,json=policyController,proto3" json:"policy_controller,omitempty"`
 	// Binauthz conifguration for the cluster.
 	Binauthz *BinauthzConfig `protobuf:"bytes,3,opt,name=binauthz,proto3" json:"binauthz,omitempty"`

--- a/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
@@ -73,7 +73,7 @@ type FeaturemembershipConfigmanagement struct {
 	// +optional
 	HierarchyController *FeaturemembershipHierarchyController `json:"hierarchyController,omitempty"`
 
-	/* Policy Controller configuration for the cluster. */
+	/* **DEPRECATED** Configuring Policy Controller through the configmanagement feature is no longer recommended. Use the policycontroller feature instead. */
 	// +optional
 	PolicyController *FeaturemembershipPolicyController `json:"policyController,omitempty"`
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
@@ -514,7 +514,7 @@ projectRef:
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}Policy Controller configuration for the cluster.{% endverbatim %}</p>
+            <p>{% verbatim %}**DEPRECATED** Configuring Policy Controller through the configmanagement feature is no longer recommended. Use the policycontroller feature instead.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION

### Change description

Add a deprecation note that Policy Controller should be configured through the policycontroller feature instead.

This is to reduce the usage of configuring Policy Controller using the ACM KCC resource.


<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
