### PR TITLE
test: second PR to update mutable fields for bigQueryDataset

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_export_fullybigquerydataset.golden
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_export_fullybigquerydataset.golden
@@ -9,19 +9,22 @@ metadata:
   name: bigquerydataset${uniqueId}
 spec:
   access:
+  - domain: google.com
+    role: READER
   - role: OWNER
     specialGroup: projectOwners
+  - role: OWNER
+    userByEmail: user@google.com
   defaultCollation: und:ci
   defaultEncryptionConfiguration:
     kmsKeyRef:
       external: projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}
-  defaultPartitionExpirationMs: 3600000
-  defaultTableExpirationMs: 3600000
-  description: Fully Configured BigQuery Dataset
-  friendlyName: bigquerydataset-fullyconfigured
-  isCaseInsensitive: true
+  defaultPartitionExpirationMs: 3800000
+  defaultTableExpirationMs: 3800000
+  description: Fully Configured BigQuery Dataset updated
+  friendlyName: bigquerydataset-fullyconfigured-updated
   location: US
-  maxTimeTravelHours: "72"
+  maxTimeTravelHours: "96"
   projectRef:
     external: ${projectId}
   resourceID: bigquerydataset${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_object_fullybigquerydataset.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_object_fullybigquerydataset.golden.yaml
@@ -14,19 +14,23 @@ metadata:
   namespace: ${uniqueId}
 spec:
   access:
+  - domain: google.com
+    role: READER
   - role: OWNER
     specialGroup: projectOwners
-  defaultCollation: und:ci
+  - role: OWNER
+    userByEmail: user@google.com
+  defaultCollation: ""
   defaultEncryptionConfiguration:
     kmsKeyRef:
       name: kmscryptokey-${uniqueId}
-  defaultPartitionExpirationMs: 3600000
-  defaultTableExpirationMs: 3600000
-  description: Fully Configured BigQuery Dataset
-  friendlyName: bigquerydataset-fullyconfigured
-  isCaseInsensitive: true
+  defaultPartitionExpirationMs: 3800000
+  defaultTableExpirationMs: 3800000
+  description: Fully Configured BigQuery Dataset updated
+  friendlyName: bigquerydataset-fullyconfigured-updated
+  isCaseInsensitive: false
   location: US
-  maxTimeTravelHours: "72"
+  maxTimeTravelHours: "96"
   projectRef:
     external: ${projectId}
   resourceID: bigquerydataset${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_object_fullybigquerydataset.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_generated_object_fullybigquerydataset.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 2
+  generation: 3
   labels:
     cnrm-test: "true"
   name: bigquerydataset${uniqueId}
@@ -41,5 +41,5 @@ status:
   creationTime: "1970-01-01T00:00:00Z"
   etag: abcdef123456
   lastModifiedTime: "1970-01-01T00:00:00Z"
-  observedGeneration: 2
+  observedGeneration: 3
   selfLink: https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_http.log
@@ -423,6 +423,137 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
     "managed-by-cnrm": "true"
   },
   "location": "US",
+  "maxTimeTravelHours": "72"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydataset${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "defaultCollation": "und:ci",
+  "defaultEncryptionConfiguration": {
+    "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+  },
+  "defaultPartitionExpirationMs": "3600000",
+  "defaultTableExpirationMs": "3600000",
+  "description": "Fully Configured BigQuery Dataset",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerydataset-fullyconfigured",
+  "id": "000000000000000000000",
+  "isCaseInsensitive": true,
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "maxTimeTravelHours": "72",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydataset${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "defaultCollation": "und:ci",
+  "defaultEncryptionConfiguration": {
+    "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+  },
+  "defaultPartitionExpirationMs": "3600000",
+  "defaultTableExpirationMs": "3600000",
+  "description": "Fully Configured BigQuery Dataset",
+  "etag": "abcdef0123A=",
+  "friendlyName": "bigquerydataset-fullyconfigured",
+  "id": "000000000000000000000",
+  "isCaseInsensitive": true,
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "US",
+  "maxTimeTravelHours": "72",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+PUT https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    }
+  ],
+  "datasetReference": {
+    "datasetId": "bigquerydataset${uniqueId}"
+  },
+  "defaultCollation": "und:ci",
+  "defaultEncryptionConfiguration": {
+    "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+  },
+  "defaultPartitionExpirationMs": 3600000,
+  "defaultTableExpirationMs": 3600000,
+  "description": "Fully Configured BigQuery Dataset",
+  "friendlyName": "bigquerydataset-fullyconfigured",
+  "isCaseInsensitive": true,
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "US",
   "maxTimeTravelHours": "72",
   "storageBillingModel": "LOGICAL"
 }

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/_http.log
@@ -533,6 +533,14 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
 {
   "access": [
     {
+      "domain": "google.com",
+      "role": "READER"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
       "role": "OWNER",
       "specialGroup": "projectOwners"
     }
@@ -544,17 +552,16 @@ User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 t
   "defaultEncryptionConfiguration": {
     "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
   },
-  "defaultPartitionExpirationMs": 3600000,
-  "defaultTableExpirationMs": 3600000,
-  "description": "Fully Configured BigQuery Dataset",
-  "friendlyName": "bigquerydataset-fullyconfigured",
-  "isCaseInsensitive": true,
+  "defaultPartitionExpirationMs": 3800000,
+  "defaultTableExpirationMs": 3800000,
+  "description": "Fully Configured BigQuery Dataset updated",
+  "friendlyName": "bigquerydataset-fullyconfigured-updated",
   "labels": {
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
   "location": "US",
-  "maxTimeTravelHours": "72",
+  "maxTimeTravelHours": "96",
   "storageBillingModel": "LOGICAL"
 }
 
@@ -574,6 +581,14 @@ X-Xss-Protection: 0
     {
       "role": "OWNER",
       "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "domain": "google.com",
+      "role": "READER"
     }
   ],
   "creationTime": "123456789",
@@ -585,13 +600,12 @@ X-Xss-Protection: 0
   "defaultEncryptionConfiguration": {
     "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
   },
-  "defaultPartitionExpirationMs": "3600000",
-  "defaultTableExpirationMs": "3600000",
-  "description": "Fully Configured BigQuery Dataset",
+  "defaultPartitionExpirationMs": "3800000",
+  "defaultTableExpirationMs": "3800000",
+  "description": "Fully Configured BigQuery Dataset updated",
   "etag": "abcdef0123A=",
-  "friendlyName": "bigquerydataset-fullyconfigured",
+  "friendlyName": "bigquerydataset-fullyconfigured-updated",
   "id": "000000000000000000000",
-  "isCaseInsensitive": true,
   "kind": "bigquery#dataset",
   "labels": {
     "cnrm-test": "true",
@@ -599,7 +613,7 @@ X-Xss-Protection: 0
   },
   "lastModifiedTime": "123456789",
   "location": "US",
-  "maxTimeTravelHours": "72",
+  "maxTimeTravelHours": "96",
   "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset${uniqueId}",
   "storageBillingModel": "LOGICAL",
   "type": "DEFAULT"
@@ -627,6 +641,14 @@ X-Xss-Protection: 0
     {
       "role": "OWNER",
       "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "domain": "google.com",
+      "role": "READER"
     }
   ],
   "creationTime": "123456789",
@@ -638,13 +660,12 @@ X-Xss-Protection: 0
   "defaultEncryptionConfiguration": {
     "kmsKeyName": "projects/${projectId}/locations/us/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
   },
-  "defaultPartitionExpirationMs": "3600000",
-  "defaultTableExpirationMs": "3600000",
-  "description": "Fully Configured BigQuery Dataset",
+  "defaultPartitionExpirationMs": "3800000",
+  "defaultTableExpirationMs": "3800000",
+  "description": "Fully Configured BigQuery Dataset updated",
   "etag": "abcdef0123A=",
-  "friendlyName": "bigquerydataset-fullyconfigured",
+  "friendlyName": "bigquerydataset-fullyconfigured-updated",
   "id": "000000000000000000000",
-  "isCaseInsensitive": true,
   "kind": "bigquery#dataset",
   "labels": {
     "cnrm-test": "true",
@@ -652,7 +673,7 @@ X-Xss-Protection: 0
   },
   "lastModifiedTime": "123456789",
   "location": "US",
-  "maxTimeTravelHours": "72",
+  "maxTimeTravelHours": "96",
   "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydataset${uniqueId}",
   "storageBillingModel": "LOGICAL",
   "type": "DEFAULT"

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/create.yaml
@@ -33,4 +33,3 @@ spec:
   access:
     - role: OWNER
       specialGroup: projectOwners
-  storageBillingModel: LOGICAL

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerydataset/fullybigquerydataset/update.yaml
@@ -17,20 +17,24 @@ kind: BigQueryDataset
 metadata:
   name: bigquerydataset${uniqueId}
 spec:
-  description: "Fully Configured BigQuery Dataset"
-  friendlyName: bigquerydataset-fullyconfigured
-  defaultPartitionExpirationMs: 3600000
-  defaultTableExpirationMs: 3600000
-  defaultCollation: und:ci
+  description: "Fully Configured BigQuery Dataset updated"
+  friendlyName: bigquerydataset-fullyconfigured-updated
+  defaultPartitionExpirationMs: 3800000
+  defaultTableExpirationMs: 3800000
+  defaultCollation: ""
   defaultEncryptionConfiguration:
     kmsKeyRef:
       name: kmscryptokey-${uniqueId}
-  isCaseInsensitive: true
+  isCaseInsensitive: false
   location: US
-  maxTimeTravelHours: "72"
+  maxTimeTravelHours: "96"
   projectRef:
     external: ${projectId}
   access:
     - role: OWNER
       specialGroup: projectOwners
+    - role: READER
+      domain: google.com
+    - role: OWNER
+      userByEmail: bigquerydataset-dep@${projectId}.iam.gserviceaccount.co
   storageBillingModel: LOGICAL


### PR DESCRIPTION
Run the test against real GCP with annotation to set the state-into-spec to both absent and merge, without setting the storagebillingmodel.
| state-into-spec | storagebillingmodel in create.yaml | storagebillingmodel in golden object yaml |
| ----------------|----------------------------------- | ------------------------------------------| 
| absent                | Not set                                               | Not populated                                               |
| merge                 | Not set                                               | Not populated                                               |

If annotations are not set explicitly in the `create.yaml` file, it will default to absent and in the golden object yaml file, the storagebillingmodel will not be defaulted to any value by the controller as well.

In the request sent to the server recorded in the http log, storagebillingmodel is also not set.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
