### PR TITLE
Update attached clusters mockGCP responses to more closely match GCP.

### DIFF
--- a/config/samples/resources/containerattachedcluster/container-attached-cluster-basic/containerattached_v1beta1_containerattachedcluster.yaml
+++ b/config/samples/resources/containerattachedcluster/container-attached-cluster-basic/containerattached_v1beta1_containerattachedcluster.yaml
@@ -30,8 +30,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-basic

--- a/config/samples/resources/containerattachedcluster/container-attached-cluster-full/containerattached_v1beta1_containerattachedcluster.yaml
+++ b/config/samples/resources/containerattachedcluster/container-attached-cluster-full/containerattached_v1beta1_containerattachedcluster.yaml
@@ -34,8 +34,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-full

--- a/config/samples/resources/containerattachedcluster/container-attached-cluster-ignore-errors/containerattached_v1beta1_containerattachedcluster.yaml
+++ b/config/samples/resources/containerattachedcluster/container-attached-cluster-ignore-errors/containerattached_v1beta1_containerattachedcluster.yaml
@@ -30,8 +30,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-ignore-errors

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -350,6 +350,7 @@ func NewHarnessWithOptions(ctx context.Context, t *testing.T, opts *HarnessOptio
 			ProjectNumber: found.ProjectNumber,
 		}
 		testgcp.TestKCCAttachedClusterProject.Set("mock-project")
+		testgcp.TestKCCAttachedClusterPlatformVersion.Set("1.30.0-gke.1")
 		h.Project = project
 	} else if os.Getenv("E2E_GCP_TARGET") == "vcr" && os.Getenv("VCR_MODE") == "replay" {
 		h.gcpAccessToken = "dummytoken"

--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -396,6 +396,7 @@ func newSubstitutionVariables(t *testing.T, project testgcp.GCPProject) map[stri
 	subs["${DLP_TEST_BUCKET?}"] = testgcp.GetDLPTestBucket(t)
 	subs["${ATTACHED_CLUSTER_NAME?}"] = testgcp.TestAttachedClusterName.Get()
 	subs["${KCC_ATTACHED_CLUSTER_TEST_PROJECT?}"] = testgcp.TestKCCAttachedClusterProject.Get()
+	subs["${ATTACHED_CLUSTER_PLATFORM_VERSION?}"] = testgcp.TestKCCAttachedClusterPlatformVersion.Get()
 	subs["${KCC_VERTEX_AI_INDEX_TEST_BUCKET?}"] = testgcp.TestKCCVertexAIIndexBucket.Get()
 	subs["${KCC_VERTEX_AI_INDEX_TEST_DATA_URI?}"] = testgcp.TestKCCVertexAIIndexDataURI.Get()
 	return subs

--- a/pkg/test/controller/k8s.go
+++ b/pkg/test/controller/k8s.go
@@ -180,6 +180,7 @@ func ReplaceTestVars(t *testing.T, b []byte, uniqueID string, project testgcp.GC
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.HighCPUQuotaTestProject), testgcp.GetHighCPUQuotaTestProject(t), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.RecaptchaEnterpriseTestProject.Key), testgcp.RecaptchaEnterpriseTestProject.Get(), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCAttachedClusterProject.Key), testgcp.TestKCCAttachedClusterProject.Get(), -1)
+	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCAttachedClusterPlatformVersion.Key), testgcp.TestKCCAttachedClusterPlatformVersion.Get(), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCVertexAIIndexBucket.Key), testgcp.TestKCCVertexAIIndexBucket.Get(), -1)
 	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.TestKCCVertexAIIndexDataURI.Key), testgcp.TestKCCVertexAIIndexDataURI.Get(), -1)
 	return []byte(s)

