### PR TITLE
chore: refactor SecureSourceManagerInstance to work in proto

### DIFF
--- a/pkg/controller/direct/protoutils.go
+++ b/pkg/controller/direct/protoutils.go
@@ -14,7 +14,9 @@
 
 package direct
 
-import "google.golang.org/protobuf/proto"
+import (
+	"google.golang.org/protobuf/proto"
+)
 
 // ProtoClone is a type-safe wrapper around proto.Clone
 func ProtoClone[T proto.Message](t T) T {


### PR DESCRIPTION
We can keep the desired state in proto.
