### PR TITLE
chore:improve KCC build commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,18 @@ repo to quickly set up a local dev environment.
         make deploy-controller
         ```
 
+    1. If you want to install config connector on a brand new GKE cluster, the following command will install all CRDs, locally build, push and deploy all workloads to a standard GKE cluster.
+
+        ```shell
+        make deploy-kcc-standard
+        ```
+    
+        For autopilot clusters, please use the following command.
+
+        ```shell
+        make deploy-kcc-autopilot
+        ```
+
 ### Validate your environment
 
 The script `gcp-setup.sh` annotates your `default` namespace in the GKE cluster

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@
 PROJECT_ID ?= $(shell gcloud config get-value project)
 SHORT_SHA := $(shell git rev-parse --short=7 HEAD)
 BUILDER_IMG ?= gcr.io/${PROJECT_ID}/builder:${SHORT_SHA}
-CONTROLLER_IMG ?= gcr.io/${PROJECT_ID}/controller:${SHORT_SHA}
-RECORDER_IMG ?= gcr.io/${PROJECT_ID}/recorder:${SHORT_SHA}
-WEBHOOK_IMG ?= gcr.io/${PROJECT_ID}/webhook:${SHORT_SHA}
-DELETION_DEFENDER_IMG ?= gcr.io/${PROJECT_ID}/deletiondefender:${SHORT_SHA}
-UNMANAGED_DETECTOR_IMG ?= gcr.io/${PROJECT_ID}/unmanageddetector:${SHORT_SHA}
+CONTROLLER_IMG ?= gcr.io/${PROJECT_ID}/cnrm/controller:${SHORT_SHA}
+RECORDER_IMG ?= gcr.io/${PROJECT_ID}/cnrm/recorder:${SHORT_SHA}
+WEBHOOK_IMG ?= gcr.io/${PROJECT_ID}/cnrm/webhook:${SHORT_SHA}
+DELETION_DEFENDER_IMG ?= gcr.io/${PROJECT_ID}/cnrm/deletiondefender:${SHORT_SHA}
+UNMANAGED_DETECTOR_IMG ?= gcr.io/${PROJECT_ID}/cnrm/unmanageddetector:${SHORT_SHA}
 # Detects the location of the user golangci-lint cache.
 GOLANGCI_LINT_CACHE := /tmp/golangci-lint
 # When updating this, make sure to update the corresponding action in
@@ -298,7 +298,7 @@ operator-manager-bin:
 
 # Build kcc manifests for both standard and autopilot clusters
 .PHONY: all-manifests
-all-manifests: crd-manifests rbac-manifests manager-manifests
+all-manifests: crd-manifests rbac-manifests build-operator-manifests
 	cp config/installbundle/release-manifests/crds.yaml config/installbundle/release-manifests/standard/crds.yaml
 	cp config/installbundle/release-manifests/rbac.yaml config/installbundle/release-manifests/standard/rbac.yaml
 	kustomize build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
@@ -309,39 +309,45 @@ all-manifests: crd-manifests rbac-manifests manager-manifests
 
 # Build kcc manifests for standard GKE clusters
 .PHONY: config-connector-manifests-standard
-config-connector-manifests-standard: crd-manifests rbac-manifests manager-manifests
+config-connector-manifests-standard: build-crd-manifests build-rbac-manifests build-operator-manifests
 	cp config/installbundle/release-manifests/crds.yaml config/installbundle/release-manifests/standard/crds.yaml
 	cp config/installbundle/release-manifests/rbac.yaml config/installbundle/release-manifests/standard/rbac.yaml
 	kustomize build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
 
 # Build kcc manifests for autopilot clusters
 .PHONY: config-connector-manifests-autopilot
-config-connector-manifests-autopilot: crd-manifests rbac-manifests manager-manifests
+config-connector-manifests-autopilot: build-crd-manifests build-rbac-manifests build-operator-manifests
 	cp config/installbundle/release-manifests/crds.yaml config/installbundle/release-manifests/autopilot/crds.yaml
 	cp config/installbundle/release-manifests/rbac.yaml config/installbundle/release-manifests/autopilot/rbac.yaml
 	kustomize build config/installbundle/release-manifests/autopilot -o config/installbundle/release-manifests/autopilot/manifests.yaml
 
-.PHONY: crd-manifests
-crd-manifests:
+.PHONY: build-crd-manifests
+build-crd-manifests:
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 crd paths="./operator/pkg/apis/..." output:crd:artifacts:config=operator/config/crd/bases
 	kustomize build operator/config/crd -o config/installbundle/release-manifests/crds.yaml
 
-.PHONY: rbac-manifests
-rbac-manifests:
+.PHONY: build-rbac-manifests
+build-rbac-manifests:
 	kustomize build operator/config/rbac -o config/installbundle/release-manifests/rbac.yaml
 
-.PHONY: manager-manifests
-manager-manifests:
+.PHONY: build-operator-manifests
+build-operator-manifests:
 	make -C operator docker-build
 	kustomize build operator/config/autopilot-manager -o config/installbundle/release-manifests/autopilot/manager.yaml
 	kustomize build operator/config/manager -o config/installbundle/release-manifests/standard/manager.yaml
 
-.PHONY: clean-release-manifests
+.PHONY: push-operator-manifest
+push-operator-manifest:
+	make -C operator docker-push
+
+.PHONY: clean-operator-manifests
 clean-release-manifests:
 	rm config/installbundle/release-manifests/crds.yaml
 	rm config/installbundle/release-manifests/rbac.yaml
-	rm config/installbundle/release-manifests/manager.yaml
-	rm config/installbundle/release-manifests/manifests.yaml
+	rm config/installbundle/release-manifests/standard/manager.yaml
+	rm config/installbundle/release-manifests/autopilot/manager.yaml
+	rm config/installbundle/release-manifests/standard/manifests.yaml
+	rm config/installbundle/release-manifests/autopilot/manifests.yaml
 
 # deploy config connector manifests to a k8s cluster
 # make sure to connect to a k8s cluster first

--- a/config/installbundle/base/kustomization.yaml
+++ b/config/installbundle/base/kustomization.yaml
@@ -22,4 +22,5 @@ resources:
   - ../components/roles
   - ../components/rolebindings
   - ../components/recorder
+  - ../components/unmanageddetector
   - ../components/webhook


### PR DESCRIPTION
This PR 
- moves all kcc related image into the same cnrm subdirectory when pushing the built image to image registry
- add push config connector operator image to image registry

Tested on a GKE cluster:
```
$ kubectl get ns
NAME                 STATUS   AGE
default              Active   156m
gke-managed-cim      Active   156m
gke-managed-system   Active   156m
gmp-public           Active   155m
gmp-system           Active   155m
kube-node-lease      Active   156m
kube-public          Active   156m
kube-system          Active   156m

