### PR TITLE
Compositions: Implicit Getter - first attempt

### DIFF
--- a/experiments/compositions/composition/go.mod
+++ b/experiments/compositions/composition/go.mod
@@ -26,7 +26,7 @@ require (
 	sigs.k8s.io/cli-utils v0.35.0
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/kubebuilder-declarative-pattern v0.15.0-beta.1.0.20240614185435-a248ed1e894c
-	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240813172011-a8a1382c63c4
+	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240830014331-1a63d5a3bb9d
 	sigs.k8s.io/kustomize/kstatus v0.0.2-0.20200509233124-065f70705d4d
 	tailscale.com v1.62.0
 )

--- a/experiments/compositions/composition/go.sum
+++ b/experiments/compositions/composition/go.sum
@@ -580,8 +580,8 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kubebuilder-declarative-pattern v0.15.0-beta.1.0.20240614185435-a248ed1e894c h1:oDDOYsfrwJlLZ0pyzZiG7L/rF2JuQvvut+vFOYYZKQQ=
 sigs.k8s.io/kubebuilder-declarative-pattern v0.15.0-beta.1.0.20240614185435-a248ed1e894c/go.mod h1:56THnwsHGyrijk2GYKsTzcagxDoevccrdl+gBJWNocs=
-sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240813172011-a8a1382c63c4 h1:1q3oCBqWse+jT0xqxsRhmka3pPJCrUrxVzO8xzPrGCA=
-sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240813172011-a8a1382c63c4/go.mod h1:HReseUdDPJYAh1jxBreYJsh/mJ9l7AtvoSB30Jdlfmc=
+sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240830014331-1a63d5a3bb9d h1:9Re+DU/Qzv7mIz6qDFmVFvYqfFSAuc6ssi1CH/2yQX8=
+sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20240830014331-1a63d5a3bb9d/go.mod h1:HReseUdDPJYAh1jxBreYJsh/mJ9l7AtvoSB30Jdlfmc=
 sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20230303024857-d1f76c15e05b h1:VcgyLj8SawHulvC24SRgI37mnhMmR3hW+ZVqZGBmkbc=
 sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20230303024857-d1f76c15e05b/go.mod h1:smCBkOX4Z3K9+MUGAscbschHAYgbuRZ+Pri49+x2zTc=
 sigs.k8s.io/kustomize/kstatus v0.0.2-0.20200509233124-065f70705d4d h1:k+m3LgwVsvSDvcUWoaG2yUGcyN/HKR6Dq2lb0FYgbq8=

--- a/experiments/compositions/composition/tests/data/TestImplicitGetter/input.yaml
+++ b/experiments/compositions/composition/tests/data/TestImplicitGetter/input.yaml
@@ -16,10 +16,10 @@
 apiVersion: composition.google.com/v1alpha1
 kind: Composition
 metadata:
- name: team-page
+ name: team2-page
  namespace: default
 spec:
- inputAPIGroup: teampages.idp.mycompany.com  # Facade API
+ inputAPIGroup: team2pages.idp.mycompany.com  # Facade API
  readiness:
  - group: apps
    version: v1
@@ -32,23 +32,23 @@ spec:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        # Use the teampages Facade's name
-        name: team-{{ teampages.metadata.name }}
+        # Use the team2pages Facade's name
+        name: team2deployment
         # The namespace is set to the facade's namespace
         namespace: default
         labels:
           # use facade's name in the label
-          app: nginx-{{ teampages.metadata.name }}
+          app: nginx-{{ team2pages.metadata.name }}
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: nginx-{{ teampages.metadata.name }}
+            app: nginx-{{ team2pages.metadata.name }}
         template:
           metadata:
             labels:
               # use facade name in the pod's label
-              app: nginx-{{ teampages.metadata.name }}
+              app: nginx-{{ team2pages.metadata.name }}
           spec:
             containers:
               - name: server
@@ -64,39 +64,39 @@ spec:
               - name: index
                 configMap:
                   # use the configmap created by this composition
-                  name: team-{{ teampages.metadata.name }}-page
+                  name: team2-{{ team2pages.metadata.name }}-page
       ---
       apiVersion: v1
       kind: Service
       metadata:
         # include the facade name in the service name
-        name: team-{{ teampages.metadata.name }}-landing
+        name: team2service
         namespace: default
         labels:
-          app: nginx-{{ teampages.metadata.name }}
+          app: nginx-{{ team2pages.metadata.name }}
       spec:
         ports:
         - port: 80
           protocol: TCP
         selector:
           # match the web-server pod
