### PR TITLE
Shift-left the defaulting of optional and immutable spec fields

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com.yaml
@@ -1043,6 +1043,7 @@ spec:
                   type: string
                 type: array
               location:
+                default: global
                 description: |-
                   Immutable. The [Cloud Build location](https://cloud.google.com/build/docs/locations) for the trigger.
                   If not specified, "global" is used.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudidentitygroups.cloudidentity.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudidentitygroups.cloudidentity.cnrm.cloud.google.com.yaml
@@ -96,6 +96,7 @@ spec:
                 - id
                 type: object
               initialGroupConfig:
+                default: EMPTY
                 description: |-
                   Immutable. The initial configuration options for creating a Group.
 

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_firestoreindexes.firestore.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_firestoreindexes.firestore.cnrm.cloud.google.com.yaml
@@ -62,6 +62,7 @@ spec:
                 description: Immutable. The collection being indexed.
                 type: string
               database:
+                default: (default)
                 description: Immutable. The Firestore database id. Defaults to '"(default)"'.
                 type: string
               fields:

--- a/pkg/resourceoverrides/cloudbuild_trigger.go
+++ b/pkg/resourceoverrides/cloudbuild_trigger.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceoverrides
+
+import (
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func GetCloudBuildTriggerResourceOverrides() ResourceOverrides {
+	ro := ResourceOverrides{
+		Kind: "CloudBuildTrigger",
+	}
+	// Default the optional and immutable 'location' field to 'global' because
+	// implicitly defaulted value will be removed in the live state.
+	ro.Overrides = append(ro.Overrides, defaultLocationFieldToGlobal())
+	return ro
+}
+
+// defaultLocationFieldToGlobal defaults the optional top-level 'location' field
+// to 'global'.
+func defaultLocationFieldToGlobal() ResourceOverride {
+	o := ResourceOverride{}
+	o.CRDDecorate = func(crd *apiextensions.CustomResourceDefinition) error {
+		return KeepTopLevelFieldOptionalWithDefault(crd, "global", "location")
+	}
+	return o
+}

--- a/pkg/resourceoverrides/cloudidentity_group.go
+++ b/pkg/resourceoverrides/cloudidentity_group.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceoverrides
+
+import (
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func GetCloudIdentityGroupResourceOverrides() ResourceOverrides {
+	ro := ResourceOverrides{
+		Kind: "CloudIdentityGroup",
+	}
+	// Default the optional and immutable 'initialGroupConfig' field to 'EMPTY'
+	// because implicitly defaulted value will be removed in the live state.
+	ro.Overrides = append(ro.Overrides, defaultInitialGroupConfigFieldToEmpty())
+	return ro
+}
+
+// defaultInitialGroupConfigFieldToEmpty defaults the optional top-level
+// 'initialGroupConfig' field to 'EMPTY'.
+func defaultInitialGroupConfigFieldToEmpty() ResourceOverride {
+	o := ResourceOverride{}
+	o.CRDDecorate = func(crd *apiextensions.CustomResourceDefinition) error {
+		return KeepTopLevelFieldOptionalWithDefault(crd, "EMPTY", "initialGroupConfig")
+	}
+	return o
+}

--- a/pkg/resourceoverrides/firestore_index.go
+++ b/pkg/resourceoverrides/firestore_index.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceoverrides
+
+import (
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func GetFirestoreIndexResourceOverrides() ResourceOverrides {
+	ro := ResourceOverrides{
+		Kind: "FirestoreIndex",
+	}
+	// Default the optional and immutable 'database' field to '(default)'
+	// because implicitly defaulted value will be removed in the live state.
+	ro.Overrides = append(ro.Overrides, defaultDatabaseFieldToDefault())
+	return ro
+}
+
+// defaultDatabaseFieldToDefault defaults the optional top-level
+// 'database' field to '(default)'.
+func defaultDatabaseFieldToDefault() ResourceOverride {
+	o := ResourceOverride{}
+	o.CRDDecorate = func(crd *apiextensions.CustomResourceDefinition) error {
+		return KeepTopLevelFieldOptionalWithDefault(crd, "(default)", "database")
+	}
+	return o
+}

--- a/pkg/resourceoverrides/overrides.go
+++ b/pkg/resourceoverrides/overrides.go
@@ -240,4 +240,10 @@ func init() {
 	Handler.Register(GetIAMCustomRoleResourceOverrides())
 
 	Handler.Register(GetCloudIDSEndpointResourceOverrides())
+
+	// Shift-left the defaulting for optional and immutable spec field defaulted
+	// by TF.
+	Handler.Register(GetCloudBuildTriggerResourceOverrides())
+	Handler.Register(GetCloudIdentityGroupResourceOverrides())
+	Handler.Register(GetFirestoreIndexResourceOverrides())
 }


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Shift-left the defaulting of the following spec fields to fix the unexpected diffs in re-reconciliation when there is no change in the CR:

* `spec.location` in CloudBuildTrigger.
* `spec.initialGroupConfig` in CloudIdentityGroup.
* `spec.database` in FirestoreIndex.

This looks like an old bug and was only exposed when `state-into-spec: absent` became the default configuration.

_Following is the context:_

Some optional and immutable spec fields are not specified by the users, and are defaulted by TF before it makes the API call to create the resource.
During reconciliation, for an immutable field, KCC will intentionally [match the live state with the desired state when constructing the live state](https://github.com/maqiuyujoyce/k8s-config-connector/blob/master/pkg/krmtotf/fetchlivestate.go#L233). But this is an incorrect behavior for the optional and immutable spec fields defaulted by TF, because it will unset such fields in the live state while the actual desired state passed to the API is not unset, but has the implicit default value.

If a resource has a field `spec.f` like that, after applying a manifest without this field `spec.f` specified, here is what will happen.
1. During the first reconciliation, the live state is nil which indicates a creation will happen.
    * With `cnrm.cloud.google.com/state-into-spec: merge`, the successfully reconciled CR contains field `spec.f` with the default value.
    * With `cnrm.cloud.google.com/state-into-spec: absent`, the successfully reconciled CR does NOT contain field `spec.f` with the default value.
1. During the second reconciliation, 
    1. KCC controller first retrieves the live state.
        * With `cnrm.cloud.google.com/state-into-spec: merge`, the desired value of field `spec.f` is non-nil, so it is kept as is.
        * With `cnrm.cloud.google.com/state-into-spec: absent`, the desired value of field `spec.f` is nil, which indicates this field is `unset`, so live state will have this field removed, even if it exists in the underlying GCP resource.
    1.  KCC controller then uses Diff() from TF to compare the live state and the desired state. Diff will "hydrate" the desired state with the default values in the TF schema.
        * With `cnrm.cloud.google.com/state-into-spec: merge`, both the live state and the desired state of the resource have the default values for field `spec.f`, and there is no diff for this field.
        * With `cnrm.cloud.google.com/state-into-spec: absent`, the live state has field `spec.f` unset, while the desired state has field `spec.f` set to its default value, so there is an unexpected diff.

With the defaulting happening at the KCC level, the desired state will have the default value explicitly set, and avoid the issue above.

Alternatively, we can update the logic to NOT match the live state with the desired state when constructing the live state, e.g. #2716. This is a more effective fix, but it'll impact more resources (so might give us surprises), and this will keep the defaulting implicit, which isn't well-aligned with the declarative design principle. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
