### PR TITLE
Set default values to immutable and optional spec fields for certain kinds

### DIFF
--- a/pkg/krmtotf/krmtotf.go
+++ b/pkg/krmtotf/krmtotf.go
@@ -124,6 +124,25 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 	if err != nil {
 		return nil, nil, fmt.Errorf("error running custom flatteners: %w", err)
 	}
+	// Set desired state with default values.
+	defaultingMap := map[string]map[string]string{
+		"CloudBuildTrigger": {
+			"location": "global",
+		},
+		"CloudIdentityGroup": {
+			"initialGroupConfig": "EMPTY",
+		},
+		"FirestoreIndex": {
+			"database": "(default)",
+		},
+	}
+	if defaults, ok := defaultingMap[r.Kind]; ok {
+		for field, value := range defaults {
+			if v, ok := config[field]; !ok || v == "" {
+				config[field] = value
+			}
+		}
+	}
 	state := InstanceStateToMap(r.TFResource, liveState)
 	config, err = withResourceCustomResolvers(config, state, r.Kind, r.TFResource)
 	if err != nil {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Shift-left the defaulting of the following spec fields to the TF controller fix the unexpected diffs in re-reconciliation when there is no change in the CR:

* `spec.location` in `CloudBuildTrigger`.
* `spec.initialGroupConfig` in `CloudIdentityGroup`.
* `spec.database` in `FirestoreIndex`.

This looks like an old bug and was only exposed when `state-into-spec: absent` became the default configuration.

More context: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2704#issue-2529378867

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
