### PR TITLE
Deflake test using regional memberships

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_generated_object_basicacmgkehubfeaturemembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_generated_object_basicacmgkehubfeaturemembership.golden.yaml
@@ -25,15 +25,11 @@ spec:
         syncRev: HEAD
         syncWaitSecs: "20"
       sourceFormat: hierarchy
-    hierarchyController:
-      enableHierarchicalResourceQuota: true
-      enablePodTreeLabels: true
-      enabled: true
     version: 1.18.1
   featureRef:
     name: gkehubfeature-basic-acm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-basic-acm-${uniqueId}
   projectRef:

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
@@ -974,7 +974,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -992,14 +992,14 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships?alt=json&membershipId=gkehubmembership-basic-acm-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-basic-acm-${uniqueId}
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1017,7 +1017,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}"
 }
 
 200 OK
@@ -1036,14 +1036,14 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}"
 }
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1064,9 +1064,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership",
     "authority": {
@@ -1087,7 +1087,7 @@ X-Xss-Protection: 0
       "cnrm-test": "true",
       "managed-by-cnrm": "true"
     },
-    "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}",
+    "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}",
     "state": {
       "code": "READY"
     },
@@ -1098,7 +1098,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1132,7 +1132,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1176,7 +1176,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1241,7 +1241,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
         "configmanagement": {
           "configSync": {
             "sourceFormat": "unstructured"
@@ -1280,7 +1280,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1305,7 +1305,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1319,11 +1319,6 @@ User-Agent: kcc/controller-manager
             "syncWaitSecs": "20"
           },
           "sourceFormat": "hierarchy"
-        },
-        "hierarchyController": {
-          "enableHierarchicalResourceQuota": true,
-          "enablePodTreeLabels": true,
-          "enabled": true
         },
         "version": "1.18.1"
       }
@@ -1386,7 +1381,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1400,11 +1395,6 @@ X-Xss-Protection: 0
               "syncWaitSecs": "20"
             },
             "sourceFormat": "hierarchy"
-          },
-          "hierarchyController": {
-            "enableHierarchicalResourceQuota": true,
-            "enablePodTreeLabels": true,
-            "enabled": true
           },
           "version": "1.18.1"
         }
@@ -1440,7 +1430,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1454,11 +1444,6 @@ X-Xss-Protection: 0
             "syncWaitSecs": "20"
           },
           "sourceFormat": "hierarchy"
-        },
-        "hierarchyController": {
-          "enableHierarchicalResourceQuota": true,
-          "enablePodTreeLabels": true,
-          "enabled": true
         },
         "version": "1.18.1"
       }
@@ -1480,7 +1465,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1539,7 +1524,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1551,7 +1536,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1585,7 +1570,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1595,7 +1580,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1616,9 +1601,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership"
   }
@@ -1626,7 +1611,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1644,7 +1629,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-basic-acm-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/create.yaml
@@ -20,6 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-basic-acm-${uniqueId}
   featureRef:

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/dependencies.yaml
@@ -102,7 +102,7 @@ metadata:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
   name: gkehubmembership-basic-acm-${uniqueId}
 spec:
-  location: global
+  location: us-central1
   authority:
     issuer: https://container.googleapis.com/v1/projects/${TEST_DEPENDENT_ORG_PROJECT_ID_WITHOUT_QUOTATION}/locations/us-central1-a/clusters/gke-basic-acm-${uniqueId}
   description: A sample GKE Hub membership

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/update.yaml
@@ -20,7 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-basic-acm-${uniqueId}
   featureRef:
@@ -38,8 +38,4 @@ spec:
         syncWaitSecs: "20"
         syncRev: "HEAD"
         secretType: "none"
-    hierarchyController:
-      enabled: true
-      enablePodTreeLabels: true
-      enableHierarchicalResourceQuota: true
     version: "1.18.1"

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_generated_object_fullacmgkehubfeaturemembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_generated_object_fullacmgkehubfeaturemembership.golden.yaml
@@ -25,15 +25,11 @@ spec:
         syncRev: 264b37c21ef77165d8639d77b23d4ebb8fee053c
         syncWaitSecs: "30"
       sourceFormat: hierarchy
