### PR TITLE
tests: add gke to e2e

### DIFF
--- a/dev/ci/periodics/e2e-service-container
+++ b/dev/ci/periodics/e2e-service-container
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+export ONLY_TEST_APIGROUPS=container.cnrm.cloud.google.com
+
+dev/ci/periodics/_create_project_and_run_e2e


### PR DESCRIPTION
Add the container.cnrm.cloud.google.com API group to the e2e tests.
