### PR TITLE
fix: Direct controller exit criteria grammar

### DIFF
--- a/docs/develop-resources/guides/4-add-controller.md
+++ b/docs/develop-resources/guides/4-add-controller.md
@@ -47,5 +47,5 @@ KCC_USE_DIRECT_RECONCILERS=<YOUR KIND> hack/compare-mock fixtures/<your_resource
 
 ### Exit Criteria
 
-* The PRs shall pass the MockGCP tests
-* The roundtrip fuzz tests shall cover all the fields in `spec `and `status.observedState `fields [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92)
+* The PRs pass the MockGCP tests.
+* The roundtrip fuzz tests cover all the fields in `spec `and `status.observedState `fields [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/0bbac86ace6ab2f4051b574f026d5fe47fa05b75/pkg/controller/direct/redis/cluster/roundtrip_test.go#L92).


### PR DESCRIPTION
Original inspiration: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2860#discussion_r1790645953