### PR TITLE
refactor: kind aware codegen tools

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
@@ -74,7 +74,9 @@ func (f *generatedFile) Write(addCopyright bool) error {
 		return nil
 	}
 
-	dir := f.OutputDir()
+	// This will make it such that if f.key.FileName defines a directory too,
+	// we can write out the folder path
+	dir := filepath.Dir(filepath.Join(f.OutputDir(), f.key.FileName))
 
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory %q: %w", dir, err)
@@ -88,7 +90,7 @@ func (f *generatedFile) Write(addCopyright bool) error {
 
 	f.contents.WriteTo(&w)
 
-	p := filepath.Join(dir, f.key.FileName)
+	p := filepath.Join(f.OutputDir(), f.key.FileName)
 	klog.Infof("writing file %v", p)
 	if err := os.WriteFile(p, w.Bytes(), 0644); err != nil {
 		return fmt.Errorf("writing %q: %w", p, err)

--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -42,13 +42,15 @@ var protoMessagesNotMappedToGoStruct = map[string]string{
 type TypeGenerator struct {
 	generatorBase
 	goPackage             string
+	goKind                string
 	resourceProtoFullName string
 	visitedMessages       []protoreflect.MessageDescriptor
 }
 
-func NewTypeGenerator(goPackage string, outputBaseDir, resourceProtoFullName string) *TypeGenerator {
+func NewTypeGenerator(goKind, goPackage, outputBaseDir, resourceProtoFullName string) *TypeGenerator {
 	g := &TypeGenerator{
 		goPackage:             goPackage,
+		goKind:                goKind,
 		resourceProtoFullName: resourceProtoFullName,
 	}
 	g.generatorBase.init(outputBaseDir)
@@ -116,7 +118,7 @@ func (g *TypeGenerator) writeVisitedMessages() {
 
 		k := generatedFileKey{
 			GoPackage: g.goPackage,
-			FileName:  "types.generated.go",
+			FileName:  strings.ToLower(g.goKind) +".types.generated.go",
 		}
 		out := g.getOutputFile(k)
 

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -129,8 +129,9 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 		}
 	}
 
+	kind := o.ResourceKindName
 	resourceProtoFullName := o.ServiceName + "." + o.ResourceProtoName
-	typeGenerator := codegen.NewTypeGenerator(goPackage, o.OutputAPIDirectory, resourceProtoFullName)
+	typeGenerator := codegen.NewTypeGenerator(kind, goPackage, o.OutputAPIDirectory, resourceProtoFullName)
 	if err := typeGenerator.VisitProto(api); err != nil {
 		return err
 	}
@@ -140,7 +141,6 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 		return err
 	}
 
-	kind := o.ResourceKindName
 	if !scaffolder.TypeFileNotExist(kind) {
 		fmt.Printf("file %s already exists, skipping\n", scaffolder.GetTypeFile(kind))
 	} else {

--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -72,7 +72,7 @@ func generateController(service, kind string, cArgs *ccTemplate.ControllerArgs) 
 		return err
 	}
 
-	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>_controller.go
+	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>/<resource>_controller.go
 	if err := WriteToFile(controllerFilePath, controllerOutput.Bytes()); err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func generateControllerHelpers(service, kind string, cArgs *ccTemplate.Controlle
 	return nil
 }
 
-func buildResourcePath(service, filename string) (string, error) {
+func buildResourcePath(service, kind, filename string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get current working directory: %w", err)
@@ -119,7 +119,7 @@ func buildResourcePath(service, filename string) (string, error) {
 		return "", fmt.Errorf("get absolute path %s: %w", pwd, err)
 	}
 	seg := strings.Split(abs, currRelPath)
-	controllerDir := filepath.Join(seg[0], directControllerRelPath, service)
+	controllerDir := filepath.Join(seg[0], directControllerRelPath, service, kind)
 	err = os.MkdirAll(controllerDir, os.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("create controller directory %s: %w", controllerDir, err)
@@ -136,11 +136,13 @@ func buildResourcePath(service, filename string) (string, error) {
 }
 
 func buildControllerPath(service, kind string) (string, error) {
-	return buildResourcePath(service, strings.ToLower(kind)+"_controller.go")
+	kind = strings.ToLower(kind)
+	return buildResourcePath(service, kind, kind + "_controller.go")
 }
 
 func buildExternalResourcePath(service, kind string) (string, error) {
-	return buildResourcePath(service, strings.ToLower(kind)+"_externalresource.go")
+	kind = strings.ToLower(kind)
+	return buildResourcePath(service, kind, kind + "_externalresource.go")
 }
 
 func FormatImports(path string, out []byte) error {

--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -42,7 +42,7 @@ const ControllerTemplate = `
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {{.KCCService}}
+package {{.Kind | ToLower }}
 
 import (
 	"context"

--- a/dev/tools/controllerbuilder/template/controller/externalresource.go
+++ b/dev/tools/controllerbuilder/template/controller/externalresource.go
@@ -29,7 +29,7 @@ const ExternalResourceTemplate = `
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {{.KCCService}}
+package {{.Kind | ToLower }}
 
 import (
 	"fmt"


### PR DESCRIPTION
I've reworked the 3 cmds (generate-types, generate-mapper and add) to be kind aware. The new structure for `apis`:

```
bigqueryanalyticshub
├─v1alpha1
└─v1beta1
   ├─ dataexchangelisting _types.go
   ├─ dataexchange _types.go
   ├─ shared_types.go
   │--doc.go
   └─group_version.go
  ``` 

and for the `controller`:

```
bigqueryanalyticshub
├─dataexchange
|─dataexchangelisting
|   ├─dataexchangelisting_controller.go
|   ├─dataexchangelisting_externalresource.go
|   └─dataexchangelisting_mapper.generated.go
└ mapper.generated.go
   ```
NOTES:
* the `mapper.generated.go` is a catch all but ideally all relevant mappings should be in each file; I will follow on about this but for now the structure is more important
* the `shared_types.go` is more to share the direction that we are going in; the tooling doesn't support this yet but I/ we can explore that out of band.

Reviewers:
* PR is best viewed by commits