### PR TITLE
Fix failing sql postsubmit tests

### DIFF
--- a/pkg/controller/direct/sql/mapping.go
+++ b/pkg/controller/direct/sql/mapping.go
@@ -707,10 +707,10 @@ func InstanceIpConfigurationGCPToKRM(in *api.IpConfiguration) *krm.InstanceIpCon
 	out := &krm.InstanceIpConfiguration{
 		AllocatedIpRange:                        direct.LazyPtr(in.AllocatedIpRange),
 		AuthorizedNetworks:                      InstanceAuthorizedNetworksGCPToKRM(in.AuthorizedNetworks),
-		EnablePrivatePathForGoogleCloudServices: direct.LazyPtr(in.EnablePrivatePathForGoogleCloudServices),
-		Ipv4Enabled:                             direct.LazyPtr(in.Ipv4Enabled),
+		EnablePrivatePathForGoogleCloudServices: direct.PtrTo(in.EnablePrivatePathForGoogleCloudServices),
+		Ipv4Enabled:                             direct.PtrTo(in.Ipv4Enabled),
 		PscConfig:                               InstancePscConfigGCPToKRM(in.PscConfig),
-		RequireSsl:                              direct.LazyPtr(in.RequireSsl),
+		RequireSsl:                              direct.PtrTo(in.RequireSsl),
 		SslMode:                                 direct.LazyPtr(in.SslMode),
 	}
 
@@ -743,7 +743,7 @@ func InstancePscConfigGCPToKRM(in *api.PscConfig) []krm.InstancePscConfig {
 	out := []krm.InstancePscConfig{
 		{
 			AllowedConsumerProjects: in.AllowedConsumerProjects,
-			PscEnabled:              direct.LazyPtr(in.PscEnabled),
+			PscEnabled:              direct.PtrTo(in.PscEnabled),
 		},
 	}
 

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/_generated_object_sqlinstance-locationpreference.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/_generated_object_sqlinstance-locationpreference.golden.yaml
@@ -17,9 +17,10 @@ spec:
   databaseVersion: POSTGRES_16
   region: us-central1
   settings:
+    availabilityType: REGIONAL
     locationPreference:
-      secondaryZone: us-central1-f
-      zone: us-central1-c
+      secondaryZone: us-central1-c
+      zone: us-central1-b
     tier: db-custom-1-3840
 status:
   conditions:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/_http.log
@@ -43,7 +43,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "secondaryZone": "us-central1-b",
       "zone": "us-central1-a"
     },
     "pricingPlan": "PER_USE",
@@ -198,7 +197,6 @@ X-Xss-Protection: 0
     "kind": "sql#settings",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "secondaryZone": "us-central1-b",
       "zone": "us-central1-a"
     },
     "pricingPlan": "PER_USE",
@@ -334,7 +332,6 @@ X-Xss-Protection: 0
     "kind": "sql#settings",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "secondaryZone": "us-central1-b",
       "zone": "us-central1-a"
     },
     "pricingPlan": "PER_USE",
@@ -366,7 +363,7 @@ User-Agent: kcc/controller-manager
   "region": "us-central1",
   "settings": {
     "activationPolicy": "ALWAYS",
-    "availabilityType": "ZONAL",
+    "availabilityType": "REGIONAL",
     "backupConfiguration": {
       "backupRetentionSettings": {
         "retainedBackups": 7,
@@ -386,8 +383,8 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "secondaryZone": "us-central1-f",
-      "zone": "us-central1-c"
+      "secondaryZone": "us-central1-c",
+      "zone": "us-central1-b"
     },
     "pricingPlan": "PER_USE",
     "replicationType": "SYNCHRONOUS",
@@ -517,7 +514,7 @@ X-Xss-Protection: 0
   "settings": {
     "activationPolicy": "ALWAYS",
     "authorizedGaeApplications": [],
-    "availabilityType": "ZONAL",
+    "availabilityType": "REGIONAL",
     "backupConfiguration": {
       "backupRetentionSettings": {
         "retainedBackups": 7,
@@ -545,8 +542,8 @@ X-Xss-Protection: 0
     "kind": "sql#settings",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "secondaryZone": "us-central1-f",
-      "zone": "us-central1-c"
+      "secondaryZone": "us-central1-c",
+      "zone": "us-central1-b"
     },
     "pricingPlan": "PER_USE",
     "replicationType": "SYNCHRONOUS",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/create.yaml
@@ -22,7 +22,7 @@ spec:
   databaseVersion: POSTGRES_16
   region: us-central1
   settings:
+    availabilityType: ZONAL
     locationPreference:
       zone: us-central1-a
-      secondaryZone: us-central1-b
     tier: db-custom-1-3840

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/update.yaml
@@ -22,7 +22,8 @@ spec:
   databaseVersion: POSTGRES_16
   region: us-central1
   settings:
+    availabilityType: REGIONAL
     locationPreference:
-      zone: us-central1-c
-      secondaryZone: us-central1-f
+      zone: us-central1-b
+      secondaryZone: us-central1-c
     tier: db-custom-1-3840


### PR DESCRIPTION
Always return boolean fields in export (even if value is false). Also, specify regional availability type in locationPreference test cases so that the secondaryZone is utilized.
