### PR TITLE
refactor: use new externalRef convention

### DIFF
--- a/pkg/controller/direct/dataform/repository_controller.go
+++ b/pkg/controller/direct/dataform/repository_controller.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const ctrlName = "dataform-controller"
+const ctrlName = "dataform-repository-controller"
 
 func init() {
 	registry.RegisterModel(krm.DataformRepositoryGVK, NewModel)
@@ -95,6 +95,30 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 		return nil, fmt.Errorf("cannot resolve location")
 	}
 
+	var id *DataformRepositoryIdentity
+	externalRef := direct.ValueOf(obj.Status.ExternalRef)
+	if externalRef == "" {
+		id = BuildID(projectID, location, resourceID)
+	} else {
+		id, err = asID(externalRef)
+		if err != nil {
+			return nil, err
+		}
+
+		if id.project != projectID {
+			return nil, fmt.Errorf("DataformRepository %s/%s has spec.projectRef changed, expect %s, got %s",
+				u.GetNamespace(), u.GetName(), id.project, projectID)
+		}
+		if id.location != location {
+			return nil, fmt.Errorf("DataformRepository %s/%s has spec.location changed, expect %s, got %s",
+				u.GetNamespace(), u.GetName(), id.location, location)
+		}
+		if id.dataform != resourceID {
+			return nil, fmt.Errorf("DataformRepository  %s/%s has metadata.name or spec.resourceID changed, expect %s, got %s",
+				u.GetNamespace(), u.GetName(), id.dataform, resourceID)
+		}
+	}
+
 	if err := resolveOptionalRefs(ctx, reader, obj); err != nil {
 		return nil, fmt.Errorf("failed to resolve resource references %w", err)
 	}
@@ -104,11 +128,9 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 		return nil, err
 	}
 	return &Adapter{
-		resourceID: resourceID,
-		projectID:  projectID,
-		gcpClient:  gcpClient,
-		location:   location,
-		desired:    obj,
+		id:        id,
+		gcpClient: gcpClient,
+		desired:   obj,
 	}, nil
 }
 
