### PR TITLE
Feature: Support optional Name, Namespace for cel readiness rules

### DIFF
--- a/experiments/compositions/composition/api/v1alpha1/composition_types.go
+++ b/experiments/compositions/composition/api/v1alpha1/composition_types.go
@@ -97,10 +97,12 @@ const (
 
 // ReadyOn defines ready condition for a GVK
 type ReadyOn struct {
-	Group   string `json:"group"`
-	Version string `json:"version,omitempty"`
-	Kind    string `json:"kind"`
-	Ready   string `json:"readyIf"`
+	Group     string `json:"group"`
+	Version   string `json:"version,omitempty"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Ready     string `json:"readyIf"`
 }
 
 // CompositionSpec defines the desired state of Composition

--- a/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
+++ b/experiments/compositions/composition/config/crd/bases/composition.google.com_compositions.yaml
@@ -119,6 +119,10 @@ spec:
                       type: string
                     kind:
                       type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
                     readyIf:
                       type: string
                     version:

--- a/experiments/compositions/composition/pkg/applier/applier.go
+++ b/experiments/compositions/composition/pkg/applier/applier.go
@@ -292,12 +292,29 @@ func (a *Applier) Apply(oldAppliers []*Applier, prune bool) error {
 
 func (a *Applier) getReadinessRule(u *unstructured.Unstructured) string {
 	gvk := u.GetObjectKind().GroupVersionKind()
+	match := false
 	for i := range a.readiness {
 		if a.readiness[i].Group == gvk.Group &&
 			a.readiness[i].Version == gvk.Version &&
 			a.readiness[i].Kind == gvk.Kind {
-			return a.readiness[i].Ready
+			match = true
 		}
+		if !match {
+			continue
+		}
+		if a.readiness[i].Name != "" {
+			match = a.readiness[i].Name == u.GetName()
+		}
+		if !match {
+			continue
+		}
+		if a.readiness[i].Namespace != "" {
+			match = a.readiness[i].Namespace == u.GetNamespace()
+		}
+		if !match {
+			continue
+		}
+		return a.readiness[i].Ready
 	}
 	return ""
 }


### PR DESCRIPTION
### Change description

Support Name,Namespace when setting up readiness rules: 
- In addition to GVK, we want to support Name, Namespace to have custom rule per object. 
- Name and Namespace are optional.

