### PR TITLE
Add linter that targets only compositions folder

### DIFF
--- a/.github/workflows/presubmit-compositions.yaml
+++ b/.github/workflows/presubmit-compositions.yaml
@@ -27,6 +27,25 @@ on:
 env:
   GOWORK: off
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-22.04
+    timeout-minutes: 7
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: false # because of https://github.com/golangci/golangci-lint-action/issues/135
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3.7.1
+        with:
+          working-directory: ./experiments/compositions/composition
+          version: v1.59.1 # should match the version in Makefile
   verify-goimports:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/presubmit-compositions.yaml
+++ b/.github/workflows/presubmit-compositions.yaml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # because of https://github.com/golangci/golangci-lint-action/issues/135
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3.7.1
+        uses: golangci/golangci-lint-action@v6 # v3.7.1
         with:
           working-directory: ./experiments/compositions/composition
           version: v1.59.1 # should match the version in Makefile

--- a/experiments/compositions/composition/README.md
+++ b/experiments/compositions/composition/README.md
@@ -75,6 +75,7 @@ More information can be found via the [Kubebuilder Documentation](https://book.k
 
 ## License
 
+
 Copyright 2024.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/experiments/compositions/composition/expanders/getter/main_test.go
+++ b/experiments/compositions/composition/expanders/getter/main_test.go
@@ -177,6 +177,25 @@ func TestEvaluateEmptyFacade(t *testing.T) {
 	}
 }
 
+func evaluateGetterConfigurationMissingObject(t *testing.T, getter []byte, expectedErrorString string) {
+	r, err := expanderClient.Evaluate(context.Background(),
+		&pb.EvaluateRequest{
+			Config: getter,
+			Facade: sampleFacade,
+		})
+	if err != nil {
+		t.Fatalf("expected no error. got %v", err)
+	}
+
+	if r.Status != pb.Status_EVALUATE_WAIT {
+		t.Fatalf("\nexpected: EVALUATE_WAIT \n got: %s", r)
+	}
+
+	if !strings.Contains(r.Error.Message, expectedErrorString) {
+		t.Fatalf("expected error contains: %s \n got: %s", expectedErrorString, r)
+	}
+}
+
 func TestEvaluateGetterConfigurationMissingObjectGroup(t *testing.T) {
 	// Marshall GetterConfiguration config
 	getter, err := json.Marshal(&compositionv1alpha1.GetterConfiguration{
@@ -201,23 +220,8 @@ func TestEvaluateGetterConfigurationMissingObjectGroup(t *testing.T) {
 		log.Fatalf("unable to marshall getter: %v", err)
 	}
 
-	r, err := expanderClient.Evaluate(context.Background(),
-		&pb.EvaluateRequest{
-			Config: getter,
-			Facade: sampleFacade,
-		})
-	if err != nil {
-		t.Fatalf("expected no error. got %v", err)
-	}
-
-	if r.Status != pb.Status_EVALUATE_WAIT {
-		t.Fatalf("\nexpected: EVALUATE_WAIT \n got: %s", r)
-	}
-
 	expectedErrorString := "Dependent object not found: GVR: foobars.acme.something.com(v1)/composition-system/missing"
-	if !strings.Contains(r.Error.Message, expectedErrorString) {
-		t.Fatalf("expected error contains: %s \n got: %s", expectedErrorString, r)
-	}
+	evaluateGetterConfigurationMissingObject(t, getter, expectedErrorString)
 }
 
 func TestEvaluateGetterConfigurationMissingObjectResource(t *testing.T) {
@@ -244,23 +248,8 @@ func TestEvaluateGetterConfigurationMissingObjectResource(t *testing.T) {
 		log.Fatalf("unable to marshall getter: %v", err)
 	}
 
-	r, err := expanderClient.Evaluate(context.Background(),
-		&pb.EvaluateRequest{
-			Config: getter,
-			Facade: sampleFacade,
-		})
-	if err != nil {
-		t.Fatalf("expected no error. got %v", err)
-	}
-
-	if r.Status != pb.Status_EVALUATE_WAIT {
-		t.Fatalf("\nexpected: EVALUATE_WAIT \n got: %s", r.Status)
-	}
-
 	expectedErrorString := "Dependent object not found: GVR: unknown.apps(v1)/composition-system/missing"
-	if !strings.Contains(r.Error.Message, expectedErrorString) {
-		t.Fatalf("expected error contains: %s \n got: %s", expectedErrorString, r)
-	}
+	evaluateGetterConfigurationMissingObject(t, getter, expectedErrorString)
 }
 
 func TestEvaluateGetterConfigurationMissingObject(t *testing.T) {


### PR DESCRIPTION
### Change description

For some reason the global linter was not catching any errors in experiments. 

Add a github actions for experiments/compositions:
- go linter

