### PR TITLE
tests: fix env var to be ONLY_TEST_APIGROUPS

### DIFF
--- a/scripts/github-actions/tests-e2e-fixtures-sql
+++ b/scripts/github-actions/tests-e2e-fixtures-sql
@@ -20,6 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-export ONLY_TEST_APIGROUP="sql.cnrm.cloud.google.com"
+export ONLY_TEST_APIGROUPS="sql.cnrm.cloud.google.com"
 
 ${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
It was using ONLY_TEST_APIGROUP, which is the old form.
