### PR TITLE
chore: Add SQLInstance presubmit test suite

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -137,6 +137,24 @@ jobs:
         with:
           name: artifacts
           path: /tmp/artifacts/
+  tests-e2e-fixtures-sql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock fixtures tests for sql service"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-sql
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: /tmp/artifacts/
   pause-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 90

--- a/scripts/github-actions/tests-e2e-fixtures-sql
+++ b/scripts/github-actions/tests-e2e-fixtures-sql
@@ -20,6 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-export SKIP_TEST_APIGROUP="compute.cnrm.cloud.google.com,gkehub.cnrm.cloud.google.com,sql.cnrm.cloud.google.com"
+export ONLY_TEST_APIGROUP="sql.cnrm.cloud.google.com"
 
 ${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
There are enough sql tests at this point that we should split them into
a separate suite to reduce overall presubmit time.