### PR TITLE
Add GVKs supported by direct controllers to supportedgvks.All()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ manifests: generate
 	rm -rf config/crds/resources
 	rm -rf config/crds/tmp_resources
 	go build -o bin/generate-crds ./scripts/generate-crds && ./bin/generate-crds -output-dir=config/crds/tmp_resources
-	go run ./scripts/generate-cnrm-cluster-roles/main.go
 	# add kustomize patches on all CRDs
 	mkdir config/crds/resources
 	cp config/crds/kustomization.yaml kustomization.yaml
@@ -81,6 +80,10 @@ manifests: generate
 
 	# for direct controllers
 	dev/tasks/generate-crds
+
+	# Generating cnrm cluster roles is dependent on the existence of directory
+	# config/crds/resources with all the freshly generated CRDs.
+	go run ./scripts/generate-cnrm-cluster-roles/main.go
 
 # Format code
 .PHONY: fmt

--- a/config/installbundle/components/clusterroles/cnrm_admin.yaml
+++ b/config/installbundle/components/clusterroles/cnrm_admin.yaml
@@ -1159,3 +1159,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - workstations.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/installbundle/components/clusterroles/cnrm_viewer.yaml
+++ b/config/installbundle/components/clusterroles/cnrm_viewer.yaml
@@ -774,3 +774,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - workstations.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/apis/core/v1alpha1/servicemapping_types.go
+++ b/pkg/apis/core/v1alpha1/servicemapping_types.go
@@ -54,7 +54,7 @@ type ResourceConfig struct {
 	// If unset, the default API version of the service mapping will be used.
 	Version *string `json:"version"`
 
-	// Direct tells if the ResourceConfig is for ConfigConnector directly managed resources.
+	// Direct tells if the ResourceConfig is for ConfigConnector directly managed resources.
 	// Directly managed resource does not use Terraform or DCL controller, and do not rely on any TF specified fields like `SkipImport`
 	// A direct ResourceConfig is used to generate the reference doc.
 	Direct bool `json:"direct"`

--- a/pkg/controller/direct/registry/registry.go
+++ b/pkg/controller/direct/registry/registry.go
@@ -79,6 +79,7 @@ func AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) 
 	}
 	return nil, nil
 }