--- a/pkg/test/gcp/gcp.go
+++ b/pkg/test/gcp/gcp.go
@@ -64,6 +64,7 @@ var (
 	TestBillingAccountIDForBillingResources = EnvVar{Key: "BILLING_ACCOUNT_ID_FOR_BILLING_RESOURCES"}
 	TestAttachedClusterName                 = EnvVar{Key: "TEST_ATTACHED_CLUSTER_NAME"}
 	TestKCCAttachedClusterProject           = EnvVar{Key: "KCC_ATTACHED_CLUSTER_TEST_PROJECT"}
+	TestKCCAttachedClusterPlatformVersion   = EnvVar{Key: "ATTACHED_CLUSTER_PLATFORM_VERSION"}
 	FirestoreTestProject                    = EnvVar{Key: "FIRESTORE_TEST_PROJECT"}
 	IdentityPlatformTestProject             = EnvVar{Key: "IDENTITY_PLATFORM_TEST_PROJECT"}
 	RecaptchaEnterpriseTestProject          = EnvVar{Key: "RECAPTCHA_ENTERPRISE_TEST_PROJECT"}

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterbasic/_generated_object_containerattachedclusterbasic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterbasic/_generated_object_containerattachedclusterbasic.golden.yaml
@@ -34,4 +34,9 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  kubernetesVersion: "1.28"
   observedGeneration: 2
+  state: RUNNING
+  uid: "12345678"
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterbasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterbasic/_http.log
@@ -247,7 +247,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127' was not found",
+    "message": "cluster not found",
     "status": "NOT_FOUND"
   }
 }
@@ -322,18 +322,30 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-west1/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkemulticloud.v1.AttachedCluster",
+    "binaryAuthorization": {
+      "evaluationMode": "DISABLED"
+    },
+    "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "Test attached cluster",
     "distribution": "eks",
+    "etag": "abcdef0123A=",
     "fleet": {
+      "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
       "project": "projects/${projectNumber}"
     },
+    "kubernetesVersion": "1.27",
     "loggingConfig": {},
+    "monitoringConfig": {
+      "managedPrometheusConfig": {}
+    },
     "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
     "oidcConfig": {
       "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
     },
     "platformVersion": "1.27.0-gke.2",
-    "state": "RUNNING"
+    "state": "RUNNING",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
   }
 }
 
@@ -355,17 +367,30 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "binaryAuthorization": {
+    "evaluationMode": "DISABLED"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "Test attached cluster",
   "distribution": "eks",
+  "etag": "abcdef0123A=",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
+  "kubernetesVersion": "1.27",
   "loggingConfig": {},
+  "monitoringConfig": {
+    "managedPrometheusConfig": {}
+  },
   "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
   "oidcConfig": {
     "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
   },
-  "platformVersion": "1.27.0-gke.2"
+  "platformVersion": "1.27.0-gke.2",
+  "state": "RUNNING",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
@@ -375,13 +400,18 @@ Content-Type: application/json
 User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
 
 {
+  "binaryAuthorization": {
+    "evaluationMode": "DISABLED"
+  },
   "description": "Test attached cluster update",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
   "loggingConfig": {
     "componentConfig": null
   },
+  "monitoringConfig": {},
   "oidcConfig": {
     "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
   },
@@ -438,17 +468,30 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-west1/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkemulticloud.v1.AttachedCluster",
+    "binaryAuthorization": {
+      "evaluationMode": "DISABLED"
+    },
+    "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "Test attached cluster update",
     "distribution": "eks",
+    "etag": "abcdef0123A=",
     "fleet": {
+      "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
       "project": "projects/${projectNumber}"
     },
+    "kubernetesVersion": "1.28",
     "loggingConfig": {},
+    "monitoringConfig": {
+      "managedPrometheusConfig": {}
+    },
     "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
     "oidcConfig": {
       "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
     },
-    "platformVersion": "1.28.0-gke.2"
+    "platformVersion": "1.28.0-gke.2",
+    "state": "RUNNING",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
   }
 }
 
@@ -470,17 +513,30 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "binaryAuthorization": {
+    "evaluationMode": "DISABLED"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "Test attached cluster update",
   "distribution": "eks",
+  "etag": "abcdef0123A=",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
+  "kubernetesVersion": "1.28",
   "loggingConfig": {},
+  "monitoringConfig": {
+    "managedPrometheusConfig": {}
+  },
   "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
   "oidcConfig": {
     "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
   },
-  "platformVersion": "1.28.0-gke.2"
+  "platformVersion": "1.28.0-gke.2",
+  "state": "RUNNING",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterfull/_generated_object_containerattachedclusterfull.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterfull/_generated_object_containerattachedclusterfull.golden.yaml
@@ -52,4 +52,9 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  kubernetesVersion: "1.28"
   observedGeneration: 2
+  state: RUNNING
+  uid: "12345678"
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterfull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/containerattached/v1beta1/containerattachedclusterfull/_http.log
@@ -247,7 +247,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127' was not found",
+    "message": "cluster not found",
     "status": "NOT_FOUND"
   }
 }
@@ -356,11 +356,15 @@ X-Xss-Protection: 0
     "binaryAuthorization": {
       "evaluationMode": "PROJECT_SINGLETON_POLICY_ENFORCE"
     },
