### PR TITLE
tests: fix typo and add README to periodics

### DIFF
--- a/dev/ci/periodics/README.md
+++ b/dev/ci/periodics/README.md
@@ -1,0 +1,23 @@
+# Periodic tests
+
+These tests run against real GCP resources, and are run periodically against test GCP accounts.
+
+The results are not currently published publicly.
+
+If you want to run the tests locally (they will incur GCP costs), you can do something like this:
+
+```
+GCP_PROJECT_ID=$(gcloud config get-value project)
+
+PARENT_FOLDER_ID=$(gcloud projects describe ${GCP_PROJECT_ID} --format='value(parent.id)')
+export PARENT_FOLDER_ID
+
+BILLING_ACCOUNT_ID=$(gcloud billing projects describe ${GCP_PROJECT_ID} --format='value(billingAccountName)' | cut -f2 -d/)
+export BILLING_ACCOUNT_ID
+
+ARTIFACTS=`pwd`/artifactz
+mkdir -p ${ARTIFACTS}
+export ARTIFACTS
+
+dev/ci/periodics/e2e-service-monitoring
+```

--- a/dev/ci/periodics/_create_project_and_run_e2e
+++ b/dev/ci/periodics/_create_project_and_run_e2e
@@ -34,10 +34,12 @@ trap dev/tasks/cleanup-test-resources EXIT
 
 dev/tasks/run-e2e || EXIT_CODE=$?
 
-if [[ -n "${ARTIFACTS:-}"]]; then
+if [[ -n "${ARTIFACTS:-}" ]]; then
   # Capture our source tree, which includes golden output
   echo "Storing golden output in ${ARTIFACTS}/golden.zip"
   zip --recurse-paths --quiet "${ARTIFACTS}/golden.zip" apis/ pkg/
+else
+  echo "ARTIFACTS not set, not capturing golden output"
 fi
 
 exit ${EXIT_CODE}


### PR DESCRIPTION
The typo fix should now work, and the README describes how to verify them locally.
