### PR TITLE
chore: fix some linter warnings

### DIFF
--- a/scripts/resource-autogen/main.go
+++ b/scripts/resource-autogen/main.go
@@ -224,7 +224,7 @@ func convertTFSamplesToKRMTestdata(tfToGVK map[string]schema.GroupVersionKind, s
 		jsonStruct, err := convertHCLBytesToJSON(b)
 		if err != nil {
 			errToReturn := fmt.Errorf("error converting HCL to JSON for TF sample %s: %w", sf, err)
-			klog.Warningf("Failed sample conversion: %w", errToReturn)
+			klog.Warningf("Failed sample conversion: %v", errToReturn)
 			errs = multierror.Append(errs, errToReturn)
 			continue
 		}
@@ -232,14 +232,14 @@ func convertTFSamplesToKRMTestdata(tfToGVK map[string]schema.GroupVersionKind, s
 		create, dependencies, err := tfSampleToKRMTestData(kind, jsonStruct, tfToGVK, smLoader)
 		if err != nil {
 			errToReturn := fmt.Errorf("error converting TF samples to KRM test data for TF sample %s: %w", sf, err)
-			klog.Warningf("Failed sample conversion: %w", errToReturn)
+			klog.Warningf("Failed sample conversion: %v", errToReturn)
 			errs = multierror.Append(errs, errToReturn)
 			continue
 		}
 
 		if err := insertTestData(create, dependencies, autoGenType, sampleName, generatedSamples); err != nil {
 			errToReturn := fmt.Errorf("error unmarshaling json for TF sample %s: %w", sf, err)
-			klog.Warningf("Failed sample conversion: %w", errToReturn)
+			klog.Warningf("Failed sample conversion: %v", errToReturn)
 			errs = multierror.Append(errs, errToReturn)
 			continue
 		}


### PR DESCRIPTION
klog.Warningf should be used with %v, not %w
