### PR TITLE
Fix gkehub sample

### DIFF
--- a/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeature.yaml
+++ b/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeature.yaml
@@ -16,6 +16,10 @@ apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeature
 metadata:
   name: gkehubfeaturemembership-dep-acm
+  # The GKEHubFeature is a global resource in your project.
+  # In case you might have configured the resource using other clients like gcloud, abandon the resource when deleted.
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: abandon
 spec:
   projectRef:
     name: gkehubfeaturemembership-dep-acm

--- a/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeaturemembership.yaml
+++ b/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubfeaturemembership.yaml
@@ -20,6 +20,8 @@ spec:
   projectRef:
     name: gkehubfeaturemembership-dep-acm
   location: global
+  # membershipLocation needs to be explicitly set here because the dependent membership is regional.
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubfeaturemembership-dep-acm
   featureRef:
@@ -28,21 +30,7 @@ spec:
     configSync:
       sourceFormat: unstructured
       git:
-        syncRepo: "https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit"
-        syncBranch: "master"
-        policyDir: "config-connector"
-        syncWaitSecs: "20"
-        syncRev: "HEAD"
+        syncRepo: "https://github.com/GoogleCloudPlatform/anthos-config-management-samples"
+        syncBranch: "main"
+        policyDir: "config-sync-quickstart/multirepo/root"
         secretType: "none"
-    policyController:
-      enabled: true
-      exemptableNamespaces:
-        - "test-namespace"
-      referentialRulesEnabled: true
-      logDeniesEnabled: true
-      templateLibraryInstalled: true
-      auditIntervalSeconds: "20"
-    hierarchyController:
-      enabled: true
-      enablePodTreeLabels: true
-      enableHierarchicalResourceQuota: true

--- a/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubmembership.yaml
+++ b/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/gkehub_v1beta1_gkehubmembership.yaml
@@ -19,7 +19,7 @@ metadata:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
   name: gkehubfeaturemembership-dep-acm
 spec:
-  location: global
+  location: us-central1
   authority:
     # Issuer must contain a link to a valid JWT issuer. Your ContainerCluster is one.
     issuer: https://container.googleapis.com/v1/projects/gkehubfeaturemembership-dep-acm/locations/us-central1-a/clusters/gkehubfeaturemembership-dep-acm

--- a/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/serviceusage_v1beta1_service.yaml
+++ b/config/samples/resources/gkehubfeaturemembership/config-management-feature-membership/serviceusage_v1beta1_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep1-acm1
 spec:
   resourceID: container.googleapis.com
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep2-acm
 spec:
   resourceID: gkehub.googleapis.com
@@ -37,7 +37,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep3-acm
 spec:
   resourceID: anthosconfigmanagement.googleapis.com

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubfeaturemembership.md
@@ -1102,6 +1102,8 @@ spec:
   projectRef:
     name: gkehubfeaturemembership-dep-acm
   location: global
+  # membershipLocation needs to be explicitly set here because the dependent membership is regional.
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubfeaturemembership-dep-acm
   featureRef:
@@ -1110,24 +1112,10 @@ spec:
     configSync:
       sourceFormat: unstructured
       git:
-        syncRepo: "https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit"
-        syncBranch: "master"
-        policyDir: "config-connector"
-        syncWaitSecs: "20"
-        syncRev: "HEAD"
+        syncRepo: "https://github.com/GoogleCloudPlatform/anthos-config-management-samples"
+        syncBranch: "main"
+        policyDir: "config-sync-quickstart/multirepo/root"
         secretType: "none"
-    policyController:
-      enabled: true
-      exemptableNamespaces:
-        - "test-namespace"
-      referentialRulesEnabled: true
-      logDeniesEnabled: true
-      templateLibraryInstalled: true
-      auditIntervalSeconds: "20"
-    hierarchyController:
-      enabled: true
-      enablePodTreeLabels: true
-      enableHierarchicalResourceQuota: true
 ---
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
@@ -1146,6 +1134,10 @@ apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeature
 metadata:
   name: gkehubfeaturemembership-dep-acm
+  # The GKEHubFeature is a global resource in your project.
+  # In case you might have configured the resource using other clients like gcloud, abandon the resource when deleted.
+  annotations:
+    cnrm.cloud.google.com/deletion-policy: abandon
 spec:
   projectRef:
     name: gkehubfeaturemembership-dep-acm
@@ -1161,7 +1153,7 @@ metadata:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
   name: gkehubfeaturemembership-dep-acm
 spec:
-  location: global
+  location: us-central1
   authority:
     # Issuer must contain a link to a valid JWT issuer. Your ContainerCluster is one.
     issuer: https://container.googleapis.com/v1/projects/gkehubfeaturemembership-dep-acm/locations/us-central1-a/clusters/gkehubfeaturemembership-dep-acm
@@ -1189,7 +1181,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep1-acm1
 spec:
   resourceID: container.googleapis.com
@@ -1199,7 +1191,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep2-acm
 spec:
   resourceID: gkehub.googleapis.com
@@ -1209,7 +1201,7 @@ kind: Service
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: gkehubfeaturemembership-dep-acm
-    cnrm.cloud.google.com/disable-dependent-services: "false"
+    cnrm.cloud.google.com/deletion-policy: "abandon"
   name: gkehubfeaturemembership-dep3-acm
 spec:
   resourceID: anthosconfigmanagement.googleapis.com


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
* Mark the deletion policy to be "abandon" for global resources
* Remove deprecated PoCo and HNC fields in the sample
* Changed the membership resource location  from global to regional so that we don't accidentally have >=1 golbal memberships in a project, which causes KCC/Hub can't figure out the correct membership. see b/350963989#comment7

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
