### PR TITLE
test: Temporarily increase presubmit fixtures timeout

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -85,7 +85,7 @@ jobs:
           path: /tmp/artifacts/
   tests-e2e-fixtures:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/scripts/github-actions/tests-e2e-fixtures
+++ b/scripts/github-actions/tests-e2e-fixtures
@@ -35,4 +35,4 @@ GOLDEN_REQUEST_CHECKS=1 \
 E2E_KUBE_TARGET=envtest \
 E2E_GCP_TARGET=mock \
 KCC_USE_DIRECT_RECONCILERS="SQLInstance" \
-  go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures
+  go test -test.count=1 -timeout 1h30m -v ./tests/e2e -run TestAllInSeries/fixtures


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Increase test timeout to unblock dev

This will be a temporary change. When #1822 is done, we can determine a reasonable timeout.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
