### PR TITLE
fix: Reduce bigtable request size to meet project quotas

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/_generated_object_bigtableinstanceautoscaling.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/_generated_object_bigtableinstanceautoscaling.golden.yaml
@@ -18,7 +18,7 @@ spec:
   cluster:
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
       storageTarget: 2560
     clusterId: cluster-1-${uniqueId}
@@ -27,21 +27,21 @@ spec:
     zone: us-central1-a
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
       storageTarget: 2560
     clusterId: cluster-2-${uniqueId}
     numNodes: 2
     storageType: SSD
-    zone: us-west1-b
+    zone: us-central1-b
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
     clusterId: cluster-3-${uniqueId}
     numNodes: 2
     storageType: SSD
-    zone: us-east1-d
+    zone: us-central1-c
   displayName: BigtableSample
   instanceType: PRODUCTION
   resourceID: btinstance-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/_http.log
@@ -18,7 +18,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -34,7 +34,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -44,7 +44,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       },
       "defaultStorageType": "SSD",
       "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-east1-d"
+      "location": "projects/${projectId}/locations/us-central1-c"
     }
   },
   "instance": {
@@ -72,7 +72,7 @@ OK
         },
         "cluster-3-${uniqueId}": {
           "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-east1-d"
+          "location": "projects/${projectId}/locations/us-central1-c"
         }
       },
       "instance": {
@@ -114,7 +114,7 @@ OK
         },
         "cluster-3-${uniqueId}": {
           "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-east1-d"
+          "location": "projects/${projectId}/locations/us-central1-c"
         }
       },
       "instance": {
@@ -186,7 +186,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -205,7 +205,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -215,7 +215,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -265,7 +265,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -284,7 +284,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -294,7 +294,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -344,7 +344,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -363,7 +363,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -373,7 +373,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -397,7 +397,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -416,7 +416,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -426,7 +426,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -514,7 +514,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -538,7 +538,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 5,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -576,7 +576,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 5,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -597,7 +597,7 @@ OK
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -623,7 +623,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -646,7 +646,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 5,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -683,7 +683,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 5,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -703,7 +703,7 @@ OK
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -712,7 +712,7 @@ OK
       }
     },
     "defaultStorageType": "SSD",
-    "location": "projects/${projectId}/locations/us-east1-d",
+    "location": "projects/${projectId}/locations/us-central1-c",
     "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
     "serveNodes": 2,
     "state": "READY"
@@ -728,7 +728,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -739,7 +739,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateCluster
     },
     "defaultStorageType": "SSD",
     "encryptionConfig": {},
-    "location": "projects/${projectId}/locations/us-west1-b"
+    "location": "projects/${projectId}/locations/us-central1-b"
   },
   "clusterId": "cluster-2-${uniqueId}",
   "parent": "projects/${projectId}/instances/btinstance-${uniqueId}"
@@ -775,7 +775,7 @@ OK
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 5,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -786,7 +786,7 @@ OK
     },
     "defaultStorageType": "SSD",
     "encryptionConfig": {},
-    "location": "projects/${projectId}/locations/us-west1-b",
+    "location": "projects/${projectId}/locations/us-central1-b",
     "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-2-${uniqueId}",
     "serveNodes": 2,
     "state": "READY"
@@ -835,7 +835,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -854,7 +854,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -865,7 +865,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-west1-b",
+      "location": "projects/${projectId}/locations/us-central1-b",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-2-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -874,7 +874,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -883,7 +883,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -933,7 +933,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -952,7 +952,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -963,7 +963,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-west1-b",
+      "location": "projects/${projectId}/locations/us-central1-b",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-2-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -972,7 +972,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -981,7 +981,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -1031,7 +1031,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1050,7 +1050,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1061,7 +1061,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-west1-b",
+      "location": "projects/${projectId}/locations/us-central1-b",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-2-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
@@ -1070,7 +1070,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 5,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1079,7 +1079,7 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-d",
+      "location": "projects/${projectId}/locations/us-central1-c",
       "name": "projects/${projectId}/instances/btinstance-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/create.yaml
@@ -24,11 +24,11 @@ spec:
     zone: us-central1-a
     autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
   - clusterId: cluster-3-${uniqueId}