-          app: nginx-{{ teampages.metadata.name }}
+          app: nginx-{{ team2pages.metadata.name }}
       ---
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: team-{{ teampages.metadata.name }}-page
+        name: team2-{{ team2pages.metadata.name }}-page
         namespace: default
       data:
         index.html: |
            <html>
-           <h1>{{ teampages.metadata.name  }}</h1>
+           <h1>{{ team2pages.metadata.name  }}</h1>
            <table>
              <tr>
                <th>Name</th>
                <th>Role</th>
              </tr>
-           {% for member in teampages.spec.members %}
+           {% for member in team2pages.spec.members %}
              <tr>
                <td>{{ member.name }}</td>
                <td>{{ member.role }}</td>
@@ -104,27 +104,38 @@ spec:
            {% endfor %}
            </table>
            </html>
+ - type: jinja2  # pluggable expander
+   name: configmap  # stage
+   template: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: team2config
+        namespace: default
+      data:
+        ports: "{% for port in values.service.team2service.spec.ports %}{{ port.port }}({{ port.protocol }}),{% endfor %}"
+        pods: "{{ values.deployment.team2deployment.status.readyReplicas }}"
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: teampages.idp.mycompany.com
+  name: team2pages.idp.mycompany.com
 spec:
   group: idp.mycompany.com
   names:
     categories:
     - facade
     - facades
-    kind: TeamPage
-    listKind: TeamPageList
-    plural: teampages
-    singular: teampage
+    kind: Team2Page
+    listKind: Team2PageList
+    plural: team2pages
+    singular: team2page
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Team Page Creation
+        description: Team page creation
         properties:
           apiVersion:
             type: string
@@ -158,13 +169,13 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: my-team
+  name: my-team2
 ---
 apiVersion: idp.mycompany.com/v1alpha1
-kind: TeamPage
+kind: Team2Page
 metadata:
   name: landing
-  namespace: my-team
+  namespace: my-team2
 spec:
   members:
   - name: Jo

--- a/experiments/compositions/composition/tests/data/TestImplicitGetter/output.yaml
+++ b/experiments/compositions/composition/tests/data/TestImplicitGetter/output.yaml
@@ -1,0 +1,105 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx-landing
+  name: team2deployment
+  namespace: my-team2
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx-landing
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx-landing
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        imagePullPolicy: IfNotPresent
+        name: server
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html/
+          name: index
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: team2-landing-page
+        name: index
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: team2-landing-page
+  namespace: my-team2
+data:
+  index.html: |-
+    <html>
+    <h1>landing</h1>
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Role</th>
+      </tr>
+
+      <tr>
+        <td>Jo</td>
+        <td>Eng Manager</td>
+      </tr>
+
+      <tr>
+        <td>Jane</td>
+        <td>Lead</td>
+      </tr>
+
+      <tr>
+        <td>Bob</td>
+        <td>Developer</td>
+      </tr>
+
+    </table>
+    </html>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: team2config
+  namespace: my-team2
+data:
+  ports: 80(TCP),
+  pods: "1"

--- a/experiments/compositions/composition/tests/testcases/simple_test.go
+++ b/experiments/compositions/composition/tests/testcases/simple_test.go
@@ -439,6 +439,23 @@ func TestCustomStatusCELRule(t *testing.T) {
 	// Verify plan has no errors
 }
 
+func TestImplicitGetter(t *testing.T) {
+	s := scenario.NewBasic(t)
+	defer s.Cleanup()
+	s.Setup()
+
+	// Check plan object has no error
+	plan := utils.GetPlanObj("my-team2", "team2pages-landing")
+	condition := utils.GetReadyCondition("ProcessedAllStages", "")
+	s.C.MustHaveCondition(plan, condition, 5*scenario.CompositionReconcileTimeout)
+
+	// Verify that all resources objects are created
+	s.VerifyOutputExists()
+	s.VerifyOutputSpecMatches()
+
+	// Verify plan has no errors
+}
+
 func TestMultipleCompositionsDisallowedForSameGVK(t *testing.T) {
 	s := scenario.NewBasic(t)
 	defer s.Cleanup()


### PR DESCRIPTION
### Change description

Implicit Getter
- Automatically add last applied objects into the values passed to expanders
- We add the objects under path: values.<kind>.<name>. This may have conflicts
- on conflict we choose the first seen object
- Refactor Reconciler() function to separate evaluation code into
  evaluate() function to reduce cyclomatic complexity
- Add test: TestImplicitGetter
- Uses latest kdp that includes patch to return last applied object: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/404

Limitations:
- Cant use if the object name is templated on input 

Future work:
- Support templated input object name OR something similar.
- Support explicit naming of objects