### PR TITLE
feat: add mockgcp for storageNotification

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -741,6 +741,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "spanner.cnrm.cloud.google.com", Kind: "SpannerInstance"}:
 
 			case schema.GroupKind{Group: "storage.cnrm.cloud.google.com", Kind: "StorageBucket"}:
+			case schema.GroupKind{Group: "storage.cnrm.cloud.google.com", Kind: "StorageNotification"}:
 
 			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagKey"}:
 			case schema.GroupKind{Group: "tags.cnrm.cloud.google.com", Kind: "TagsTagValue"}:

--- a/mockgcp/mockpubsub/topic.go
+++ b/mockgcp/mockpubsub/topic.go
@@ -52,7 +52,32 @@ func (s *publisherService) CreateTopic(ctx context.Context, req *pb.Topic) (*pb.
 }
 
 func (s *publisherService) populateDefaultsForTopic(obj *pb.Topic) {
-
+	obj.MessageStoragePolicy = &pb.MessageStoragePolicy{
+		AllowedPersistenceRegions: []string{
+			"asia-east1",
+			"asia-northeast1",
+			"asia-southeast1",
+			"australia-southeast1",
+			"europe-north1",
+			"europe-west1",
+			"europe-west2",
+			"europe-west3",
+			"europe-west4",
+			"southamerica-west1",
+			"us-central1",
+			"us-central2",
+			"us-east1",
+			"us-east4",
+			"us-east5",
+			"us-east7",
+			"us-south1",
+			"us-west1",
+			"us-west2",
+			"us-west3",
+			"us-west4",
+			"us-west8",
+		},
+	}
 }
 
 func (s *publisherService) UpdateTopic(ctx context.Context, req *pb.UpdateTopicRequest) (*pb.Topic, error) {
@@ -106,6 +131,7 @@ func (s *publisherService) GetTopic(ctx context.Context, req *pb.GetTopicRequest
 		}
 		return nil, err
 	}
+
 	return obj, nil
 }
 

--- a/mockgcp/mockstorage/bucket.go
+++ b/mockgcp/mockstorage/bucket.go
@@ -44,7 +44,6 @@ func (s *buckets) GetBucket(ctx context.Context, req *pb.GetBucketRequest) (*pb.
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
-
 	ret := proto.Clone(obj).(*pb.Bucket)
 
 	projection := req.GetProjection()
@@ -96,6 +95,9 @@ func (s *buckets) InsertBucket(ctx context.Context, req *pb.InsertBucketRequest)
 	obj.Metageneration = PtrTo(int64(1))
 
 	obj.Etag = PtrTo(computeEtag(obj))
+	if obj.Lifecycle != nil && proto.Equal(obj.Lifecycle, &pb.BucketLifecycle{}) {
+		obj.Lifecycle = nil
+	}
 
 	iamConfiguration := obj.IamConfiguration
 	if iamConfiguration == nil {
@@ -134,7 +136,6 @@ func (s *buckets) InsertBucket(ctx context.Context, req *pb.InsertBucketRequest)
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
-
 	return obj, nil
 }
 

--- a/mockgcp/mockstorage/notification.go
+++ b/mockgcp/mockstorage/notification.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockstorage
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/fields"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/storage/v1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/proto"
+)
+
+type notifications struct {
+	*MockService
+	pb.UnimplementedNotificationsServerServer
+	id int
+}
+
+func (n *notifications) GetNotification(ctx context.Context, req *pb.GetNotificationRequest) (*pb.Notification, error) {
+	fqn := fullyQualifiedName(req.GetBucket(), req.GetName())
+	obj := &pb.Notification{}
+	if err := n.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	// The real GCP service stores what the request gives but returns the topic with the PubSub domain.
+	obj.Topic = PtrTo("//pubsub.googleapis.com/" + direct.ValueOf(obj.Topic))
+	ret := proto.Clone(obj).(*pb.Notification)
+	return ret, nil
+
+}
+
+func (n *notifications) InsertNotification(ctx context.Context, req *pb.InsertNotificationRequest) (*pb.Notification, error) {
+	n.id += 1
+	fqn := fullyQualifiedName(req.GetBucket(), fmt.Sprint(n.id))
+
+	obj := proto.Clone(req.GetNotification()).(*pb.Notification)
+	obj.Id = PtrTo(fmt.Sprint(n.id))
+	obj.Etag = PtrTo(fields.ComputeWeakEtag(obj))
+	obj.SelfLink = PtrTo("https://www.googleapis.com/storage/v1/b/" + req.GetBucket() + "/notificationConfigs/" + fmt.Sprint(n.id))
+	obj.Kind = PtrTo("storage#notification")
+	if err := n.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+	// The real GCP service stores what the request gives but returns the topic with the PubSub domain.
+	obj.Topic = PtrTo("//pubsub.googleapis.com/" + direct.ValueOf(obj.Topic))
+	return obj, nil
+}
+
+func (n *notifications) DeleteNotification(ctx context.Context, req *pb.DeleteNotificationRequest) (*empty.Empty, error) {
+	fqn := fullyQualifiedName(req.GetBucket(), direct.ValueOf(req.Name))
+	deletedObj := &pb.Notification{}
+	if err := n.storage.Delete(ctx, fqn, deletedObj); err != nil {
+		return nil, err
+	}
+	httpmux.SetStatusCode(ctx, http.StatusNoContent)
+	return &empty.Empty{}, nil
+}
+
+func fullyQualifiedName(bucket, notification string) string {
+	return "storage/" + bucket + "/notificationConfigs/" + notification
+}

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/_http.log
@@ -330,6 +330,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -354,6 +380,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -1366,6 +1418,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
@@ -16,6 +16,30 @@ metadata:
   name: pubsubtopic-sample-${uniqueId}
   namespace: ${uniqueId}
 spec:
