### PR TITLE
Delete unit test TestAllServicesInMap

### DIFF
--- a/pkg/test/constants/presubmitconstants_test.go
+++ b/pkg/test/constants/presubmitconstants_test.go
@@ -14,44 +14,16 @@
 package testconstants
 
 import (
-	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/fileutil"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/slice"
 )
 
-func TestAllServicesInMap(t *testing.T) {
-	testDataPath := repo.GetBasicIntegrationTestDataPath()
-	services, err := fileutil.SubdirsIn(testDataPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	smLoader, err := servicemappingloader.New()
-	if err != nil {
-		t.Fatalf("error loading service mappings: %v", err)
-	}
-	autoGenOnlyGroup := smLoader.GetAutoGenOnlyGroups()
-	for _, s := range services {
-		group := fmt.Sprintf("%s.cnrm.cloud.google.com", s)
-		if _, ok := autoGenOnlyGroup[group]; ok {
-			// Services with only auto-generated resources can be excluded from
-			// presubmit test suite.
-			continue
-		}
-		if skip, ok := skipCRUDTests[s]; ok && skip {
-			continue
-		}
-		if _, ok := RepresentativeCRUDTestsForAllServices[s]; !ok {
-			t.Fatalf("Missing an entry in the `RepresentativeCRUDTestsForAllServices` map for service: %s", s)
-		}
-	}
-}
 func TestMappedServicesExistInDir(t *testing.T) {
 	testDataPath := repo.GetBasicIntegrationTestDataPath()
 	services, err := fileutil.SubdirsIn(testDataPath)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Presubmit constants are rarely used these days and covering all services in map is no longer important. Removing TestAllServicesInMap to reduce cost to maintain the constant whenever a new service is supported.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
