### PR TITLE
feat: add export for TagsKey

### DIFF
--- a/pkg/controller/direct/resourcemanager/mappings.go
+++ b/pkg/controller/direct/resourcemanager/mappings.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	pb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/tags/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+func TagsTagKeySpec_FromProto(mapCtx *direct.MapContext, r *pb.TagKey) *krm.TagsTagKeySpec {
+	if r == nil {
+		return nil
+	}
+
+	out := &krm.TagsTagKeySpec{}
+	out.Description = direct.LazyPtr(r.Description)
+	out.Purpose = direct.LazyPtr(r.GetPurpose().String())
+	out.PurposeData = r.PurposeData
+	out.ShortName = r.ShortName
+
+	return out
+}

--- a/pkg/controller/direct/resourcemanager/tagkey_controller.go
+++ b/pkg/controller/direct/resourcemanager/tagkey_controller.go
@@ -254,7 +254,25 @@ func (a *tagKeyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 }
 
 func (a *tagKeyAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
-	return nil, nil
+	if a.actual == nil {
+		return nil, fmt.Errorf("Find() not called")
+	}
+	u := &unstructured.Unstructured{}
+
+	obj := &krm.TagsTagKey{}
+	mapCtx := &direct.MapContext{}
+	obj.Spec = direct.ValueOf(TagsTagKeySpec_FromProto(mapCtx, a.actual))
+	if mapCtx.Err() != nil {
+		return nil, mapCtx.Err()
+	}
+
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u.Object = uObj
+	return u, nil
 }
 
 func (a *tagKeyAdapter) fullyQualifiedName() string {


### PR DESCRIPTION
Adds `Export` for the direct resource TagsKey. This was an early resource.