-    zone: us-east1-d
+    zone: us-central1-c
     autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling/update.yaml
@@ -24,17 +24,17 @@ spec:
     zone: us-central1-a
     autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
   - clusterId: cluster-2-${uniqueId}
-    zone: us-west1-b
+    zone: us-central1-b
     autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2
   - clusterId: cluster-3-${uniqueId}
-    zone: us-east1-d
+    zone: us-central1-c
     autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 20
+      maxNodes: 5
       minNodes: 2

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/_generated_object_bigtableinstanceautoscaling2.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/_generated_object_bigtableinstanceautoscaling2.golden.yaml
@@ -18,40 +18,40 @@ spec:
   cluster:
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 30
+      maxNodes: 5
       minNodes: 3
       storageTarget: 2560
-    clusterId: us-central1-a
+    clusterId: cluster-1-${uniqueId}
     numNodes: 3
     storageType: SSD
     zone: us-central1-a
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-east1-b
+    clusterId: cluster-2-${uniqueId}
     numNodes: 2
     storageType: SSD
-    zone: us-east1-b
+    zone: us-central1-b
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-west1-a
-    numNodes: 2
-    storageType: SSD
-    zone: us-west1-a
-  - autoscalingConfig:
-      cpuTarget: 80
-      maxNodes: 20
-      minNodes: 2
-      storageTarget: 2560
-    clusterId: us-central1-c
+    clusterId: cluster-3-${uniqueId}
     numNodes: 2
     storageType: SSD
     zone: us-central1-c
+  - autoscalingConfig:
+      cpuTarget: 80
+      maxNodes: 4
+      minNodes: 2
+      storageTarget: 2560
+    clusterId: cluster-4-${uniqueId}
+    numNodes: 2
+    storageType: SSD
+    zone: us-central1-f
   displayName: bigtableinstance
   instanceType: PRODUCTION
   resourceID: bt-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/_http.log