$ kubectl get deployments -A
NAMESPACE     NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
gmp-system    gmp-operator                    1/1     1            1           156m
gmp-system    rule-evaluator                  0/0     0            0           156m
kube-system   event-exporter-gke              1/1     1            1           156m
kube-system   konnectivity-agent              6/6     6            6           156m
kube-system   konnectivity-agent-autoscaler   1/1     1            1           156m
kube-system   kube-dns                        2/2     2            2           156m
kube-system   kube-dns-autoscaler             1/1     1            1           156m
kube-system   l7-default-backend              1/1     1            1           156m
kube-system   metrics-server-v1.30.3          1/1     1            1           156m

$ make deploy-kcc-autopilot
...
namespace/configconnector-operator-system created
customresourcedefinition.apiextensions.k8s.io/configconnectorcontexts.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/configconnectors.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/controllerresources.customize.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/namespacedcontrollerreconcilers.customize.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/namespacedcontrollerresources.customize.core.cnrm.cloud.google.com created
customresourcedefinition.apiextensions.k8s.io/validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com created
serviceaccount/configconnector-operator created
clusterrole.rbac.authorization.k8s.io/configconnector-operator-cnrm-viewer created
clusterrole.rbac.authorization.k8s.io/configconnector-operator-manager-role created
clusterrolebinding.rbac.authorization.k8s.io/configconnector-operator-cnrm-viewer-role-binding created
clusterrolebinding.rbac.authorization.k8s.io/configconnector-operator-rolebinding created
service/configconnector-operator-service created
statefulset.apps/configconnector-operator created
...
namespace/cnrm-system created
serviceaccount/cnrm-controller-manager created
serviceaccount/cnrm-deletiondefender created
serviceaccount/cnrm-resource-stats-recorder created
serviceaccount/cnrm-unmanaged-detector created
serviceaccount/cnrm-webhook-manager created
role.rbac.authorization.k8s.io/cnrm-deletiondefender-cnrm-system-role created
role.rbac.authorization.k8s.io/cnrm-webhook-cnrm-system-role created
clusterrole.rbac.authorization.k8s.io/cnrm-admin created
clusterrole.rbac.authorization.k8s.io/cnrm-deletiondefender-role created
clusterrole.rbac.authorization.k8s.io/cnrm-manager-cluster-role created
clusterrole.rbac.authorization.k8s.io/cnrm-manager-ns-role created
clusterrole.rbac.authorization.k8s.io/cnrm-recorder-role created
clusterrole.rbac.authorization.k8s.io/cnrm-viewer created
clusterrole.rbac.authorization.k8s.io/cnrm-webhook-role created
rolebinding.rbac.authorization.k8s.io/cnrm-deletiondefender-role-binding created
rolebinding.rbac.authorization.k8s.io/cnrm-webhook-role-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-admin-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-deletiondefender-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-manager-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-manager-watcher-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-recorder-binding created
clusterrolebinding.rbac.authorization.k8s.io/cnrm-webhook-binding created
service/cnrm-deletiondefender created
service/cnrm-manager created
service/cnrm-resource-stats-recorder-service created
deployment.apps/cnrm-resource-stats-recorder created
deployment.apps/cnrm-webhook-manager created
statefulset.apps/cnrm-controller-manager created
statefulset.apps/cnrm-deletiondefender created
statefulset.apps/cnrm-unmanaged-detector created
horizontalpodautoscaler.autoscaling/cnrm-webhook created

$ kubectl get ns
NAME                              STATUS   AGE
cnrm-system                       Active   2m50s  // created kcc namespace
configconnector-operator-system   Active   3m // created kcc namespace 
default                           Active   175m
gke-managed-cim                   Active   175m
gke-managed-system                Active   175m
gmp-public                        Active   175m
gmp-system                        Active   175m
kube-node-lease                   Active   175m
kube-public                       Active   175m
kube-system                       Active   175m

$ kubectl get deployments -n cnrm-system
NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
cnrm-resource-stats-recorder   1/1     1            1           3m51s
cnrm-webhook-manager           2/2     2            2           3m51s

$ kubectl get statefulsets -n cnrm-system
NAME                      READY   AGE
cnrm-controller-manager   1/1     5m10s
cnrm-deletiondefender     1/1     5m10s
cnrm-unmanaged-detector   1/1     5m10s

$ kubectl get statefulsets -n configconnector-operator-system
NAME                       READY   AGE
configconnector-operator   1/1     3m10s
```