### PR TITLE
fix: Skip testNoChangeAfterUpdate if update resource is empty

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -296,6 +296,15 @@ func testNoChangeAfterCreate(ctx context.Context, t *testing.T, testContext test
 
 // testNoChangeAfterUpdate is enabled only on resources allowlisted inside the function.
 func testNoChangeAfterUpdate(ctx context.Context, t *testing.T, testContext testrunner.TestContext, systemContext testrunner.SystemContext, resourceContext contexts.ResourceContext) {
+	// Do not run for tests with `SkipUpdate` explicitly set to 'true'.
+	if resourceContext.SkipUpdate {
+		return
+	}
+	// Do not run for tests without an update.yaml set.
+	if testContext.UpdateUnstruct == nil {
+		t.Logf("UpdateUnstruct not set; skipping testNoChangeAfterUpdate")
+		return
+	}
 	switch testContext.ResourceFixture.GVK.GroupKind() {
 	case schema.GroupKind{Group: "sql.cnrm.cloud.google.com", Kind: "SQLInstance"}: // test coverage for https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/1802
 	default:


### PR DESCRIPTION
This issue was never hit before because testNoChangeAfterUpdate is currently only enabled for SQLInstances resources. We recently added a SQLInstance test case that does not set an update.yaml resource (sqlinstance-clone-minimal), and it revealed the problem causing a nil pointer dereference when getting update object.