### PR TITLE
tests: skipDriftDetection for direct resources

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -511,6 +511,12 @@ func shouldSkipDriftDetection(t *testing.T, resourceContext contexts.ResourceCon
 		return true
 	}
 
+	// TODO(acpana): Unskip drift detection once we have a strategy for testing
+	// server-generated ids in direct resources
+	if resourceContext.IsDirectResource {
+		return true
+	}
+
 	// Skip drift detection test for dcl-based resources with server-generated id.
 	if resourceContext.IsDCLResource {
 		s, found := dclextension.GetNameFieldSchema(resourceContext.DCLSchema)


### PR DESCRIPTION
For now skip drift detection testing. As of now all post submits are failing after https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2590/files.

Tested w a logging test after fix:

```
$ go test -v -tags=integration ./pkg/controller/dynamic/ -timeout 1600s -test.count=1 -test.run 'TestCreateNoChangeUpdateDelete/logging/basic-logbucketmetric'  2>&1
...
ok      github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      79.235s
```

Same test is failing today:

```
...
    dynamic_controller_integration_test.go:408: reconcile for LoggingLogMetric:nb5sfyk26aibuimrov7q/logginglogmetric-nb5sfyk26aibuimrov7q took 694.813963ms, result was ({false 7m17.800330501s}, <nil>)
    dynamic_controller_integration_test.go:519: error getting resource config: couldn't find any ResourceConfig defined for kind LoggingLogMetric
...
```

Kudos to Joyce for helping root cause.