### PR TITLE
tools: do not skip type generation when scaffolding a new resource

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
@@ -109,6 +109,9 @@ func (v *generatorBase) WriteFiles(addCopyright bool) error {
 func (g *TypeGenerator) findTypeDeclaration(goTypeName string, srcDir string, skipGenerated bool) (*string, error) {
 	files, err := os.ReadDir(srcDir)
 	if err != nil {
+		if os.IsNotExist(err) { // type declaration does not exist
+			return nil, nil
+		}
 		return nil, fmt.Errorf("reading directory %q: %w", srcDir, err)
 	}
 


### PR DESCRIPTION
When scaffolding a new resource, the directory for types file is not yet created. In this case, we should not skip generating the types.

/cc @jasonvigil
