### PR TITLE
Remove incorrect assertions for invalid expander tests

### DIFF
--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderInvalid/input.yaml
@@ -132,24 +132,3 @@ spec:
         name: {{ managedProject }}
         billingAccountRef: "010101-ABABCD-BCAB11"
         folderRef: "000000111100"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: team-a
----
-apiVersion: composition.google.com/v1alpha1
-kind: Context
-metadata:
-  name: context
-  namespace: team-a
-spec:
-  project: proj-a
----
-apiVersion: facade.foocorp.com/v1alpha1
-kind: PConfig
-metadata:
-  name: team-a-config
-  namespace: team-a
-spec:
-  project: proj-a

--- a/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestSimpleExpanderVersionInvalid/input.yaml
@@ -132,24 +132,3 @@ spec:
         name: {{ managedProject }}
         billingAccountRef: "010101-ABABCD-BCAB11"
         folderRef: "000000111100"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: team-a
----
-apiVersion: composition.google.com/v1alpha1
-kind: Context
-metadata:
-  name: context
-  namespace: team-a
-spec:
-  project: proj-a
----
-apiVersion: facade.foocorp.com/v1alpha1
-kind: PConfig
-metadata:
-  name: team-a-config
-  namespace: team-a
-spec:
-  project: proj-a

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -367,10 +367,6 @@ func TestSimpleExpanderInvalid(t *testing.T) {
 	composition := utils.GetCompositionObj("default", "projectconfigmap")
 	condition := utils.GetErrorCondition("ValidationFailed", "")
 	s.C.MustHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
-
-	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
-	condition = utils.GetErrorCondition("MissingExpanderCR", "")
-	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimpleExpanderVersionInvalid(t *testing.T) {
@@ -381,10 +377,6 @@ func TestSimpleExpanderVersionInvalid(t *testing.T) {
 	composition := utils.GetCompositionObj("default", "projectconfigmap")
 	condition := utils.GetErrorCondition("ValidationFailed", "")
 	s.C.MustHaveCondition(composition, condition, scenario.CompositionReconcileTimeout)
-
-	plan := utils.GetPlanObj("team-a", "pconfigs-team-a-config")
-	condition = utils.GetErrorCondition("VersionNotFound", "")
-	s.C.MustHaveCondition(plan, condition, scenario.CompositionReconcileTimeout)
 }
 
 func TestSimpleCompositionExpanderLoggingEnabled(t *testing.T) {


### PR DESCRIPTION
### Change description

The two tests which verify controller behavior for compositions with invalid expanders have been asserting that the resultant Plan objects similarly show an error. This check is incorrect because a resource relying on an invalid Composition should never generate a Plan to begin with. An existing bug is creating Plans incorrectly and the test was mistakenly checking on those.

Remove the check of the Plan and only verify the Composition status.

