### PR TITLE
fix: Fix sqlinstance-datacacheconfig periodic

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/_http.log
@@ -47,7 +47,7 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
     },
     "pricingPlan": "PER_USE",
     "storageAutoResize": true,
-    "tier": "db-custom-1-3840",
+    "tier": "db-perf-optimized-N-2",
     "userLabels": {
       "cnrm-test": "true",
       "managed-by-cnrm": "true"
@@ -235,7 +235,7 @@ X-Xss-Protection: 0
     "settingsVersion": "123",
     "storageAutoResize": true,
     "storageAutoResizeLimit": "0",
-    "tier": "db-custom-1-3840",
+    "tier": "db-perf-optimized-N-2",
     "userLabels": {
       "cnrm-test": "true",
       "managed-by-cnrm": "true"

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
@@ -34,4 +34,5 @@ spec:
     # explicity specified.
     locationPreference:
       zone: us-central1-a
-    tier: db-custom-1-3840
+    # ENTERPRISE_PLUS edition requires using preset (non-custom) tiers.
+    tier: db-perf-optimized-N-2


### PR DESCRIPTION
Missed this required update in the previous fix: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2832