### PR TITLE
kompanion: fix namespace auto-selection logic

### DIFF
--- a/experiments/kompanion/cmd/export/export.go
+++ b/experiments/kompanion/cmd/export/export.go
@@ -338,8 +338,7 @@ func RunExport(ctx context.Context, opts *ExportOptions) error {
 
 	// Parallize across resources, unless we are scoped to a few namespaces
 	// The thought is that if users target a particular namespace (or a few), they may not have cluster-wide permission.
-	perNamespace := len(opts.targetNamespaces) == 0
-
+	perNamespace := len(opts.targetNamespaces) > 0
 	if perNamespace {
 		for _, ns := range namespaces.Items {
 			if shouldExclude(ns.Name, opts.ignoreNamespaces, opts.targetNamespaces) {


### PR DESCRIPTION
I simply had the test backwards before.