@@ -14,11 +14,11 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
 
 {
   "clusters": {
-    "us-central1-a": {
+    "cluster-1-${uniqueId}": {
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -31,11 +31,28 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       "encryptionConfig": {},
       "location": "projects/${projectId}/locations/us-central1-a"
     },
-    "us-central1-c": {
+    "cluster-2-${uniqueId}": {
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 10,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "encryptionConfig": {},
+      "location": "projects/${projectId}/locations/us-central1-b"
+    },
+    "cluster-3-${uniqueId}": {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -48,11 +65,11 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       "encryptionConfig": {},
       "location": "projects/${projectId}/locations/us-central1-c"
     },
-    "us-east1-b": {
+    "cluster-4-${uniqueId}": {
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 3,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -63,24 +80,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/CreateInstance
       },
       "defaultStorageType": "SSD",
       "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-east1-b"
-    },
-    "us-west1-a": {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "encryptionConfig": {},
-      "location": "projects/${projectId}/locations/us-west1-a"
+      "location": "projects/${projectId}/locations/us-central1-f"
     }
   },
   "instance": {
@@ -102,21 +102,21 @@ OK
     "@type": "type.googleapis.com/google.bigtable.admin.v2.CreateInstanceMetadata",
     "originalRequest": {
       "clusters": {
-        "us-central1-a": {
+        "cluster-1-${uniqueId}": {
           "defaultStorageType": "SSD",
           "location": "projects/${projectId}/locations/us-central1-a"
         },
-        "us-central1-c": {
+        "cluster-2-${uniqueId}": {
+          "defaultStorageType": "SSD",
+          "location": "projects/${projectId}/locations/us-central1-b"
+        },
+        "cluster-3-${uniqueId}": {
           "defaultStorageType": "SSD",
           "location": "projects/${projectId}/locations/us-central1-c"
         },
-        "us-east1-b": {
+        "cluster-4-${uniqueId}": {
           "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-east1-b"
-        },
-        "us-west1-a": {
-          "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-west1-a"
+          "location": "projects/${projectId}/locations/us-central1-f"
         }
       },
       "instance": {
@@ -152,21 +152,21 @@ OK
     "finishTime": "2024-04-01T12:34:56.123456Z",
     "originalRequest": {
       "clusters": {
-        "us-central1-a": {
+        "cluster-1-${uniqueId}": {
           "defaultStorageType": "SSD",
           "location": "projects/${projectId}/locations/us-central1-a"
         },
-        "us-central1-c": {
+        "cluster-2-${uniqueId}": {
+          "defaultStorageType": "SSD",
+          "location": "projects/${projectId}/locations/us-central1-b"
+        },
+        "cluster-3-${uniqueId}": {
           "defaultStorageType": "SSD",
           "location": "projects/${projectId}/locations/us-central1-c"
         },
-        "us-east1-b": {
+        "cluster-4-${uniqueId}": {
           "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-east1-b"
-        },
-        "us-west1-a": {
-          "defaultStorageType": "SSD",
-          "location": "projects/${projectId}/locations/us-west1-a"
+          "location": "projects/${projectId}/locations/us-central1-f"
         }
       },
       "instance": {
@@ -238,7 +238,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -249,7 +249,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -257,7 +257,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 10,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -268,7 +287,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -276,7 +295,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 3,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -286,27 +305,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -355,7 +355,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -366,7 +366,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -374,7 +374,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 10,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -385,7 +404,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -393,7 +412,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 3,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -403,27 +422,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -472,7 +472,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -483,7 +483,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -491,7 +491,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 10,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -502,7 +521,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -510,7 +529,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 3,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -520,27 +539,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -563,7 +563,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -574,7 +574,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -582,7 +582,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 10,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -593,7 +612,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -601,7 +620,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 3,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -611,27 +630,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -718,7 +718,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 30,
+          "maxServeNodes": 5,
           "minServeNodes": 3
         },
         "autoscalingTargets": {
@@ -727,7 +727,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
         }
       }
     },
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a"
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}"
   },
   "updateMask": "clusterConfig.clusterAutoscalingConfig"
 }
@@ -742,7 +742,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 30,
+              "maxServeNodes": 5,
               "minServeNodes": 3
             },
             "autoscalingTargets": {
@@ -751,13 +751,13 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 ---
@@ -765,7 +765,7 @@ OK
 GRPC /google.longrunning.Operations/GetOperation
 
 {
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 OK
@@ -780,7 +780,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 30,
+              "maxServeNodes": 5,
               "minServeNodes": 3
             },
             "autoscalingTargets": {
@@ -789,19 +789,19 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a/locations/us-central1-a/operations/${operationID}",
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}/locations/us-central1-a/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.bigtable.admin.v2.Cluster",
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 30,
+          "maxServeNodes": 5,
           "minServeNodes": 3
         },
         "autoscalingTargets": {
@@ -812,7 +812,7 @@ OK
     },
     "defaultStorageType": "SSD",
     "location": "projects/${projectId}/locations/us-central1-a",
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
     "serveNodes": 3,
     "state": "READY"
   }
@@ -827,7 +827,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 4,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -836,7 +836,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
         }
       }
     },
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c"
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}"
   },
   "updateMask": "clusterConfig.clusterAutoscalingConfig"
 }
