### PR TITLE
ci: exclude mapper generations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ issues:
     - third_party
     - pkg/clients/generated
     - temp-vendor
+    - dev/tools/proto-to-mapper
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
Small change to exclude the tooling generate snippets from lint as they don't compile yet.