### PR TITLE
Allow CC-BY-3.0 license

### DIFF
--- a/.github/license-lint-config.yml
+++ b/.github/license-lint-config.yml
@@ -18,6 +18,7 @@ unrestricted_licenses:
   - BSD-3-Clause
   - BSD-2-Clause
   - 0BSD
+  - CC-BY-3.0
 
 reciprocal_licenses:
   - MPL-2.0


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
license-lint became flaky after `github.com/apache/arrow/go/v15` is added to go.mod and sometimes fails with the following error at master HEAD:

```
ERROR: Some modules have unrecognized licenses:
  github.com/apache/arrow/go/v15: similar to CC-BY-3.0, 1.000000 confidence, path '/home/runner/go/pkg/mod/github.com/apache/arrow/go/v15@v15.0.2/LICENSE.txt'
```

Considering that `CC-BY-3.0` is a notice license that should be fine to allow, we should just add it to `unrestricted_licenses` list in the config.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