@@ -851,7 +851,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 4,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -860,13 +860,13 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 ---
@@ -874,7 +874,7 @@ OK
 GRPC /google.longrunning.Operations/GetOperation
 
 {
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 OK
@@ -889,7 +889,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 4,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -898,19 +898,128 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c/locations/us-central1-a/operations/${operationID}",
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}/locations/us-central1-a/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.bigtable.admin.v2.Cluster",
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 4,
+          "minServeNodes": 2
+        },
+        "autoscalingTargets": {
+          "cpuUtilizationPercent": 80,
+          "storageUtilizationGibPerNode": 2560
+        }
+      }
+    },
+    "defaultStorageType": "SSD",
+    "location": "projects/${projectId}/locations/us-central1-b",
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+    "serveNodes": 2,
+    "state": "READY"
+  }
+}
+
+---
+
+GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
+
+{
+  "cluster": {
+    "clusterConfig": {
+      "clusterAutoscalingConfig": {
+        "autoscalingLimits": {
+          "maxServeNodes": 4,
+          "minServeNodes": 2
+        },
+        "autoscalingTargets": {
+          "cpuUtilizationPercent": 80,
+          "storageUtilizationGibPerNode": 2560
+        }
+      }
+    },
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}"
+  },
+  "updateMask": "clusterConfig.clusterAutoscalingConfig"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.bigtable.admin.v2.PartialUpdateClusterMetadata",
+    "originalRequest": {
+      "cluster": {
+        "clusterConfig": {
+          "clusterAutoscalingConfig": {
+            "autoscalingLimits": {
+              "maxServeNodes": 4,
+              "minServeNodes": 2
+            },
+            "autoscalingTargets": {
+              "cpuUtilizationPercent": 80,
+              "storageUtilizationGibPerNode": 2560
+            }
+          }
+        },
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}"
+      },
+      "updateMask": "clusterConfig.clusterAutoscalingConfig"
+    },
+    "requestTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}/locations/us-central1-a/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}/locations/us-central1-a/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.bigtable.admin.v2.PartialUpdateClusterMetadata",
+    "finishTime": "2024-04-01T12:34:56.123456Z",
+    "originalRequest": {
+      "cluster": {
+        "clusterConfig": {
+          "clusterAutoscalingConfig": {
+            "autoscalingLimits": {
+              "maxServeNodes": 4,
+              "minServeNodes": 2
+            },
+            "autoscalingTargets": {
+              "cpuUtilizationPercent": 80,
+              "storageUtilizationGibPerNode": 2560
+            }
+          }
+        },
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}"
+      },
+      "updateMask": "clusterConfig.clusterAutoscalingConfig"
+    },
+    "requestTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}/locations/us-central1-a/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.bigtable.admin.v2.Cluster",
+    "clusterConfig": {
+      "clusterAutoscalingConfig": {
+        "autoscalingLimits": {
+          "maxServeNodes": 4,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -921,7 +1030,7 @@ OK
     },
     "defaultStorageType": "SSD",
     "location": "projects/${projectId}/locations/us-central1-c",
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
     "serveNodes": 2,
     "state": "READY"
   }
@@ -936,7 +1045,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 4,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -945,7 +1054,7 @@ GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
         }
       }
     },
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b"
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}"
   },
   "updateMask": "clusterConfig.clusterAutoscalingConfig"
 }
@@ -960,7 +1069,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 4,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -969,13 +1078,13 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 ---
@@ -983,7 +1092,7 @@ OK
 GRPC /google.longrunning.Operations/GetOperation
 
 {
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b/locations/us-central1-a/operations/${operationID}"
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}/locations/us-central1-a/operations/${operationID}"
 }
 
 OK
@@ -998,7 +1107,7 @@ OK
         "clusterConfig": {
           "clusterAutoscalingConfig": {
             "autoscalingLimits": {
-              "maxServeNodes": 20,
+              "maxServeNodes": 4,
               "minServeNodes": 2
             },
             "autoscalingTargets": {
@@ -1007,19 +1116,19 @@ OK
             }
           }
         },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b"
+        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}"
       },
       "updateMask": "clusterConfig.clusterAutoscalingConfig"
     },
     "requestTime": "2024-04-01T12:34:56.123456Z"
   },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b/locations/us-central1-a/operations/${operationID}",
