### PR TITLE
fix: Fix FirestoreDatabase postsubmit failures

### DIFF
--- a/pkg/controller/direct/firestore/firestoredatabase_controller.go
+++ b/pkg/controller/direct/firestore/firestoredatabase_controller.go
@@ -237,12 +237,18 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 
 	updateMask := &fieldmaskpb.FieldMask{}
 	if !reflect.DeepEqual(resource.ConcurrencyMode, a.actual.ConcurrencyMode) {
-		newDb.ConcurrencyMode = resource.ConcurrencyMode
-		updateMask.Paths = append(updateMask.Paths, "concurrency_mode")
+		// Skip update if concurrency_mode is unspecified
+		if resource.ConcurrencyMode != firestorepb.Database_CONCURRENCY_MODE_UNSPECIFIED {
+			newDb.ConcurrencyMode = resource.ConcurrencyMode
+			updateMask.Paths = append(updateMask.Paths, "concurrency_mode")
+		}
 	}
 	if !reflect.DeepEqual(resource.PointInTimeRecoveryEnablement, a.actual.PointInTimeRecoveryEnablement) {
-		newDb.PointInTimeRecoveryEnablement = resource.PointInTimeRecoveryEnablement
-		updateMask.Paths = append(updateMask.Paths, "point_in_time_recovery_enablement")
+		// Skip update if point_in_time_recovery_enablement is unspecified
+		if resource.PointInTimeRecoveryEnablement != firestorepb.Database_POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED {
+			newDb.PointInTimeRecoveryEnablement = resource.PointInTimeRecoveryEnablement
+			updateMask.Paths = append(updateMask.Paths, "point_in_time_recovery_enablement")
+		}
 	}
 
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -249,6 +249,11 @@ func validateCreate(ctx context.Context, t *testing.T, testContext testrunner.Te
 	if err := kubeClient.Get(ctx, testContext.NamespacedName, reconciledUnstruct); err != nil {
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
+
+	// Hack: Optionally wait before getting the object in GCP. This is to work around some issues with troublesome
+	// services in GCP that claim to be done with creating / updating the resource before it is actually available.
+	time.Sleep(resourceContext.PostModifyDelay)
+
 	gcpUnstruct, err := resourceContext.Get(ctx, t, reconciledUnstruct, systemContext.TFProvider, kubeClient, systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter, systemContext.HttpClient)
 	if err != nil {
 		t.Fatalf("[validateCreate] unexpected error when GET-ing '%v': %v", initialUnstruct.GetName(), err)
@@ -422,6 +427,10 @@ func testUpdate(ctx context.Context, t *testing.T, testContext testrunner.TestCo
 		// Generation should have incremented at most once, only due to defaulted field sync-back.
 		t.Fatalf("unexpected generation increase %v", generationIncrease)
 	}
+
+	// Hack: Optionally wait before getting the object in GCP. This is to work around some issues with troublesome
+	// services in GCP that claim to be done with creating / updating the resource before it is actually available.
+	time.Sleep(resourceContext.PostModifyDelay)
 
 	// Check labels match on update
 	gcpUnstruct, err := resourceContext.Get(ctx, t, reconciledUnstruct, systemContext.TFProvider, kubeClient, systemContext.SMLoader, systemContext.DCLConfig, systemContext.DCLConverter, nil)

--- a/pkg/test/resourcefixture/contexts/firestore_context.go
+++ b/pkg/test/resourcefixture/contexts/firestore_context.go
@@ -14,7 +14,29 @@
 
 package contexts
 
+import "time"
+
 func init() {
+	resourceContextMap["firestoredatabase-minimal"] = ResourceContext{
+		ResourceKind: "FirestoreDatabase",
+		// Firestore Databases return success for create / update before the changes are actually visible
+		// in GCP. It's probably a bug with the service, or some issue with eventual consistency.
+		PostModifyDelay: 60 * time.Second,
+		// After deleting a FirestoreDatabase, the database name is reserved for a while, so we cannot
+		// immediately re-create the database with the same name.
+		SkipDriftDetection: true,
+	}
+
+	resourceContextMap["firestoredatabase-full"] = ResourceContext{
+		ResourceKind: "FirestoreDatabase",
+		// Firestore Databases return success for create / update before the changes are actually visible
+		// in GCP. It's probably a bug with the service, or some issue with eventual consistency.
+		PostModifyDelay: 60 * time.Second,
+		// After deleting a FirestoreDatabase, the database name is reserved for a while, so we cannot
+		// immediately re-create the database with the same name.
+		SkipDriftDetection: true,
+	}
+
 	resourceContextMap["firestoreindex"] = ResourceContext{
 		ResourceKind: "FirestoreIndex",
 		SkipUpdate:   true,

--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -62,6 +62,10 @@ type ResourceContext struct {
 	IsDCLResource    bool
 	IsDirectResource bool
 
+	// Hack: Optionally wait before getting the object in GCP. This is to work around some issues with troublesome
+	// services in GCP that claim to be done with creating / updating the resource before it is actually available.
+	PostModifyDelay time.Duration
+
 	// Time to delay before recreating the resource as part of the drift detection test.
 	// The default wait time is 10 seconds. However, some resources appear to need to
 	// wait longer before recreating, so this value is customizable.


### PR DESCRIPTION
Due to issue with FirestoreDatabase service LRO / eventual consistency, wait after creating / updating so that the changes eventually become visible.

Also, do not attempt to update if the concurrency_mode or point_in_time_recovery_enablement fields are unspecified.