+  messageStoragePolicy:
+    allowedPersistenceRegions:
+    - asia-east1
+    - asia-northeast1
+    - asia-southeast1
+    - australia-southeast1
+    - europe-north1
+    - europe-west1
+    - europe-west2
+    - europe-west3
+    - europe-west4
+    - southamerica-west1
+    - us-central1
+    - us-central2
+    - us-east1
+    - us-east4
+    - us-east5
+    - us-east7
+    - us-south1
+    - us-west1
+    - us-west2
+    - us-west3
+    - us-west4
+    - us-west8
   resourceID: pubsubtopic-sample-${uniqueId}
   schemaSettings:
     encoding: JSON

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_http.log
@@ -137,6 +137,32 @@ X-Xss-Protection: 0
     "label-one": "value-one",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
   "schemaSettings": {
     "encoding": "JSON",
@@ -166,6 +192,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "label-one": "value-one",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
   "schemaSettings": {

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/secretmanagersecret/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/secretmanagersecret/_http.log
@@ -50,6 +50,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }
 
@@ -74,6 +100,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }
@@ -426,6 +478,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlserverinstance/_http.log
@@ -73,7 +73,6 @@ Vary: X-Origin
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "lifecycle": {},
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "1",
@@ -120,7 +119,6 @@ Vary: X-Origin
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "lifecycle": {},
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "1",
@@ -784,7 +782,6 @@ Vary: X-Origin
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "lifecycle": {},
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "1",

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationbase/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationbase/_http.log
@@ -399,9 +399,10 @@ GET https://storage.googleapis.com/storage/v1/b/storagebucket-${uniqueId}/notifi
 User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
 200 OK
-Cache-Control: private, max-age=0, must-revalidate, no-transform
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Content-Type: application/json; charset=UTF-8
-Expires: {now+0m}
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Pragma: no-cache
 Server: UploadServer
 Vary: Origin
 Vary: X-Origin
@@ -591,7 +592,7 @@ Vary: X-Origin
   },
   "location": "US",
   "locationType": "multi-region",
-  "metageneration": "3",
+  "metageneration": "1",
   "name": "storagebucket-${uniqueId}",
   "projectNumber": "${projectNumber}",
   "rpo": "DEFAULT",

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationfull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationfull/_http.log
@@ -417,9 +417,10 @@ GET https://storage.googleapis.com/storage/v1/b/storagebucket-${uniqueId}/notifi
 User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
 200 OK
-Cache-Control: private, max-age=0, must-revalidate, no-transform
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Content-Type: application/json; charset=UTF-8
-Expires: {now+0m}
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Pragma: no-cache
 Server: UploadServer
 Vary: Origin
 Vary: X-Origin
@@ -618,7 +619,7 @@ Vary: X-Origin
   },
   "location": "US",
   "locationType": "multi-region",
-  "metageneration": "3",
+  "metageneration": "1",
   "name": "storagebucket-${uniqueId}",
   "projectNumber": "${projectNumber}",
   "rpo": "DEFAULT",

--- a/pkg/test/resourcefixture/testdata/directives/forcedestroy/_http.log
+++ b/pkg/test/resourcefixture/testdata/directives/forcedestroy/_http.log
@@ -79,7 +79,6 @@ Vary: X-Origin
     "label-one": "value-one",
     "managed-by-cnrm": "true"
   },
-  "lifecycle": {},
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "1",
@@ -130,7 +129,6 @@ Vary: X-Origin
     "label-one": "value-one",
     "managed-by-cnrm": "true"
   },
-  "lifecycle": {},
   "location": "US",
   "locationType": "multi-region",
   "metageneration": "1",

--- a/pkg/test/resourcefixture/testdata/iammemberreferences/serviceaccountref/_http.log
+++ b/pkg/test/resourcefixture/testdata/iammemberreferences/serviceaccountref/_http.log
@@ -137,6 +137,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -161,6 +187,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -333,6 +385,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
+++ b/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
@@ -419,6 +419,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -443,6 +469,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -615,6 +667,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }


### PR DESCRIPTION
based from #2446

- add MockGCP for StorageNotification (v1beta1)
- Fixed MockGCP for `StorageBucket` and `PubSubTopic` to fit real GCP outcome.