### PR TITLE
Updating makefile to get latest changes for cloud/kms api

### DIFF
--- a/mockgcp/Makefile
+++ b/mockgcp/Makefile
@@ -143,4 +143,9 @@ generate-protos-from-openapi:
 	mkdir -p apis/mockgcp/cloud/ids/v1/
 	cd tools/gapic; go run . --proto-version=2 --proto-package mockgcp.cloud.ids.v1 ../../temp/ids-api-v1.json > ../../apis/mockgcp/cloud/ids/v1/service.proto
 
+
+	wget -O temp/ids-api-v1.json https://raw.githubusercontent.com/googleapis/google-api-go-client/main/cloudkms/v1/cloudkms-api.json
+	mkdir -p apis/mockgcp/cloud/cloudkms/v1/
+	cd tools/gapic; go run . --proto-version=2 --proto-package mockgcp.cloud.kms.v1 ../../temp/kms-api-v1.json > ../../apis/mockgcp/cloud/kms/v1/service.proto
+
 	rm -r temp


### PR DESCRIPTION
### To sync CloudKMS autokey proto from googleapi

Working on supporting cloudkms autokey feature via KCC. As a first step syncing cloud kms api proto.

### Tests you have done
- [X] Run `make ready-pr` to ensure this PR is ready for review. (done)
- [ ] Perform necessary E2E testing for changed resources. (NA)
