### PR TITLE
Fix TestSecretManagerSecretVersion

### DIFF
--- a/mockgcp/mocksecretmanager/tests/service_test.go
+++ b/mockgcp/mocksecretmanager/tests/service_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+	"time"
 
 	cloudresourcemanagerv1 "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/option"
@@ -56,8 +57,20 @@ func TestSecretManagerSecretVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}
+
+	for i := 0; i < 10; i++ {
+		if op.Done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+		latest, err := crm.Operations.Get(op.Name).Context(ctx).Do()
+		if err != nil {
+			t.Fatalf("error getting operation %q: %v", op.Name, err)
+		}
+		op = latest
+	}
 	if !op.Done {
-		t.Fatalf("expected mock create project operation to be done immediately")
+		t.Fatalf("expected mock create project operation to be done")
 	}
 
 	t.Logf("creating secret")

--- a/pkg/controller/mocktests/secretmanager_secret_test.go
+++ b/pkg/controller/mocktests/secretmanager_secret_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
 	cloudresourcemanagerv1 "google.golang.org/api/cloudresourcemanager/v1"
@@ -99,8 +100,19 @@ func TestSecretManagerSecretVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}
+	for i := 0; i < 10; i++ {
+		if op.Done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+		latest, err := crm.Operations.Get(op.Name).Context(h.Ctx).Do()
+		if err != nil {
+			t.Fatalf("error getting operation %q: %v", op.Name, err)
+		}
+		op = latest
+	}
 	if !op.Done {
-		t.Fatalf("expected mock create project operation to be done immediately")
+		t.Fatalf("expected mock create project operation to be done")
 	}
 
 	t.Logf("creating controller")

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -18,7 +18,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 make -C operator test
-UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/... ./scripts/generate-go-crd-clients/... ./scripts/resource-autogen/... ./tests/... | grep -v mocktests | grep -v tests/e2e)
+UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/... ./scripts/generate-go-crd-clients/... ./scripts/resource-autogen/... ./tests/... ./mockgcp/... | grep -v tests/e2e)
 if [ -z ${GITHUB_ACTION+x} ]; then
     go run gotest.tools/gotestsum@latest --format testname -- ${UNIT_TEST_PACKAGES} -coverprofile cover.out -count=1
 else


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
* Fixed TestSecretManagerSecretVersion. It failed because the mockresourcemanager change when creating a new mock project: it no longer immediately marks LRO done.
* Added the failed test to the unit test suite as this is the main reason why it failed for so long but didn't get much attention.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
