### PR TITLE
Avoid loading CRDs when registering the webhook

### DIFF
--- a/pkg/webhook/register.go
+++ b/pkg/webhook/register.go
@@ -78,10 +78,7 @@ func GetCommonWebhookConfigs() ([]Config, error) {
 		return nil, fmt.Errorf("error getting new dcl schema loader: %w", err)
 	}
 	serviceMetadataLoader := metadata.New()
-	allGVKs, err := supportedgvks.All(smLoader, serviceMetadataLoader)
-	if err != nil {
-		return nil, fmt.Errorf("error loading all supported GVKs: %w", err)
-	}
+	allGVKs := supportedgvks.AllWithoutDirect(smLoader, serviceMetadataLoader)
 	allResourcesRules := getRulesFromResources(allGVKs)
 	dynamicResourcesRules := getRulesFromResources(supportedgvks.AllDynamicTypes(smLoader, serviceMetadataLoader))
 	handwrittenIamResourcesRules := getRulesFromResources(supportedgvks.BasedOnHandwrittenIAMTypes())


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Webhook failed with `unable to locate repo root in working directory "/"` because supportedgvks.All() calls LoadCRDs() which checks the local git path. This won't work if the webhook is registered/created at the path where a local [k8s-config-connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) Git repo doesn't exist. LoadCRDs() should only be called under the repo path.

Using supportedgvks.AllWithoutDirect() in the webhook instead to avoid loading CRDs.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
