### PR TITLE
tests: turn off VCR tests for SQLUser

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -804,7 +804,9 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 		case "service":
 		case "sourcereporepository":
 		case "spannerdatabase":
-		case "sqluser":
+
+		// Disabled because tests failing, needs re-record:
+		// case "sqluser":
 
 		case "computenodegroup":
 		case "computenodetemplate":


### PR DESCRIPTION
The tests are currently failing and it probably needs a re-record.
