### PR TITLE
tools: require "--kind" and "--proto-resource" when generating types

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -80,6 +80,9 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 	if o.ResourceProtoName == "" {
 		return fmt.Errorf("`--proto-resource` is required")
 	}
+	if o.ResourceKindName == "" {
+		return fmt.Errorf("`--kind` is required")
+	}
 	o.ResourceProtoName = capitalizeFirstRune(o.ResourceProtoName)
 
 	gv, err := schema.ParseGroupVersion(o.APIVersion)
@@ -127,9 +130,6 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 	}
 
 	kind := o.ResourceKindName
-	if kind == "" {
-		kind = o.ResourceProtoName
-	}
 	if !scaffolder.TypeFileNotExist(kind) {
 		fmt.Printf("file %s already exists, skipping\n", scaffolder.GetTypeFile(kind))
 	} else {

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -77,6 +77,10 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 	if o.GenerateOptions.ProtoSourcePath == "" {
 		return fmt.Errorf("`proto-source-path` is required")
 	}
+	if o.ResourceProtoName == "" {
+		return fmt.Errorf("`--proto-resource` is required")
+	}
+	o.ResourceProtoName = capitalizeFirstRune(o.ResourceProtoName)
 
 	gv, err := schema.ParseGroupVersion(o.APIVersion)
 	if err != nil {
@@ -122,23 +126,26 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 		return err
 	}
 
-	if o.ResourceProtoName != "" {
-		kind := o.ResourceKindName
-		if kind == "" {
-			output := []rune{unicode.ToUpper(rune(o.ResourceProtoName[0]))}
-			for _, val := range o.ResourceProtoName[1:] {
-				output = append(output, val)
-			}
-			kind = string(output)
-		}
-		if !scaffolder.TypeFileNotExist(kind) {
-			fmt.Printf("file %s already exists, skipping\n", scaffolder.GetTypeFile(kind))
-		} else {
-			err := scaffolder.AddTypeFile(kind, o.ResourceProtoName)
-			if err != nil {
-				return fmt.Errorf("add type file %s: %w", scaffolder.GetTypeFile(kind), err)
-			}
+	kind := o.ResourceKindName
+	if kind == "" {
+		kind = o.ResourceProtoName
+	}
+	if !scaffolder.TypeFileNotExist(kind) {
+		fmt.Printf("file %s already exists, skipping\n", scaffolder.GetTypeFile(kind))
+	} else {
+		err := scaffolder.AddTypeFile(kind, o.ResourceProtoName)
+		if err != nil {
+			return fmt.Errorf("add type file %s: %w", scaffolder.GetTypeFile(kind), err)
 		}
 	}
 	return nil
+}
+
+func capitalizeFirstRune(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }


### PR DESCRIPTION
This PR introduces the following changes:

 - Marks the `--proto-resource` flag as explicitly required, since the proto resource name is required for identifying the starting point of type generation.
 - Ensures that the first character (rune) of the proto resource name is automatically capitalized within the tool, eliminating the need for users to remember to capitalize the first letter in their input.
 - Also marks the `--kind` flag as required, given that kind and proto message often do not have the same name.