@@ -150,28 +172,26 @@ func (m *model) AdapterForURL(ctx context.Context, url string) (directbase.Adapt
 }
 
 type Adapter struct {
-	resourceID string
-	projectID  string
-	location   string
-	gcpClient  *gcp.Client
-	desired    *krm.DataformRepository
-	actual     *dataformpb.Repository
+	id        *DataformRepositoryIdentity
+	gcpClient *gcp.Client
+	desired   *krm.DataformRepository
+	actual    *dataformpb.Repository
 }
 
 var _ directbase.Adapter = &Adapter{}
 
 func (a *Adapter) Find(ctx context.Context) (bool, error) {
-	if a.resourceID == "" {
+	if a.id.dataform == "" {
 		return false, nil
 	}
 
-	req := &dataformpb.GetRepositoryRequest{Name: a.fullyQualifiedName()}
+	req := &dataformpb.GetRepositoryRequest{Name: a.id.FullyQualifiedName()}
 	actual, err := a.gcpClient.GetRepository(ctx, req)
 	if err != nil {
 		if direct.IsNotFound(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("getting DataformRepository %q: %w", a.fullyQualifiedName(), err)
+		return false, fmt.Errorf("getting DataformRepository %q: %w", a.id.FullyQualifiedName(), err)
 	}
 
 	a.actual = actual
@@ -184,14 +204,6 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating object", "u", u)
 
-	projectID := a.projectID
-	if projectID == "" {
-		return fmt.Errorf("project is empty")
-	}
-	if a.resourceID == "" {
-		return fmt.Errorf("resourceID is empty")
-	}
-
 	desired := a.desired.DeepCopy()
 	mapCtx := &direct.MapContext{}
 	resource := DataformRepositorySpec_ToProto(mapCtx, &desired.Spec)
@@ -200,9 +212,9 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	}
 
 	req := &dataformpb.CreateRepositoryRequest{
-		Parent:       a.getParent(),
+		Parent:       a.id.Parent(),
 		Repository:   resource,
-		RepositoryId: a.resourceID,
+		RepositoryId: a.id.dataform,
 	}
 	_, err := a.gcpClient.CreateRepository(ctx, req)
 	if err != nil {
@@ -210,7 +222,7 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	}
 
 	status := &krm.DataformRepositoryStatus{}
-	status.ExternalRef = direct.LazyPtr(a.fullyQualifiedName())
+	status.ExternalRef = a.id.AsExternalRef()
 
 	// TODO(acpana): add observed state
 	return setStatus(u, status)
@@ -262,7 +274,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 		return fmt.Errorf("converting DataformRepository spec to api: %w", mapCtx.Err())
 	}
 
-	resource.Name = a.fullyQualifiedName()
+	resource.Name = a.id.FullyQualifiedName()
 	req := &dataformpb.UpdateRepositoryRequest{UpdateMask: updateMask, Repository: resource}
 	_, err := a.gcpClient.UpdateRepository(ctx, req)
 	if err != nil {
@@ -270,7 +282,6 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	}
 
 	status := &krm.DataformRepositoryStatus{}
-	status.ExternalRef = direct.LazyPtr(a.fullyQualifiedName())
 
 	// TODO(acpana): add observed state
 	return setStatus(u, status)
@@ -283,24 +294,12 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 
 // Delete implements the Adapter interface.
 func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
-	if a.resourceID == "" {
-		return false, nil
-	}
-
-	req := &dataformpb.DeleteRepositoryRequest{Name: a.fullyQualifiedName()}
+	req := &dataformpb.DeleteRepositoryRequest{Name: a.id.FullyQualifiedName()}
 	if err := a.gcpClient.DeleteRepository(ctx, req); err != nil {
-		return false, fmt.Errorf("deleting DataformRepository %s: %w", a.fullyQualifiedName(), err)
+		return false, fmt.Errorf("deleting DataformRepository %s: %w", a.id.FullyQualifiedName(), err)
 	}
 
 	return true, nil
-}
-
-func (a *Adapter) fullyQualifiedName() string {
-	return fmt.Sprintf("projects/%s/locations/%s/repositories/%s", a.projectID, a.location, a.resourceID)
-}
-
-func (a *Adapter) getParent() string {
-	return fmt.Sprintf("projects/%s/locations/%s", a.projectID, a.location)
 }
 
 func setStatus(u *unstructured.Unstructured, typedStatus any) error {
@@ -313,6 +312,7 @@ func setStatus(u *unstructured.Unstructured, typedStatus any) error {
 	if old != nil {
 		status["conditions"] = old["conditions"]
 		status["observedGeneration"] = old["observedGeneration"]
+		status["externalRef"] = old["externalRef"]
 	}
 
 	u.Object["status"] = status

--- a/pkg/controller/direct/dataform/repository_externalresource.go
+++ b/pkg/controller/direct/dataform/repository_externalresource.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataform
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	serviceDomain = "//dataform.googleapis.com"
+)
+
+type DataformRepositoryIdentity struct {
+	project  string
+	location string
+	dataform string
+}
+
+// Parent builds a DataformRepository parent of the format projects/<project>/locations/<location>
+func (c *DataformRepositoryIdentity) Parent() string {
+	return fmt.Sprintf("projects/%s/locations/%s", c.project, c.location)
+}
+
+// FullyQualifiedName builds a DataformRepository resource of the format projects/<project>/locations/<location>/repositories/<dataformRepository>
+func (c *DataformRepositoryIdentity) FullyQualifiedName() string {
+	return fmt.Sprintf("projects/%s/locations/%s/repositories/%s", c.project, c.location, c.dataform)
+}
+
+// AsExternalRef builds a externalRef from a DataformRepositoryIdentity
+func (c *DataformRepositoryIdentity) AsExternalRef() *string {
+	e := serviceDomain + "/" + c.FullyQualifiedName()
+	return &e
+}
+
+// asID builds a DataformRepositoryIdentity from a externalRef
+func asID(externalRef string) (*DataformRepositoryIdentity, error) {
+	if !strings.HasPrefix(externalRef, serviceDomain) {
+		return nil, fmt.Errorf("externalRef should have prefix %s, got %s", serviceDomain, externalRef)
+	}
+	path := strings.TrimPrefix(externalRef, serviceDomain+"/")
+	tokens := strings.Split(path, "/")
+	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "repositories" {
+		return nil, fmt.Errorf("externalRef should be %s/projects/<project>/locations/<location>/repositories/<dataform_repository>, got %s",
+			serviceDomain, externalRef)
+	}
+	return &DataformRepositoryIdentity{
+		project:  tokens[1],
+		location: tokens[3],
+		dataform: tokens[5],
+	}, nil
+}
+
+// BuildID builds a DataformRepositoryIdentity from resource components.
+func BuildID(project, location, dataform string) *DataformRepositoryIdentity {
+	return &DataformRepositoryIdentity{
+		project:  project,
+		location: location,
+		dataform: dataform,
+	}
+}

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-base/_generated_object_dataformrepository-base.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-base/_generated_object_dataformrepository-base.golden.yaml
@@ -22,5 +22,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  externalRef: projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}
+  externalRef: //dataform.googleapis.com/projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}
   observedGeneration: 1

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_generated_object_dataformrepository-full.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_generated_object_dataformrepository-full.golden.yaml
@@ -26,5 +26,5 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  externalRef: projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}
+  externalRef: //dataform.googleapis.com/projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}
   observedGeneration: 2


### PR DESCRIPTION
Refactor DataformRepository's externalRef as per https://github.com/yuwenma/k8s-config-connector/blob/real-id/docs/develop-resources/api-conventions/external-reference.md