### PR TITLE
[For discussion]refactor: Updates on ref resolvers

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
@@ -70,8 +70,8 @@ spec:
                           - external
                         properties:
                           external:
-                            description: The compute network selflink of form "projects/<project>/global/networks/<network>",
-                              when not managed by Config Connector.
+                            description: An external value of a `ComputeNetwork` resource,
+                              when not managed by KCC.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.
@@ -275,8 +275,8 @@ spec:
                           - external
                         properties:
                           external:
-                            description: The compute network selflink of form "projects/<project>/global/networks/<network>",
-                              when not managed by Config Connector.
+                            description: An external value of a `ComputeNetwork` resource,
+                              when not managed by KCC.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
@@ -78,8 +78,8 @@ spec:
                   - external
                 properties:
                   external:
-                    description: The compute network selflink of form "projects/<project>/global/networks/<network>",
-                      when not managed by Config Connector.
+                    description: An external value of a `ComputeNetwork` resource,
+                      when not managed by KCC.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.
@@ -154,8 +154,8 @@ spec:
                         - external
                       properties:
                         external:
-                          description: The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}",
-                            when not managed by KCC.
+                          description: An external value of a `ComputeSubnetwork`
+                            resource, when not managed by KCC.
                           type: string
                         name:
                           description: The `name` field of a `ComputeSubnetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
@@ -122,8 +122,8 @@ spec:
                         - external
                       properties:
                         external:
-                          description: The compute network selflink of form "projects/<project>/global/networks/<network>",
-                            when not managed by Config Connector.
+                          description: An external value of a `ComputeNetwork` resource,
+                            when not managed by KCC.
                           type: string
                         name:
                           description: The `name` field of a `ComputeNetwork` resource.
@@ -262,9 +262,8 @@ spec:
                                 - external
                               properties:
                                 external:
-                                  description: The compute network selflink of form
-                                    "projects/<project>/global/networks/<network>",
-                                    when not managed by Config Connector.
+                                  description: An external value of a `ComputeNetwork`
+                                    resource, when not managed by KCC.
                                   type: string
                                 name:
                                   description: The `name` field of a `ComputeNetwork`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
@@ -498,8 +498,8 @@ spec:
                           - external
                         properties:
                           external:
-                            description: The compute network selflink of form "projects/<project>/global/networks/<network>",
-                              when not managed by Config Connector.
+                            description: An external value of a `ComputeNetwork` resource,
+                              when not managed by KCC.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.

--- a/mockgcp/mockcompute/networksv1.go
+++ b/mockgcp/mockcompute/networksv1.go
@@ -43,9 +43,6 @@ func (s *NetworksV1) Get(ctx context.Context, req *pb.GetNetworkRequest) (*pb.Ne
 
 	obj := &pb.Network{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, status.Errorf(codes.NotFound, "The resource '%s' was not found", fqn)
-		}
 		return nil, err
 	}
 

--- a/pkg/controller/direct/cloudbuild/workerpool_controller.go
+++ b/pkg/controller/direct/cloudbuild/workerpool_controller.go
@@ -128,12 +128,12 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 
 	// Get computeNetwork
 	if obj.Spec.PrivatePoolConfig.NetworkConfig != nil {
-		networkRef, err := refs.ResolveComputeNetwork(ctx, reader, obj, &obj.Spec.PrivatePoolConfig.NetworkConfig.PeeredNetworkRef)
+		networkRef, err := refs.ResolveComputeNetwork(ctx, reader, obj, &obj.Spec.PrivatePoolConfig.NetworkConfig.PeeredNetworkRef, "id")
 		if err != nil {
 			return nil, err
 
 		}
-		obj.Spec.PrivatePoolConfig.NetworkConfig.PeeredNetworkRef.External = networkRef.String()
+		obj.Spec.PrivatePoolConfig.NetworkConfig.PeeredNetworkRef.External = networkRef.External
 	}
 
 	// Get CloudBuild GCP client

--- a/pkg/controller/direct/networkconnectivity/refs.go
+++ b/pkg/controller/direct/networkconnectivity/refs.go
@@ -53,17 +53,15 @@ func (r *refNormalizer) VisitField(path string, v any) error {
 	}
 
 	if networkRef, ok := v.(*refs.ComputeNetworkRef); ok {
-		resolved, err := refs.ResolveComputeNetwork(r.ctx, r.kube, r.src, networkRef)
+		resolved, err := refs.ResolveComputeNetwork(r.ctx, r.kube, r.src, networkRef, "id")
 		if err != nil {
 			return err
 		}
-		*networkRef = refs.ComputeNetworkRef{
-			External: resolved.String(),
-		}
+		*networkRef = *resolved
 	}
 
 	if subnetworkRef, ok := v.(*refs.ComputeSubnetworkRef); ok {
-		resolved, err := refs.ResolveComputeSubnetwork(r.ctx, r.kube, r.src, subnetworkRef)
+		resolved, err := refs.ResolveComputeSubnetwork(r.ctx, r.kube, r.src, subnetworkRef, "id")
 		if err != nil {
 			return err
 		}
@@ -73,7 +71,7 @@ func (r *refNormalizer) VisitField(path string, v any) error {
 	if subnetworkRefs, ok := v.([]refs.ComputeSubnetworkRef); ok {
 		for i := range subnetworkRefs {
 			subnetworkRef := &subnetworkRefs[i]
-			resolved, err := refs.ResolveComputeSubnetwork(r.ctx, r.kube, r.src, subnetworkRef)
+			resolved, err := refs.ResolveComputeSubnetwork(r.ctx, r.kube, r.src, subnetworkRef, "id")
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/direct/sql/normalize.go
+++ b/pkg/controller/direct/sql/normalize.go
@@ -236,12 +236,12 @@ func normalizePrivateNetworkRef(ctx context.Context, kube client.Reader, obj *kr
 		Name:      resRef.Name,
 		Namespace: resRef.Namespace,
 	}
-	net, err := refs.ResolveComputeNetwork(ctx, kube, obj, netRef)
+	net, err := refs.ResolveComputeNetwork(ctx, kube, obj, netRef, "id")
 	if err != nil {
 		return "", err
 	}
 
-	return net.String(), nil
+	return net.External, nil
 }
 
 func normalizeAuditLogBucketRef(ctx context.Context, kube client.Reader, obj *krm.SQLInstance) (string, error) {

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
@@ -168,7 +168,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The compute network selflink of form "projects/<project>/global/networks/<network>", when not managed by Config Connector.{% endverbatim %}</p>
+            <p>{% verbatim %}An external value of a `ComputeNetwork` resource, when not managed by KCC.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
@@ -1122,7 +1122,7 @@ settings:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The compute network selflink of form "projects/<project>/global/networks/<network>", when not managed by Config Connector.{% endverbatim %}</p>
+            <p>{% verbatim %}An external value of a `ComputeNetwork` resource, when not managed by KCC.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Currently, the KCC controller (TF/DCL) does not validate external values of refs, and the format of externals can vary. Therefore, it is difficult to have a fixed pattern for external values. We rely on the GCP API to determine the valid format and to fail the request if it is invalid.

External is used for non-KCC managed resource, so we should let underlying GCP to manage/validate it. 
I'm more concerned about the Beta to direct migration here; strict checks on External might introduce breaking changes to our users.

- Removed the check on fixed External format.
- Added "targetField" so that we are able to control the field of refs we want to reference if its KCC managed resource. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
