### PR TITLE
tests: refactor to share code for removing extra events

### DIFF
--- a/pkg/test/eventsink.go
+++ b/pkg/test/eventsink.go
@@ -102,6 +102,8 @@ func (s *LogEntries) RemoveHTTPResponseHeader(key string) {
 	}
 }
 
+// KeepIf returns a new LogEntries with only the entries that satisfy the predicate.
+// (where the predicate function returns true)
 func (s LogEntries) KeepIf(pred func(e *LogEntry) bool) LogEntries {
 	var keep LogEntries
 	for _, entry := range s {

--- a/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/batchdataflowflextemplatejob/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/batchdataflowflextemplatejob/_http.log
@@ -197,43 +197,6 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentState": "JOB_STATE_QUEUED",
-  "currentStateTime": "2024-04-01T12:34:56.123456Z",
-  "environment": {
-    "dataset": "bigquery.googleapis.com/cloud_dataflow"
-  },
-  "id": "000000000000000000000",
-  "labels": {
-    "goog-dataflow-provided-template-name": "file_format_conversion",
-    "goog-dataflow-provided-template-type": "flex"
-  },
-  "location": "us-central1",
-  "name": "dataflowflextemplatejob-${uniqueId}",
-  "pipelineDescription": {
-    "removed": "simplicity"
-  },
-  "projectId": "${projectId}",
-  "startTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://dataflow.googleapis.com/v1b3/projects/${projectId}/locations/us-central1/jobs/${jobID}?alt=json&prettyPrint=false&view=JOB_VIEW_ALL
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
   "currentState": "JOB_STATE_RUNNING",
   "currentStateTime": "2024-04-01T12:34:56.123456Z",
   "environment": {

--- a/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/_http.log
@@ -627,43 +627,6 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentState": "JOB_STATE_QUEUED",
-  "currentStateTime": "2024-04-01T12:34:56.123456Z",
-  "environment": {
-    "dataset": "bigquery.googleapis.com/cloud_dataflow"
-  },
-  "id": "000000000000000000000",
-  "labels": {
-    "goog-dataflow-provided-template-name": "file_format_conversion",
-    "goog-dataflow-provided-template-type": "flex"
-  },
-  "location": "us-central1",
-  "name": "dataflowflextemplatejob-${uniqueId}",
-  "pipelineDescription": {
-    "removed": "simplicity"
-  },
-  "projectId": "${projectId}",
-  "startTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://dataflow.googleapis.com/v1b3/projects/${projectId}/locations/us-central1/jobs/${jobID}?alt=json&prettyPrint=false&view=JOB_VIEW_ALL
-User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
-
-200 OK
-Cache-Control: private
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
   "currentState": "JOB_STATE_RUNNING",
   "currentStateTime": "2024-04-01T12:34:56.123456Z",
   "environment": {

--- a/tests/e2e/httplog.go
+++ b/tests/e2e/httplog.go
@@ -39,17 +39,9 @@ func NewNormalizer(uniqueID string, project testgcp.GCPProject) *Normalizer {
 	}
 }
 
-func (x *Normalizer) Render(events test.LogEntries) string {
-
-	// Replace any dynamic IDs that appear in URLs
-	for _, event := range events {
-		url := event.Request.URL
-		for k, v := range x.PathIDs {
-			url = strings.ReplaceAll(url, "/"+k, "/"+v)
-		}
-		event.Request.URL = url
-	}
-
+// RemoveExtraEvents removes events that are not as relevant to our golden logs
+// In particular, we remove LRO polling operations (and things that look like LROs)
+func RemoveExtraEvents(events test.LogEntries) test.LogEntries {
 	// Remove operation polling requests (ones where the operation is not ready)
 	events = events.KeepIf(func(e *test.LogEntry) bool {
 		if !isGetOperation(e) {
@@ -62,9 +54,46 @@ func (x *Normalizer) Render(events test.LogEntries) string {
 		if done, _, _ := unstructured.NestedBool(responseBody, "done"); done {
 			return true
 		}
+		// compute operations return status==DONE
+		if status, _, _ := unstructured.NestedString(responseBody, "status"); status == "DONE" {
+			return true
+		}
 		// remove if not done - and done can be omitted when false
 		return false
 	})
+
+	// Remove dataflow operation polling requests (ones where the job is PENDING or QUEUED)
+	events = events.KeepIf(func(e *test.LogEntry) bool {
+		if !strings.HasPrefix(e.Request.URL, "https://dataflow.googleapis.com/v1b3/") {
+			return true
+		}
+		responseBody := e.Response.ParseBody()
+		if responseBody == nil {
+			return true
+		}
+		currentState, _, _ := unstructured.NestedString(responseBody, "currentState")
+		switch currentState {
+		case "JOB_STATE_PENDING", "JOB_STATE_QUEUED":
+			return false
+		}
+		return true
+	})
+
+	return events
+}
+
+func (x *Normalizer) Render(events test.LogEntries) string {
+
+	// Replace any dynamic IDs that appear in URLs
+	for _, event := range events {
+		url := event.Request.URL
+		for k, v := range x.PathIDs {
+			url = strings.ReplaceAll(url, "/"+k, "/"+v)
+		}
+		event.Request.URL = url
+	}
+
+	events = RemoveExtraEvents(events)
 
 	jsonMutators := []test.JSONMutator{}
 	addReplacement := func(path string, newValue string) {

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -740,6 +740,8 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 
 					NormalizeHTTPLog(t, events, project, uniqueID)
 
+					events = RemoveExtraEvents(events)
+
 					// Remove repeated GET requests (after normalization)
 					{
 						var previous *test.LogEntry


### PR DESCRIPTION
LROs (and things like LROs) are timing dependent, so we remove them from LROs.
