### PR TITLE
tests: use a longer timeout in (real) e2e tests

### DIFF
--- a/dev/ci/periodics/_create_project_and_run_e2e
+++ b/dev/ci/periodics/_create_project_and_run_e2e
@@ -32,7 +32,7 @@ EXIT_CODE=0
 dev/tasks/create-test-project
 trap dev/tasks/cleanup-test-resources EXIT
 
-dev/tasks/run-e2e || EXIT_CODE=$?
+TEST_TIMEOUT=240m dev/tasks/run-e2e || EXIT_CODE=$?
 
 if [[ -n "${ARTIFACTS:-}" ]]; then
   # Capture our source tree, which includes golden output

--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -70,7 +70,7 @@ if [[ "${E2E_GCP_TARGET}" == "real" ]]; then
 fi
 
 if [[ -z "${TEST_TIMEOUT:-}" ]]; then
-  TEST_TIMEOUT=7200s
+  TEST_TIMEOUT=120m
 fi
 echo "Using TEST_TIMEOUT=${TEST_TIMEOUT}"
 


### PR DESCRIPTION
Some of our test suites take a long time.