-    hierarchyController:
-      enableHierarchicalResourceQuota: false
-      enablePodTreeLabels: false
-      enabled: false
     version: 1.18.2
   featureRef:
     name: gkehubfeature-full-acm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-full-acm-${uniqueId}
   projectRef:

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
@@ -974,7 +974,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -992,14 +992,14 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships?alt=json&membershipId=gkehubmembership-full-acm-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-full-acm-${uniqueId}
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1017,7 +1017,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}"
 }
 
 200 OK
@@ -1036,14 +1036,14 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}"
 }
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1064,9 +1064,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership",
     "authority": {
@@ -1087,7 +1087,7 @@ X-Xss-Protection: 0
       "cnrm-test": "true",
       "managed-by-cnrm": "true"
     },
-    "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}",
+    "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}",
     "state": {
       "code": "READY"
     },
@@ -1098,7 +1098,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1132,7 +1132,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1176,7 +1176,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1190,11 +1190,6 @@ User-Agent: kcc/controller-manager
             "syncWaitSecs": "20"
           },
           "sourceFormat": "hierarchy"
-        },
-        "hierarchyController": {
-          "enableHierarchicalResourceQuota": true,
-          "enablePodTreeLabels": true,
-          "enabled": true
         },
         "version": "1.18.1"
       }
@@ -1256,7 +1251,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1270,11 +1265,6 @@ X-Xss-Protection: 0
               "syncWaitSecs": "20"
             },
             "sourceFormat": "hierarchy"
-          },
-          "hierarchyController": {
-            "enableHierarchicalResourceQuota": true,
-            "enablePodTreeLabels": true,
-            "enabled": true
           },
           "version": "1.18.1"
         }
@@ -1310,7 +1300,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1324,11 +1314,6 @@ X-Xss-Protection: 0
             "syncWaitSecs": "20"
           },
           "sourceFormat": "hierarchy"
-        },
-        "hierarchyController": {
-          "enableHierarchicalResourceQuota": true,
-          "enablePodTreeLabels": true,
-          "enabled": true
         },
         "version": "1.18.1"
       }
@@ -1350,7 +1335,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1365,7 +1350,6 @@ User-Agent: kcc/controller-manager
           },
           "sourceFormat": "hierarchy"
         },
-        "hierarchyController": {},
         "version": "1.18.2"
       }
     }
@@ -1427,7 +1411,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1442,7 +1426,6 @@ X-Xss-Protection: 0
             },
             "sourceFormat": "hierarchy"
           },
-          "hierarchyController": {},
           "version": "1.18.2"
         }
       }
@@ -1477,7 +1460,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1492,7 +1475,6 @@ X-Xss-Protection: 0
           },
           "sourceFormat": "hierarchy"
         },
-        "hierarchyController": {},
         "version": "1.18.2"
       }
     }
@@ -1513,7 +1495,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1572,7 +1554,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1584,7 +1566,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1618,7 +1600,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1628,7 +1610,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1649,9 +1631,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership"
   }
@@ -1659,7 +1641,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1677,7 +1659,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-full-acm-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/create.yaml
@@ -20,7 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-full-acm-${uniqueId}
   featureRef:
@@ -38,8 +38,4 @@ spec:
         syncWaitSecs: "20"
         syncRev: "HEAD"
         secretType: "none"
-    hierarchyController:
-      enabled: true
-      enablePodTreeLabels: true
-      enableHierarchicalResourceQuota: true
     version: "1.18.1"

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/dependencies.yaml
@@ -102,7 +102,7 @@ metadata:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
   name: gkehubmembership-full-acm-${uniqueId}
 spec:
-  location: global
+  location: us-central1
   authority:
     issuer: https://container.googleapis.com/v1/projects/${TEST_DEPENDENT_ORG_PROJECT_ID_WITHOUT_QUOTATION}/locations/us-central1-a/clusters/gke-full-acm-${uniqueId}
   description: A sample GKE Hub membership

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/update.yaml
@@ -20,7 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-full-acm-${uniqueId}
   featureRef:
@@ -38,8 +38,4 @@ spec:
         syncWaitSecs: "30"
         syncRev: "264b37c21ef77165d8639d77b23d4ebb8fee053c"
         secretType: "none"
