### PR TITLE
Compositions: Fix manual install version

### DIFF
--- a/experiments/compositions/composition/release/manifest.yaml
+++ b/experiments/compositions/composition/release/manifest.yaml
@@ -1608,7 +1608,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: gcr.io/krmapihosting-release/composition:v0.0.406
+        image: gcr.io/krmapihosting-release/composition:0.0.406
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
### Change description

Manual install version had a `v` prefix which our release images does not have. 
