### PR TITLE
refactor:ci: selectively run pause tests

### DIFF
--- a/scripts/github-actions/ga-pause-test.sh
+++ b/scripts/github-actions/ga-pause-test.sh
@@ -23,8 +23,21 @@ source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
 	fetch_tools && \
 	setup_envs
 
+if [[ -z "${RUN_TESTS:-}" ]]; then
+  RUN_TESTS=""
+  RUN_TESTS+="TestPauseInSeries/fixtures/iamserviceaccount" # IAM
+  RUN_TESTS+="|TestPauseInSeries/fixtures/logbucketmetric" # Direct
+  RUN_TESTS+="|TestPauseInSeries/fixtures/cloudidsendpoint" # DCL
+  RUN_TESTS+="|TestPauseInSeries/fixtures/computemanagedsslcertificate" # TF
+  RUN_TESTS+="|TestPauseInSeries/fixtures/billingaccountiampolicy" # IAM
+  RUN_TESTS+="|TestPauseInSeries/fixtures/billingaccountiampolicymember" # IAM
+  RUN_TESTS+="|TestPauseInSeries/fixtures/organizationiampolicy" # IAM
+  RUN_TESTS+="|TestPauseInSeries/fixtures/organizationiampolicymember" # IAM
+fi
+echo "Running tests matching: ${RUN_TESTS}"
+
 cd ${REPO_ROOT}/
-echo "Running mock e2e pause tests..."
+echo "Running mock e2e pause tests for select fixtures..."
 E2E_KUBE_TARGET=envtest \
 	RUN_E2E=1 GOLDEN_REQUEST_CHECKS=1 E2E_GCP_TARGET=mock \
-	go test -test.count=1 -timeout 1h30m -v ./tests/e2e -run TestPauseInSeries 2>&1
+	go test -test.count=1 -timeout 1h30m -v ./tests/e2e -run $RUN_TESTS 2>&1


### PR DESCRIPTION
When I first added the e2e pause tests, the idea was for us to make sure that when KCC is paused, we don't send requests to GCP. We easily do this with mocks (check the log). As we've added more fixtures tests, the run time has ballooned and I think it's overly ambitious to run these for every fixture. 

A given KCC resource will use one of the 4 controllers:

- the Direct controller
- the Terraform (TF) controller
- the DCL controller
- a hand-rolled/ special controller (usually IAM related)

So if any resource can be reduced to one of the 4 categories, it is sufficient (and necessary) to only test an example of each flavor of controller. 

This change will significantly decrease the runtime for the ci job for pause while still fully testing the feature functionality.