### PR TITLE
mockgcp: improve cloud build worder pool

### DIFF
--- a/mockgcp/mockcloudbuild/workerpool.go
+++ b/mockgcp/mockcloudbuild/workerpool.go
@@ -79,6 +79,9 @@ func (s *CloudBuildV1) CreateWorkerPool(ctx context.Context, req *pb.CreateWorke
 		result.UpdateTime = now
 		result.State = pb.WorkerPool_RUNNING
 		result.Etag = fields.ComputeWeakEtag(result)
+		if err := s.storage.Update(ctx, fqn, result); err != nil { // update resource object when LRO is done
+			return nil, err
+		}
 		return result, nil
 	})
 }
@@ -125,6 +128,9 @@ func (s *CloudBuildV1) UpdateWorkerPool(ctx context.Context, req *pb.UpdateWorke
 		result.UpdateTime = now
 		result.State = pb.WorkerPool_RUNNING
 		result.Etag = fields.ComputeWeakEtag(result)
+		if err := s.storage.Update(ctx, fqn, result); err != nil { // update resource object when LRO is done
+			return nil, err
+		}
 		return result, nil
 	})
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
@@ -667,7 +667,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "displayName": "New CloudBuild WorkerPool",
+  "etag": "abcdef0123A=",
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
   "privatePoolV1Config": {
     "networkConfig": {
@@ -679,7 +681,9 @@ X-Xss-Protection: 0
       "diskSizeGb": "100",
       "machineType": "e2-medium"
     }
-  }
+  },
+  "state": 2,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
@@ -691,6 +695,7 @@ x-goog-request-params: location=us-central1
 
 {
   "displayName": "Updated CloudBuild WorkerPool",
+  "etag": "abcdef0123A=",
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
   "privatePoolV1Config": {
     "networkConfig": {
@@ -755,6 +760,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.devtools.cloudbuild.v1.WorkerPool",
+    "createTime": "2024-04-01T12:34:56.123456Z",
     "displayName": "New CloudBuild WorkerPool",
     "etag": "abcdef0123A=",
     "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
@@ -793,7 +799,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "displayName": "New CloudBuild WorkerPool",
+  "etag": "abcdef0123A=",
   "name": "projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
   "privatePoolV1Config": {
     "networkConfig": {
@@ -806,6 +814,7 @@ X-Xss-Protection: 0
       "machineType": "e2-medium"
     }
   },
+  "state": 2,
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 


### PR DESCRIPTION
When LRO is finished, we should update the resource object in mockgcp storage.

I checked against real GCP, a `GET` call on Cloud Build Worker Pool does include "createTime, etag, state" in the response.