### PR TITLE
generate mockGCP tests for bigquery table resource

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -641,6 +641,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "artifactregistry.cnrm.cloud.google.com", Kind: "ArtifactRegistryRepository"}:
 
 			case schema.GroupKind{Group: "bigquery.cnrm.cloud.google.com", Kind: "BigQueryDataset"}:
+			case schema.GroupKind{Group: "bigquery.cnrm.cloud.google.com", Kind: "BigQueryTable"}:
 
 			case schema.GroupKind{Group: "bigqueryconnection.cnrm.cloud.google.com", Kind: "BigQueryConnectionConnection"}:
 

--- a/mockgcp/mockbigquery/service.go
+++ b/mockgcp/mockbigquery/service.go
@@ -52,10 +52,11 @@ func (s *MockService) ExpectedHost() string {
 
 func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterDatasetsServerServer(grpcServer, &datasetsServer{MockService: s})
+	pb.RegisterTablesServerServer(grpcServer, &tablesServer{MockService: s})
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
-	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{}, pb.RegisterDatasetsServerHandler)
+	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{}, pb.RegisterDatasetsServerHandler, pb.RegisterTablesServerHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockbigquery/tables.go
+++ b/mockgcp/mockbigquery/tables.go
@@ -1,0 +1,298 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockbigquery
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/bigquery/v2"
+	"github.com/golang/protobuf/ptypes/empty"
+)
+
+type tablesServer struct {
+	*MockService
+	pb.UnimplementedTablesServerServer
+}
+
+func (s *tablesServer) GetTable(ctx context.Context, req *pb.GetTableRequest) (*pb.Table, error) {
+	name, err := s.buildTableName(req.GetProjectId(), req.GetDatasetId(), req.GetTableId())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.Table{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Not found: Table %s:%s.%s", name.Project.ID, name.DatasetID, name.TableID)
+		}
+		return nil, err
+	}
+	if obj.RequirePartitionFilter == nil {
+		obj.RequirePartitionFilter = PtrTo(false)
+	}
+
+	return obj, nil
+}
+
+func (s *tablesServer) InsertTable(ctx context.Context, req *pb.InsertTableRequest) (*pb.Table, error) {
+	name, err := s.buildTableName(req.GetProjectId(), req.GetDatasetId(), req.GetTable().GetTableReference().GetTableId())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	now := time.Now()
+
+	obj := proto.Clone(req.GetTable()).(*pb.Table)
+
+	if obj.TableReference == nil {
+		obj.TableReference = &pb.TableReference{}
+	}
+	if obj.GetTableReference().GetProjectId() == "" {
+		obj.TableReference.ProjectId = req.ProjectId
+	}
+	obj.CreationTime = PtrTo(now.UnixMilli())
+	obj.LastModifiedTime = PtrTo(uint64(now.UnixMilli()))
+	obj.Id = PtrTo(obj.GetTableReference().GetProjectId() + ":" + obj.GetTableReference().GetTableId())
+	obj.Kind = PtrTo("bigquery#table")
+	if obj.Location == nil {
+		obj.Location = PtrTo("US")
+	}
+	if obj.Type == nil {
+		obj.Type = PtrTo("EXTERNAL")
+	}
+
+	if obj.NumActiveLogicalBytes == nil {
+		obj.NumActiveLogicalBytes = PtrTo(int64(0))
+	}
+	if obj.NumBytes == nil {
+		obj.NumBytes = PtrTo(int64(0))
+	}
+	if obj.NumLongTermBytes == nil {
+		obj.NumLongTermBytes = PtrTo(int64(0))
+	}
+	if obj.NumLongTermLogicalBytes == nil {
+		obj.NumLongTermLogicalBytes = PtrTo(int64(0))
+	}
+	if obj.NumRows == nil {
+		obj.NumRows = PtrTo(uint64(0))
+	}
+	if obj.NumTotalLogicalBytes == nil {
+		obj.NumTotalLogicalBytes = PtrTo(int64(0))
+	}
+
+	if obj.Schema == nil {
+		obj.Schema = &pb.TableSchema{
+			Fields: []*pb.TableFieldSchema{
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_0"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_1"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_2"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_3"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_4"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_5"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_6"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_7"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_8"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_9"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_10"),
+					Type: PtrTo("STRING"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_11"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("int64_field_12"),
+					Type: PtrTo("INTEGER"),
+				},
+				{
+					Mode: PtrTo("NULLABLE"),
+					Name: PtrTo("string_field_13"),
+					Type: PtrTo("STRING"),
+				},
+			},
+		}
+
+	}
+	obj.SelfLink = PtrTo("https://bigquery.googleapis.com/bigquery/v2/" + name.String())
+
+	//sortAccess(obj)
+
+	obj.Etag = PtrTo(computeEtag(obj))
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, status.Errorf(codes.Internal, "error creating Table: %v", err)
+	}
+
+	return obj, nil
+}
+
+func (s *tablesServer) UpdateTable(ctx context.Context, req *pb.UpdateTableRequest) (*pb.Table, error) {
+	name, err := s.buildTableName(req.GetProjectId(), req.GetDatasetId(), req.GetTableId())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	existing := &pb.Table{}
+	if err := s.storage.Get(ctx, fqn, existing); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+
+	updated := req.GetTable()
+	updated.TableReference = existing.TableReference
+
+	updated.CreationTime = existing.CreationTime
+	updated.LastModifiedTime = PtrTo(uint64(now.UnixMilli()))
+	updated.Id = PtrTo(existing.GetTableReference().GetProjectId() + ":" + existing.GetTableReference().GetTableId())
+	updated.Kind = PtrTo("bigquery#table")
+	updated.Location = existing.Location
+	updated.Type = existing.Type
+	updated.NumActiveLogicalBytes = existing.NumActiveLogicalBytes
+	updated.NumBytes = existing.NumBytes
+	updated.NumLongTermBytes = existing.NumLongTermBytes
+	updated.NumLongTermLogicalBytes = existing.NumLongTermLogicalBytes
+	updated.NumRows = existing.NumRows
+	updated.NumTotalLogicalBytes = existing.NumTotalLogicalBytes
+	updated.Schema = existing.Schema
+	updated.SelfLink = PtrTo("https://bigquery.googleapis.com/bigquery/v2/" + name.String())
+	if updated.RequirePartitionFilter == nil {
+		updated.RequirePartitionFilter = PtrTo(false)
+	}
+
+	//sortAccess(updated)
+
+	updated.Etag = PtrTo(computeEtag(updated))
+
+	if err := s.storage.Update(ctx, fqn, updated); err != nil {
+		return nil, err
+	}
+
+	return updated, err
+}
+
+func (s *tablesServer) DeleteTable(ctx context.Context, req *pb.DeleteTableRequest) (*empty.Empty, error) {
+	name, err := s.buildTableName(req.GetProjectId(), req.GetDatasetId(), req.GetTableId())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.Table{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	httpmux.SetStatusCode(ctx, http.StatusNoContent)
+
+	return &empty.Empty{}, nil
+}
+
+type tableName struct {
+	Project   *projects.ProjectData
+	DatasetID string
+	TableID   string
+}
+
+func (n *tableName) String() string {
+	return "projects/" + n.Project.ID + "/datasets/" + n.DatasetID + "/tables/" + n.TableID
+}
+
+// parseTableName parses a string into a tableName.
+// The expected form is projects/<projectID>/datasets/<DatasetID>/tables/<TableID> --> TODO
+func (s *MockService) parseTableName(name string) (*tableName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "datasets" && tokens[4] == "tables" {
+		return s.buildTableName(tokens[1], tokens[3], tokens[5])
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}
+
+func (s *MockService) buildTableName(projectName string, datasetID string, tableID string) (*tableName, error) {
+	project, err := s.Projects.GetProjectByID(projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	name := &tableName{
+		Project:   project,
+		DatasetID: datasetID,
+		TableID:   tableID,
+	}
+
+	return name, nil
+}

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable/_http.log
@@ -1,0 +1,902 @@
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Dataset ${projectId}:bigquerydatasetsample${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Dataset ${projectId}:bigquerydatasetsample${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}"
+  },
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Table ${projectId}:bigquerydatasetsample${uniqueId}.bigquerytablesample${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Table ${projectId}:bigquerydatasetsample${uniqueId}.bigquerytablesample${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "requirePartitionFilter": true,
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+PUT https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "policyTags": {},
+        "type": "STRING"
+      }
+    ]
+  },
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": false,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": false,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json&deleteContents=false
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0

--- a/pkg/test/resourcefixture/testdata/resourceid/referencewithuserspecifiedresourceid/_generated_object_referencewithuserspecifiedresourceid.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/resourceid/referencewithuserspecifiedresourceid/_generated_object_referencewithuserspecifiedresourceid.golden.yaml
@@ -1,0 +1,35 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: merge
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: bigquerytable-resourceid-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  datasetRef:
+    name: bigquerydataset-resourceid-${uniqueId}
+  friendlyName: bigquerytable-sample-updated
+  resourceID: bigquerytable_resourceid_${uniqueId}
+  schema: '[{"mode":"NULLABLE","name":"string_field_0","type":"STRING"},{"mode":"NULLABLE","name":"string_field_1","type":"STRING"},{"mode":"NULLABLE","name":"string_field_2","type":"STRING"},{"mode":"NULLABLE","name":"string_field_3","type":"STRING"},{"mode":"NULLABLE","name":"string_field_4","type":"STRING"},{"mode":"NULLABLE","name":"string_field_5","type":"STRING"},{"mode":"NULLABLE","name":"int64_field_6","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_7","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_8","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_9","type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_10","type":"STRING"},{"mode":"NULLABLE","name":"int64_field_11","type":"INTEGER"},{"mode":"NULLABLE","name":"int64_field_12","type":"INTEGER"},{"mode":"NULLABLE","name":"string_field_13","type":"STRING"}]'
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  creationTime: "1970-01-01T00:00:00Z"
+  etag: abcdef123456
+  lastModifiedTime: "1970-01-01T00:00:00Z"
+  location: US
+  observedGeneration: 3
+  selfLink: https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}/tables/bigquerytable_resourceid_${uniqueId}
+  type: EXTERNAL

--- a/pkg/test/resourcefixture/testdata/resourceid/referencewithuserspecifiedresourceid/_http.log
+++ b/pkg/test/resourcefixture/testdata/resourceid/referencewithuserspecifiedresourceid/_http.log
@@ -1,0 +1,852 @@
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Dataset ${projectId}:bigquerydataset_resourceid_${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Dataset ${projectId}:bigquerydataset_resourceid_${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "datasetReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}"
+  },
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytable_resourceid_${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Table ${projectId}:bigquerydataset_resourceid_${uniqueId}.bigquerytable_resourceid_${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Table ${projectId}:bigquerydataset_resourceid_${uniqueId}.bigquerytable_resourceid_${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "friendlyName": "bigquerytable-sample",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}/tables/bigquerytable_resourceid_${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytable_resourceid_${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": false,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}/tables/bigquerytable_resourceid_${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+PUT https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytable_resourceid_${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "friendlyName": "bigquerytable-sample-updated",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "policyTags": {},
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "policyTags": {},
+        "type": "STRING"
+      }
+    ]
+  },
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": false,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}/tables/bigquerytable_resourceid_${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytable_resourceid_${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": false,
+  "schema": {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_0",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_1",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_2",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_3",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_4",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_5",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_6",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_7",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_8",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_9",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_10",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_11",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "int64_field_12",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "string_field_13",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}/tables/bigquerytable_resourceid_${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytable_resourceid_${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytable_resourceid_${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    },
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydataset_resourceid_${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset_resourceid_${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json&deleteContents=false
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0


### PR DESCRIPTION
### Change description

Add required mockGCP tests for bigquery tables, including mock testing against the golden http logs from the real GCP service.

This PR is to complement a previous merged one: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/1733

Fixes https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/1654

E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock GOLDEN_OBJECT_CHECKS=1 GOLDEN_REQUEST_CHECKS=1 \                  
       go test -timeout 600s -v ./tests/e2e \
      -run TestAllInSeries/fixtures/bigquerytable


- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
