### PR TITLE
tests: increase default e2e timeout to 2 hours

### DIFF
--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -65,9 +65,14 @@ if [[ "${E2E_GCP_TARGET}" == "real" ]]; then
   export TEST_BILLING_ACCOUNT_ID
 fi
 
+if [[ -z "${TEST_TIMEOUT:-}" ]]; then
+  TEST_TIMEOUT=7200s
+fi
+echo "Using TEST_TIMEOUT=${TEST_TIMEOUT}"
+
 # Run e2e tests against real gcp, capturing output
 GOLDEN_REQUEST_CHECKS=1 \
 GOLDEN_OBJECT_CHECKS=1 \
 WRITE_GOLDEN_OUTPUT=1 \
 RUN_E2E=1 \
- go test ./tests/e2e -timeout 3600s -v -run $RUN_TESTS
+ go test ./tests/e2e -timeout ${TEST_TIMEOUT} -v -run $RUN_TESTS

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -164,7 +164,7 @@ func TestE2EScript(t *testing.T) {
 					switch testCommand {
 					case "APPLY":
 						applyObject(h, obj)
-						create.WaitForReady(h, obj)
+						create.WaitForReady(h, create.DefaultWaitForReadyTimeout, obj)
 						appliedObjects[k] = obj
 
 					case "APPLY-10-SEC":
@@ -193,7 +193,7 @@ func TestE2EScript(t *testing.T) {
 
 					case "PATCH-EXTERNALLY-MANAGED-FIELDS":
 						patchObjectWithExternallyManagedFields(h, obj)
-						create.WaitForReady(h, obj)
+						create.WaitForReady(h, create.DefaultWaitForReadyTimeout, obj)
 
 					case "TOUCH":
 						// Force re-reconciliation with an annotation
@@ -271,7 +271,7 @@ func TestE2EScript(t *testing.T) {
 							h.Fatalf("error setting spec.resourceID: %v", err)
 						}
 						applyObject(h, obj)
-						create.WaitForReady(h, obj)
+						create.WaitForReady(h, create.DefaultWaitForReadyTimeout, obj)
 						appliedObjects[k] = obj
 
 					default:


### PR DESCRIPTION
Also refactor to demonstrate where the 35 minute pause comes from.
