### PR TITLE
feat:refactor: kind aware cmd add

### DIFF
--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -61,7 +61,7 @@ func generateController(service, kind string, cArgs *ccTemplate.ControllerArgs) 
 		return err
 	}
 
-	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>/<resource>_controller.go
+	// Write the generated controller.go to  pkg/controller/direct/<service>/<resource>_controller.go
 	if err := WriteToFile(controllerFilePath, controllerOutput.Bytes()); err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func generateController(service, kind string, cArgs *ccTemplate.ControllerArgs) 
 	return nil
 }
 
-func buildResourcePath(service, kind, filename string) (string, error) {
+func buildResourcePath(service, filename string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get current working directory: %w", err)
@@ -83,7 +83,7 @@ func buildResourcePath(service, kind, filename string) (string, error) {
 		return "", fmt.Errorf("get absolute path %s: %w", pwd, err)
 	}
 	seg := strings.Split(abs, currRelPath)
-	controllerDir := filepath.Join(seg[0], directControllerRelPath, service, kind)
+	controllerDir := filepath.Join(seg[0], directControllerRelPath, service)
 	err = os.MkdirAll(controllerDir, os.ModePerm)
 	if err != nil {
 		return "", fmt.Errorf("create controller directory %s: %w", controllerDir, err)
@@ -100,8 +100,7 @@ func buildResourcePath(service, kind, filename string) (string, error) {
 }
 
 func buildControllerPath(service, kind string) (string, error) {
-	kind = strings.ToLower(kind)
-	return buildResourcePath(service, kind, kind+"_controller.go")
+	return buildResourcePath(service, strings.ToLower(kind)+"_controller.go")
 }
 
 func FormatImports(path string, out []byte) error {

--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -78,20 +78,20 @@ const (
 )
 
 func init() {
-	registry.RegisterModel(krm.{{.Kind}}GVK, NewModel)
+	registry.RegisterModel(krm.{{.Kind}}GVK, New{{.Kind}}Model)
 }
 
-func NewModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
-	return &model{config: *config}, nil
+func New{{.Kind}}Model(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &model{{.Kind}}{config: *config}, nil
 }
 
-var _ directbase.Model = &model{}
+var _ directbase.Model = &model{{.Kind}}{}
 
-type model struct {
+type model{{.Kind}} struct {
 	config config.ControllerConfig
 }
 
-func (m *model) client(ctx context.Context) (*gcp.Client, error) {
+func (m *model{{.Kind}}) client(ctx context.Context) (*gcp.Client, error) {
 	var opts []option.ClientOption
 	opts, err := m.config.RESTClientOptions()
 	if err != nil {
@@ -104,7 +104,7 @@ func (m *model) client(ctx context.Context) (*gcp.Client, error) {
 	return gcpClient, err
 }
 
-func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+func (m *model{{.Kind}}) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
 	obj := &krm.{{.Kind}}{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
 		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
@@ -120,28 +120,28 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 	if err != nil {
 		return nil, err
 	}
-	return &Adapter{
+	return &{{.Kind}}Adapter{
 		id:        id,
 		gcpClient:  gcpClient,
 		desired:    obj,
 	}, nil
 }
 
-func (m *model) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+func (m *model{{.Kind}}) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
 	// TODO: Support URLs
 	return nil, nil
 }
 
-type Adapter struct {
+type {{.Kind}}Adapter struct {
 	id         *krm.{{.Kind}}Ref
 	gcpClient  *gcp.Client
 	desired    *krm.{{.Kind}}
 	actual     *{{.KCCService}}pb.{{.ProtoResource}}
 }
 
-var _ directbase.Adapter = &Adapter{}
+var _ directbase.Adapter = &{{.Kind}}Adapter{}
 
-func (a *Adapter) Find(ctx context.Context) (bool, error) {
+func (a *{{.Kind}}Adapter) Find(ctx context.Context) (bool, error) {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("getting {{.Kind}}", "name", a.id.External)
 
@@ -158,7 +158,7 @@ func (a *Adapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+func (a *{{.Kind}}Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("creating {{.ProtoResource}}", "name", a.id.External)
 	mapCtx := &direct.MapContext{}
@@ -197,7 +197,7 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	return createOp.UpdateStatus(ctx, status, nil)
 }
 
-func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+func (a *{{.Kind}}Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("updating {{.ProtoResource}}", "name", a.id.External)
 	mapCtx := &direct.MapContext{}
@@ -242,7 +242,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 
-func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+func (a *{{.Kind}}Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
 	if a.actual == nil {
 		return nil, fmt.Errorf("Find() not called")
 	}
@@ -270,7 +270,7 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 }
 
 // Delete implements the Adapter interface.
-func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+func (a *{{.Kind}}Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
 	log := klog.FromContext(ctx).WithName(ctrlName)
 	log.V(2).Info("deleting {{.ProtoResource}}", "name", a.id.External)
 

--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -42,7 +42,7 @@ const ControllerTemplate = `
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package {{.Kind | ToLower }}
+package {{.KCCService}}
 
 import (
 	"context"


### PR DESCRIPTION
This work comes back to look at the controller builder cmd.

* it reverts the per package work as we're moving away from that direction to having a structure like:
```
resourceA_controller.go
resourceB_controller.go
```
* For any datastructure or function that needs a resource specific name, I added the necessary changes in the template.

Been testing this with the `BigQueryAnalyticsHubDataExchange` and `BigQueryAnalyticsHubListing`