### PR TITLE
tools: update controller template to use dynamic GVK in registry registration

### DIFF
--- a/dev/tools/controllerbuilder/template/controller.go
+++ b/dev/tools/controllerbuilder/template/controller.go
@@ -66,7 +66,7 @@ const (
 )
 
 func init() {
-	registry.RegisterModel(krm.GroupVersionKind, NewModel)
+	registry.RegisterModel(krm.{{.Kind}}GVK, NewModel)
 }
 
 func NewModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {


### PR DESCRIPTION
More consistent with the latest version of the "_types" template.