### PR TITLE
feat: Implement "Export" for SQLInstance

### DIFF
--- a/pkg/controller/direct/sql/sqlinstance_controller.go
+++ b/pkg/controller/direct/sql/sqlinstance_controller.go
@@ -122,14 +122,14 @@ func (a *sqlInstanceAdapter) Find(ctx context.Context) (bool, error) {
 	a.actual = instance
 
 	log := klog.FromContext(ctx).WithName(ctrlName)
-	log.V(2).Info("found cloudsql instance", "actual", a.actual)
+	log.V(2).Info("found SQLInstance", "actual", a.actual)
 
 	return true, nil
 }
 
 func (a *sqlInstanceAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
 	log := klog.FromContext(ctx).WithName(ctrlName)
-	log.V(2).Info("creating instance", "desired", a.desired)
+	log.V(2).Info("creating SQLInstance", "desired", a.desired)
 
 	if a.projectID == "" {
 		return fmt.Errorf("project is empty")
@@ -216,7 +216,7 @@ func (a *sqlInstanceAdapter) Create(ctx context.Context, u *unstructured.Unstruc
 
 func (a *sqlInstanceAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
 	log := klog.FromContext(ctx)
-	log.V(2).Info("updating instance", "desired", a.desired)
+	log.V(2).Info("updating SQLInstance", "desired", a.desired)
 
 	// First, handle database version updates
 	if a.desired.Spec.DatabaseVersion != nil && *a.desired.Spec.DatabaseVersion != a.actual.DatabaseVersion {
@@ -261,7 +261,7 @@ func (a *sqlInstanceAdapter) Update(ctx context.Context, u *unstructured.Unstruc
 	// Next, update rest of the fields
 	merged, diffDetected, err := MergeDesiredSQLInstanceWithActual(a.desired, a.refs, a.actual)
 	if err != nil {
-		return fmt.Errorf("diff SQL instances failed: %w", err)
+		return fmt.Errorf("diff SQLInstances failed: %w", err)
 	}
 
 	if diffDetected {
@@ -310,7 +310,7 @@ func (a *sqlInstanceAdapter) Update(ctx context.Context, u *unstructured.Unstruc
 // Delete implements the Adapter interface.
 func (a *sqlInstanceAdapter) Delete(ctx context.Context) (bool, error) {
 	log := klog.FromContext(ctx).WithName(ctrlName)
-	log.V(2).Info("deleting instance", "actual", a.actual)
+	log.V(2).Info("deleting SQLInstance", "actual", a.actual)
 
 	if a.resourceID == "" {
 		return false, nil
@@ -320,7 +320,7 @@ func (a *sqlInstanceAdapter) Delete(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("deleting SQLInstance %s: %w", a.resourceID, err)
 	}
 
-	log.V(2).Info("deleted instance", "op", op)
+	log.V(2).Info("deleted SQLInstance", "op", op)
 
 	return true, nil
 }
@@ -332,12 +332,12 @@ func (a *sqlInstanceAdapter) Export(ctx context.Context) (*unstructured.Unstruct
 
 	sqlInstance, err := SQLInstanceGCPToKRM(a.actual)
 	if err != nil {
-		return nil, fmt.Errorf("error converting SQL Instance from API %w", err)
+		return nil, fmt.Errorf("error converting SQLInstance from API %w", err)
 	}
 
 	sqlInstanceObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sqlInstance)
 	if err != nil {
-		return nil, fmt.Errorf("error converting SQL Instance spec to unstructured: %w", err)
+		return nil, fmt.Errorf("error converting SQLInstance spec to unstructured: %w", err)
 	}
 
 	u := &unstructured.Unstructured{

--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -465,9 +465,10 @@ func testDriftCorrection(ctx context.Context, t *testing.T, testContext testrunn
 	if err := resourceContext.Delete(ctx, t, testUnstruct, systemContext.TFProvider, systemContext.Manager.GetClient(), systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter, systemContext.HttpClient); err != nil {
 		t.Fatalf("error deleting: %v", err)
 	}
+
 	// Underlying APIs may not have strongly-consistent reads due to caching. Sleep before attempting a re-reconcile, to
 	// give the underlying system some time to propagate the deletion info.
-	time.Sleep(time.Second * 10)
+	time.Sleep(resourceContext.RecreateDelay)
 
 	// get the current state
 	t.Logf("reconcile with %v\r", testUnstruct)

--- a/pkg/test/resourcefixture/contexts/sql_context.go
+++ b/pkg/test/resourcefixture/contexts/sql_context.go
@@ -14,17 +14,56 @@
 
 package contexts
 
+import "time"
+
 func init() {
 	resourceContextMap["mysqlinstance"] = ResourceContext{
-		// SQL instances names are reserved for 1 week after use: https://cloud.google.com/sql/docs/mysql/delete-instance
-		SkipDriftDetection: true,
-		ResourceKind:       "SQLInstance",
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
+	}
+
+	resourceContextMap["mysqlinstancebasic"] = ResourceContext{
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
+	}
+
+	resourceContextMap["postgresinstance"] = ResourceContext{
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
+	}
+
+	resourceContextMap["postgresinstancebasic"] = ResourceContext{
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
 	}
 
 	resourceContextMap["sqlserverinstance"] = ResourceContext{
-		// SQL instances names are reserved for 1 week after use: https://cloud.google.com/sql/docs/mysql/delete-instance
-		SkipDriftDetection: true,
-		ResourceKind:       "SQLInstance",
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
+	}
+
+	resourceContextMap["sqlserverinstancebasic"] = ResourceContext{
+		// SQL instances need a bit of additional time before attempting to recreate with
+		// the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
+	}
+
+	resourceContextMap["sqlinstanceencryptionkey"] = ResourceContext{
+		// SQL instances appear to need a bit of additional time before attempting to recreate
+		// with the exact same name. Otherwise, the GCP API returns "unknown error".
+		RecreateDelay: time.Second * 60,
+		ResourceKind:  "SQLInstance",
 	}
 
 	resourceContextMap["sqldatabase"] = ResourceContext{


### PR DESCRIPTION
This fixes some of the failing SQL Instance dynamic tests caused by nil pointer dereferences of nil objects returned by the (previously) empty export implementation.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
