### PR TITLE
refactor: use resource name in ctrl name

### DIFF
--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -74,7 +74,7 @@ import (
 )
 
 const (
-	ctrlName = "{{.KCCService}}-controller"
+	ctrlName = "{{.KCCService}}-{{.ProtoResource | ToLower }}-controller"
     // TODO(user): Confirm service domain
 	serviceDomain = "//{{.KCCService}}.googleapis.com"
 )


### PR DESCRIPTION
As I'm working with more resources in the BigQueryAnalyticsHub service group, I want to start adding nice-ness to the tooling when having more than one resource.