### PR TITLE
InputReconciler length note

### DIFF
--- a/experiments/compositions/README.md
+++ b/experiments/compositions/README.md
@@ -25,3 +25,6 @@ kubectl apply -f composition_role_binding.yaml
 SAMPLES
 each of composition and facade has a sample directory with sample yaml to test
 the controllers.
+
+
+**Note: It can take up to 5 minutes for the `InputReconciler` to create resources accessible by `kubectl` commands. Please wait for that duration to examine if resources have been created as intended.**


### PR DESCRIPTION


While developing a KCC Composition, I often was unsure whether resources were created or not, due to not immediately being able to see them via `kubectl`. This note provides some guidance and can inform the dev experience.

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes #

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
