### PR TITLE
Support SetLabels() in mock compute image

### DIFF
--- a/mockgcp/mockcompute/imagesv1.go
+++ b/mockgcp/mockcompute/imagesv1.go
@@ -114,6 +114,27 @@ func (s *ImagesV1) Patch(ctx context.Context, req *pb.PatchImageRequest) (*pb.Op
 	return s.newLRO(ctx, name.Project.ID)
 }
 
+func (s *ImagesV1) SetLabels(ctx context.Context, req *pb.SetLabelsImageRequest) (*pb.Operation, error) {
+	name, err := s.parseImageName(req.GetProject(), req.GetResource())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	obj := &pb.Image{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	obj.Labels = req.GetGlobalSetLabelsRequestResource().GetLabels()
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return s.newLRO(ctx, name.Project.ID)
+}
+
 func (s *ImagesV1) Delete(ctx context.Context, req *pb.DeleteImageRequest) (*pb.Operation, error) {
 	name, err := s.parseImageName(req.GetProject(), req.GetImage())
 	if err != nil {

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeimage/_generated_object_computeimage.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeimage/_generated_object_computeimage.golden.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeImage
 metadata:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Support SetLabels() in mock compute image to avoid 501 errors when regenerating the http logs.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

`WRITE_GOLDEN_OUTPUT=1 RUN_E2E=1 GOLDEN_OBJECT_CHECKS=1 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock KCC_USE_DIRECT_RECONCILERS="SQLInstance"   go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures/computeimage` passed.