### PR TITLE
fix: check set for enum

### DIFF
--- a/pkg/controller/direct/bigqueryanalyticshub/dataexchange_controller.go
+++ b/pkg/controller/direct/bigqueryanalyticshub/dataexchange_controller.go
@@ -204,7 +204,6 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	log.V(2).Info("updating DataExchange", "name", a.id.FullyQualifiedName())
 	mapCtx := &direct.MapContext{}
 
-	// TODO(user): (Optional) Add GCP mutable fields.
 	// TODO(kcc): Autogen "func immutable()" for each field
 	// TODO(kcc): autogen updateMastk.path for mutable gcp fields.
 	updateMask := &fieldmaskpb.FieldMask{}
@@ -224,7 +223,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	// if !reflect.DeepEqual(a.desired.Spec.Icon, string(a.actual.Icon)) {
 	// 	updateMask.Paths = append(updateMask.Paths, "icon")
 	// }
-	if !reflect.DeepEqual(a.desired.Spec.DiscoveryType, a.actual.DiscoveryType.String()) {
+	if a.desired.Spec.DiscoveryType != nil && !reflect.DeepEqual(a.desired.Spec.DiscoveryType, a.actual.DiscoveryType.String()) {
 		updateMask.Paths = append(updateMask.Paths, "discovery_type")
 	}
 

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_generated_object_bigqueryanalyticshubdataexchange-full.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_generated_object_bigqueryanalyticshubdataexchange-full.golden.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   description: example data exchange
-  discoveryType: DISCOVERY_TYPE_PRIVATE
+  discoveryType: DISCOVERY_TYPE_PUBLIC
   displayName: my_data_exchange
   documentation: an updated documentation
   location: US

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/_http.log
@@ -21,7 +21,7 @@ x-goog-request-params: parent=projects%2F${projectId}%2Flocations%2FUS
 
 {
   "description": "example data exchange",
-  "discoveryType": 0,
+  "discoveryType": 1,
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "primaryContact": "a@contact.com"
@@ -33,7 +33,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "icon": "",
@@ -56,7 +56,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_UNSPECIFIED",
+  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
   "displayName": "my_data_exchange",
   "documentation": "a documentation",
   "icon": "",
@@ -75,7 +75,7 @@ x-goog-request-params: data_exchange.name=projects%2F${projectId}%2Flocations%2F
 
 {
   "description": "example data exchange",
-  "discoveryType": 1,
+  "discoveryType": 2,
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "name": "projects/${projectId}/locations/US/dataExchanges/bigqueryanalyticshubdataexchange${uniqueId}",
@@ -88,7 +88,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
+  "discoveryType": "DISCOVERY_TYPE_PUBLIC",
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "icon": "",
@@ -111,7 +111,7 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "description": "example data exchange",
-  "discoveryType": "DISCOVERY_TYPE_PRIVATE",
+  "discoveryType": "DISCOVERY_TYPE_PUBLIC",
   "displayName": "my_data_exchange",
   "documentation": "an updated documentation",
   "icon": "",

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/create.yaml
@@ -21,7 +21,7 @@ spec:
   description: example data exchange
   primaryContact: a@contact.com
   documentation: a documentation
-  discoveryType: DISCOVERY_TYPE_UNSPECIFIED
+  discoveryType: DISCOVERY_TYPE_PRIVATE
   location: US
   projectRef:
     external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshubdataexchange-full/update.yaml
@@ -21,7 +21,7 @@ spec:
   description: example data exchange
   primaryContact: another@contact.com
   documentation: an updated documentation
-  discoveryType: DISCOVERY_TYPE_PRIVATE
+  discoveryType: DISCOVERY_TYPE_PUBLIC
   location: US
   projectRef:
     external: ${projectId}


### PR DESCRIPTION
We should have a check for enums that verifies whether the field was set or not. `discoveryType` is an optional field. Without this check, we will always find a diff with the defaulted server value.