### PR TITLE
tests: funnel all tests through run-e2e

### DIFF
--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -20,7 +20,11 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
+echo "Downloading envtest assets..."
 export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+
+echo "Using direct controllers: SQLInstance,ComputeForwardingRule"
+export KCC_USE_DIRECT_RECONCILERS=SQLInstance,ComputeForwardingRule
 
 if [[ -z "${RUN_TESTS:-}" ]]; then
   RUN_TESTS=TestAllInSeries/fixtures

--- a/scripts/github-actions/tests-e2e-fixtures
+++ b/scripts/github-actions/tests-e2e-fixtures
@@ -18,25 +18,8 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-
 cd ${REPO_ROOT}/
-
-echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
-# Transient controller can only choose one controller type (Direct vs TF/DCL) to check the golden log,
-# so as we are moving resources to direct actuation, we add them here.
-# e.g. export KCC_USE_DIRECT_RECONCILERS=MonitoringDashboard
-
-echo "Using direct controllers: SQLInstance,ComputeForwardingRule"
-export KCC_USE_DIRECT_RECONCILERS=SQLInstance,ComputeForwardingRule
-
-echo "Running fixtures in tests/e2e..."
 
 export SKIP_TEST_APIGROUP="compute.cnrm.cloud.google.com,gkehub.cnrm.cloud.google.com"
 
-RUN_E2E=1 \
-GOLDEN_OBJECT_CHECKS=1 \
-GOLDEN_REQUEST_CHECKS=1 \
-E2E_KUBE_TARGET=envtest \
-E2E_GCP_TARGET=mock \
-  go test -test.count=1 -timeout 1h30m -v ./tests/e2e -run TestAllInSeries/fixtures
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-compute
+++ b/scripts/github-actions/tests-e2e-fixtures-compute
@@ -18,18 +18,8 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-
 cd ${REPO_ROOT}/
 
-echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export ONLY_TEST_APIGROUP="compute.cnrm.cloud.google.com"
 
-echo "Running compute fixtures in tests/e2e..."
-
-RUN_E2E=1 \
-GOLDEN_OBJECT_CHECKS=1 \
-GOLDEN_REQUEST_CHECKS=1 \
-E2E_KUBE_TARGET=envtest \
-E2E_GCP_TARGET=mock \
-ONLY_TEST_APIGROUP="compute.cnrm.cloud.google.com" \
-  go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-gkehub
+++ b/scripts/github-actions/tests-e2e-fixtures-gkehub
@@ -18,18 +18,8 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-
 cd ${REPO_ROOT}/
 
-echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export ONLY_TEST_APIGROUP="gkehub.cnrm.cloud.google.com"
 
-echo "Running gkehub fixtures in tests/e2e for gkehub..."
-
-RUN_E2E=1 \
-GOLDEN_OBJECT_CHECKS=1 \
-GOLDEN_REQUEST_CHECKS=1 \
-E2E_KUBE_TARGET=envtest \
-E2E_GCP_TARGET=mock \
-ONLY_TEST_APIGROUP="gkehub.cnrm.cloud.google.com" \
-  go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures
+${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
This means we only need to maintain the KCC_USE_DIRECT_RECONCILERS list in one spot.
