### PR TITLE
Update release-1.123.md with announcement about state-into-spec absent

### DIFF
--- a/docs/releasenotes/release-1.123.md
+++ b/docs/releasenotes/release-1.123.md
@@ -8,6 +8,15 @@
   contributions to this release.
 TODO: list contributors with `git log v1.122.0... | grep Merge | grep from | awk '{print $6}' | cut -d '/' -f 1 | sort | uniq`
 
+## Announcement
+
+* Starting from this version, all the new CRs (CustomResources) will have the `cnrm.cloud.google.com/state-into-spec`
+  annotation defaulted to `absent`. This means Config Connector will not populate any unspecified fields into the
+  `spec` after a successful reconciliation of the resource. The behavior of existing CRs will not be impacted. More
+  details about the Absent behavior can be found
+  [here](https://cloud.google.com/config-connector/docs/concepts/ignore-unspecified-fields#absent).
+
+
 ## Direct Cloud Reconciler:
 
 * `BigQueryDataTransferConfig` (v1alpha1)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Added the announcement that all the new CRs will by default support `state-into-spec: absent` since v1.123.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
