### PR TITLE
fix: Adjust sqlinstance-datacacheconfig test case for tf controller

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/create.yaml
@@ -25,6 +25,10 @@ spec:
   settings:
     dataCacheConfig:
       dataCacheEnabled: false
+    # The legacy terraform-based reconciler cannot update ENTERPRISE -> ENTERPRISE_PLUS
+    # edition at the same time as changing dataCacheEnabled false -> true. However, the
+    # direct controller is able to perform this update. So, for the direct controller
+    # test case, we will specify `edition: ENTERPRISE` here.
     edition: ENTERPRISE
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/_http.log
@@ -41,7 +41,7 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
     "availabilityType": "ZONAL",
     "dataCacheConfig": {},
     "dataDiskType": "PD_SSD",
-    "edition": "ENTERPRISE",
+    "edition": "ENTERPRISE_PLUS",
     "locationPreference": {
       "zone": "us-central1-a"
     },
@@ -219,7 +219,7 @@ X-Xss-Protection: 0
     "dataDiskSizeGb": "10",
     "dataDiskType": "PD_SSD",
     "deletionProtectionEnabled": false,
-    "edition": "ENTERPRISE",
+    "edition": "ENTERPRISE_PLUS",
     "ipConfiguration": {
       "authorizedNetworks": [],
       "ipv4Enabled": true,

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
@@ -24,7 +24,10 @@ spec:
   settings:
     dataCacheConfig:
       dataCacheEnabled: false
-    edition: ENTERPRISE
+    # The legacy terraform-based reconciler cannot update ENTERPRISE -> ENTERPRISE_PLUS
+    # edition at the same time as changing dataCacheEnabled false -> true. Therefore,
+    # we must set `edition: ENTERPRISE_PLUS` here.
+    edition: ENTERPRISE_PLUS
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone
     # preference based on availability. Therefore it could potentially vary if not


### PR DESCRIPTION
TF-based controller cannot update the edition at the same time as modifying dataCacheEnabled.