### PR TITLE
tests: add discovery type

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/_generated_object_bigqueryanalyticshubdataexchange-base.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/_generated_object_bigqueryanalyticshubdataexchange-base.golden.yaml
@@ -12,6 +12,7 @@ metadata:
   name: bigqueryanalyticshubdataexchange${uniqueId}
   namespace: ${uniqueId}
 spec:
+  discoveryType: DISCOVERY_TYPE_PRIVATE
   displayName: my_data_exchange
   location: US
   projectRef:

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/_http.log
@@ -20,7 +20,7 @@ User-Agent: kcc/controller-manager
 x-goog-request-params: parent=projects%2F${projectId}%2Flocations%2FUS
 
 {
-  "discoveryType": 0,
+  "discoveryType": 1,
   "displayName": "my_data_exchange"
 }
 
@@ -30,7 +30,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "",
   "icon": "",
@@ -53,7 +53,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "",
   "icon": "",

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-base/create.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   displayName: my_data_exchange
   location: US
+  discoveryType: DISCOVERY_TYPE_PRIVATE
   projectRef:
     external: ${projectId}
   resourceID: bigqueryanalyticshubdataexchange${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_generated_object_bigqueryanalyticshubdataexchange-full.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_generated_object_bigqueryanalyticshubdataexchange-full.golden.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   description: example data exchange
-  discoveryType: DISCOVERY_TYPE_PRIVATE
+  discoveryType: DISCOVERY_TYPE_PUBLIC
   displayName: my_data_exchange
   documentation: an updated documentation
   location: US

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_http.log
@@ -21,7 +21,7 @@ x-goog-request-params: parent=projects%2F${projectId}%2Flocations%2FUS
 
 {
   "description": "example data exchange",
-  "discoveryType": 0,
+  "discoveryType": 1,
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "primaryContact": "a@contact.com"
@@ -33,7 +33,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "icon": "",
@@ -56,7 +56,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "icon": "",
@@ -75,7 +75,7 @@ x-goog-request-params: data_exchange.name=projects%2F${projectId}%2Flocations%2F
 
 {
   "description": "example data exchange",
-  "discoveryType": 1,
+  "discoveryType": 2,
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "name": "projects/${projectId}/locations/US/dataExchanges/bigqueryanalyticshubdataexchange${uniqueId}",
@@ -88,7 +88,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
+  "discoveryType": "DISCOVERY_TYPE_PUBLIC",
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "icon": "",
@@ -111,7 +111,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
+  "discoveryType": "DISCOVERY_TYPE_PUBLIC",
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "icon": "",

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/create.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   displayName: my_data_exchange
   description: example data exchange
+  discoveryType: DISCOVERY_TYPE_PRIVATE
   primaryContact: a@contact.com
   documentation: a documentation
-  discoveryType: DISCOVERY_TYPE_UNSPECIFIED
   location: US
   projectRef:
     external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/update.yaml
@@ -21,7 +21,7 @@ spec:
   description: example data exchange
   primaryContact: another@contact.com
   documentation: an updated documentation
-  discoveryType: DISCOVERY_TYPE_PRIVATE
+  discoveryType: DISCOVERY_TYPE_PUBLIC
   location: US
   projectRef:
     external: ${projectId}


### PR DESCRIPTION
It seems the post submit dynamic tests are failing with:

```
reconcile.go:193: error was not considered transient; chain is [[*fmt.wrapError: Update call failed: error updating: updating DataExchange projects/cnrm-test-eogyhy2r2nhrelge/locations/US/dataExchanges/bigqueryanalyticshubdataexchangeroymf4stav6dveq: googleapi: Error 
400: Discovery type must be specified.] [*fmt.wrapError: error updating: updating DataExchange projects/cnrm-test-eogyhy2r2nhrelge/locations/US/dataExchanges/bigqueryanalyticshubdataexchangeroymf4stav6dveq: googleapi: Error 
400: Discovery type must be specified.] [*fmt.wrapError: updating DataExchange projects/cnrm-test-eogyhy2r2nhrelge/locations/US/dataExchanges/bigqueryanalyticshubdataexchangeroymf4stav6dveq: googleapi: Error 
400: Discovery type must be specified.] [*apierror.APIError: googleapi: Error 400: Discovery type must be specified.] 
[*googleapi.Error: googleapi: Error 400: Discovery type must be specified.]]
```

`dicoveryType ` should be optional as per https://cloud.google.com/bigquery/docs/reference/analytics-hub/rest/v1/projects.locations.dataExchanges . Indeed the unified test passes against `E2E_GCP_TARGET=real` too.