### PR TITLE
(Part 4)Fix diffs in compute forwarding rule: normalize `IPAddress` in golden logs

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrule/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrule/_http.log
@@ -747,7 +747,7 @@ User-Agent: kcc/controller-manager
 x-goog-request-params: project=${projectId}
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "description": "A global forwarding rule",
   "labels": {
     "cnrm-test": "true",
@@ -840,7 +840,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",
@@ -919,7 +919,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",
@@ -1031,7 +1031,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrulefull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeforwardingrule/globalcomputeforwardingrulefull/_http.log
@@ -747,7 +747,7 @@ User-Agent: kcc/controller-manager
 x-goog-request-params: project=${projectId}
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "description": "A global forwarding rule",
   "ipVersion": "IPV4",
@@ -854,7 +854,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",
@@ -945,7 +945,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",
@@ -1112,7 +1112,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "IPAddress": "0.0.0.0",
+  "IPAddress": "8.8.8.8",
   "IPProtocol": "TCP",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "description": "A global forwarding rule",

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -527,6 +527,9 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					addReplacement("natIP", "192.0.0.10")
 					addReplacement("labelFingerprint", "abcdef0123A=")
 					addReplacement("fingerprint", "abcdef0123A=")
+					// Matches the mock ip address of Compute forwarding rule
+					addReplacement("IPAddress", "8.8.8.8")
+
 					// Extract resource targetID numbers from compute operations
 					for _, event := range events {
 						body := event.Response.ParseBody()


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
based on #2724, check the last commit in this PR

When executing the tests against realGCP, the ip address will be generated by GCP if not provided. Normalize the ip address to be `8.8.8.8` as the fake ip we wrote in ComputeAddress mock server, to avoid diffs between mock and real.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
