### PR TITLE
refactor: pass operation objects to adapters

### DIFF
--- a/dev/tools/controllerbuilder/template/controller.go
+++ b/dev/tools/controllerbuilder/template/controller.go
@@ -192,7 +192,9 @@ func (a *Adapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating {{.Kind}}", "name", a.id.fullyQualifiedName())
 	mapCtx := &direct.MapContext{}
@@ -238,7 +240,9 @@ func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 	return setStatus(u, status)
 }
 
-func (a *Adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("updating {{.Kind}}", "name", a.id.fullyQualifiedName())
 	mapCtx := &direct.MapContext{}
@@ -288,7 +292,7 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 }
 
 // Delete implements the Adapter interface.
-func (a *Adapter) Delete(ctx context.Context) (bool, error) {
+func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("deleting {{.Kind}}", "name", a.id.fullyQualifiedName())
 

--- a/pkg/controller/direct/alloydb/cluster_controller.go
+++ b/pkg/controller/direct/alloydb/cluster_controller.go
@@ -143,7 +143,7 @@ func (a *clusterAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *clusterAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *clusterAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Already deleted
 	if a.resourceID == "" {
 		return false, nil
@@ -181,7 +181,9 @@ func (a *clusterAdapter) waitForOp(ctx context.Context, op *api.Operation) error
 }
 
 // Create implements the Adapter interface.
-func (a *clusterAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *clusterAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(0).Info("creating object", "u", u)
 
@@ -228,7 +230,9 @@ func (a *clusterAdapter) Create(ctx context.Context, u *unstructured.Unstructure
 }
 
 // Update implements the Adapter interface.
-func (a *clusterAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *clusterAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(0).Info("updating object", "u", u)
 	var latest *api.Cluster

--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -168,7 +168,7 @@ func (a *adapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *adapter) Delete(ctx context.Context) (bool, error) {
+func (a *adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// TODO: Delete via status selfLink?
 	req := &pb.DeleteKeyRequest{
 		Name: a.fullyQualifiedName(),
@@ -204,7 +204,9 @@ func (a *adapter) buildCreateRequest() (*pb.CreateKeyRequest, error) {
 }
 
 // Create implements the Adapter interface.
-func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("creating object", "u", u)
 
@@ -228,7 +230,9 @@ func (a *adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 }
 
 // Update implements the Adapter interface.
-func (a *adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	// u := Op.GetUnstructured()
+
 	// TODO: Skip updates if no changes
 	// TODO: Where/how do we want to enforce immutability?
 	updateMask := &fieldmaskpb.FieldMask{}

--- a/pkg/controller/direct/cloudbuild/workerpool_controller.go
+++ b/pkg/controller/direct/cloudbuild/workerpool_controller.go
@@ -168,7 +168,9 @@ func (a *Adapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating object", "u", u)
 
@@ -203,7 +205,9 @@ func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 	return setStatus(u, status)
 }
 
-func (a *Adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	updateMask := &fieldmaskpb.FieldMask{}
 
 	if !reflect.DeepEqual(a.desired.Spec.DisplayName, a.actual.DisplayName) {
@@ -293,7 +297,7 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 
 // Delete implements the Adapter interface.
 // TODO: Delete can rely on status.externalRef and do not need spec.projectRef.
-func (a *Adapter) Delete(ctx context.Context) (bool, error) {
+func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	req := &cloudbuildpb.DeleteWorkerPoolRequest{Name: a.id.FullyQualifiedName(), AllowMissing: true}
 	op, err := a.gcpClient.DeleteWorkerPool(ctx, req)
 	if err != nil {

--- a/pkg/controller/direct/compute/forwardingrule_controller.go
+++ b/pkg/controller/direct/compute/forwardingrule_controller.go
@@ -228,7 +228,9 @@ func (a *forwardingRuleAdapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *forwardingRuleAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *forwardingRuleAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	if a.id.project == "" {
 		return fmt.Errorf("project is empty")
 	}
@@ -302,7 +304,9 @@ func (a *forwardingRuleAdapter) Create(ctx context.Context, u *unstructured.Unst
 	return setStatus(u, status)
 }
 
-func (a *forwardingRuleAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *forwardingRuleAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	if a.id.forwardingRule == "" {
 		return fmt.Errorf("resourceID is empty")
 	}
@@ -429,7 +433,7 @@ func (a *forwardingRuleAdapter) Export(ctx context.Context) (*unstructured.Unstr
 }
 
 // Delete implements the Adapter interface.
-func (a *forwardingRuleAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *forwardingRuleAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	if a.id.forwardingRule == "" {
 		return false, fmt.Errorf("resourceID is empty")
 	}

--- a/pkg/controller/direct/dataform/repository_controller.go
+++ b/pkg/controller/direct/dataform/repository_controller.go
@@ -178,7 +178,9 @@ func (a *Adapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating object", "u", u)
 
@@ -214,7 +216,8 @@ func (a *Adapter) Create(ctx context.Context, u *unstructured.Unstructured) erro
 	return setStatus(u, status)
 }
 
-func (a *Adapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
 
 	updateMask := &fieldmaskpb.FieldMask{}
 
@@ -279,7 +282,7 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 }
 
 // Delete implements the Adapter interface.
-func (a *Adapter) Delete(ctx context.Context) (bool, error) {
+func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	if a.resourceID == "" {
 		return false, nil
 	}

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -263,7 +263,8 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 			return true, nil
 		}
 		if !k8s.HasAbandonAnnotation(u) {
-			if _, err := adapter.Delete(ctx); err != nil {
+			deleteOp := NewDeleteOperation(u)
+			if _, err := adapter.Delete(ctx, deleteOp); err != nil {
 				if !errors.Is(err, k8s.ErrIAMNotFound) && !k8s.IsReferenceNotFoundError(err) {
 					if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 						logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))
@@ -287,7 +288,8 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 	//policy.Spec.Etag = ""
 
 	if !existsAlready {
-		if err := adapter.Create(ctx, u); err != nil {
+		createOp := NewCreateOperation(u)
+		if err := adapter.Create(ctx, createOp); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))
 				return r.handleUnresolvableDeps(ctx, u, unwrappedErr)
@@ -295,7 +297,8 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 			return false, r.handleUpdateFailed(ctx, u, fmt.Errorf("error creating: %w", err))
 		}
 	} else {
-		if err := adapter.Update(ctx, u); err != nil {
+		updateOp := NewUpdateOperation(u)
+		if err := adapter.Update(ctx, updateOp); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))
 				return r.handleUnresolvableDeps(ctx, u, unwrappedErr)

--- a/pkg/controller/direct/directbase/interfaces.go
+++ b/pkg/controller/direct/directbase/interfaces.go
@@ -39,7 +39,7 @@ type Adapter interface {
 	// It returns (true, nil) if the object was deleted,
 	// and (false, nil) if the object was not found but should be presumed deleted.
 	// In an error, the state is not fully determined - a delete might be in progress.
-	Delete(ctx context.Context) (deleted bool, err error)
+	Delete(ctx context.Context, op *DeleteOperation) (deleted bool, err error)
 
 	// Find must be called as the first operation (unless we are deleting).
 	// It returns whether the corresponding GCP object was found.
@@ -48,12 +48,12 @@ type Adapter interface {
 	// Create creates a new GCP object.
 	// This should only be called when Find has previously returned false.
 	// The implementation should write the updated status into `u`.
-	Create(ctx context.Context, u *unstructured.Unstructured) error
+	Create(ctx context.Context, op *CreateOperation) error
 
 	// Update updates an existing GCP object.
 	// This should only be called when Find has previously returned true.
 	// The implementation should write the updated status into `u`.
-	Update(ctx context.Context, u *unstructured.Unstructured) error
+	Update(ctx context.Context, op *UpdateOperation) error
 
 	// Export fetches the cloud provider's representation of the object
 	// as an unstructured.Unstructured.

--- a/pkg/controller/direct/directbase/operations.go
+++ b/pkg/controller/direct/directbase/operations.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package directbase
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+type UpdateOperation struct {
+	object *unstructured.Unstructured
+}
+
+func NewUpdateOperation(object *unstructured.Unstructured) *UpdateOperation {
+	return &UpdateOperation{
+		object: object,
+	}
+}
+
+func (o *UpdateOperation) GetUnstructured() *unstructured.Unstructured {
+	return o.object
+}
+
+type CreateOperation struct {
+	object *unstructured.Unstructured
+}
+
+func NewCreateOperation(object *unstructured.Unstructured) *CreateOperation {
+	return &CreateOperation{
+		object: object,
+	}
+}
+
+func (o *CreateOperation) GetUnstructured() *unstructured.Unstructured {
+	return o.object
+}
+
+type DeleteOperation struct {
+	object *unstructured.Unstructured
+}
+
+func NewDeleteOperation(object *unstructured.Unstructured) *DeleteOperation {
+	return &DeleteOperation{
+		object: object,
+	}
+}
+
+func (o *DeleteOperation) GetUnstructured() *unstructured.Unstructured {
+	return o.object
+}

--- a/pkg/controller/direct/gkehub/featuremembership_controller.go
+++ b/pkg/controller/direct/gkehub/featuremembership_controller.go
@@ -157,7 +157,7 @@ func (a *gkeHubAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *gkeHubAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *gkeHubAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	exist, err := a.Find(ctx)
 	if err != nil {
 		return false, fmt.Errorf("finding feature for %s:%w", a.featureID, err)
@@ -185,7 +185,9 @@ func (a *gkeHubAdapter) patchMembershipSpec(ctx context.Context) ([]byte, error)
 	return op.Response, nil
 }
 
-func (a *gkeHubAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *gkeHubAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating gkehubfeaturemembership", "obj", u)
 
@@ -198,7 +200,9 @@ func (a *gkeHubAdapter) Create(ctx context.Context, u *unstructured.Unstructured
 	return nil
 }
 
-func (a *gkeHubAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *gkeHubAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("updating object", "u", u)
 	actual := a.actual.MembershipSpecs[a.membershipID]

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -157,7 +157,7 @@ func (a *logMetricAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *logMetricAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *logMetricAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Already deleted
 	if a.resourceID == "" {
 		return false, nil
@@ -174,7 +174,9 @@ func (a *logMetricAdapter) Delete(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *logMetricAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *logMetricAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating object", "u", u)
 
@@ -235,7 +237,9 @@ func logMetricStatusToKRM(in *api.LogMetric, out *krm.LoggingLogMetricStatus) er
 	return nil
 }
 
-func (a *logMetricAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *logMetricAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 
 	latest := a.actual

--- a/pkg/controller/direct/monitoring/monitoringdashboard_controller.go
+++ b/pkg/controller/direct/monitoring/monitoringdashboard_controller.go
@@ -166,7 +166,7 @@ func (a *dashboardAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *dashboardAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *dashboardAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Check if exists / already deleted
 	// Technically we can just delete, but this is a little cleaner in logs etc.
 	exists, err := a.Find(ctx)
@@ -193,7 +193,9 @@ func (a *dashboardAdapter) Delete(ctx context.Context) (bool, error) {
 }
 
 // Create implements the Adapter interface.
-func (a *dashboardAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *dashboardAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("creating object", "u", u)
 
@@ -226,7 +228,9 @@ func (a *dashboardAdapter) Create(ctx context.Context, u *unstructured.Unstructu
 }
 
 // Update implements the Adapter interface.
-func (a *dashboardAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *dashboardAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("updating object", "u", u)
 

--- a/pkg/controller/direct/networkconnectivity/serviceconnectionpolicy_controller.go
+++ b/pkg/controller/direct/networkconnectivity/serviceconnectionpolicy_controller.go
@@ -194,7 +194,7 @@ func (a *serviceConnectionPolicyAdapter) waitForOperation(ctx context.Context, o
 }
 
 // Delete implements the Adapter interface.
-func (a *serviceConnectionPolicyAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *serviceConnectionPolicyAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Check if exists / already deleted
 	// Technically we can just delete, but this is a little cleaner in logs etc.
 	exists, err := a.Find(ctx)
@@ -225,7 +225,9 @@ func (a *serviceConnectionPolicyAdapter) Delete(ctx context.Context) (bool, erro
 }
 
 // Create implements the Adapter interface.
-func (a *serviceConnectionPolicyAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *serviceConnectionPolicyAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("creating object", "u", u)
 
@@ -270,7 +272,9 @@ func (a *serviceConnectionPolicyAdapter) Create(ctx context.Context, u *unstruct
 }
 
 // Update implements the Adapter interface.
-func (a *serviceConnectionPolicyAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *serviceConnectionPolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("updating object", "u", u)
 

--- a/pkg/controller/direct/privateca/privatecapool_controller.go
+++ b/pkg/controller/direct/privateca/privatecapool_controller.go
@@ -134,17 +134,17 @@ func (m *caPoolModel) AdapterForURL(ctx context.Context, url string) (directbase
 }
 
 // Delete implements the Adapter interface.
-func (a *caPoolAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *caPoolAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
 
 // Create implements the Adapter interface.
-func (a *caPoolAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *caPoolAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
 	return fmt.Errorf("not implemented")
 }
 
 // Update implements the Adapter interface.
-func (a *caPoolAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *caPoolAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
 	return fmt.Errorf("not implemented")
 }
 

--- a/pkg/controller/direct/redis/cluster/rediscluster_controller.go
+++ b/pkg/controller/direct/redis/cluster/rediscluster_controller.go
@@ -171,7 +171,7 @@ func (a *redisClusterAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *redisClusterAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *redisClusterAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Already deleted
 	if a.resourceID == "" {
 		return false, nil
@@ -202,7 +202,9 @@ func (a *redisClusterAdapter) Export(ctx context.Context) (*unstructured.Unstruc
 }
 
 // Create implements the Adapter interface.
-func (a *redisClusterAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *redisClusterAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(0).Info("creating object", "u", u)
 
@@ -243,7 +245,9 @@ func (a *redisClusterAdapter) Create(ctx context.Context, u *unstructured.Unstru
 }
 
 // Update implements the Adapter interface.
-func (a *redisClusterAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *redisClusterAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(0).Info("updating object", "u", u)
 

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -122,7 +122,7 @@ func (a *tagKeyAdapter) Find(ctx context.Context) (bool, error) {
 }
 
 // Delete implements the Adapter interface.
-func (a *tagKeyAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *tagKeyAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	// Already deleted
 	if a.resourceID == "" {
 		return false, nil
@@ -150,7 +150,9 @@ func (a *tagKeyAdapter) Delete(ctx context.Context) (bool, error) {
 }
 
 // Create implements the Adapter interface.
-func (a *tagKeyAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *tagKeyAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("creating object", "u", u)
 
@@ -216,7 +218,7 @@ func timeToKRMString(t *timestamppb.Timestamp) *string {
 }
 
 // Update implements the Adapter interface.
-func (a *tagKeyAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *tagKeyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
 	// TODO: Skip updates at the higher level if no changes?
 	updateMask := &fieldmaskpb.FieldMask{}
 	update := &pb.TagKey{}

--- a/pkg/controller/direct/sql/sqlinstance_controller.go
+++ b/pkg/controller/direct/sql/sqlinstance_controller.go
@@ -142,7 +142,9 @@ func (a *sqlInstanceAdapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *sqlInstanceAdapter) Create(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *sqlInstanceAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	u := createOp.GetUnstructured()
+
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating SQLInstance", "desired", a.desired)
 
@@ -282,7 +284,9 @@ func (a *sqlInstanceAdapter) insertInstance(ctx context.Context, u *unstructured
 	return setStatus(u, status)
 }
 
-func (a *sqlInstanceAdapter) Update(ctx context.Context, u *unstructured.Unstructured) error {
+func (a *sqlInstanceAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	u := updateOp.GetUnstructured()
+
 	log := klog.FromContext(ctx)
 	log.V(2).Info("updating SQLInstance", "desired", a.desired)
 
@@ -376,7 +380,7 @@ func (a *sqlInstanceAdapter) Update(ctx context.Context, u *unstructured.Unstruc
 }
 
 // Delete implements the Adapter interface.
-func (a *sqlInstanceAdapter) Delete(ctx context.Context) (bool, error) {
+func (a *sqlInstanceAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("deleting SQLInstance", "actual", a.actual)
 

--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -401,7 +401,8 @@ func directCreate(ctx context.Context, u *unstructured.Unstructured, c client.Cl
 		return nil, fmt.Errorf("GVK %s '%v' already exist", u.GroupVersionKind(), u.GetName())
 	}
 
-	err = a.Create(ctx, u)
+	op := directbase.NewCreateOperation(u)
+	err = a.Create(ctx, op)
 	if err != nil {
 		return nil, err
 	}
@@ -422,6 +423,7 @@ func directDelete(ctx context.Context, u *unstructured.Unstructured, c client.Cl
 		return fmt.Errorf("GVK %s '%v' is not found", u.GroupVersionKind(), u.GetName())
 	}
 
-	_, err = a.Delete(ctx)
+	op := directbase.NewDeleteOperation(u)
+	_, err = a.Delete(ctx, op)
 	return err
 }


### PR DESCRIPTION
This should allow for richer behaviours, such as intermediate updates of status.
