### PR TITLE
docs: Update workflow for resource migration with reconciler annotation

### DIFF
--- a/docs/develop-resources/guides/4-add-controller.md
+++ b/docs/develop-resources/guides/4-add-controller.md
@@ -41,11 +41,16 @@ hack/compare-mock fixtures/<your_resource_test>
 
 ### Existing DCL/TF based resource
 
-```
-KCC_USE_DIRECT_RECONCILERS=<YOUR KIND> hack/compare-mock fixtures/<your_resource_test>
-```
+Copy all existing test cases and add `-direct` suffix to the test names [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/61e85e1fc5f48de8c5c652cdb73aae48dd7dfecf/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance).
+
+Enable direct controller for the the new test cases by setting the annotation `alpha.cnrm.cloud.google.com/reconciler: direct` in `create.yaml` and `update.yaml`. [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/c0a77915723788e5068a819c93f22c4661e47b6b/pkg/test/resourcefixture/testdata/basic/dataflow/v1beta1/dataflowflextemplatejob/batchdataflowflextemplatejob-direct/create.yaml#L20)
+
+This will override the `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` annotations in the CRD and enable the direct controller for the new test cases. The previously-existing test cases will continue to use the TF/DCL-based controller.
+
+Verify the new `-direct` test cases have equivalent behavior to the existing test cases (though not necessarily the exact same API interactions, if the direct controller achieves the same end result differently than the TF/DCL-based controller).
 
 ### Exit Criteria
 
 * The PRs shall pass the MockGCP tests
 * The roundtrip fuzz tests shall cover all the fields in `spec `and `status.observedState `fields [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92)
+* There are equivalent Direct and TF/DCL-based mockgcp test cases, and all tests are passing.

--- a/docs/develop-resources/guides/5-releases.md
+++ b/docs/develop-resources/guides/5-releases.md
@@ -1,14 +1,10 @@
 # 5. Release
 
-## 5.1 Turn on your Direct controller (TF/DCL Beta Only)
+## 5.1 Make Direct controller the default (for migration from TF/DCL)
 
-### For TF-based Beta resource
+* Remove the `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` go tag from the CRD struct, and run `dev/tasks/generate-crds` to use Direct as the permanent controller.
 
-* Remove the `cnrm.cloud.google.com/tf2crd: "true"` label from the CRD will turn on SciFi controller. [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/196a4b9a28b59b17936a443d5b36bb65f3c42fd9/apis/apikeys/v1alpha1/apikey_type.go#L44)
-
-### For DCL-based Beta resource
-
-* Remove the `cnrm.cloud.google.com/dcl2crd: "true"` label from the CRD will turn on SciFi controller.
+* Remove all of the duplicate `-direct` mockgcp test cases, and re-record mockgcp interactions (now using direct controller instead of legacy TF/DCL).
 
 ## 5.2 Bump from v1alpha1 to v1beta1
 

--- a/docs/develop-resources/scenarios/migrate-tf-resource-alpha.md
+++ b/docs/develop-resources/scenarios/migrate-tf-resource-alpha.md
@@ -22,7 +22,7 @@ Follow [Step 2](../guides/2-define-apis.md)
 The PR shall contain the types and deepcopy codes. It shall follow the Direct resource recommended styles and conventions. (TODO add the link) **It can change the existing fields since this is a Alpha resource**.
 
 * We always start from Alpha resources. So the migration shall first be placed under `./apis/service>/v1alpha1`. Once the alpha resource is released, we then bump it to Beta.
-* Add `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` to the API tag [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92), to continue using TF-based controllers. 
+* Add `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` to the API tag [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92), to continue using TF-based controllers by default (for now).
 
 ### PR Reviews
 
@@ -39,10 +39,7 @@ This PR adds the Direct mapper. You can do this together with the previous step 
 
 Follow [Step 4](../guides/4-add-controller.md).
 
-* Use the `KCC_USE_DIRECT_RECONCILERS` flag [exampe](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/dev/tasks/run-e2e#L27). This will override the tf2crd and dcl2crd label to force using the Direct controller. 
-
-
 ### PR Reviews
 
 * We require the roundtrip fuzz tests to cover all the fields in `spec` and `status.observedState` fields [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92) (For mapper)
-* We require removing the `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` tags from the API and the presubmit test passes.
+* We require duplicating all existing test cases (by copying and adding `-direct` suffix to test names), and enabling the direct controller in the new test cases (by setting the `alpha.cnrm.cloud.google.com/reconciler: direct` annotation).

--- a/docs/develop-resources/scenarios/migrate-tf-resource-beta.md
+++ b/docs/develop-resources/scenarios/migrate-tf-resource-beta.md
@@ -23,7 +23,7 @@ The PR shall contain the types and deepcopy codes. It shall make modifications t
 
 * You may need to modify the auto-generated `types.go` to keep the existing fields the same (even if it is not following the recommended styles and conventions). You can run `dev/tasks/generate-crds` (repeatedly) to make sure the CRD are the same (comment changes are acceptable).
 
-* Add `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` to the API tag [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92), to continue using TF-based controllers. 
+* Add `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` to the API tag [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92), to continue using TF-based controllers by default (for now).
 
 * You may see some new fields added to the CRD. These are expected since the TF/DCL based resources could be out of date (and users are looking forward to these new fields!). You **shall comment out** those new fields using `/*NOTYET ..*/` in this PR if they are not supported in the TF-based controller yet (we will add them later).
 
@@ -43,10 +43,6 @@ The PR adds the Direct mapper. You can do this together with the previous step o
 
 Follow [Step 4](../guides/4-add-controller.md)
 
-* Use the `KCC_USE_DIRECT_RECONCILERS` flag [exampe](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/dev/tasks/run-e2e#L27). 
-
-*Tips* The `KCC_USE_DIRECT_RECONCILERS` will override the `tf2crd` and `dcl2crd` label to force using the Direct controller, but it will not affect the releases which will still use the TF/DCL based controllers until the Direct controller is ready. This allows developing the API and controller separately. 
-
 ### PR Reviews
 
 * We require the roundtrip fuzz tests to cover all the fields in `spec` and `status.observedState` fields [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92) (For mapper)
@@ -65,8 +61,7 @@ You need to update both `types.go` and `mapping.go`, and may need to adjust the 
 
 ## Release
 
-* Remove the `cnrm.cloud.google.com/dcl2crd: "true"` or `cnrm.cloud.google.com/tf2crd: "true"` go tag, and run `dev/tasks/generate-crds` to use Direct as the permanent controller (step 5)
-* Remove your resource from the `KCC_USE_DIRECT_RECONCILERS` flag since it is no longer needed.
+Follow [Step 5](../guides/5-releases.md)
 
 ### PR Reviews
 


### PR DESCRIPTION
This is the first step in removing KCC_USE_DIRECT_RECONCILERS, and switching over to using the user-configurable annotation instead.

This lets us simultaneously test/review the behavior of legacy TF/DCL-based controllers and the new direct controllers.
