### PR TITLE
fix: Update ref template to return ReferenceNotReadyError

### DIFF
--- a/dev/tools/controllerbuilder/template/apis/refs.go
+++ b/dev/tools/controllerbuilder/template/apis/refs.go
@@ -80,8 +80,8 @@ func (r *{{.Kind}}Ref) NormalizedExternal(ctx context.Context, reader client.Rea
 	if err != nil {
 		return "", fmt.Errorf("reading status.externalRef: %w", err)
 	}
-	if actualExternalRef == "" {
-		return "", fmt.Errorf("{{.Kind}} is not ready yet")
+	if actualExternalRef == ""
+		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
 	r.External = actualExternalRef
 	return r.External, nil

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -40,6 +40,10 @@ func (e *ReferenceNotReadyError) Error() string {
 	return fmt.Sprintf("reference %v %v is not ready", e.RefResourceGVK.Kind, e.RefResource)
 }
 
+func NewReferenceNotReadyError(refResourceGVK schema.GroupVersionKind, refResource types.NamespacedName) *ReferenceNotReadyError {
+	return &ReferenceNotReadyError{refResourceGVK, refResource}
+}
+
 func NewReferenceNotReadyErrorForResource(r *Resource) *ReferenceNotReadyError {
 	return &ReferenceNotReadyError{
 		r.GroupVersionKind(),


### PR DESCRIPTION
This way, we will properly detect the source of the error being an unresolveable dependency and can requeue immediately once it's ready.
