### PR TITLE
dev:tool: small fix for interface type

### DIFF
--- a/dev/tools/controllerbuilder/pkg/gocode/ast.go
+++ b/dev/tools/controllerbuilder/pkg/gocode/ast.go
@@ -145,9 +145,7 @@ func (p *Package) inspect(packageName string, pkg *ast.Package) error {
 			case *ast.Ident:
 				// type alias
 			case *ast.InterfaceType:
-				if n.Name.String() == "ExternalNormalizer" {
-					// skip this for now
-				}
+				// always skip, nothing to generate for interface
 			default:
 				errs = append(errs, fmt.Errorf("unhandled type spec in %q: %T, %+v", n.Name, n.Type, n.Type))
 			}

--- a/dev/tools/controllerbuilder/pkg/gocode/ast.go
+++ b/dev/tools/controllerbuilder/pkg/gocode/ast.go
@@ -144,6 +144,10 @@ func (p *Package) inspect(packageName string, pkg *ast.Package) error {
 				}
 			case *ast.Ident:
 				// type alias
+			case *ast.InterfaceType:
+				if n.Name.String() == "ExternalNormalizer" {
+					// skip this for now
+				}
 			default:
 				errs = append(errs, fmt.Errorf("unhandled type spec in %q: %T, %+v", n.Name, n.Type, n.Type))
 			}
@@ -155,9 +159,8 @@ func (p *Package) inspect(packageName string, pkg *ast.Package) error {
 			// A CommentGroup contains a list of comments
 			// Do not truncate comments when we encounter the group
 		default:
-			if n != nil {
-				comments = nil
-			}
+			// n != nil
+			comments = nil
 		}
 
 		return true


### PR DESCRIPTION
When running the mapper tool (example: 

```
go run main.go generate-mapper \
     --service google.cloud.bigquery.analyticshub.v1 \
     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
     --output-dir $REPO_ROOT/pkg/controller/direct/ \
     --api-dir $REPO_ROOT/apis \
     --api-go-package-path $REPO_ROOT/apis/bigqueryanalyticshub \
     --api-version "bigqueryanalyticshub.cnrm.cloud.google.com/v1alpha1"
```
), I ran into the following err:

```
...
inspecting go code: loading package "<MY_PATH>/kcc/8/k8s-config-connector/apis/refs/v1beta1": inspecting package "v1beta1": unhandled type spec in "ExternalNormalizer": *ast.InterfaceType, &{Interface:24559 Methods:0xc00d5d7620 Incomplete:false}
exit status 1
```