### PR TITLE
tools: add default values to type and mapper generator flags

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
@@ -17,6 +17,7 @@ package generatemapper
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/codegen"
@@ -36,8 +37,16 @@ type GenerateMapperOptions struct {
 	OutputMapperDirectory string
 }
 
-func (o *GenerateMapperOptions) InitDefaults() {
-
+func (o *GenerateMapperOptions) InitDefaults() error {
+	root, err := options.RepoRoot()
+	if err != nil {
+		return nil
+	}
+	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
+	o.APIGoPackagePath = "github.com/GoogleCloudPlatform/k8s-config-connector/apis/"
+	o.APIDirectory = root + "/apis/"
+	o.OutputMapperDirectory = root + "/pkg/controller/direct/"
+	return nil
 }
 
 func (o *GenerateMapperOptions) BindFlags(cmd *cobra.Command) {
@@ -51,7 +60,10 @@ func BuildCommand(baseOptions *options.GenerateOptions) *cobra.Command {
 		GenerateOptions: baseOptions,
 	}
 
-	opt.InitDefaults()
+	if err := opt.InitDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing defaults: %v\n", err)
+		os.Exit(1)
+	}
 
 	cmd := &cobra.Command{
 		Use:   "generate-mapper",

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -17,6 +17,7 @@ package generatetypes
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"unicode"
 
@@ -37,7 +38,14 @@ type GenerateCRDOptions struct {
 	ResourceProtoName  string
 }
 
-func (o *GenerateCRDOptions) InitDefaults() {
+func (o *GenerateCRDOptions) InitDefaults() error {
+	root, err := options.RepoRoot()
+	if err != nil {
+		return nil
+	}
+	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
+	o.OutputAPIDirectory = root + "/apis/"
+	return nil
 }
 
 func (o *GenerateCRDOptions) BindFlags(cmd *cobra.Command) {
@@ -51,7 +59,10 @@ func BuildCommand(baseOptions *options.GenerateOptions) *cobra.Command {
 		GenerateOptions: baseOptions,
 	}
 
-	opt.InitDefaults()
+	if err := opt.InitDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing defaults: %v\n", err)
+		os.Exit(1)
+	}
 
 	cmd := &cobra.Command{
 		Use:   "generate-types",

--- a/dev/tools/controllerbuilder/pkg/options/generateoptions.go
+++ b/dev/tools/controllerbuilder/pkg/options/generateoptions.go
@@ -14,7 +14,12 @@
 
 package options
 
-import "github.com/spf13/cobra"
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 type GenerateOptions struct {
 	ProtoSourcePath string
@@ -29,4 +34,14 @@ func (o *GenerateOptions) BindPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.ProtoSourcePath, "proto-source-path", o.ProtoSourcePath, "path to (compiled) proto for APIs")
 	cmd.PersistentFlags().StringVarP(&o.APIVersion, "api-version", "v", o.APIVersion, "the KRM API version. used to import the KRM API")
 	cmd.PersistentFlags().StringVarP(&o.ServiceName, "service", "s", o.ServiceName, "the GCP service name")
+}
+
+func RepoRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	repoRoot := strings.TrimSpace(string(output))
+	return repoRoot, nil
 }


### PR DESCRIPTION
Add default values to some of the flags used by type generator and mapper generator. So that users do not need to specify them.