### PR TITLE
enh:kompanion: support goroutines

### DIFF
--- a/experiments/kompanion/README.md
+++ b/experiments/kompanion/README.md
@@ -33,5 +33,4 @@ The command will generate a timestamped report `tar.gz` file to use as a snapsho
 
 # Light Roadmap
 
-* [ ] Some multithread support for exports to fasten it up
 * [ ] Debug/ audit logs for the tool itself


### PR DESCRIPTION
Adds worker support so namespaces can be processed in parallel. 

I've also marked where I can add debug level logs and will add those as a follow on PR.