### PR TITLE
Add a note for deprecating Hierarchy Controller in Config Management feature

### DIFF
--- a/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
+++ b/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
@@ -70,7 +70,7 @@ type FeaturemembershipConfigmanagement struct {
 	// +optional
 	ConfigSync *FeaturemembershipConfigSync `json:"configSync,omitempty"`
 
-	/* Hierarchy Controller configuration for the cluster. */
+	/* **DEPRECATED** Configuring Hierarchy Controller through the configmanagement feature is no longer recommended. Use https://github.com/kubernetes-sigs/hierarchical-namespaces instead. */
 	// +optional
 	HierarchyController *FeaturemembershipHierarchyController `json:"hierarchyController,omitempty"`
 

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_gkehubfeaturememberships.gkehub.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_gkehubfeaturememberships.gkehub.cnrm.cloud.google.com.yaml
@@ -233,7 +233,10 @@ spec:
                         type: string
                     type: object
                   hierarchyController:
-                    description: Hierarchy Controller configuration for the cluster.
+                    description: '**DEPRECATED** Configuring Hierarchy Controller
+                      through the configmanagement feature is no longer recommended.
+                      Use https://github.com/kubernetes-sigs/hierarchical-namespaces
+                      instead.'
                     properties:
                       enableHierarchicalResourceQuota:
                         description: Whether hierarchical resource quota is enabled

--- a/mockgcp/generated/mockgcp/cloud/gkehub/v1beta/configmanagement/configmanagement.pb.go
+++ b/mockgcp/generated/mockgcp/cloud/gkehub/v1beta/configmanagement/configmanagement.pb.go
@@ -288,7 +288,7 @@ type MembershipSpec struct {
 	PolicyController *PolicyController `protobuf:"bytes,2,opt,name=policy_controller,json=policyController,proto3" json:"policy_controller,omitempty"`
 	// Binauthz conifguration for the cluster.
 	Binauthz *BinauthzConfig `protobuf:"bytes,3,opt,name=binauthz,proto3" json:"binauthz,omitempty"`
-	// Hierarchy Controller configuration for the cluster.
+	// **DEPRECATED** Configuring Hierarchy Controller through the configmanagement feature is no longer recommended. Use https://github.com/kubernetes-sigs/hierarchical-namespaces instead.
 	HierarchyController *HierarchyControllerConfig `protobuf:"bytes,4,opt,name=hierarchy_controller,json=hierarchyController,proto3" json:"hierarchy_controller,omitempty"`
 	// Version of ACM installed.
 	Version string `protobuf:"bytes,10,opt,name=version,proto3" json:"version,omitempty"`

--- a/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
+++ b/pkg/clients/generated/apis/gkehub/v1beta1/gkehubfeaturemembership_types.go
@@ -69,7 +69,7 @@ type FeaturemembershipConfigmanagement struct {
 	// +optional
 	ConfigSync *FeaturemembershipConfigSync `json:"configSync,omitempty"`
 
-	/* Hierarchy Controller configuration for the cluster. */
+	/* **DEPRECATED** Configuring Hierarchy Controller through the configmanagement feature is no longer recommended. Use https://github.com/kubernetes-sigs/hierarchical-namespaces instead. */
 	// +optional
 	HierarchyController *FeaturemembershipHierarchyController `json:"hierarchyController,omitempty"`
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
@@ -474,7 +474,7 @@ projectRef:
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}Hierarchy Controller configuration for the cluster.{% endverbatim %}</p>
+            <p>{% verbatim %}**DEPRECATED** Configuring Hierarchy Controller through the configmanagement feature is no longer recommended. Use https://github.com/kubernetes-sigs/hierarchical-namespaces instead.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION

### Change description

Add a note for deprecating Hierarchy Controller in Config Management feature. This is to reduce the usage of configuring Hierarchy Controller using the ACM KCC resource.

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes #

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