-    hierarchyController:
-      enabled: false
-      enablePodTreeLabels: false
-      enableHierarchicalResourceQuota: false
     version: "1.18.2"

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_generated_object_meshgkehubfeaturemembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_generated_object_meshgkehubfeaturemembership.golden.yaml
@@ -15,7 +15,7 @@ spec:
   featureRef:
     name: gkehubfeature-mesh-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-mesh-${uniqueId}
   mesh:

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
@@ -883,7 +883,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -901,14 +901,14 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships?alt=json&membershipId=gkehubmembership-mesh-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-mesh-${uniqueId}
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -926,7 +926,7 @@ User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}"
 }
 
 200 OK
@@ -945,14 +945,14 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}"
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}"
 }
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -973,9 +973,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership",
     "authority": {
@@ -996,7 +996,7 @@ X-Xss-Protection: 0
       "cnrm-test": "true",
       "managed-by-cnrm": "true"
     },
-    "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}",
+    "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}",
     "state": {
       "code": "READY"
     },
@@ -1007,7 +1007,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1041,7 +1041,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1085,7 +1085,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
       "mesh": {
         "management": "MANAGEMENT_MANUAL"
       }
@@ -1147,7 +1147,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
         "mesh": {
           "management": "MANAGEMENT_MANUAL"
         }
@@ -1183,7 +1183,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
       "mesh": {
         "management": "MANAGEMENT_MANUAL"
       }
@@ -1205,7 +1205,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
       "mesh": {
         "management": "MANAGEMENT_AUTOMATIC"
       }
@@ -1268,7 +1268,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
         "mesh": {
           "management": "MANAGEMENT_AUTOMATIC"
         }
@@ -1304,7 +1304,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
       "mesh": {
         "management": "MANAGEMENT_AUTOMATIC"
       }
@@ -1326,7 +1326,7 @@ User-Agent: kcc/controller-manager
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
   },
   "name": "projects/example-project-01/locations/global/features/servicemesh",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1385,7 +1385,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
     },
     "name": "projects/example-project-01/locations/global/features/servicemesh",
     "resourceState": {
@@ -1397,7 +1397,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1431,7 +1431,7 @@ X-Xss-Protection: 0
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}",
   "state": {
     "code": "READY"
   },
@@ -1441,7 +1441,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1462,9 +1462,9 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.OperationMetadata",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "target": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}"
+    "target": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}"
   },
-  "name": "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}",
+  "name": "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.gkehub.v1beta1.Membership"
   }
@@ -1472,7 +1472,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -1490,7 +1490,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 404,
-    "message": "membership \"projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}\" not found",
+    "message": "membership \"projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}\" not found",
     "status": "NOT_FOUND"
   }
 }
@@ -1518,7 +1518,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/global/memberships/gkehubmembership-mesh-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
   },
   "name": "projects/example-project-01/locations/global/features/servicemesh",
   "updateTime": "2024-04-01T12:34:56.123456Z"

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/create.yaml
@@ -20,6 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-mesh-${uniqueId}
   featureRef:

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/dependencies.yaml
@@ -90,7 +90,7 @@ metadata:
     cnrm.cloud.google.com/project-id: ${TEST_DEPENDENT_ORG_PROJECT_ID}
   name: gkehubmembership-mesh-${uniqueId}
 spec:
-  location: global
+  location: us-central1
   authority:
     issuer: https://container.googleapis.com/v1/projects/${TEST_DEPENDENT_ORG_PROJECT_ID_WITHOUT_QUOTATION}/locations/us-central1-a/clusters/gke-mesh-${uniqueId}
   description: A sample GKE Hub membership

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/update.yaml
@@ -20,7 +20,7 @@ spec:
   projectRef:
     name: gkehubfm-${uniqueId}
   location: global
-  membershipLocation: global
+  membershipLocation: us-central1
   membershipRef:
     name: gkehubmembership-mesh-${uniqueId}
   featureRef:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
* Use regional membership instead of global one to deflake the parallel tests.
* Removed HNC fields in the tests as it is deprecated  https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/gkehub_v1beta1_gkehubfeaturemembership.yaml#L245



### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
