### PR TITLE
chore: change the _type.go template to not skip target resource when --kind is specified

### DIFF
--- a/dev/tools/controllerbuilder/generate.sh
+++ b/dev/tools/controllerbuilder/generate.sh
@@ -30,7 +30,8 @@ go run . generate-types \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
-    --kinds SecureSourceManagerInstance
+    --kind SecureSourceManagerInstance \
+    --proto-resource Instance
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
@@ -46,7 +47,8 @@ go run . generate-types  \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1alpha1  \
     --output-api ${APIS_DIR} \
-    --kinds RedisCluster 
+    --kind RedisCluster \
+    --proto-resource Cluster
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
@@ -63,7 +65,8 @@ go run . generate-types  \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --output-api ${APIS_DIR} \
-    --kinds BigtableInstance
+    --kind BigtableInstance \
+    --proto-resource Instance
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
@@ -79,7 +82,8 @@ go run . generate-types \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
-    --kinds NetworkConnectivityServiceConnectionPolicy
+    --kind NetworkConnectivityServiceConnectionPolicy \
+    --proto-resource ServiceConnecqionPolicy
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \

--- a/dev/tools/controllerbuilder/generate.sh
+++ b/dev/tools/controllerbuilder/generate.sh
@@ -28,14 +28,14 @@ OUTPUT_MAPPER=${REPO_ROOT}/pkg/controller/direct/
 go run . generate-types \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.cloud.securesourcemanager.v1 \
-    --version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
+    --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --kinds SecureSourceManagerInstance
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.cloud.securesourcemanager.v1 \
-    --version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
+    --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
     --output-dir ${OUTPUT_MAPPER} \
     --api-dir ${APIS_DIR}
@@ -44,14 +44,14 @@ go run . generate-mapper \
 go run . generate-types  \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.cloud.redis.cluster.v1 \
-    --version redis.cnrm.cloud.google.com/v1alpha1  \
+    --api-version redis.cnrm.cloud.google.com/v1alpha1  \
     --output-api ${APIS_DIR} \
     --kinds RedisCluster 
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.cloud.redis.cluster.v1 \
-    --version redis.cnrm.cloud.google.com/v1alpha1  \
+    --api-version redis.cnrm.cloud.google.com/v1alpha1  \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
     --output-dir ${OUTPUT_MAPPER} \
     --api-dir ${APIS_DIR}
@@ -61,14 +61,14 @@ go run . generate-mapper \
 go run . generate-types  \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.bigtable.admin.v2 \
-    --version bigtable.cnrm.cloud.google.com/v1beta1  \
+    --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --output-api ${APIS_DIR} \
     --kinds BigtableInstance
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service google.bigtable.admin.v2 \
-    --version bigtable.cnrm.cloud.google.com/v1beta1  \
+    --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
     --output-dir ${OUTPUT_MAPPER} \
     --api-dir ${APIS_DIR}
@@ -77,14 +77,14 @@ go run . generate-mapper \
 go run . generate-types \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service mockgcp.cloud.networkconnectivity.v1 \
-    --version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
+    --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --kinds NetworkConnectivityServiceConnectionPolicy
 
 go run . generate-mapper \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --service mockgcp.cloud.networkconnectivity.v1 \
-    --version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
+    --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
     --output-dir ${OUTPUT_MAPPER} \
     --api-dir ${APIS_DIR}

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -133,7 +133,7 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 
 	if o.KindNames != nil {
 		if gv.Group == "" {
-			return fmt.Errorf("--group must be specified with --kinds")
+			return fmt.Errorf("--apiVersion must be specified with --kinds")
 		}
 		scaffolder := &scaffold.APIScaffolder{
 			BaseDir:         o.OutputAPIDirectory,

--- a/dev/tools/controllerbuilder/pkg/options/generateoptions.go
+++ b/dev/tools/controllerbuilder/pkg/options/generateoptions.go
@@ -27,6 +27,6 @@ func (o *GenerateOptions) InitDefaults() {
 
 func (o *GenerateOptions) BindPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.ProtoSourcePath, "proto-source-path", o.ProtoSourcePath, "path to (compiled) proto for APIs")
-	cmd.PersistentFlags().StringVarP(&o.APIVersion, "version", "v", o.APIVersion, "the KRM API version. used to import the KRM API")
+	cmd.PersistentFlags().StringVarP(&o.APIVersion, "api-version", "v", o.APIVersion, "the KRM API version. used to import the KRM API")
 	cmd.PersistentFlags().StringVarP(&o.ServiceName, "service", "s", o.ServiceName, "the GCP service name")
 }

--- a/dev/tools/controllerbuilder/scaffold/apis.go
+++ b/dev/tools/controllerbuilder/scaffold/apis.go
@@ -49,20 +49,15 @@ func (a *APIScaffolder) GetTypeFile(kind string) string {
 	return filepath.Join(a.BaseDir, a.GoPackage, fileName)
 }
 
-func (a *APIScaffolder) AddTypeFile(kind string) error {
-	gcpResource := kind
-	// if !strings.HasPrefix(strings.ToLower(kind), a.Service) {
-	// 	s, size := utf8.DecodeRuneInString(a.Service)
-	// 	uc := unicode.ToUpper(s)
-	// 	kind = string(uc) + a.Service[size:] + kind
-	// }
+func (a *APIScaffolder) AddTypeFile(kind, proto string) error {
 	typeFilePath := a.GetTypeFile(kind)
 	cArgs := &apis.APIArgs{
 		Group:           a.Group,
 		Version:         a.Version,
 		Kind:            kind,
 		PackageProtoTag: a.PackageProtoTag,
-		KindProtoTag:    a.PackageProtoTag + "." + gcpResource,
+		KindProtoTag:    a.PackageProtoTag + "." + proto,
+		GcpResource:     proto,
 	}
 	return scaffoldTypeFile(typeFilePath, cArgs)
 }

--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -99,7 +99,7 @@ func WriteToFile(path string, out []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", filepath.Dir(path), err)
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Problem:
When we export the generated type to `./apis`, the _types.go generation no longer works (triggered by `--kind` flag). 
Because the _type.go file template contains the same `kcc:proto` tag as the _type.generated.go file suppose to use. This skips the actual proto-to-go generation of that resource.  
