### PR TITLE
(Part 3)Fix diffs in compute forwarding rule: remove `networkTier` field from global forwarding rule

### DIFF
--- a/pkg/controller/direct/compute/forwardingrule_controller.go
+++ b/pkg/controller/direct/compute/forwardingrule_controller.go
@@ -299,6 +299,11 @@ func (a *forwardingRuleAdapter) Create(ctx context.Context, createOp *directbase
 	var err error
 	op := &gcp.Operation{}
 	if a.id.location == "global" {
+		// todo(yuhou): TF does not support networkTier field for global forwarding rule
+		// It will always use GCP's default value, which is "PREMIUM." Any value set by the user will be ignored and not sent to GCP.
+		// To align with the TF controller, I remove this field.
+		// Ideally, direct controller should support this field and validate that the value.
+		forwardingRule.NetworkTier = nil
 		req := &computepb.InsertGlobalForwardingRuleRequest{
 			ForwardingRuleResource: forwardingRule,
 			Project:                a.id.project,

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrulefull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrulefull/_http.log
@@ -770,7 +770,6 @@ x-goog-request-params: project=${projectId}
   ],
   "name": "computeglobalforwardingrule-${uniqueId}",
   "network": "projects/${projectId}/global/networks/${networkID}",
-  "networkTier": "PREMIUM",
   "portRange": "80",
   "target": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/targetHttpProxies/computetargethttpproxy-${uniqueId}"
 }


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Based on #2723. To review the change, check the last commit in this PR.

TF does not support networkTier field for global forwarding rule, It will always use GCP's default value "PREMIUM". Any value set by the user will be ignored and not sent to GCP.

Not sure if that's an ideal behavior, but let's try to match TF controller at this point.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
