### PR TITLE
chore: mark *.generated.go as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 mockgcp/generated/** linguist-generated=true
 pkg/clients/generated/** linguist-generated=true
+**/*.generated.go linguist-generated=true
 
 **/go.sum linguist-generated=true


### PR DESCRIPTION
This should make PR review a bit easier.
