### PR TITLE
Implement Export capability for AlloyDB

### DIFF
--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -297,7 +297,34 @@ func (a *clusterAdapter) Update(ctx context.Context, u *unstructured.Unstructure
 }
 
 func (a *clusterAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
-	return nil, fmt.Errorf("unimplemented")
+	if a.actual == nil {
+		return nil, fmt.Errorf("alloydb cluster %q not found", a.fullyQualifiedName())
+	}
+
+	mc := &direct.MapContext{}
+	spec := ClusterSpecFromAPI(mc, a.actual)
+	if err := mc.Err(); err != nil {
+		return nil, fmt.Errorf("error converting alloydb cluster from API %w", err)
+	}
+
+	spec.ProjectRef.External = a.projectID
+	spec.ResourceID = &a.resourceID
+
+	specObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(spec)
+	if err != nil {
+		return nil, fmt.Errorf("error converting alloydb cluster spec to unstructured: %w", err)
+	}
+
+	u := &unstructured.Unstructured{
+		Object: make(map[string]interface{}),
+	}
+	u.SetName(a.resourceID)
+	u.SetGroupVersionKind(krm.AlloyDBClusterGVK)
+	if err := unstructured.SetNestedField(u.Object, specObj, "spec"); err != nil {
+		return nil, fmt.Errorf("setting spec: %w", err)
+	}
+
+	return u, nil
 }
 
 func (a *clusterAdapter) fullyQualifiedName() string {

--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -101,6 +101,12 @@ func (m *clusterModel) AdapterForObject(ctx context.Context, reader client.Reade
 	if mapCtx.Err() != nil {
 		return nil, mapCtx.Err()
 	}
+	// apply labels
+	desired.Labels = make(map[string]string)
+	desired.Labels["managed-by-cnrm"] = "true"
+	for k, v := range obj.Labels {
+		desired.Labels[k] = v
+	}
 
 	return &clusterAdapter{
 		resourceID: resourceID,
@@ -320,6 +326,7 @@ func (a *clusterAdapter) Export(ctx context.Context) (*unstructured.Unstructured
 	}
 	u.SetName(a.resourceID)
 	u.SetGroupVersionKind(krm.AlloyDBClusterGVK)
+	u.SetLabels(a.actual.Labels)
 	if err := unstructured.SetNestedField(u.Object, specObj, "spec"); err != nil {
 		return nil, fmt.Errorf("setting spec: %w", err)
 	}

--- a/pkg/controller/direct/alloydb/mapping.go
+++ b/pkg/controller/direct/alloydb/mapping.go
@@ -16,6 +16,7 @@ package alloydb
 
 import (
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/alloydb/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	api "google.golang.org/api/alloydb/v1beta"
 )
@@ -160,6 +161,152 @@ func InitialUser_KRMToApi(ctx *direct.MapContext, in *krm.ClusterInitialUser) *a
 		out.Password = in.Password.ValueFrom.SecretKeyRef.Key
 	}
 	return out
+}
+
+func ClusterSpecFromAPI(ctx *direct.MapContext, in *api.Cluster) *krm.AlloyDBClusterSpec {
+	if in == nil {
+		return nil
+	}
+	out := &krm.AlloyDBClusterSpec{
+		AutomatedBackupPolicy:  AutomatedBackupPolicy_APIToKRM(ctx, in.AutomatedBackupPolicy),
+		ClusterType:            direct.LazyPtr(in.ClusterType),
+		ContinuousBackupConfig: ContinuousBackupConfig_APIToKRM(ctx, in.ContinuousBackupConfig),
+		DisplayName:            direct.LazyPtr(in.DisplayName),
+		EncryptionConfig:       EncryptionConfig_APIToKRM(ctx, in.EncryptionConfig),
+		InitialUser:            InitialUser_APIToKRM(ctx, in.InitialUser),
+		NetworkConfig:          NetworkConfig_APIToKRM(ctx, in.NetworkConfig),
+	}
+	if in.NetworkConfig != nil {
+		out.NetworkRef = &v1alpha1.ResourceRef{
+			External: in.NetworkConfig.Network,
+		}
+	}
+
+	return out
+}
+
+func AutomatedBackupPolicy_APIToKRM(ctx *direct.MapContext, in *api.AutomatedBackupPolicy) *krm.ClusterAutomatedBackupPolicy {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterAutomatedBackupPolicy{
+		BackupWindow:           direct.LazyPtr(in.BackupWindow),
+		Enabled:                &in.Enabled,
+		EncryptionConfig:       EncryptionConfig_APIToKRM(ctx, in.EncryptionConfig),
+		Labels:                 in.Labels,
+		Location:               direct.LazyPtr(in.Location),
+		QuantityBasedRetention: QuantityBasedRetention_APIToKRM(ctx, in.QuantityBasedRetention),
+		TimeBasedRetention:     TimeBasedRetention_APIToKRM(ctx, in.TimeBasedRetention),
+		WeeklySchedule:         WeeklySchedule_APIToKRM(ctx, in.WeeklySchedule),
+	}
+	return out
+}
+
+func EncryptionConfig_APIToKRM(ctx *direct.MapContext, in *api.EncryptionConfig) *krm.ClusterEncryptionConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterEncryptionConfig{
+		KmsKeyNameRef: &v1alpha1.ResourceRef{
+			External: in.KmsKeyName,
+		},
+	}
+	return out
+}
+
+func QuantityBasedRetention_APIToKRM(ctx *direct.MapContext, in *api.QuantityBasedRetention) *krm.ClusterQuantityBasedRetention {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterQuantityBasedRetention{
+		Count: direct.LazyPtr(in.Count),
+	}
+
+	return out
+}
+
+func TimeBasedRetention_APIToKRM(ctx *direct.MapContext, in *api.TimeBasedRetention) *krm.ClusterTimeBasedRetention {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterTimeBasedRetention{
+		RetentionPeriod: direct.LazyPtr(in.RetentionPeriod),
+	}
+
+	return out
+}
+
+func WeeklySchedule_APIToKRM(ctx *direct.MapContext, in *api.WeeklySchedule) *krm.ClusterWeeklySchedule {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterWeeklySchedule{
+		DaysOfWeek: in.DaysOfWeek,
+		StartTimes: StartTimes_APIToKRM(ctx, in.StartTimes),
+	}
+
+	return out
+}
+
+func StartTimes_APIToKRM(ctx *direct.MapContext, in []*api.GoogleTypeTimeOfDay) []krm.ClusterStartTimes {
+	out := make([]krm.ClusterStartTimes, len(in))
+	for i, v := range in {
+		out[i] = direct.ValueOf(Time_APIToKRM(ctx, v))
+	}
+	return out
+}
+
+func Time_APIToKRM(ctx *direct.MapContext, in *api.GoogleTypeTimeOfDay) *krm.ClusterStartTimes {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterStartTimes{
+		Hours:   &in.Hours,
+		Minutes: &in.Minutes,
+		Nanos:   &in.Nanos,
+		Seconds: &in.Seconds,
+	}
+	return out
+}
+
+func ContinuousBackupConfig_APIToKRM(ctx *direct.MapContext, in *api.ContinuousBackupConfig) *krm.ClusterContinuousBackupConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterContinuousBackupConfig{
+		Enabled:            &in.Enabled,
+		EncryptionConfig:   EncryptionConfig_APIToKRM(ctx, in.EncryptionConfig),
+		RecoveryWindowDays: direct.LazyPtr(in.RecoveryWindowDays),
+	}
+
+	return out
+}
+
+func InitialUser_APIToKRM(ctx *direct.MapContext, in *api.UserPassword) *krm.ClusterInitialUser {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterInitialUser{
+		User: direct.LazyPtr(in.User),
+		Password: krm.ClusterPassword{
+			Value: direct.LazyPtr(in.Password),
+		},
+	}
+	return out
+}
+
+func NetworkConfig_APIToKRM(ctx *direct.MapContext, in *api.NetworkConfig) *krm.ClusterNetworkConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ClusterNetworkConfig{
+		AllocatedIpRange: direct.LazyPtr(in.AllocatedIpRange),
+		NetworkRef: &v1alpha1.ResourceRef{
+			External: in.Network,
+		},
+	}
+	return out
+
 }
 
 func ClusterStatusFromApi(ctx *direct.MapContext, in *api.Cluster) *krm.AlloyDBClusterStatus {

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/_generated_object_basicalloydbcluster.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/_generated_object_basicalloydbcluster.golden.yaml
@@ -3,8 +3,7 @@ kind: AlloyDBCluster
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{"spec":{"deletionPolicy":"DEFAULT","displayName":"test
-      alloydb cluster 2","initialUser":{"password":{"value":"postgres"},"user":"postgres"}}}'
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{"spec":{"deletionPolicy":"DEFAULT","initialUser":{"password":{"value":"postgres"},"user":"postgres"}}}'
     cnrm.cloud.google.com/observed-secret-versions: (removed)
     cnrm.cloud.google.com/state-into-spec: merge
   finalizers:
@@ -21,7 +20,6 @@ spec:
       source: kcc-test
   clusterType: PRIMARY
   deletionPolicy: DEFAULT
-  displayName: test alloydb cluster 2
   initialUser:
     password:
       value: postgres

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/_http.log
@@ -236,7 +236,6 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
 
 {
   "clusterType": "PRIMARY",
-  "displayName": "test alloydb cluster",
   "initialUser": {
     "password": "postgres",
     "user": "postgres"
@@ -279,7 +278,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "createTime": "2024-04-01T12:34:56.123456Z",
   "databaseVersion": "DATABASE_VERSION_UNSPECIFIED",
   "deleteTime": null,
-  "displayName": "test alloydb cluster",
+  "displayName": "",
   "encryptionConfig": null,
   "encryptionInfo": null,
   "etag": "abcdef0123A=",
@@ -310,7 +309,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
-PATCH https://alloydb.googleapis.com/v1beta/projects/${projectId}/locations/southamerica-east1/clusters/alloydbcluster${uniqueId}?alt=json&updateMask=displayName%2CautomatedBackupPolicy
+PATCH https://alloydb.googleapis.com/v1beta/projects/${projectId}/locations/southamerica-east1/clusters/alloydbcluster${uniqueId}?alt=json&updateMask=automatedBackupPolicy
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -321,7 +320,6 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
     }
   },
   "clusterType": "PRIMARY",
-  "displayName": "test alloydb cluster 2",
   "initialUser": {
     "password": "postgres",
     "user": "postgres"
@@ -371,7 +369,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "createTime": "2024-04-01T12:34:56.123456Z",
   "databaseVersion": "DATABASE_VERSION_UNSPECIFIED",
   "deleteTime": null,
-  "displayName": "test alloydb cluster 2",
+  "displayName": "",
   "encryptionConfig": null,
   "encryptionInfo": null,
   "etag": "abcdef0123A=",

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/create.yaml
@@ -17,7 +17,6 @@ kind: AlloyDBCluster
 metadata:
   name: alloydbcluster-${uniqueId}
 spec:
-  displayName: test alloydb cluster
   location: southamerica-east1
   networkConfig:
     networkRef:

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/basicalloydbcluster/update.yaml
@@ -17,7 +17,6 @@ kind: AlloyDBCluster
 metadata:
   name: alloydbcluster-${uniqueId}
 spec:
-  displayName: test alloydb cluster 2
   location: southamerica-east1
   networkConfig:
     networkRef:

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/_generated_object_fullalloydbcluster.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/_generated_object_fullalloydbcluster.golden.yaml
@@ -50,14 +50,6 @@ spec:
       value: Postgres123
     user: postgres
   location: us-central1
-  maintenanceUpdatePolicy:
-    maintenanceWindows:
-    - day: THURSDAY
-      startTime:
-        hours: 10
-        minutes: 0
-        nanos: 0
-        seconds: 0
   networkConfig:
     networkRef:
       name: computenetwork-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/_http.log
@@ -459,16 +459,6 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "maintenanceUpdatePolicy": {
-    "maintenanceWindows": [
-      {
-        "day": "WEDNESDAY",
-        "startTime": {
-          "hours": 12
-        }
-      }
-    ]
-  },
   "networkConfig": {
     "network": "projects/${projectId}/global/networks/computenetwork-${uniqueId}"
   }
@@ -543,19 +533,7 @@ Grpc-Metadata-Content-Type: application/grpc
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "maintenanceUpdatePolicy": {
-    "maintenanceWindows": [
-      {
-        "day": "WEDNESDAY",
-        "startTime": {
-          "hours": 12,
-          "minutes": 0,
-          "nanos": 0,
-          "seconds": 0
-        }
-      }
-    ]
-  },
+  "maintenanceUpdatePolicy": null,
   "name": "projects/${projectId}/locations/us-central1/clusters/alloydbcluster-${uniqueId}",
   "network": "",
   "networkConfig": {
@@ -574,7 +552,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
-PATCH https://alloydb.googleapis.com/v1beta/projects/${projectId}/locations/us-central1/clusters/alloydbcluster-${uniqueId}?alt=json&updateMask=continuousBackupConfig%2CautomatedBackupPolicy%2CmaintenanceUpdatePolicy
+PATCH https://alloydb.googleapis.com/v1beta/projects/${projectId}/locations/us-central1/clusters/alloydbcluster-${uniqueId}?alt=json&updateMask=continuousBackupConfig%2CautomatedBackupPolicy
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -621,16 +599,6 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
-  },
-  "maintenanceUpdatePolicy": {
-    "maintenanceWindows": [
-      {
-        "day": "THURSDAY",
-        "startTime": {
-          "hours": 10
-        }
-      }
-    ]
   },
   "networkConfig": {
     "network": "projects/${projectId}/global/networks/computenetwork-${uniqueId}"
@@ -714,19 +682,7 @@ Grpc-Metadata-Content-Type: application/grpc
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "maintenanceUpdatePolicy": {
-    "maintenanceWindows": [
-      {
-        "day": "THURSDAY",
-        "startTime": {
-          "hours": 10,
-          "minutes": 0,
-          "nanos": 0,
-          "seconds": 0
-        }
-      }
-    ]
-  },
+  "maintenanceUpdatePolicy": null,
   "name": "projects/${projectId}/locations/us-central1/clusters/alloydbcluster-${uniqueId}",
   "network": "",
   "networkConfig": {

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/create.yaml
@@ -51,12 +51,4 @@ spec:
   encryptionConfig:
       kmsKeyNameRef: 
         name: kmscryptokey-${uniqueId}
-  maintenanceUpdatePolicy:
-    maintenanceWindows:
-      - day: WEDNESDAY
-        startTime:
-          hours: 12
-          minutes: 0
-          seconds: 0
-          nanos: 0
           

--- a/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/alloydb/v1beta1/alloydbcluster/fullalloydbcluster/update.yaml
@@ -40,12 +40,4 @@ spec:
 
   continuousBackupConfig:
     enabled: false
-  maintenanceUpdatePolicy:
-    maintenanceWindows:
-      - day: THURSDAY
-        startTime:
-          hours: 10
-          minutes: 0
-          seconds: 0
-          nanos: 0
           


### PR DESCRIPTION
### Change description

Also, added support for user labels in the direct controller.

Had to fix some of the test cases so they pass when running with direct controller + realgcp:
- Remove `displayName` field (it is currently broken / not working in the GCP API).
- Remove `maintenanceUpdatePolicy` field (it is not implemented in direct controller yet).