### PR TITLE
Add a step to automate the kube object comparison in powertool test

### DIFF
--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -551,11 +551,11 @@ func runCLI(h *create.Harness, args []string, uniqueID string, baseOutputPath st
 func getKubeObjectInStringFromFile(path string) (string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return "", fmt.Errorf("error converting path %q to absolute path: %v", path, err)
+		return "", fmt.Errorf("error converting path %q to absolute path: %w", path, err)
 	}
 	objInBytes, err := os.ReadFile(absPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file %q: %v", absPath, err)
+		return "", fmt.Errorf("failed to read file %q: %w", absPath, err)
 	}
 	objInString := string(objInBytes)
 	return objInString, nil

--- a/tests/e2e/testdata/scenarios/README.md
+++ b/tests/e2e/testdata/scenarios/README.md
@@ -31,6 +31,10 @@ a top-level field `TEST` on the object:
 * Setting `TEST: READ-OBJECT` skips the apply; we read the current value of the
   object without changing it.
 
+* Setting `TEST: READ-OBJECT-AND-COMPARE-SPEC` does what `TEST: READ-OBJECT`
+  does and compares the spec of the golden objects of the current step and the
+  step configured in `TARGET_STEP_FOR_READ_AND_COMPARE`.
+
 * Setting `TEST: DELETE` will delete the KCC object and wait for the deletion
   to complete; it will automatically skip
   the GCP export and the kube export.  It suffices to set

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/SCENARIO_README.md
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/SCENARIO_README.md
@@ -26,7 +26,11 @@ How to construct the test:
     3.  With the virtual kind, `RunCLI`, use the powertool to update the
         `cnrm.cloud.google.com/state-into-spec` annotation from `merge` to
         `absent` and to remove the externally-managed fields.
-    4.  Use `TEST: READ-OBJECT` to read the LoggingLogMetric.
+    4.  Use `TEST: READ-OBJECT-AND-COMPARE-SPEC` and
+        `TARGET_STEP_FOR_READ_AND_COMPARE: 1` to read the kube object of
+        LoggingLogMetric and compare it with the kube object in step 1 to ensure
+        the powertool has successfully removed all the externally-managed
+        fields.
 
 *   Files started with `_`
     1.  Generate the golden files with `WRITE_GOLDEN_OUTPUT=1` when running the
@@ -34,4 +38,3 @@ How to construct the test:
     2.  Ensure `_cli-2-stdout.log` only contains changes for the
         `cnrm.cloud.google.com/state-into-spec` annotation and the
         externally-managed fields.
-    3.  Ensure `_object00.yaml` and `_object03.yaml` have identical `spec`.

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/script.yaml
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/script.yaml
@@ -45,7 +45,8 @@ spec:
 kind: RunCLI
 args: [ "powertools", "change-state-into-spec", "--namespace=${projectId}", "--kind=LoggingLogMetric", "--name=logginglogmetric-${uniqueId}" ]
 ---
-TEST: READ-OBJECT
+TEST: READ-OBJECT-AND-COMPARE-SPEC
+TARGET_STEP_FOR_READ_AND_COMPARE: 1
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

* Added the test step `READ-OBJECT-AND-COMPARE-SPEC` to compare the spec of the golden objects of the current step and the step configured in `TARGET_STEP_FOR_READ_AND_COMPARE`.
* Configured the newly added test step for logginglogmetric_clear_state_into_spec test case.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
