### PR TITLE
tests: don't fail on changes in the http log during e2e

### DIFF
--- a/dev/ci/periodics/_create_project_and_run_e2e
+++ b/dev/ci/periodics/_create_project_and_run_e2e
@@ -23,6 +23,10 @@ cd ${REPO_ROOT}
 export RUN_TESTS=TestAllInSeries/fixtures
 export E2E_GCP_TARGET=real
 
+# We don't want to fail on changes in the http.log,
+# because that happens e.g. whenever there's a new field in the upstream service.
+export ONLY_WARN_ON_GOLDEN_DIFFS=_http.log
+
 EXIT_CODE=0
 
 dev/tasks/create-test-project

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -96,7 +96,19 @@ func CompareGoldenFile(t *testing.T, p string, got string, normalizers ...func(s
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("unexpected diff in %s: %s", p, diff)
+		onlyWarn := false
+		for _, f := range strings.Split(os.Getenv("ONLY_WARN_ON_GOLDEN_DIFFS"), ",") {
+			if f == filepath.Base(p) {
+				onlyWarn = true
+			}
+		}
+
+		if onlyWarn {
+			t.Logf("found diff in golden output %s, but ONLY_WARN_ON_GOLDEN_DIFFS=%s so will treat as a warning", p, os.Getenv("ONLY_WARN_ON_GOLDEN_DIFFS"))
+			t.Logf("unexpected diff in %s: %s", p, diff)
+		} else {
+			t.Errorf("unexpected diff in %s: %s", p, diff)
+		}
 	}
 
 	if writeGoldenOutput {

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -751,7 +751,6 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					}
 
 					got := events.FormatHTTP()
-					expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
 					normalizers := []func(string) string{}
 					normalizers = append(normalizers, IgnoreComments)
 					normalizers = append(normalizers, ReplaceString(uniqueID, "${uniqueId}"))
@@ -777,6 +776,8 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					if testPause {
 						assertNoRequest(t, got, normalizers...)
 					} else {
+						expectedPath := filepath.Join(fixture.SourceDir, "_http.log")
+
 						h.CompareGoldenFile(expectedPath, got, normalizers...)
 					}
 				}


### PR DESCRIPTION
Because we don't want to treat a new upstream field as an error here.
