### PR TITLE
fixit: Fix samples test data for internal-managed-load-balancing-backend-service

### DIFF
--- a/config/samples/resources/computebackendservice/internal-managed-load-balancing-backend-service/compute_v1beta1_computebackendservice.yaml
+++ b/config/samples/resources/computebackendservice/internal-managed-load-balancing-backend-service/compute_v1beta1_computebackendservice.yaml
@@ -21,7 +21,7 @@ spec:
   localityLbPolicy: MAGLEV
   timeoutSec: 86400
   consistentHash:
-    httpHeaderName: "Hash string"
+    httpHeaderName: "Hash_String"
   healthChecks:
   - healthCheckRef:
       name: computebackendservice-dep-internalmanagedloadbalancing

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
@@ -2496,7 +2496,7 @@ spec:
   localityLbPolicy: MAGLEV
   timeoutSec: 86400
   consistentHash:
-    httpHeaderName: "Hash string"
+    httpHeaderName: "Hash_String"
   healthChecks:
   - healthCheckRef:
       name: computebackendservice-dep-internalmanagedloadbalancing


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Error message:  error applying desired state: summary: Error creating RegionBackendService: googleapi: Error 400: Invalid value for field 'resource.consistentHash.httpHeaderName': 'Hash string'. Must be a match of regex '[!#$%&'*+-.^_`|~0-9a-zA-Z]+', invalid"}

Local test passed:
```
--- PASS: TestAll (1.02s)
    --- PASS: TestAll/internal-managed-load-balancing-backend-service (119.04s)
PASS
{"severity":"info","timestamp":"2024-08-15T22:05:16.896Z","msg":"Stopping and waiting for non leader election runnables"}
{"severity":"info","timestamp":"2024-08-15T22:05:16.896Z","msg":"Stopping and waiting for leader election runnables"}
{"severity":"info","timestamp":"2024-08-15T22:05:16.896Z","msg":"Stopping and waiting for caches"}
{"severity":"info","timestamp":"2024-08-15T22:05:16.896Z","msg":"Stopping and waiting for webhooks"}
{"severity":"info","timestamp":"2024-08-15T22:05:16.897Z","logger":"controller-runtime.webhook","msg":"Shutting down webhook server with timeout of 1 minute"}
{"severity":"info","timestamp":"2024-08-15T22:05:16.897Z","msg":"Wait completed, proceeding to shutdown the manager"}
ok      github.com/GoogleCloudPlatform/k8s-config-connector/config/tests/samples/create 189.028s

```

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
