### PR TITLE
Fix SpannerDatabase resource name in testdata and improve mockspanner

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_generated_object_spannerdatabase.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_generated_object_spannerdatabase.golden.yaml
@@ -13,7 +13,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: spannerdatabase-${uniqueId}
+  name: spannerdb-${uniqueId}
   namespace: ${uniqueId}
 spec:
   databaseDialect: GOOGLE_STANDARD_SQL
@@ -21,7 +21,7 @@ spec:
   - CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)
   instanceRef:
     name: spannerinstance-${uniqueId}
-  resourceID: spannerdatabase-${uniqueId}
+  resourceID: spannerdb-${uniqueId}
   versionRetentionPeriod: 1h
 status:
   conditions:

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_http.log
@@ -125,7 +125,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}?alt=json
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -143,7 +143,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "database \"projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}\" not found",
+    "message": "database \"projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }
@@ -155,7 +155,7 @@ Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
 {
-  "createStatement": "CREATE DATABASE `spannerdatabase-${uniqueId}`"
+  "createStatement": "CREATE DATABASE `spannerdb-${uniqueId}`"
 }
 
 200 OK
@@ -172,14 +172,14 @@ X-Xss-Protection: 0
 {
   "metadata": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.CreateDatabaseMetadata",
-    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}"
+    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}"
   },
-  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}"
+  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}"
 }
 
 ---
 
-GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}?alt=json
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -198,14 +198,14 @@ X-Xss-Protection: 0
   "done": true,
   "metadata": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.CreateDatabaseMetadata",
-    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}"
+    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}"
   },
-  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}",
+  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.Database",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "databaseDialect": "GOOGLE_STANDARD_SQL",
-    "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}",
+    "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}",
     "state": "READY",
     "versionRetentionPeriod": "1h"
   }
@@ -213,7 +213,7 @@ X-Xss-Protection: 0
 
 ---
 
-PATCH https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/ddl?alt=json
+PATCH https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/ddl?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -237,17 +237,17 @@ X-Xss-Protection: 0
 {
   "metadata": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata",
-    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}",
+    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}",
     "statements": [
       "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)"
     ]
   },
-  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}"
+  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}"
 }
 
 ---
 
-GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}?alt=json
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -266,17 +266,17 @@ X-Xss-Protection: 0
   "done": true,
   "metadata": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata",
-    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}",
+    "database": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}",
     "statements": [
       "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)"
     ]
   },
-  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}/operations/${operationID}",
+  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.spanner.admin.database.v1.Database",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "databaseDialect": "GOOGLE_STANDARD_SQL",
-    "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}",
+    "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}",
     "state": "READY",
     "versionRetentionPeriod": "1h"
   }
@@ -284,7 +284,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}?alt=json
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
@@ -302,14 +302,14 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "databaseDialect": "GOOGLE_STANDARD_SQL",
-  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}",
+  "name": "projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}",
   "state": "READY",
   "versionRetentionPeriod": "1h"
 }
 
 ---
 
-DELETE https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdatabase-${uniqueId}?alt=json
+DELETE https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-${uniqueId}/databases/spannerdb-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_vcr_cassettes/tf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/_vcr_cassettes/tf.yaml
@@ -298,7 +298,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -329,7 +329,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"createStatement":"CREATE DATABASE `spannerdatabase-3eej62fms64k6`"}
+            {"createStatement":"CREATE DATABASE `spannerdb-3eej62fms64k6`"}
         form: {}
         headers:
             Content-Type:
@@ -346,10 +346,10 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543",
               "metadata": {
                 "@type": "type.googleapis.com/google.spanner.admin.database.v1.CreateDatabaseMetadata",
-                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6"
+                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6"
               }
             }
         headers:
@@ -376,7 +376,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -388,15 +388,15 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_7b3efdd90c06b543",
               "metadata": {
                 "@type": "type.googleapis.com/google.spanner.admin.database.v1.CreateDatabaseMetadata",
-                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6"
+                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6"
               },
               "done": true,
               "response": {
                 "@type": "type.googleapis.com/google.spanner.admin.database.v1.Database",
-                "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6",
+                "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6",
                 "state": "READY",
                 "createTime": "2024-06-18T23:37:24.573540Z",
                 "versionRetentionPeriod": "1h",
@@ -429,7 +429,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/ddl?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/ddl?alt=json
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -441,10 +441,10 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456",
               "metadata": {
                 "@type": "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata",
-                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6",
+                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6",
                 "statements": [
                   "CREATE TABLE t1 (\n  t1 INT64 NOT NULL,\n) PRIMARY KEY(t1)"
                 ],
@@ -488,7 +488,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -500,10 +500,10 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6/operations/_auto_op_f2e2ff6f79751456",
               "metadata": {
                 "@type": "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata",
-                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6",
+                "database": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6",
                 "statements": [
                   "CREATE TABLE t1 (\n  t1 INT64 NOT NULL,\n) PRIMARY KEY(t1)"
                 ],
@@ -556,7 +556,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -568,7 +568,7 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6",
               "state": "READY",
               "createTime": "2024-06-18T23:37:24.573540Z",
               "versionRetentionPeriod": "1h",
@@ -604,7 +604,7 @@ interactions:
         headers:
             Content-Type:
                 - application/json
-        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6?alt=json
+        url: https://spanner.googleapis.com/v1/projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6?alt=json
         method: GET
       response:
         proto: HTTP/2.0
@@ -616,7 +616,7 @@ interactions:
         uncompressed: true
         body: |
             {
-              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdatabase-3eej62fms64k6",
+              "name": "projects/example-project/instances/spannerinstance-3eej62fms64k6/databases/spannerdb-3eej62fms64k6",
               "state": "READY",
               "createTime": "2024-06-18T23:37:24.573540Z",
               "versionRetentionPeriod": "1h",

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerdatabase/create.yaml
@@ -15,8 +15,9 @@
 apiVersion: spanner.cnrm.cloud.google.com/v1beta1
 kind: SpannerDatabase
 metadata:
-  # Database names can be only 30 characters max
-  name: spannerdatabase-${uniqueId}
+  # Database names can be only 30 characters max. As ${uniqueId} is a 20-char
+  # long random alphanumeric string, the prefix can be at most 9-char long.
+  name: spannerdb-${uniqueId}
 spec:
   instanceRef:
     name: spannerinstance-${uniqueId}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Spanner database has a length limitation of 30 but the current name (and by default, the resource ID) of SpannerDatabase in testdata exceeds the limit and caused test failures against the real GCP API. So shortened the name to match the length limitation and improved mockspanner to detect the violation.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
