### PR TITLE
tool:kompanion: add version

### DIFF
--- a/experiments/kompanion/main.go
+++ b/experiments/kompanion/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/experiments/kompanion/cmd/export"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/experiments/kompanion/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(commands...)
+	rootCmd.Version = version.GetVersion()
 }
 
 func main() {

--- a/experiments/kompanion/pkg/version/version.go
+++ b/experiments/kompanion/pkg/version/version.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+const (
+	name    = "kompanion"
+	unknown = "unknown"
+)
+
+func GetVersion() string {
+	version := "" // todo acpana in the future factor this out for major releases
+	vcsrevision := unknown
+	vcstimestamp := unknown
+	vcsdirty := ""
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, v := range info.Settings {
+			switch v.Key {
+			case "vcs.revision":
+				vcsrevision = v.Value
+			case "vcs.modified":
+				if v.Value == "true" {
+					vcsdirty = "-dirty"
+				}
+			case "vcs.time":
+				vcstimestamp = v.Value
+			}
+		}
+	}
+
+	version = fmt.Sprintf("devel (%s)", vcsrevision)
+	return fmt.Sprintf("%s/%s (%s/%s) %s%s/%s", name, version, runtime.GOOS, runtime.GOARCH, vcsrevision, vcsdirty, vcstimestamp)
+}


### PR DESCRIPTION
Let's include a version "watermark" so we can distinguish between version, especially in the early stages:


```
$ kompanion -v
kompanion version kompanion/devel (ff6b33cf00a80c04c1d324f30a49caf826c2761a) (linux/amd64) ff6b33cf00a80c04c1d324f30a49caf826c2761a-dirty/2024-07-29T23:13:55Z
```