### PR TITLE
tool: remove unnecessary optional annotation in template

### DIFF
--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -54,15 +54,12 @@ type {{ .Kind }}Status struct {
 	Conditions []v1alpha1.Condition ` + "`" + `json:"conditions,omitempty"` + "`" + ` 
 
 	// ObservedGeneration is the generation of the resource that was most recently observed by the Config Connector controller. If this is equal to metadata.generation, then that means that the current reported status reflects the most recent desired state of the resource.
-	// +optional
 	ObservedGeneration *int64 ` + "`" + `json:"observedGeneration,omitempty"` + "`" + `
 
 	// A unique specifier for the {{ .Kind }} resource in GCP.
-	// +optional
 	ExternalRef *string ` + "`" + `json:"externalRef,omitempty"` + "`" + `
 
 	// ObservedState is the state of the resource as most recently observed in GCP.
-	// +optional
 	ObservedState *{{ .Kind }}ObservedState ` + "`" + `json:"observedState,omitempty"` + "`" + `
 }
 


### PR DESCRIPTION
In controller builder template, remove unnecessary `// +optional` annotations in resource `Status`.