### PR TITLE
chore: Update golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,4 +46,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3.7.1
         with:
-          version: v1.56.2 # should match the version in Makefile
+          version: v1.59.1 # should match the version in Makefile

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,8 @@
 
 run:
   timeout: 5m
-  skip-dirs:
+issues:
+  exclude-dirs:
     - third_party
     - pkg/clients/generated
     - temp-vendor

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ UNMANAGED_DETECTOR_IMG ?= gcr.io/${PROJECT_ID}/unmanageddetector:${SHORT_SHA}
 GOLANGCI_LINT_CACHE := /tmp/golangci-lint
 # When updating this, make sure to update the corresponding action in
 # ./github/workflows/lint.yaml
-GOLANGCI_LINT_VERSION := v1.56.2
+GOLANGCI_LINT_VERSION := v1.59.1
 
 # Use Docker BuildKit when building images to allow usage of 'setcap' in
 # multi-stage builds (https://github.com/moby/moby/issues/38132)


### PR DESCRIPTION
Previously, was getting the following error when running `make ready-pr` locally:
```
level=error msg="Running error: context loading failed: failed to load
packages: failed to load with go/packages: err: exit status 1: stderr:
go: go.work requires go >= 1.22.5 (running go 1.22.0;
GOTOOLCHAIN=local)\n"
```

Also, updated .golangci.yaml to move away from deprecated `run.skip-dirs` to the new `issues.exclude-dirs` rule.

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
