### PR TITLE
Fix broken Golang install, and make installed version managed by upda…

### DIFF
--- a/dev/codebots/update-golang-version
+++ b/dev/codebots/update-golang-version
@@ -36,6 +36,11 @@ for f in $(git ls-files 'Dockerfile*' '**/Dockerfile*'); do
   sed -i -e "s/FROM golang:[0-9.]*/FROM golang:$GO_VERSION/g" $f
 done
 
+# Update golang setup script version
+cd ${REPO_ROOT}
+sed -i "s|^GO_VERSION=.*|GO_VERSION=\"$GO_VERSION\"|" scripts/environment-setup/golang-setup.sh
+echo "Updating scripts/environment-setup/golang-setup.sh to go version $GO_VERSION"
+
 # Ignore third_party changes
 cd ${REPO_ROOT}
 git checkout -- third_party/

--- a/scripts/environment-setup/golang-setup.sh
+++ b/scripts/environment-setup/golang-setup.sh
@@ -16,10 +16,9 @@
 # Script to set up golang on cloudtop
 set -o errexit
 
-# This will pull the current go version used in the repository
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd ${REPO_ROOT}
-GO_VERSION=`cat go.mod | grep -P -o "(?<=^go ).*"`
+# Automatically updated by dev/codebots/update-golang-version
+GO_VERSION="1.22.6"
+
 sudo apt-get install wget
 wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
 sudo tar -xvzf go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

The `scripts/environment-setup/golang-setup.sh` setup script as part of the first time contributor setup is broken. This is caused by Go version 1.21+ no longer trimming the patch version for the `0` patch release (https://go.dev/doc/go1.21#introduction).

Updated the install script to use an explicit `GO_VERSION` variable, and added logic to `dev/codebots/update-golang-version` to update this based on the go toolchain version.



### Tests you have done

Tested the installation, and the `update-golang-version` script.
