### PR TITLE
chore: Remove '+optional' marker from types template

### DIFF
--- a/apis/bigquery/v1beta1/bigquerydataset_types.go
+++ b/apis/bigquery/v1beta1/bigquerydataset_types.go
@@ -28,7 +28,6 @@ var BigQueryDatasetGVK = GroupVersion.WithKind("BigQueryDataset")
 // +kcc:proto=google.cloud.bigquery.v2.dataset
 type BigQueryDatasetSpec struct {
 	// The BigQueryDataset name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// An array of objects that define dataset access for one or more entities.

--- a/apis/bigqueryconnection/v1alpha1/connection_types.go
+++ b/apis/bigqueryconnection/v1alpha1/connection_types.go
@@ -39,7 +39,6 @@ type BigQueryConnectionConnectionSpec struct {
 
 	// The BigQuery ConnectionID. This is a server-generated ID in the UUID format.
 	// If not provided, ConfigConnector will create a new Connection and store the UUID in `status.serviceGeneratedID` field.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// User provided display name for the connection.

--- a/apis/bigquerydatatransfer/v1alpha1/bigquerydatatransferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1alpha1/bigquerydatatransferconfig_types.go
@@ -85,7 +85,6 @@ type BigQueryDataTransferConfigSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// Immutable.
 	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Data transfer schedule.

--- a/apis/bigtable/v1beta1/bigtableinstance_types.go
+++ b/apis/bigtable/v1beta1/bigtableinstance_types.go
@@ -28,7 +28,6 @@ var (
 // +kcc:proto=google.bigtable.admin.v2.Instance
 type BigtableInstanceSpec struct {
 	// The Instance name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	//     // The unique name of the instance. Values are of the form

--- a/apis/cloudbuild/v1beta1/workerpool_types.go
+++ b/apis/cloudbuild/v1beta1/workerpool_types.go
@@ -32,7 +32,6 @@ type CloudBuildWorkerPoolSpec struct {
 	DisplayName string `json:"displayName,omitempty"`
 
 	// The `WorkerPool` name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// +required

--- a/apis/firestore/v1alpha1/firestoredatabase_types.go
+++ b/apis/firestore/v1alpha1/firestoredatabase_types.go
@@ -32,7 +32,6 @@ type FirestoreDatabaseSpec struct {
 	ProjectRef v1beta1.ProjectRef `json:"projectRef"`
 
 	// The FirestoreDatabase name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// The location of the database. Available locations are listed at

--- a/apis/networkconnectivity/v1alpha1/networkconnectivityserviceconnectionpolicy_types.go
+++ b/apis/networkconnectivity/v1alpha1/networkconnectivityserviceconnectionpolicy_types.go
@@ -40,7 +40,6 @@ type NetworkConnectivityServiceConnectionPolicySpec struct {
 	Location *string `json:"location"`
 
 	// The NetworkConnectivityServiceConnectionPolicy name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// A description of this resource.

--- a/apis/redis/v1alpha1/rediscluster_types.go
+++ b/apis/redis/v1alpha1/rediscluster_types.go
@@ -33,7 +33,6 @@ type RedisClusterSpec struct {
 	Location *string `json:"location"`
 
 	// The RedisCluster name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. The authorization mode of the Redis cluster.

--- a/apis/secretmanager/v1beta1/secretmanagersecret_types.go
+++ b/apis/secretmanager/v1beta1/secretmanagersecret_types.go
@@ -31,7 +31,6 @@ type SecretManagerSecretSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// Immutable.
 	// The SecretManagerSecret name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Immutable. The replication policy of the secret data attached to

--- a/apis/workstations/v1alpha1/workstationcluster_types.go
+++ b/apis/workstations/v1alpha1/workstationcluster_types.go
@@ -39,7 +39,6 @@ type WorkstationClusterSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// Immutable.
 	// The WorkstationCluster name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation cluster.

--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -43,7 +43,6 @@ type {{ .Kind }}Spec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// Immutable.
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `
 }
 

--- a/pkg/apis/common/v1alpha1/types.go
+++ b/pkg/apis/common/v1alpha1/types.go
@@ -21,7 +21,6 @@ import (
 
 type CommonSpec struct {
 	// The GCP resource identifier. If not given, the metadata.name will be used.
-	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// TODO: Do we still need a CommonSpec for resources that do not need project dependency? Those seems to be exceptional any ways.


### PR DESCRIPTION
It is optional (because omitempty is specified in the struct tag), and
our docs recommend only specifying '+required' markers.

Follow-on to https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2833#issuecomment-2389692484