### PR TITLE
fix: write finalizers eagerly in direct controller

### DIFF
--- a/pkg/k8s/finalizers.go
+++ b/pkg/k8s/finalizers.go
@@ -28,6 +28,7 @@ func EnsureFinalizer(o metav1.Object, finalizer string) (found bool) {
 	return false
 }
 
+// EnsureFinalizers adds the specified finalizers, returning true if the finalizers were already present (i.e. no changes)
 func EnsureFinalizers(o metav1.Object, finalizers ...string) (found bool) {
 	found = true
 	for _, f := range finalizers {


### PR DESCRIPTION
This avoids exiting early and not setting them.
