### PR TITLE
tools: fix naming mismatch on ObservedState in template

### DIFF
--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -231,7 +231,7 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	log.V(2).Info("successfully created {{.ProtoResource}}", "name", a.id.FullyQualifiedName())
 
 	status := &krm.{{.Kind}}Status{}
-	status.ObservedState = {{.Kind}}StatusObservedState_FromProto(mapCtx, created)
+	status.ObservedState = {{.Kind}}ObservedState_FromProto(mapCtx, created)
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
@@ -279,7 +279,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	log.V(2).Info("successfully updated {{.ProtoResource}}", "name", a.id.FullyQualifiedName())
 
 	status := &krm.{{.Kind}}Status{}
-	status.ObservedState = {{.Kind}}StatusObservedState_FromProto(mapCtx, updated)
+	status.ObservedState = {{.Kind}}ObservedState_FromProto(mapCtx, updated)
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}


### PR DESCRIPTION
Fix naming mismatch between
https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/93278d704875450549554368b37a5742f8c29856/dev/tools/controllerbuilder/template/controller/controller.go#L234
and 
https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/93278d704875450549554368b37a5742f8c29856/dev/tools/controllerbuilder/template/apis/types.go#L70