### PR TITLE
tests: log resource name for dependency failure

### DIFF
--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -142,12 +142,12 @@ func (r *TestReconciler) ReconcileObjectMeta(ctx context.Context, om metav1.Obje
 }
 
 // Creates and reconciles all unstructureds in the unstruct list. Returns a cleanup function that should be defered immediately after calling this function.
-func (r *TestReconciler) CreateAndReconcile(ctx context.Context, unstructs []*unstructured.Unstructured, cleanupPolicy ResourceCleanupPolicy) func() {
+func (r *TestReconciler) CreateAndReconcile(ctx context.Context, dependencies []*unstructured.Unstructured, cleanupPolicy ResourceCleanupPolicy, mainResource *unstructured.Unstructured) func() {
 	r.t.Helper()
-	cleanupFuncs := make([]func(), 0, len(unstructs))
-	for _, u := range unstructs {
+	cleanupFuncs := make([]func(), 0, len(dependencies))
+	for _, u := range dependencies {
 		if err := r.mgr.GetClient().Create(ctx, u); err != nil {
-			r.t.Fatalf("error creating resource '%v': %v", u.GetKind(), err)
+			r.t.Fatalf("error creating dependecy '%v' for resource '%v/%v': %v", u.GetKind(), mainResource.GetName(), mainResource.GetKind(), err)
 		}
 		cleanupFuncs = append(cleanupFuncs, r.BuildCleanupFunc(ctx, u, cleanupPolicy))
 		r.ReconcileIfManagedByKCC(ctx, u, ExpectedSuccessfulReconcileResultFor(r, u), nil)

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -79,7 +79,7 @@ func RunAllWithObjectCreated(ctx context.Context, t *testing.T, mgr manager.Mana
 
 func RunAllWithDependenciesCreatedButNotObject(ctx context.Context, t *testing.T, mgr manager.Manager, shouldRunFunc ShouldRunFunc, testCaseFunc TestCaseFunc) {
 	testFunc := func(ctx context.Context, t *testing.T, testContext TestContext, sysContext SystemContext) {
-		dependencyCleanup := sysContext.Reconciler.CreateAndReconcile(ctx, testContext.DependencyUnstructs, testreconciler.CleanupPolicyAlways)
+		dependencyCleanup := sysContext.Reconciler.CreateAndReconcile(ctx, testContext.DependencyUnstructs, testreconciler.CleanupPolicyAlways, testContext.CreateUnstruct)
 		defer dependencyCleanup()
 		testCaseFunc(ctx, t, testContext, sysContext)
 	}


### PR DESCRIPTION
Some simple log lines to help me to more easily narrow down which resources are failing to create dependencies.