### PR TITLE
fix: Enable sqlinstance-denymaintenanceperiod nochange test

### DIFF
--- a/pkg/test/resourcefixture/contexts/sql_context.go
+++ b/pkg/test/resourcefixture/contexts/sql_context.go
@@ -196,8 +196,6 @@ func init() {
 	}
 
 	resourceContextMap["sqlinstance-denymaintenanceperiod"] = ResourceContext{
-		// TODO: Remove after switching to use direct controller.
-		SkipNoChange: true,
 		// SQL instances appear to need a bit of additional time before attempting to recreate
 		// with the exact same name. Otherwise, the GCP API returns "unknown error".
 		RecreateDelay: time.Second * 60,
@@ -205,8 +203,6 @@ func init() {
 	}
 
 	resourceContextMap["sqlinstance-denymaintenanceperiod-direct"] = ResourceContext{
-		// TODO: Remove after switching to use direct controller.
-		SkipNoChange: true,
 		// SQL instances appear to need a bit of additional time before attempting to recreate
 		// with the exact same name. Otherwise, the GCP API returns "unknown error".
 		RecreateDelay: time.Second * 60,


### PR DESCRIPTION
Now that we are using the GCP-preferred format (done in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2908), the terraform-based controller passes the nochange test.

Forgot to include this in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2908