### PR TITLE
tool: mark resourceID as immutable field in template

### DIFF
--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -40,6 +40,8 @@ var {{ .Kind }}GVK = GroupVersion.WithKind("{{ .Kind }}")
 // +kcc:proto={{ .KindProtoTag }}
 {{- end }}
 type {{ .Kind }}Spec struct {
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
+	// Immutable.
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
 	// + optional
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `


### PR DESCRIPTION
In controller builder template, use CEL to validate `resourceID` as immutable field.