### PR TITLE
feat: Record events when updating SQLInstances

### DIFF
--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -306,7 +306,7 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 		hasSetReadyCondition = createOp.HasSetReadyCondition
 		requeueRequested = createOp.RequeueRequested
 	} else {
-		updateOp := NewUpdateOperation(r.Reconciler.Client, u)
+		updateOp := NewUpdateOperation(r.Reconciler.LifecycleHandler, r.Reconciler.Client, u)
 		if err := adapter.Update(ctx, updateOp); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))

--- a/pkg/controller/direct/directbase/operations.go
+++ b/pkg/controller/direct/directbase/operations.go
@@ -20,6 +20,9 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/lifecyclehandler"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,13 +59,21 @@ func (o *operationBase) GetUnstructured() *unstructured.Unstructured {
 
 type UpdateOperation struct {
 	operationBase
+
+	lifecycleHandler lifecyclehandler.LifecycleHandler
 }
 
-func NewUpdateOperation(client client.Client, object *unstructured.Unstructured) *UpdateOperation {
+func NewUpdateOperation(lifecycleHandler lifecyclehandler.LifecycleHandler, client client.Client, object *unstructured.Unstructured) *UpdateOperation {
 	op := &UpdateOperation{}
+	op.lifecycleHandler = lifecycleHandler
 	op.client = client
 	op.object = object
 	return op
+}
+
+func (o *UpdateOperation) RecordUpdatingEvent() {
+	r := o.lifecycleHandler.Recorder
+	r.Event(o.object, corev1.EventTypeNormal, k8s.Updating, k8s.UpdatingMessage)
 }
 
 type CreateOperation struct {

--- a/pkg/controller/direct/sql/sqlinstance_controller.go
+++ b/pkg/controller/direct/sql/sqlinstance_controller.go
@@ -387,6 +387,8 @@ func (a *sqlInstanceAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	}
 
 	if !InstancesMatch(desiredGCP, a.actual) {
+		updateOp.RecordUpdatingEvent()
+
 		// GCP API requires we set the current settings version, otherwise update will fail.
 		desiredGCP.Settings.SettingsVersion = a.actual.Settings.SettingsVersion
 


### PR DESCRIPTION
This will help detect issues with the direct reconciler in the periodic tests.

Now, "testNoChange" will be able to detect when SQLInstance is incorrectly / unnecessarily performing updates.

Also, it provides a similar UX as the TF/DCL controllers, which record events and conditions on update.