### PR TITLE
refactor: have compare-mock call into run-e2e

### DIFF
--- a/hack/compare-mock
+++ b/hack/compare-mock
@@ -1,21 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-set -e
-set -x
+set -o errexit
+set -o nounset
+set -o pipefail
 
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
 
-rm -rf $(pwd)/artifactz/mocks
+# Run the tests specified on the command line
+export RUN_TESTS=TestAllInSeries/$1
 
-RUN_TESTS=TestAllInSeries/$1
+# Clear existing artifacts
+rm -rf $(pwd)/artifactz/mock
 
 # Run e2e tests against our mockgcp, capturing output
-ARTIFACTS=$(pwd)/artifactz/mocks \
-E2E_KUBE_TARGET=envtest \
-E2E_GCP_TARGET=mock \
-GOLDEN_REQUEST_CHECKS=1 \
-GOLDEN_OBJECT_CHECKS=1 \
-WRITE_GOLDEN_OUTPUT=1 \
-KCC_USE_DIRECT_RECONCILERS="SQLInstance,ComputeForwardingRule,DataflowFlexTemplateJob" \
-RUN_E2E=1 \
- go test ./tests/e2e -timeout 3600s -v -run $RUN_TESTS
+E2E_GCP_TARGET=mock dev/tasks/run-e2e


### PR DESCRIPTION
This avoids another copy of the direct-reconciler list, with the accompanying possibilities for skew.