+  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}/locations/us-central1-a/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.bigtable.admin.v2.Cluster",
     "clusterConfig": {
       "clusterAutoscalingConfig": {
         "autoscalingLimits": {
-          "maxServeNodes": 20,
+          "maxServeNodes": 4,
           "minServeNodes": 2
         },
         "autoscalingTargets": {
@@ -1029,117 +1138,8 @@ OK
       }
     },
     "defaultStorageType": "SSD",
-    "location": "projects/${projectId}/locations/us-east1-b",
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-    "serveNodes": 2,
-    "state": "READY"
-  }
-}
-
----
-
-GRPC /google.bigtable.admin.v2.BigtableInstanceAdmin/PartialUpdateCluster
-
-{
-  "cluster": {
-    "clusterConfig": {
-      "clusterAutoscalingConfig": {
-        "autoscalingLimits": {
-          "maxServeNodes": 20,
-          "minServeNodes": 2
-        },
-        "autoscalingTargets": {
-          "cpuUtilizationPercent": 80,
-          "storageUtilizationGibPerNode": 2560
-        }
-      }
-    },
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a"
-  },
-  "updateMask": "clusterConfig.clusterAutoscalingConfig"
-}
-
-OK
-
-{
-  "metadata": {
-    "@type": "type.googleapis.com/google.bigtable.admin.v2.PartialUpdateClusterMetadata",
-    "originalRequest": {
-      "cluster": {
-        "clusterConfig": {
-          "clusterAutoscalingConfig": {
-            "autoscalingLimits": {
-              "maxServeNodes": 20,
-              "minServeNodes": 2
-            },
-            "autoscalingTargets": {
-              "cpuUtilizationPercent": 80,
-              "storageUtilizationGibPerNode": 2560
-            }
-          }
-        },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a"
-      },
-      "updateMask": "clusterConfig.clusterAutoscalingConfig"
-    },
-    "requestTime": "2024-04-01T12:34:56.123456Z"
-  },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a/locations/us-central1-a/operations/${operationID}"
-}
-
----
-
-GRPC /google.longrunning.Operations/GetOperation
-
-{
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a/locations/us-central1-a/operations/${operationID}"
-}
-
-OK
-
-{
-  "done": true,
-  "metadata": {
-    "@type": "type.googleapis.com/google.bigtable.admin.v2.PartialUpdateClusterMetadata",
-    "finishTime": "2024-04-01T12:34:56.123456Z",
-    "originalRequest": {
-      "cluster": {
-        "clusterConfig": {
-          "clusterAutoscalingConfig": {
-            "autoscalingLimits": {
-              "maxServeNodes": 20,
-              "minServeNodes": 2
-            },
-            "autoscalingTargets": {
-              "cpuUtilizationPercent": 80,
-              "storageUtilizationGibPerNode": 2560
-            }
-          }
-        },
-        "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a"
-      },
-      "updateMask": "clusterConfig.clusterAutoscalingConfig"
-    },
-    "requestTime": "2024-04-01T12:34:56.123456Z"
-  },
-  "name": "operations/projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a/locations/us-central1-a/operations/${operationID}",
-  "response": {
-    "@type": "type.googleapis.com/google.bigtable.admin.v2.Cluster",
-    "clusterConfig": {
-      "clusterAutoscalingConfig": {
-        "autoscalingLimits": {
-          "maxServeNodes": 20,
-          "minServeNodes": 2
-        },
-        "autoscalingTargets": {
-          "cpuUtilizationPercent": 80,
-          "storageUtilizationGibPerNode": 2560
-        }
-      }
-    },
-    "defaultStorageType": "SSD",
-    "location": "projects/${projectId}/locations/us-west1-a",
-    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+    "location": "projects/${projectId}/locations/us-central1-f",
+    "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
     "serveNodes": 2,
     "state": "READY"
   }
@@ -1187,7 +1187,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -1198,7 +1198,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -1206,7 +1206,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1217,7 +1236,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -1225,7 +1244,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1235,27 +1254,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -1304,7 +1304,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -1315,7 +1315,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -1323,7 +1323,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1334,7 +1353,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -1342,7 +1361,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1352,27 +1371,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }
@@ -1421,7 +1421,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 30,
+            "maxServeNodes": 5,
             "minServeNodes": 3
           },
           "autoscalingTargets": {
@@ -1432,7 +1432,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-a",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-1-${uniqueId}",
       "serveNodes": 3,
       "state": "READY"
     },
