### PR TITLE
Return an error in dynamic test when Export() is not supported

### DIFF
--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -132,7 +132,11 @@ func (rc ResourceContext) Create(ctx context.Context, _ *testing.T, u *unstructu
 
 func (rc ResourceContext) Get(ctx context.Context, _ *testing.T, u *unstructured.Unstructured, provider *tfschema.Provider, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader, cfg *mmdcl.Config, dclConverter *dclconversion.Converter, httpClient *http.Client) (*unstructured.Unstructured, error) {
 	if rc.IsDirectResource() {
-		return directExport(ctx, u, c)
+		result, err := directExport(ctx, u, c)
+		if result == nil && err == nil {
+			return nil, fmt.Errorf("%v uses direct controller and Export() is not implemented yet", u.GetKind())
+		}
+		return result, err
 	}
 
 	if rc.DCLBased {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Return an error when Export() is not supported so the dynamic test won't panic.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

`mysqlinstance` test failed with the expected message:

```
    dynamic_controller_integration_test.go:248: [validateCreate] unexpected error when GET-ing 'sqlinstance-sample-20240812': SQLInstance uses direct controller and Export() is not implemented yet
```
