### PR TITLE
chore: Remove "state-into-spec" annotation for sqlinstance tests

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/_generated_object_sqlinstance-activationpolicy-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/_generated_object_sqlinstance-activationpolicy-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-activationpolicy-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-activationpolicy-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-activationpolicy-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-activationpolicy-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/_generated_object_sqlinstance-auditconfig-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/_generated_object_sqlinstance-auditconfig-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-auditconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-auditconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-auditconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-auditconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/_generated_object_sqlinstance-authorizednetworks-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/_generated_object_sqlinstance-authorizednetworks-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-authorizednetworks-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-authorizednetworks-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-authorizednetworks-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-authorizednetworks-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/_generated_object_sqlinstance-backupconfiguration-binarylog-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/_generated_object_sqlinstance-backupconfiguration-binarylog-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-binarylog-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-binarylog-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-binarylog-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: MYSQL_5_7
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-binarylog-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: MYSQL_5_7
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/_generated_object_sqlinstance-backupconfiguration-pitr-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/_generated_object_sqlinstance-backupconfiguration-pitr-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-pitr-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-pitr-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-pitr-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-backupconfiguration-pitr-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_generated_object_sqlinstance-clone-minimal-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_generated_object_sqlinstance-clone-minimal-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-clone-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   cloneSource:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/dependencies.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-source-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/_generated_object_sqlinstance-connectorenforcement-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/_generated_object_sqlinstance-connectorenforcement-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-connectorenforcement-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-connectorenforcement-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-connectorenforcement-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-connectorenforcement-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/_generated_object_sqlinstance-databaseflags-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/_generated_object_sqlinstance-databaseflags-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-databaseflags-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-databaseflags-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-databaseflags-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-databaseflags-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_generated_object_sqlinstance-datacacheconfig-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_generated_object_sqlinstance-datacacheconfig-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-datacacheconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-datacacheconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-datacacheconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-datacacheconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/_generated_object_sqlinstance-deletionprotection-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/_generated_object_sqlinstance-deletionprotection-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-deletionprotection-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-deletionprotection-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-deletionprotection-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-deletionprotection-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/_generated_object_sqlinstance-denymaintenanceperiod-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/_generated_object_sqlinstance-denymaintenanceperiod-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-denymaintenanceperiod-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-denymaintenanceperiod-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-denymaintenanceperiod-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-denymaintenanceperiod-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/_generated_object_sqlinstance-encryptionkey-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/_generated_object_sqlinstance-encryptionkey-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/create.yaml
@@ -19,7 +19,6 @@ metadata:
     label-one: "value-one"
   name: sqlinstance-encryptionkey-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/update.yaml
@@ -19,7 +19,6 @@ metadata:
     label-one: "new-value"
   name: sqlinstance-encryptionkey-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey/create.yaml
@@ -18,8 +18,6 @@ metadata:
   labels:
     label-one: "value-one"
   name: sqlinstance-encryptionkey-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   encryptionKMSCryptoKeyRef:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey/update.yaml
@@ -18,8 +18,6 @@ metadata:
   labels:
     label-one: "new-value"
   name: sqlinstance-encryptionkey-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   encryptionKMSCryptoKeyRef:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/_generated_object_sqlinstance-insightsconfig-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/_generated_object_sqlinstance-insightsconfig-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-insightsconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-insightsconfig-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-insightsconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-insightsconfig-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/_generated_object_sqlinstance-locationpreference-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/_generated_object_sqlinstance-locationpreference-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-locationpreference-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-locationpreference-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-locationpreference-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-locationpreference-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/_generated_object_sqlinstance-maintenancewindow-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/_generated_object_sqlinstance-maintenancewindow-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-maintenancewindow-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-maintenancewindow-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-maintenancewindow-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-maintenancewindow-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/_generated_object_sqlinstance-multithreading-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/_generated_object_sqlinstance-multithreading-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-multithreading-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-multithreading-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-multithreading-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-multithreading-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/_generated_object_sqlinstance-mysql-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/_generated_object_sqlinstance-mysql-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/create.yaml
@@ -19,7 +19,6 @@ metadata:
     label-one: "value-one"
   name: sqlinstance-mysql-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/update.yaml
@@ -19,7 +19,6 @@ metadata:
     label-one: "value-one"
   name: sqlinstance-mysql-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/_generated_object_sqlinstance-mysql-minimal-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/_generated_object_sqlinstance-mysql-minimal-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-mysql-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-mysql-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: MYSQL_8_0

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-mysql-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: MYSQL_5_7
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-mysql-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: MYSQL_8_0
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/create.yaml
@@ -18,8 +18,6 @@ metadata:
   labels:
     label-one: "value-one"
   name: sqlinstance-mysql-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   region: us-central1
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql/update.yaml
@@ -18,8 +18,6 @@ metadata:
   labels:
     label-one: "value-one"
   name: sqlinstance-mysql-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   region: us-central1
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/_generated_object_sqlinstance-passwordvalidationpolicy-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/_generated_object_sqlinstance-passwordvalidationpolicy-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-passwordvalidationpolicy-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-passwordvalidationpolicy-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-passwordvalidationpolicy-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-passwordvalidationpolicy-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/_generated_object_sqlinstance-postgres-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/_generated_object_sqlinstance-postgres-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_9_6

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_9_6

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/_generated_object_sqlinstance-postgres-minimal-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/_generated_object_sqlinstance-postgres-minimal-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_9_6
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-postgres-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_9_6
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/_generated_object_sqlinstance-privatenetwork-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/_generated_object_sqlinstance-privatenetwork-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/_generated_object_sqlinstance-privatenetwork-legacyref-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/_generated_object_sqlinstance-privatenetwork-legacyref-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-legacyref-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-legacyref-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-legacyref-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-legacyref-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-privatenetwork-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_generated_object_sqlinstance-replica-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_generated_object_sqlinstance-replica-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-replica-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: MYSQL_5_7

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-replica-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: MYSQL_5_7
   instanceType: READ_REPLICA_INSTANCE

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/_generated_object_sqlinstance-sqlserver-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/_generated_object_sqlinstance-sqlserver-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/_generated_object_sqlinstance-sqlserver-minimal-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/_generated_object_sqlinstance-sqlserver-minimal-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-minimal-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-minimal-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2022_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-sqlserver-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: SQLSERVER_2019_EXPRESS
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/_generated_object_sqlinstance-ssl-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/_generated_object_sqlinstance-ssl-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-ssl-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-ssl-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_16

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-ssl-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-ssl-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_16
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/_generated_object_sqlinstance-storage-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/_generated_object_sqlinstance-storage-direct.golden.yaml
@@ -5,7 +5,6 @@ metadata:
     alpha.cnrm.cloud.google.com/reconciler: direct
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/project-id: ${projectId}
-    cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/create.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-storage-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/update.yaml
@@ -17,7 +17,6 @@ kind: SQLInstance
 metadata:
   name: sqlinstance-storage-direct-${uniqueId}
   annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
     alpha.cnrm.cloud.google.com/reconciler: "direct"
 spec:
   databaseVersion: POSTGRES_15

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage/create.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-storage-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage/update.yaml
@@ -16,8 +16,6 @@ apiVersion: sql.cnrm.cloud.google.com/v1beta1
 kind: SQLInstance
 metadata:
   name: sqlinstance-storage-${uniqueId}
-  annotations:
-    cnrm.cloud.google.com/state-into-spec: absent
 spec:
   databaseVersion: POSTGRES_15
   region: us-central1


### PR DESCRIPTION
It is no longer necessary to explicitly set "state-into-spec: absent" because the default is now default "absent".
