### PR TITLE
Compositions: Refactor Reconcile loop

### DIFF
--- a/experiments/compositions/composition/pkg/applier/applier.go
+++ b/experiments/compositions/composition/pkg/applier/applier.go
@@ -155,9 +155,13 @@ func (a *Applier) Load() error {
 		a.logger.Info(".spec.stages did not have a matching expander name")
 		return fmt.Errorf(".spec.stages did not have a matching expander name")
 	}
+
+	a.objects = []applyset.ApplyableObject{}
+
+	// We dont error out on empty manifests
 	if stage.Manifest == "" {
 		a.logger.Info(".spec.stages[name] has empty manifests. Nothing to apply")
-		return fmt.Errorf(".spec.stages[name] has empty manifests. Nothing to apply.")
+		return nil
 	}
 
 	objects, err := manifest.ParseObjects(a.ctx, stage.Manifest)
@@ -173,7 +177,6 @@ func (a *Applier) Load() error {
 	}
 	a.addStageLabel(objects)
 
-	a.objects = []applyset.ApplyableObject{}
 	// loop over objects and extract unstructured
 	for _, item := range objects.Items {
 


### PR DESCRIPTION
### Change description

Refactor Reconcile loop

- Existing loop does eager evaluation; evaluate as many expanders as possible before apply loop.
- New one does a simple for all expanders: evaluate + apply loop

Why this change:
We want to start implementing implicit getter. This requires us passing latest objects to evaluate() functions. 
So having apply after evaluate allows us to grab latest applied results for next evaluate stage.


