### PR TITLE
fix: Delete mysql root user after creation

### DIFF
--- a/pkg/controller/direct/sql/sqlinstance_controller.go
+++ b/pkg/controller/direct/sql/sqlinstance_controller.go
@@ -253,7 +253,7 @@ func (a *sqlInstanceAdapter) insertInstance(ctx context.Context, u *unstructured
 			if user.Name == "root" && strings.HasPrefix(created.DatabaseVersion, "MYSQL") {
 				// Delete "root" user to match Terraform behavior, to improve default security.
 				// Ref: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance
-				op, err := a.sqlUsersClient.Delete(a.projectID, a.resourceID).Context(ctx).Name(user.Name).Do()
+				op, err := a.sqlUsersClient.Delete(a.projectID, a.resourceID).Context(ctx).Name(user.Name).Host(user.Host).Do()
 				if err != nil {
 					return fmt.Errorf("deleting SQLInstance %s root user failed: %w", a.desired.Name, err)
 				}

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/_http.log
@@ -311,7 +311,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/mysqlbasic-${uniqueId}/users?alt=json&name=root&prettyPrint=false
+DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/mysqlbasic-${uniqueId}/users?alt=json&host=%25&name=root&prettyPrint=false
 User-Agent: kcc/controller-manager
 
 200 OK

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/_http.log
@@ -312,7 +312,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}/users?alt=json&name=root&prettyPrint=false
+DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-sample-${uniqueId}/users?alt=json&host=%25&name=root&prettyPrint=false
 User-Agent: kcc/controller-manager
 
 200 OK

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqluser/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqluser/_http.log
@@ -308,7 +308,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqluser-dep-${uniqueId}/users?alt=json&name=root&prettyPrint=false
+DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqluser-dep-${uniqueId}/users?alt=json&host=%25&name=root&prettyPrint=false
 User-Agent: kcc/controller-manager
 
 200 OK

--- a/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
+++ b/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
@@ -308,7 +308,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-${uniqueId}/users?alt=json&name=root&prettyPrint=false
+DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-${uniqueId}/users?alt=json&host=%25&name=root&prettyPrint=false
 User-Agent: kcc/controller-manager
 
 200 OK


### PR DESCRIPTION
MySQL requires that the host is passed-in along with the username. Otherwise, the delete request will fail.
