### PR TITLE
tests: use GCP_PROJECT_ID (if set) as default project

### DIFF
--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -50,6 +50,7 @@ if [[ "${E2E_GCP_TARGET}" == "real" ]]; then
     GCP_PROJECT_ID=$(gcloud config get-value project)
   fi
   echo "Using GCP_PROJECT_ID: ${GCP_PROJECT_ID}"
+  export GCP_PROJECT_ID
 
   TEST_FOLDER_ID=$(gcloud projects describe ${GCP_PROJECT_ID} --format='value(parent.id)')
   export TEST_FOLDER_ID

--- a/pkg/test/gcp/gcp.go
+++ b/pkg/test/gcp/gcp.go
@@ -93,10 +93,16 @@ var (
 // GetDefaultProjectID returns the ID of user's configured default GCP project.
 func GetDefaultProjectID(t *testing.T) string {
 	t.Helper()
-	projectID, err := gcp.GetDefaultProjectID()
-	if err != nil {
-		t.Fatalf("error retrieving gcloud sdk credentials: %v", err)
+
+	projectID := os.Getenv("GCP_PROJECT_ID")
+	if projectID == "" {
+		s, err := gcp.GetDefaultProjectID()
+		if err != nil {
+			t.Fatalf("error getting default project: %v", err)
+		}
+		projectID = s
 	}
+
 	return projectID
 }
 
@@ -110,10 +116,8 @@ func GetDefaultProject(t *testing.T) GCPProject {
 	t.Helper()
 	ctx := context.TODO()
 
-	projectID, err := gcp.GetDefaultProjectID()
-	if err != nil {
-		t.Fatalf("error getting default project: %v", err)
-	}
+	projectID := GetDefaultProjectID(t)
+
 	projectNumber, err := GetProjectNumber(ctx, projectID)
 	if err != nil {
 		t.Fatalf("error getting project number for %q: %v", projectID, err)


### PR DESCRIPTION
Otherwise we fall back to the credentials and gcloud default project.

This allows us to override the project in our e2e tests.
