### PR TITLE
chore: update golangci-lint-action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # because of https://github.com/golangci/golangci-lint-action/issues/135
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3.7.1
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: v1.59.1 # should match the version in Makefile


### PR DESCRIPTION
We were seeing some failures from it without corresponding error
messages, try updating.
