### PR TITLE
fix: improve MockPusub fidelity on AllowedPersistenceRegions

### DIFF
--- a/mockgcp/mockpubsub/topic.go
+++ b/mockgcp/mockpubsub/topic.go
@@ -53,35 +53,32 @@ func (s *publisherService) CreateTopic(ctx context.Context, req *pb.Topic) (*pb.
 }
 
 func (s *publisherService) populateDefaultsForTopic(obj *pb.Topic) {
-	// TODO: When _is_ this populated?
-	populateMessageStoragePolicy := false
-	if populateMessageStoragePolicy {
-		obj.MessageStoragePolicy = &pb.MessageStoragePolicy{
-			AllowedPersistenceRegions: []string{
-				"asia-east1",
-				"asia-northeast1",
-				"asia-southeast1",
-				"australia-southeast1",
-				"europe-north1",
-				"europe-west1",
-				"europe-west2",
-				"europe-west3",
-				"europe-west4",
-				"southamerica-west1",
-				"us-central1",
-				"us-central2",
-				"us-east1",
-				"us-east4",
-				"us-east5",
-				"us-east7",
-				"us-south1",
-				"us-west1",
-				"us-west2",
-				"us-west3",
-				"us-west4",
-				"us-west8",
-			},
-		}
+	// create and update methods populate the AllowedPersistenceRegions
+	obj.MessageStoragePolicy = &pb.MessageStoragePolicy{
+		AllowedPersistenceRegions: []string{
+			"asia-east1",
+			"asia-northeast1",
+			"asia-southeast1",
+			"australia-southeast1",
+			"europe-north1",
+			"europe-west1",
+			"europe-west2",
+			"europe-west3",
+			"europe-west4",
+			"southamerica-west1",
+			"us-central1",
+			"us-central2",
+			"us-east1",
+			"us-east4",
+			"us-east5",
+			"us-east7",
+			"us-south1",
+			"us-west1",
+			"us-west2",
+			"us-west3",
+			"us-west4",
+			"us-west8",
+		},
 	}
 }
 
@@ -116,6 +113,7 @@ func (s *publisherService) UpdateTopic(ctx context.Context, req *pb.UpdateTopicR
 			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
 		}
 	}
+	s.populateDefaultsForTopic(updated)
 
 	if err := s.storage.Update(ctx, fqn, updated); err != nil {
 		return nil, err

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/_http.log
@@ -330,6 +330,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -354,6 +380,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -1410,6 +1462,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob/_http.log
@@ -330,6 +330,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }
 
@@ -354,6 +380,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }
@@ -412,6 +464,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic1-${uniqueId}"
 }
 
@@ -436,6 +514,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic1-${uniqueId}"
 }
@@ -1239,6 +1343,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic1-${uniqueId}"
 }
 
@@ -1282,6 +1412,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob2/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/streamingdataflowflextemplatejob2/_http.log
@@ -50,6 +50,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }
 
@@ -74,6 +100,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }
@@ -1207,6 +1259,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic0-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubsubscription/basicpubsubsubscription/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubsubscription/basicpubsubsubscription/_http.log
@@ -52,6 +52,32 @@ X-Xss-Protection: 0
     "label-one": "value-one",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}"
 }
 
@@ -77,6 +103,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "label-one": "value-one",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}"
 }
@@ -347,6 +399,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "label-one": "value-one",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubsubscription/bigquerypubsubsubscription/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubsubscription/bigquerypubsubsubscription/_http.log
@@ -50,6 +50,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -74,6 +100,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -1649,6 +1701,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
@@ -16,6 +16,30 @@ metadata:
   name: pubsubtopic-sample-${uniqueId}
   namespace: ${uniqueId}
 spec:
+  messageStoragePolicy:
+    allowedPersistenceRegions:
+    - asia-east1
+    - asia-northeast1
+    - asia-southeast1
+    - australia-southeast1
+    - europe-north1
+    - europe-west1
+    - europe-west2
+    - europe-west3
+    - europe-west4
+    - southamerica-west1
+    - us-central1
+    - us-central2
+    - us-east1
+    - us-east4
+    - us-east5
+    - us-east7
+    - us-south1
+    - us-west1
+    - us-west2
+    - us-west3
+    - us-west4
+    - us-west8
   resourceID: pubsubtopic-sample-${uniqueId}
   schemaSettings:
     encoding: JSON

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/_http.log
@@ -137,6 +137,32 @@ X-Xss-Protection: 0
     "label-one": "value-one",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
   "schemaSettings": {
     "encoding": "JSON",
@@ -166,6 +192,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "label-one": "value-one",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
   "schemaSettings": {

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/secretmanagersecret/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/secretmanagersecret/_http.log
@@ -50,6 +50,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }
 
@@ -74,6 +100,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }
@@ -426,6 +478,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/topic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationbase/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationbase/_http.log
@@ -189,6 +189,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -213,6 +239,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -459,6 +511,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationfull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagenotification/storagenotificationfull/_http.log
@@ -189,6 +189,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -213,6 +239,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -486,6 +538,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/externalref/externalwithname/_http.log
+++ b/pkg/test/resourcefixture/testdata/externalref/externalwithname/_http.log
@@ -50,6 +50,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -74,6 +100,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -331,6 +383,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/iammemberreferences/serviceaccountref/_http.log
+++ b/pkg/test/resourcefixture/testdata/iammemberreferences/serviceaccountref/_http.log
@@ -137,6 +137,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -161,6 +187,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -333,6 +385,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }

--- a/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
+++ b/pkg/test/resourcefixture/testdata/iammemberreferences/sqlinstanceref/_http.log
@@ -419,6 +419,32 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
+  },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
 
@@ -443,6 +469,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }
@@ -615,6 +667,32 @@ X-Xss-Protection: 0
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
+  },
+  "messageStoragePolicy": {
+    "allowedPersistenceRegions": [
+      "asia-east1",
+      "asia-northeast1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "southamerica-west1",
+      "us-central1",
+      "us-central2",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-east7",
+      "us-south1",
+      "us-west1",
+      "us-west2",
+      "us-west3",
+      "us-west4",
+      "us-west8"
+    ]
   },
   "name": "projects/${projectId}/topics/pubsubtopic-${uniqueId}"
 }


### PR DESCRIPTION
The PubSub is a dependency to many resources. This `AllowedPersistenceRegions` is trivial but has bothered me every time using Pubsub as a dependency. It is just easier to fix it now than later as we grow the mockgcp coverage.
The outcome is verified by comparing the real GCP log with the Mock one in MockSecretManager. 