### PR TITLE
mockgcp: we don't need the alloydb maintenance_update_policy patch any more

### DIFF
--- a/mockgcp/apply-proto-patches.sh
+++ b/mockgcp/apply-proto-patches.sh
@@ -26,26 +26,28 @@ cd ${REPO_ROOT}/mockgcp
 
 cd tools/patch-proto
 
-# Use our proto patch tool to add the missing maintenanceUpdatePolicy field for alloydb
-# TODO: Remove once the public protos are updated
-go run . --file ${REPO_ROOT}/mockgcp/third_party/googleapis/google/cloud/alloydb/v1beta/resources.proto --message Cluster <<EOF
-  // MaintenanceUpdatePolicy defines the policy for system updates.
-  message MaintenanceUpdatePolicy {
-    // MaintenanceWindow specifies a preferred day and time for maintenance.
-    message MaintenanceWindow {
-      // Preferred day of the week for maintenance, e.g. MONDAY, TUESDAY, etc.
-      google.type.DayOfWeek day = 1;
+# This is an example proto patch; the maintenance_update_policy field has now been added upstream,
+# so we don't need it, but we are keeping it as a comment here for reference.
+#
+# # Use our proto patch tool to add the missing maintenanceUpdatePolicy field for alloydb
+# go run . --file ${REPO_ROOT}/mockgcp/third_party/googleapis/google/cloud/alloydb/v1beta/resources.proto --message Cluster <<EOF
+#   // MaintenanceUpdatePolicy defines the policy for system updates.
+#   message MaintenanceUpdatePolicy {
+#     // MaintenanceWindow specifies a preferred day and time for maintenance.
+#     message MaintenanceWindow {
+#       // Preferred day of the week for maintenance, e.g. MONDAY, TUESDAY, etc.
+#       google.type.DayOfWeek day = 1;
 
-      // Preferred time to start the maintenance operation on the specified day.
-      // Maintenance will start within 1 hour of this time.
-      google.type.TimeOfDay start_time = 2;
-    }
+#       // Preferred time to start the maintenance operation on the specified day.
+#       // Maintenance will start within 1 hour of this time.
+#       google.type.TimeOfDay start_time = 2;
+#     }
 
-    // Preferred windows to perform maintenance. Currently limited to 1.
-    repeated MaintenanceWindow maintenance_windows = 1;
-  }
+#     // Preferred windows to perform maintenance. Currently limited to 1.
+#     repeated MaintenanceWindow maintenance_windows = 1;
+#   }
 
-  // The maintenance update policy determines when to allow or deny updates.
-  MaintenanceUpdatePolicy maintenance_update_policy = 32;
-EOF
+#   // The maintenance update policy determines when to allow or deny updates.
+#   MaintenanceUpdatePolicy maintenance_update_policy = 32;
+# EOF
 


### PR DESCRIPTION
maintenance_update_policy has now been published in the public protos.

Keep it around as a comment though, so we know how to use this for next time - it isn't trivial.
