### PR TITLE
chore: Change `KCC` in field description to `Config Connector`

### DIFF
--- a/apis/refs/v1beta1/alertpolicyref.go
+++ b/apis/refs/v1beta1/alertpolicyref.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 type MonitoringAlertPolicyRef struct {
-	/* The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC. */
+	/* The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `MonitoringAlertPolicy` resource. */
 	Name string `json:"name,omitempty"`

--- a/apis/refs/v1beta1/computerefs.go
+++ b/apis/refs/v1beta1/computerefs.go
@@ -105,7 +105,7 @@ func ResolveComputeNetwork(ctx context.Context, reader client.Reader, src client
 }
 
 type ComputeSubnetworkRef struct {
-	/* The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by KCC. */
+	/* The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeSubnetwork` resource. */
 	Name string `json:"name,omitempty"`
@@ -180,7 +180,7 @@ func ResolveComputeSubnetwork(ctx context.Context, reader client.Reader, src cli
 }
 
 type ComputeAddressRef struct {
-	/* The ComputeAddress selflink in the form "projects/{{project}}/regions/{{region}}/addresses/{{name}}" when not managed by KCC. */
+	/* The ComputeAddress selflink in the form "projects/{{project}}/regions/{{region}}/addresses/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeAddress` resource. */
 	Name string `json:"name,omitempty"`
@@ -189,7 +189,7 @@ type ComputeAddressRef struct {
 }
 
 type ComputeBackendServiceRef struct {
-	/* The ComputeBackendService selflink in the form "projects/{{project}}/global/backendServices/{{name}}" or "projects/{{project}}/regions/{{region}}/backendServices/{{name}}" when not managed by KCC. */
+	/* The ComputeBackendService selflink in the form "projects/{{project}}/global/backendServices/{{name}}" or "projects/{{project}}/regions/{{region}}/backendServices/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeBackendService` resource. */
 	Name string `json:"name,omitempty"`
@@ -198,7 +198,7 @@ type ComputeBackendServiceRef struct {
 }
 
 type ComputeServiceAttachmentRef struct {
-	/* The ComputeServiceAttachment selflink in the form "projects/{{project}}/regions/{{region}}/serviceAttachments/{{name}}" when not managed by KCC. */
+	/* The ComputeServiceAttachment selflink in the form "projects/{{project}}/regions/{{region}}/serviceAttachments/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeServiceAttachment` resource. */
 	Name string `json:"name,omitempty"`
@@ -207,7 +207,7 @@ type ComputeServiceAttachmentRef struct {
 }
 
 type ComputeTargetGrpcProxyRef struct {
-	/* The ComputeTargetGrpcProxy selflink in the form "projects/{{project}}/global/targetGrpcProxies/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetGrpcProxy selflink in the form "projects/{{project}}/global/targetGrpcProxies/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetGrpcProxy` resource. */
 	Name string `json:"name,omitempty"`
@@ -216,7 +216,7 @@ type ComputeTargetGrpcProxyRef struct {
 }
 
 type ComputeTargetHTTPProxyRef struct {
-	/* The ComputeTargetHTTPProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetHTTPProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetHTTPProxy` resource. */
 	Name string `json:"name,omitempty"`
@@ -225,7 +225,7 @@ type ComputeTargetHTTPProxyRef struct {
 }
 
 type ComputeTargetHTTPSProxyRef struct {
-	/* The ComputeTargetHTTPSProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetHTTPSProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetHTTPSProxy` resource. */
 	Name string `json:"name,omitempty"`
@@ -234,7 +234,7 @@ type ComputeTargetHTTPSProxyRef struct {
 }
 
 type ComputeTargetSSLProxyRef struct {
-	/* The ComputeTargetSSLProxy selflink in the form "projects/{{project}}/global/targetSslProxies/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetSSLProxy selflink in the form "projects/{{project}}/global/targetSslProxies/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetSSLProxy` resource. */
 	Name string `json:"name,omitempty"`
@@ -243,7 +243,7 @@ type ComputeTargetSSLProxyRef struct {
 }
 
 type ComputeTargetTCPProxyRef struct {
-	/* The ComputeTargetTCPProxy selflink in the form "projects/{{project}}/global/targetTcpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetTCPProxy selflink in the form "projects/{{project}}/global/targetTcpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetTCPProxy` resource. */
 	Name string `json:"name,omitempty"`
@@ -252,7 +252,7 @@ type ComputeTargetTCPProxyRef struct {
 }
 
 type ComputeTargetVPNGatewayRef struct {
-	/* The ComputeTargetVPNGateway selflink in the form "projects/{{project}}/regions/{{region}}/targetVpnGateways/{{name}}" when not managed by KCC. */
+	/* The ComputeTargetVPNGateway selflink in the form "projects/{{project}}/regions/{{region}}/targetVpnGateways/{{name}}" when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeTargetVPNGateway` resource. */
 	Name string `json:"name,omitempty"`

--- a/apis/refs/v1beta1/projectref.go
+++ b/apis/refs/v1beta1/projectref.go
@@ -29,7 +29,7 @@ import (
 
 // The Project that this resource belongs to.
 type ProjectRef struct {
-	/* The `projectID` field of a project, when not managed by KCC. */
+	/* The `projectID` field of a project, when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `Project` resource. */
 	Name string `json:"name,omitempty"`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_apikeyskeys.apikeys.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_apikeyskeys.apikeys.cnrm.cloud.google.com.yaml
@@ -83,7 +83,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
@@ -114,7 +114,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must
@@ -331,7 +331,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
@@ -115,7 +115,7 @@ spec:
                   external:
                     description: The ComputeBackendService selflink in the form "projects/{{project}}/global/backendServices/{{name}}"
                       or "projects/{{project}}/regions/{{region}}/backendServices/{{name}}"
-                      when not managed by KCC.
+                      when not managed by Config Connector.
                     type: string
                   name:
                     description: The `name` field of a `ComputeBackendService` resource.
@@ -169,7 +169,7 @@ spec:
                     properties:
                       external:
                         description: The ComputeAddress selflink in the form "projects/{{project}}/regions/{{region}}/addresses/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeAddress` resource.
@@ -458,7 +458,7 @@ spec:
                 properties:
                   external:
                     description: The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}",
-                      when not managed by KCC.
+                      when not managed by Config Connector.
                     type: string
                   name:
                     description: The `name` field of a `ComputeSubnetwork` resource.
@@ -492,7 +492,7 @@ spec:
                       external:
                         description: The ComputeServiceAttachment selflink in the
                           form "projects/{{project}}/regions/{{region}}/serviceAttachments/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeServiceAttachment`
@@ -522,7 +522,7 @@ spec:
                       external:
                         description: The ComputeTargetGrpcProxy selflink in the form
                           "projects/{{project}}/global/targetGrpcProxies/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetGrpcProxy`
@@ -553,7 +553,7 @@ spec:
                         description: The ComputeTargetHTTPProxy selflink in the form
                           "projects/{{project}}/global/targetHttpProxies/{{name}}"
                           or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetHTTPProxy`
@@ -584,7 +584,7 @@ spec:
                         description: The ComputeTargetHTTPSProxy selflink in the form
                           "projects/{{project}}/global/targetHttpProxies/{{name}}"
                           or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetHTTPSProxy`
@@ -614,7 +614,7 @@ spec:
                       external:
                         description: The ComputeTargetSSLProxy selflink in the form
                           "projects/{{project}}/global/targetSslProxies/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetSSLProxy`
@@ -645,7 +645,7 @@ spec:
                         description: The ComputeTargetTCPProxy selflink in the form
                           "projects/{{project}}/global/targetTcpProxies/{{name}}"
                           or "projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetTCPProxy`
@@ -675,7 +675,7 @@ spec:
                       external:
                         description: The ComputeTargetVPNGateway selflink in the form
                           "projects/{{project}}/regions/{{region}}/targetVpnGateways/{{name}}"
-                          when not managed by KCC.
+                          when not managed by Config Connector.
                         type: string
                       name:
                         description: The `name` field of a `ComputeTargetVPNGateway`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com.yaml
@@ -225,7 +225,7 @@ spec:
                 properties:
                   external:
                     description: The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}",
-                      when not managed by KCC.
+                      when not managed by Config Connector.
                     type: string
                   name:
                     description: The `name` field of a `ComputeSubnetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataformrepositories.dataform.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataformrepositories.dataform.cnrm.cloud.google.com.yaml
@@ -199,7 +199,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_logginglogmetrics.logging.cnrm.cloud.google.com.yaml
@@ -335,7 +335,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_monitoringdashboards.monitoring.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_monitoringdashboards.monitoring.cnrm.cloud.google.com.yaml
@@ -101,7 +101,7 @@ spec:
                                       external:
                                         description: The MonitoringAlertPolicy link
                                           in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                          when not managed by KCC.
+                                          when not managed by Config Connector.
                                         type: string
                                       name:
                                         description: The `name` field of a `MonitoringAlertPolicy`
@@ -158,7 +158,7 @@ spec:
                                       properties:
                                         external:
                                           description: The `projectID` field of a
-                                            project, when not managed by KCC.
+                                            project, when not managed by Config Connector.
                                           type: string
                                         kind:
                                           description: The kind of the Project resource;
@@ -244,7 +244,7 @@ spec:
                                         external:
                                           description: The MonitoringAlertPolicy link
                                             in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                            when not managed by KCC.
+                                            when not managed by Config Connector.
                                           type: string
                                         name:
                                           description: The `name` field of a `MonitoringAlertPolicy`
@@ -2152,7 +2152,7 @@ spec:
                                 external:
                                   description: The MonitoringAlertPolicy link in the
                                     form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                    when not managed by KCC.
+                                    when not managed by Config Connector.
                                   type: string
                                 name:
                                   description: The `name` field of a `MonitoringAlertPolicy`
@@ -2207,7 +2207,7 @@ spec:
                                 properties:
                                   external:
                                     description: The `projectID` field of a project,
-                                      when not managed by KCC.
+                                      when not managed by Config Connector.
                                     type: string
                                   kind:
                                     description: The kind of the Project resource;
@@ -2292,7 +2292,7 @@ spec:
                                   external:
                                     description: The MonitoringAlertPolicy link in
                                       the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                      when not managed by KCC.
+                                      when not managed by Config Connector.
                                     type: string
                                   name:
                                     description: The `name` field of a `MonitoringAlertPolicy`
@@ -4019,7 +4019,7 @@ spec:
                                     external:
                                       description: The MonitoringAlertPolicy link
                                         in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                        when not managed by KCC.
+                                        when not managed by Config Connector.
                                       type: string
                                     name:
                                       description: The `name` field of a `MonitoringAlertPolicy`
@@ -4075,7 +4075,7 @@ spec:
                                     properties:
                                       external:
                                         description: The `projectID` field of a project,
-                                          when not managed by KCC.
+                                          when not managed by Config Connector.
                                         type: string
                                       kind:
                                         description: The kind of the Project resource;
@@ -4161,7 +4161,7 @@ spec:
                                       external:
                                         description: The MonitoringAlertPolicy link
                                           in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                          when not managed by KCC.
+                                          when not managed by Config Connector.
                                         type: string
                                       name:
                                         description: The `name` field of a `MonitoringAlertPolicy`
@@ -5973,7 +5973,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must
@@ -6032,7 +6032,7 @@ spec:
                                       external:
                                         description: The MonitoringAlertPolicy link
                                           in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                          when not managed by KCC.
+                                          when not managed by Config Connector.
                                         type: string
                                       name:
                                         description: The `name` field of a `MonitoringAlertPolicy`
@@ -6089,7 +6089,7 @@ spec:
                                       properties:
                                         external:
                                           description: The `projectID` field of a
-                                            project, when not managed by KCC.
+                                            project, when not managed by Config Connector.
                                           type: string
                                         kind:
                                           description: The kind of the Project resource;
@@ -6175,7 +6175,7 @@ spec:
                                         external:
                                           description: The MonitoringAlertPolicy link
                                             in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]",
-                                            when not managed by KCC.
+                                            when not managed by Config Connector.
                                           type: string
                                         name:
                                           description: The `name` field of a `MonitoringAlertPolicy`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
@@ -107,7 +107,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must
@@ -155,7 +155,7 @@ spec:
                       properties:
                         external:
                           description: The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}",
-                            when not managed by KCC.
+                            when not managed by Config Connector.
                           type: string
                         name:
                           description: The `name` field of a `ComputeSubnetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
@@ -118,7 +118,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerinstances.securesourcemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerinstances.securesourcemanager.cnrm.cloud.google.com.yaml
@@ -88,7 +88,7 @@ spec:
                 properties:
                   external:
                     description: The `projectID` field of a project, when not managed
-                      by KCC.
+                      by Config Connector.
                     type: string
                   kind:
                     description: The kind of the Project resource; optional but must

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringdashboard_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringdashboard_types.go
@@ -257,7 +257,7 @@ type DashboardPieChart struct {
 }
 
 type DashboardProjectRefs struct {
-	/* The `projectID` field of a project, when not managed by KCC. */
+	/* The `projectID` field of a project, when not managed by Config Connector. */
 	// +optional
 	External *string `json:"external,omitempty"`
 

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
@@ -238,7 +238,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
@@ -237,7 +237,7 @@ internal load balancer.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeBackendService selflink in the form "projects/{{project}}/global/backendServices/{{name}}" or "projects/{{project}}/regions/{{region}}/backendServices/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeBackendService selflink in the form "projects/{{project}}/global/backendServices/{{name}}" or "projects/{{project}}/regions/{{region}}/backendServices/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -315,7 +315,7 @@ range of the subnet or network configured for this forwarding rule.{% endverbati
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeAddress selflink in the form "projects/{{project}}/regions/{{region}}/addresses/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeAddress selflink in the form "projects/{{project}}/regions/{{region}}/addresses/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -774,7 +774,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -824,7 +824,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeServiceAttachment selflink in the form "projects/{{project}}/regions/{{region}}/serviceAttachments/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeServiceAttachment selflink in the form "projects/{{project}}/regions/{{region}}/serviceAttachments/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -864,7 +864,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetGrpcProxy selflink in the form "projects/{{project}}/global/targetGrpcProxies/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetGrpcProxy selflink in the form "projects/{{project}}/global/targetGrpcProxies/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -904,7 +904,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetHTTPProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetHTTPProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -944,7 +944,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetHTTPSProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetHTTPSProxy selflink in the form "projects/{{project}}/global/targetHttpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -984,7 +984,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetSSLProxy selflink in the form "projects/{{project}}/global/targetSslProxies/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetSSLProxy selflink in the form "projects/{{project}}/global/targetSslProxies/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1024,7 +1024,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetTCPProxy selflink in the form "projects/{{project}}/global/targetTcpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetTCPProxy selflink in the form "projects/{{project}}/global/targetTcpProxies/{{name}}" or "projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1064,7 +1064,7 @@ subnetwork must be specified.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetVPNGateway selflink in the form "projects/{{project}}/regions/{{region}}/targetVpnGateways/{{name}}" when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetVPNGateway selflink in the form "projects/{{project}}/regions/{{region}}/targetVpnGateways/{{name}}" when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataflow/dataflowflextemplatejob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataflow/dataflowflextemplatejob.md
@@ -405,7 +405,7 @@ transformNameMapping: {}
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeSubnetwork selflink of form "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/logging/logginglogmetric.md
@@ -495,7 +495,7 @@ valueExtractor: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringdashboard.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/monitoring/monitoringdashboard.md
@@ -1414,7 +1414,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1504,7 +1504,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -1664,7 +1664,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -4674,7 +4674,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -4764,7 +4764,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -4924,7 +4924,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -7884,7 +7884,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -7974,7 +7974,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -8134,7 +8134,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -11054,7 +11054,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -11184,7 +11184,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -11274,7 +11274,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `projectID` field of a project, when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The `projectID` field of a project, when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -11434,7 +11434,7 @@ rowLayout:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by KCC.{% endverbatim %}</p>
+            <p>{% verbatim %}The MonitoringAlertPolicy link in the form "projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]", when not managed by Config Connector.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes comment https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2599#discussion_r1742680977

Note: There are still many `KCC` usages in existing code comments and function names. Since they are not directly exposed to Cx, I think it's fine to keep them as is.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
