### PR TITLE
Add build for config connector manifests

### DIFF
--- a/config/installbundle/release-manifests/kustomization.yaml
+++ b/config/installbundle/release-manifests/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+namespace: configconnector-operator-system
+commonLabels:
+  cnrm.cloud.google.com/operator-system: "true"
+commonAnnotations:
+  cnrm.cloud.google.com/operator-version: 1.121.0
+resources:
+  - crds.yaml
+  - rbac.yaml
+  - manager.yaml


### PR DESCRIPTION
Add build commands to generate the config connector manifests for standard GKE clusters.

The config connector manifests  is generated with a reference to https://cloud.google.com/config-connector/docs/how-to/install-manually#installing_the_operator.

example release manifests generated by running
`make all-manifests`
https://paste.googleplex.com/5174914120417280#l=1332