@@ -1440,7 +1440,26 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
+            "minServeNodes": 2
+          },
+          "autoscalingTargets": {
+            "cpuUtilizationPercent": 80,
+            "storageUtilizationGibPerNode": 2560
+          }
+        }
+      },
+      "defaultStorageType": "SSD",
+      "location": "projects/${projectId}/locations/us-central1-b",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-2-${uniqueId}",
+      "serveNodes": 2,
+      "state": "READY"
+    },
+    {
+      "clusterConfig": {
+        "clusterAutoscalingConfig": {
+          "autoscalingLimits": {
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1451,7 +1470,7 @@ OK
       },
       "defaultStorageType": "SSD",
       "location": "projects/${projectId}/locations/us-central1-c",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-central1-c",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-3-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     },
@@ -1459,7 +1478,7 @@ OK
       "clusterConfig": {
         "clusterAutoscalingConfig": {
           "autoscalingLimits": {
-            "maxServeNodes": 20,
+            "maxServeNodes": 4,
             "minServeNodes": 2
           },
           "autoscalingTargets": {
@@ -1469,27 +1488,8 @@ OK
         }
       },
       "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-east1-b",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-east1-b",
-      "serveNodes": 2,
-      "state": "READY"
-    },
-    {
-      "clusterConfig": {
-        "clusterAutoscalingConfig": {
-          "autoscalingLimits": {
-            "maxServeNodes": 20,
-            "minServeNodes": 2
-          },
-          "autoscalingTargets": {
-            "cpuUtilizationPercent": 80,
-            "storageUtilizationGibPerNode": 2560
-          }
-        }
-      },
-      "defaultStorageType": "SSD",
-      "location": "projects/${projectId}/locations/us-west1-a",
-      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/us-west1-a",
+      "location": "projects/${projectId}/locations/us-central1-f",
+      "name": "projects/${projectId}/instances/bt-${uniqueId}/clusters/cluster-4-${uniqueId}",
       "serveNodes": 2,
       "state": "READY"
     }

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/create.yaml
@@ -20,36 +20,36 @@ spec:
   cluster:
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 30
+      maxNodes: 5
       minNodes: 3
       storageTarget: 2560
-    clusterId: us-central1-a
+    clusterId: cluster-1-${uniqueId}
     storageType: SSD
     zone: us-central1-a
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-east1-b
+    clusterId: cluster-2-${uniqueId}
     storageType: SSD
-    zone: us-east1-b
+    zone: us-central1-b
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-west1-a
-    storageType: SSD
-    zone: us-west1-a
-  - autoscalingConfig:
-      cpuTarget: 80
-      maxNodes: 10
-      minNodes: 2
-      storageTarget: 2560
-    clusterId: us-central1-c
+    clusterId: cluster-3-${uniqueId}
     storageType: SSD
     zone: us-central1-c
+  - autoscalingConfig:
+      cpuTarget: 80
+      maxNodes: 3
+      minNodes: 2
+      storageTarget: 2560
+    clusterId: cluster-4-${uniqueId}
+    storageType: SSD
+    zone: us-central1-f
   displayName: bigtableinstance
   instanceType: PRODUCTION
   resourceID: bt-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableinstance/bigtableinstanceautoscaling2/update.yaml
@@ -20,36 +20,36 @@ spec:
   cluster:
   - autoscalingConfig:
       cpuTarget: 70
-      maxNodes: 30
+      maxNodes: 5
       minNodes: 3
       storageTarget: 2560
-    clusterId: us-central1-a
+    clusterId: cluster-1-${uniqueId}
     storageType: SSD
     zone: us-central1-a
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-east1-b
+    clusterId: cluster-2-${uniqueId}
     storageType: SSD
-    zone: us-east1-b
+    zone: us-central1-b
   - autoscalingConfig:
       cpuTarget: 80
-      maxNodes: 20
+      maxNodes: 4
       minNodes: 2
       storageTarget: 2560
-    clusterId: us-west1-a
-    storageType: SSD
-    zone: us-west1-a
-  - autoscalingConfig:
-      cpuTarget: 80
-      maxNodes: 20
-      minNodes: 2
-      storageTarget: 2560
-    clusterId: us-central1-c
+    clusterId: cluster-3-${uniqueId}
     storageType: SSD
     zone: us-central1-c
+  - autoscalingConfig:
+      cpuTarget: 80
+      maxNodes: 4
+      minNodes: 2
+      storageTarget: 2560
+    clusterId: cluster-4-${uniqueId}
+    storageType: SSD
+    zone: us-central1-f
   displayName: bigtableinstance
   instanceType: PRODUCTION
   resourceID: bt-${uniqueId}


### PR DESCRIPTION
Integration tests have been failing due to the large bigtable maxNodes request sizes. This PR adjusts the bigtable maxNode requests to be smaller, and moves all resources into zones with larger quota limits.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