+    "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "Test attached cluster",
     "distribution": "eks",
+    "etag": "abcdef0123A=",
     "fleet": {
+      "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
       "project": "projects/${projectNumber}"
     },
+    "kubernetesVersion": "1.27",
     "loggingConfig": {
       "componentConfig": {
         "enableComponents": [
@@ -368,12 +372,17 @@ X-Xss-Protection: 0
         ]
       }
     },
+    "monitoringConfig": {
+      "managedPrometheusConfig": {}
+    },
     "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
     "oidcConfig": {
       "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
     },
     "platformVersion": "1.27.0-gke.2",
-    "state": "RUNNING"
+    "state": "RUNNING",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
   }
 }
 
@@ -409,11 +418,15 @@ X-Xss-Protection: 0
   "binaryAuthorization": {
     "evaluationMode": "PROJECT_SINGLETON_POLICY_ENFORCE"
   },
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "Test attached cluster",
   "distribution": "eks",
+  "etag": "abcdef0123A=",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
+  "kubernetesVersion": "1.27",
   "loggingConfig": {
     "componentConfig": {
       "enableComponents": [
@@ -421,11 +434,17 @@ X-Xss-Protection: 0
       ]
     }
   },
+  "monitoringConfig": {
+    "managedPrometheusConfig": {}
+  },
   "name": "projects/${projectId}/locations/us-west1/attachedClusters/kcc-attached-cluster-127",
   "oidcConfig": {
     "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
   },
-  "platformVersion": "1.27.0-gke.2"
+  "platformVersion": "1.27.0-gke.2",
+  "state": "RUNNING",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
@@ -455,6 +474,7 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
   },
   "description": "Test attached cluster update",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
   "loggingConfig": {
@@ -544,11 +564,15 @@ X-Xss-Protection: 0
     "binaryAuthorization": {
       "evaluationMode": "DISABLED"
     },
+    "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "Test attached cluster update",
     "distribution": "eks",
+    "etag": "abcdef0123A=",
     "fleet": {
+      "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
       "project": "projects/${projectNumber}"
     },
+    "kubernetesVersion": "1.28",
     "loggingConfig": {
       "componentConfig": {
         "enableComponents": [
@@ -566,7 +590,10 @@ X-Xss-Protection: 0
     "oidcConfig": {
       "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
     },
-    "platformVersion": "1.28.0-gke.2"
+    "platformVersion": "1.28.0-gke.2",
+    "state": "RUNNING",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
   }
 }
 
@@ -606,11 +633,15 @@ X-Xss-Protection: 0
   "binaryAuthorization": {
     "evaluationMode": "DISABLED"
   },
+  "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "Test attached cluster update",
   "distribution": "eks",
+  "etag": "abcdef0123A=",
   "fleet": {
+    "membership": "projects/${projectNumber}/locations/global/memberships/kcc-attached-cluster-127",
     "project": "projects/${projectNumber}"
   },
+  "kubernetesVersion": "1.28",
   "loggingConfig": {
     "componentConfig": {
       "enableComponents": [
@@ -628,7 +659,10 @@ X-Xss-Protection: 0
   "oidcConfig": {
     "issuerUrl": "https://oidc.eks.us-west-2.amazonaws.com/id/A115FE1C770C2452C75219524036FC0F"
   },
-  "platformVersion": "1.28.0-gke.2"
+  "platformVersion": "1.28.0-gke.2",
+  "state": "RUNNING",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -737,8 +737,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-basic
@@ -797,8 +797,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-full
@@ -859,8 +859,8 @@ spec:
   oidcConfig:
     # Replace ${ISSUER_URL?} with the OIDC issuer URL of the underlying attached cluster
     issuerUrl: ${ISSUER_URL?}
-  # Replace ${PLATFORM_VERSION?} with the platform version of the underlying attached cluster
-  platformVersion: ${PLATFORM_VERSION?}
+  # Replace ${ATTACHED_CLUSTER_PLATFORM_VERSION?} with the platform version of the underlying attached cluster
+  platformVersion: ${ATTACHED_CLUSTER_PLATFORM_VERSION?}
   fleet:
     projectRef:
       name: containerattachedcluster-dep-ignore-errors


### PR DESCRIPTION
- Set all the fields that are returned by the attached cluster service
- Update resource not found message
- Regenerate golden files
- Update env var substitution for platform version so the samples tests pass