### PR TITLE
refactor: make add cmd kind aware

### DIFF
--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -72,7 +72,7 @@ func generateController(service, kind string, cArgs *ccTemplate.ControllerArgs) 
 		return err
 	}
 
-	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>_controller.go
+	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>/<resource>_controller.go
 	if err := WriteToFile(controllerFilePath, controllerOutput.Bytes()); err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func generateControllerHelpers(service, kind string, cArgs *ccTemplate.Controlle
 	return nil
 }
 
-func buildResourcePath(service, filename string) (string, error) {
+func buildResourcePath(service, kind, filename string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get current working directory: %w", err)
@@ -119,7 +119,7 @@ func buildResourcePath(service, filename string) (string, error) {
 		return "", fmt.Errorf("get absolute path %s: %w", pwd, err)
 	}
 	seg := strings.Split(abs, currRelPath)
-	controllerDir := filepath.Join(seg[0], directControllerRelPath, service)
+	controllerDir := filepath.Join(seg[0], directControllerRelPath, service, kind)
 	err = os.MkdirAll(controllerDir, os.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("create controller directory %s: %w", controllerDir, err)
@@ -136,11 +136,13 @@ func buildResourcePath(service, filename string) (string, error) {
 }
 
 func buildControllerPath(service, kind string) (string, error) {
-	return buildResourcePath(service, strings.ToLower(kind)+"_controller.go")
+	kind = strings.ToLower(kind)
+	return buildResourcePath(service, kind, kind + "_controller.go")
 }
 
 func buildExternalResourcePath(service, kind string) (string, error) {
-	return buildResourcePath(service, strings.ToLower(kind)+"_externalresource.go")
+	kind = strings.ToLower(kind)
+	return buildResourcePath(service, kind, kind + "_externalresource.go")
 }
 
 func FormatImports(path string, out []byte) error {

--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -42,7 +42,7 @@ const ControllerTemplate = `
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {{.KCCService}}
+package {{.Kind | ToLower }}
 
 import (
 	"context"

--- a/dev/tools/controllerbuilder/template/controller/externalresource.go
+++ b/dev/tools/controllerbuilder/template/controller/externalresource.go
@@ -29,7 +29,7 @@ const ExternalResourceTemplate = `
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {{.KCCService}}
+package {{.Kind | ToLower }}
 
 import (
 	"fmt"


### PR DESCRIPTION
Breaking off from https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2839, cherry-picked the controller part of the effort which is more straightforward than the types gen.