+
 func Init(ctx context.Context, config *config.ControllerConfig) error {
 	for _, registration := range singleton.registrations {
 		model, err := registration.factory(ctx, config)

--- a/pkg/controller/mocktests/harness.go
+++ b/pkg/controller/mocktests/harness.go
@@ -133,7 +133,10 @@ func (h *Harness) WithObjects(initObjs ...*unstructured.Unstructured) {
 	if err != nil {
 		h.Fatalf("error getting new service mapping loader: %v", err)
 	}
-	supportedGVKs := supportedgvks.All(smLoader, dclmetadata.New())
+	supportedGVKs, err := supportedgvks.All(smLoader, dclmetadata.New())
+	if err != nil {
+		h.Fatalf("error loading all supported GVKs: %v", err)
+	}
 	for _, gvk := range supportedGVKs {
 		var resource string
 		switch gvk.Kind {

--- a/pkg/crd/crdgeneration/dcl2crdgeneration_test.go
+++ b/pkg/crd/crdgeneration/dcl2crdgeneration_test.go
@@ -1234,7 +1234,10 @@ func TestDCLSchemaToJSONSchema(t *testing.T) {
 	smLoader := servicemappingloader.NewFromServiceMappings(test.FakeServiceMappingsWithHierarchicalResources())
 	serviceMetadataLoader := dclmetadata.NewFromServiceList(testservicemetadataloader.FakeServiceMetadataWithHierarchicalResources())
 	dclSchemaLoader := testdclschemaloader.New(dclSchemaMap())
-	allSupportedGVKs := supportedgvks.All(smLoader, serviceMetadataLoader)
+	allSupportedGVKs, err := supportedgvks.All(smLoader, serviceMetadataLoader)
+	if err != nil {
+		t.Fatalf("error loading all supported GVKs: %v", err)
+	}
 	a := New(serviceMetadataLoader, dclSchemaLoader, allSupportedGVKs)
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/gvks/supportedgvks/supportedgvks.go
+++ b/pkg/gvks/supportedgvks/supportedgvks.go
@@ -15,7 +15,10 @@
 package supportedgvks
 
 import (
+	"fmt"
+
 	iamapi "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/crdloader"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/krmtotf"
@@ -26,20 +29,79 @@ import (
 
 // All returns GroupVersionKinds corresponding to all the GCP resources
 // supported by KCC.
-func All(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader) []schema.GroupVersionKind {
+func All(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader) ([]schema.GroupVersionKind, error) {
+	return resourcesWithDirect(smLoader, serviceMetaLoader, true)
+}
+
+func AllWithoutDirect(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader) []schema.GroupVersionKind {
 	return resources(smLoader, serviceMetaLoader, true)
 }
 
 // ManualResources returns GroupVersionKinds for all the manually configured KCC
 // resources.
-func ManualResources(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader) []schema.GroupVersionKind {
-	return resources(smLoader, serviceMetaLoader, false)
+func ManualResources(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader) ([]schema.GroupVersionKind, error) {
+	return resourcesWithDirect(smLoader, serviceMetaLoader, false)
+}
+
+func resourcesWithDirect(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader, includesAutoGen bool) ([]schema.GroupVersionKind, error) {
+	gvks := resources(smLoader, serviceMetaLoader, includesAutoGen)
+
+	directGVKs, err := DirectResources()
+	if err != nil {
+		return nil, fmt.Errorf("error getting direct resource GVKs: %w", err)
+	}
+	for _, gvk := range gvks {
+		if _, ok := directGVKs[gvk]; ok {
+			delete(directGVKs, gvk)
+		}
+	}
+	for gvk, _ := range directGVKs {
+		gvks = append(gvks, gvk)
+	}
+	return gvks, nil
 }
 
 func resources(smLoader *servicemappingloader.ServiceMappingLoader, serviceMetaLoader metadata.ServiceMetadataLoader, includesAutoGen bool) []schema.GroupVersionKind {
 	gvks := dynamicTypes(smLoader, serviceMetaLoader, includesAutoGen)
 	gvks = append(gvks, BasedOnHandwrittenIAMTypes()...)
 	return gvks
+}
+
+func DirectResources() (map[schema.GroupVersionKind]bool, error) {
+	crds, err := crdloader.LoadCRDs()
+	if err != nil {
+		return nil, fmt.Errorf("error loading crds: %w", err)
+	}
+	handWrittenIAMTypes := make(map[schema.GroupVersionKind]bool)
+	directResources := make(map[schema.GroupVersionKind]bool)
+	for _, gvk := range BasedOnHandwrittenIAMTypes() {
+		handWrittenIAMTypes[gvk] = true
+	}
+	for _, crd := range crds {
+		if crd.ObjectMeta.Labels["cnrm.cloud.google.com/tf2crd"] == "true" {
+			continue
+		}
+		if crd.ObjectMeta.Labels["cnrm.cloud.google.com/dcl2crd"] == "true" {
+			continue
+		}
+		versions := crd.Spec.Versions
+		highestVersion := k8s.KCCAPIVersionV1Alpha1
+		for _, version := range versions {
+			if version.Name == k8s.KCCAPIVersionV1Beta1 {
+				highestVersion = k8s.KCCAPIVersionV1Beta1
+			}
+		}
+		gvk := schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Kind:    crd.Spec.Names.Kind,
+			Version: highestVersion,
+		}
+		if _, ok := handWrittenIAMTypes[gvk]; ok {
+			continue
+		}
+		directResources[gvk] = true
+	}
+	return directResources, nil
 }
 
 // AllDynamicTypes returns GroupVersionKinds generated from:

--- a/pkg/gvks/supportedgvks/supportedgvks_test.go
+++ b/pkg/gvks/supportedgvks/supportedgvks_test.go
@@ -26,7 +26,10 @@ import (
 )
 
 func TestAllIncludesIAMResource(t *testing.T) {
-	allResources := supportedgvks.All(testservicemappingloader.New(t), dclmetadata.New())
+	allResources, err := supportedgvks.All(testservicemappingloader.New(t), dclmetadata.New())
+	if err != nil {
+		t.Fatalf("error loading all supported GVKs: %v", err)
+	}
 	iamResources := []schema.GroupVersionKind{
 		v1beta1.IAMAuditConfigGVK,
 		v1beta1.IAMPolicyGVK,

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -92,7 +92,7 @@ func NewTestReconciler(t *testing.T, mgr manager.Manager, provider *tfschema.Pro
 	smLoader := testservicemappingloader.New(t)
 	dclSchemaLoader, err := dclschemaloader.New()
 	if err != nil {
-		log.Fatalf("error creating a DCL schema loader: %v", err)
+		t.Fatalf("error creating a DCL schema loader: %v", err)
 	}
 	serviceMetaLoader := metadata.New()
 	dclConverter := conversion.New(dclSchemaLoader, serviceMetaLoader)
@@ -101,7 +101,7 @@ func NewTestReconciler(t *testing.T, mgr manager.Manager, provider *tfschema.Pro
 	if err := registry.Init(context.TODO(), &config.ControllerConfig{
 		HTTPClient: httpClient,
 	}); err != nil {
-		log.Fatalf("error intializing direct registry: %v", err)
+		t.Fatalf("error intializing direct registry: %v", err)
 	}
 
 	return &TestReconciler{

--- a/pkg/webhook/iam_defaulter.go
+++ b/pkg/webhook/iam_defaulter.go
@@ -113,7 +113,10 @@ func defaultAPIVersionForIAMResourceRef(obj *unstructured.Unstructured,
 func apiVersionForKind(kind string,
 	smLoader *servicemappingloader.ServiceMappingLoader,
 	serviceMetadataLoader metadata.ServiceMetadataLoader) (string, error) {
-	gvk, ok := gvks.GVKForKind(kind, smLoader, serviceMetadataLoader)
+	gvk, ok, err := gvks.GVKForKind(kind, smLoader, serviceMetadataLoader)
+	if err != nil {
+		return "", fmt.Errorf("error finding a GroupVersionKind for kind '%v': %w", kind, err)
+	}
 	if !ok {
 		return "", fmt.Errorf("couldn't find a GroupVersionKind for kind '%v'", kind)
 	}

--- a/pkg/webhook/register.go
+++ b/pkg/webhook/register.go
@@ -78,7 +78,10 @@ func GetCommonWebhookConfigs() ([]Config, error) {
 		return nil, fmt.Errorf("error getting new dcl schema loader: %w", err)
 	}
 	serviceMetadataLoader := metadata.New()
-	allGVKs := supportedgvks.All(smLoader, serviceMetadataLoader)
+	allGVKs, err := supportedgvks.All(smLoader, serviceMetadataLoader)
+	if err != nil {
+		return nil, fmt.Errorf("error loading all supported GVKs: %w", err)
+	}
 	allResourcesRules := getRulesFromResources(allGVKs)
 	dynamicResourcesRules := getRulesFromResources(supportedgvks.AllDynamicTypes(smLoader, serviceMetadataLoader))
 	handwrittenIamResourcesRules := getRulesFromResources(supportedgvks.BasedOnHandwrittenIAMTypes())

--- a/scripts/generate-cnrm-cluster-roles/main.go
+++ b/scripts/generate-cnrm-cluster-roles/main.go
@@ -48,8 +48,10 @@ func main() {
 		log.Fatalf("error getting new service mapping loader: %v", err)
 	}
 	serviceMetadataLoader := dclmetadata.New()
-	gvks := supportedgvks.All(smLoader, serviceMetadataLoader)
-
+	gvks, err := supportedgvks.All(smLoader, serviceMetadataLoader)
+	if err != nil {
+		log.Fatalf("error loading all supported GVKs: %v", err)
+	}
 	apis := make(map[string]bool)
 	for _, gvk := range gvks {
 		apis[gvk.Group] = true

--- a/scripts/generate-crds/main.go
+++ b/scripts/generate-crds/main.go
@@ -163,7 +163,7 @@ func generateDCLBasedCRDs() []*apiextensions.CustomResourceDefinition {
 	if err != nil {
 		log.Fatalf("could not create service mapping loader: %v", err)
 	}
-	generator := crdgeneration.New(serviceMetadataLoader, schemaLoader, supportedgvks.All(smLoader, serviceMetadataLoader))
+	generator := crdgeneration.New(serviceMetadataLoader, schemaLoader, supportedgvks.AllWithoutDirect(smLoader, serviceMetadataLoader))
 	gvks := supportedgvks.BasedOnDCL(serviceMetadataLoader)
 	for _, gvk := range gvks {
 		s, err := dclschemaloader.GetDCLSchemaForGVK(gvk, serviceMetadataLoader, schemaLoader)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes #2646

* Added direct GVKs into supportedgvks.All() function so that reference doc generation and cnrm role generation logic can cover direct GVKs.
   * Added supportedgvks.AllWithoutDirect() to handle the situations when direct GVKs are not necessary. We should avoid calling supportedgvks.All() repetitively, and we should avoid calling it during resource reconciliation. supportedgvks.All() loops through all the CRDs (i.e. 400+ files) and it is time consuming.
* Updated the reference doc generation logic to make it work for direct GVKs.

I think we should enforce samples and reference doc template work for Scifi as well. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.