### PR TITLE
Add field mapper for attached clusters direct controller migration.

### DIFF
--- a/apis/containerattached/v1beta1/containerattachedcluster_types.go
+++ b/apis/containerattached/v1beta1/containerattachedcluster_types.go
@@ -25,9 +25,8 @@ var ContainerAttachedClusterGVK = GroupVersion.WithKind("ContainerAttachedCluste
 // ContainerAttachedClusterSpec defines the desired state of ContainerAttachedCluster
 // +kcc:proto=google.cloud.gkemulticloud.v1.AttachedCluster
 type ContainerAttachedClusterSpec struct {
-	/* The ID of the project in which the resource belongs. If it is not provided, the provider project is used. */
-	// +optional
-	ProjectRef *refs.ProjectRef `json:"projectRef,omitempty"`
+	/* The ID of the project in which the resource belongs.*/
+	ProjectRef *refs.ProjectRef `json:"projectRef"`
 
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// Immutable, Optional.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
@@ -239,7 +239,6 @@ spec:
                 type: string
               projectRef:
                 description: The ID of the project in which the resource belongs.
-                  If it is not provided, the provider project is used.
                 oneOf:
                 - not:
                     required:
@@ -283,6 +282,7 @@ spec:
             - location
             - oidcConfig
             - platformVersion
+            - projectRef
             type: object
           status:
             description: ContainerAttachedClusterStatus defines the config connector

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	cloud.google.com/go/dataflow v0.10.0
 	cloud.google.com/go/dataform v0.10.0
 	cloud.google.com/go/firestore v1.16.0
+	cloud.google.com/go/gkemulticloud v1.3.0
 	cloud.google.com/go/iam v1.2.0
 	cloud.google.com/go/monitoring v1.21.0
 	cloud.google.com/go/privilegedaccessmanager v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/firestore v1.16.0 h1:YwmDHcyrxVRErWcgxunzEaZxtNbc8QoFYA/JOEwDPgc=
 cloud.google.com/go/firestore v1.16.0/go.mod h1:+22v/7p+WNBSQwdSwP57vz47aZiY+HrDkrOsJNhk7rg=
+cloud.google.com/go/gkemulticloud v1.3.0 h1:4wJPaNK7HFYLniVqMue+Eo/SpX+yf+aMvRITjUpirgM=
+cloud.google.com/go/gkemulticloud v1.3.0/go.mod h1:XmcOUQ+hJI62fi/klCjEGs6lhQ56Zjs14sGPXsGP0mE=
 cloud.google.com/go/iam v1.2.0 h1:kZKMKVNk/IsSSc/udOb83K0hL/Yh/Gcqpz+oAkoIFN8=
 cloud.google.com/go/iam v1.2.0/go.mod h1:zITGuWgsLZxd8OwAlX+eMFgZDXzBm7icj1PVTYG766Q=
 cloud.google.com/go/longrunning v0.6.0 h1:mM1ZmaNsQsnb+5n1DNPeL0KwQd9jQRqSqSDEkBZr+aI=

--- a/pkg/clients/generated/apis/containerattached/v1beta1/containerattachedcluster_types.go
+++ b/pkg/clients/generated/apis/containerattached/v1beta1/containerattachedcluster_types.go
@@ -167,9 +167,8 @@ type ContainerAttachedClusterSpec struct {
 	/* Required. The platform version for the cluster (e.g. `1.30.0-gke.1`). */
 	PlatformVersion string `json:"platformVersion"`
 
-	/* The ID of the project in which the resource belongs. If it is not provided, the provider project is used. */
-	// +optional
-	ProjectRef *v1alpha1.ResourceRef `json:"projectRef,omitempty"`
+	/* The ID of the project in which the resource belongs. */
+	ProjectRef v1alpha1.ResourceRef `json:"projectRef"`
 
 	/* Immutable, Optional. The ContainerAttachedCluster name. If not given, the metadata.name will be used. */
 	// +optional

--- a/pkg/clients/generated/apis/containerattached/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/containerattached/v1beta1/zz_generated.deepcopy.go
@@ -374,11 +374,7 @@ func (in *ContainerAttachedClusterSpec) DeepCopyInto(out *ContainerAttachedClust
 		(*in).DeepCopyInto(*out)
 	}
 	in.OidcConfig.DeepCopyInto(&out.OidcConfig)
-	if in.ProjectRef != nil {
-		in, out := &in.ProjectRef, &out.ProjectRef
-		*out = new(v1alpha1.ResourceRef)
-		**out = **in
-	}
+	out.ProjectRef = in.ProjectRef
 	if in.ResourceID != nil {
 		in, out := &in.ResourceID, &out.ResourceID
 		*out = new(string)

--- a/pkg/controller/direct/containerattached/containerattachedcluster_mappings.go
+++ b/pkg/controller/direct/containerattached/containerattachedcluster_mappings.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerattached
+
+import (
+	pb "cloud.google.com/go/gkemulticloud/apiv1/gkemulticloudpb"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/containerattached/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+func Fleet_FromProto(mapCtx *direct.MapContext, in *pb.Fleet) *krm.Fleet {
+	if in == nil {
+		return nil
+	}
+	out := &krm.Fleet{}
+	out.ProjectRef.External = in.GetProject()
+	out.Membership = direct.LazyPtr(in.GetMembership())
+	return out
+}
+
+func Fleet_ToProto(mapCtx *direct.MapContext, in *krm.Fleet) *pb.Fleet {
+	if in == nil {
+		return nil
+	}
+	out := &pb.Fleet{}
+	if in.ProjectRef.External == "" {
+		mapCtx.Errorf("Fleet project external reference was not pre-resolved")
+	}
+	out.Project = in.ProjectRef.External
+	out.Membership = direct.ValueOf(in.Membership)
+	return out
+}
+
+func AttachedClustersAuthorization_FromProto(mapCtx *direct.MapContext, in *pb.AttachedClustersAuthorization) *krm.AttachedClustersAuthorization {
+	if in == nil {
+		return nil
+	}
+	out := &krm.AttachedClustersAuthorization{}
+	out.AdminUsers = direct.Slice_FromProto(mapCtx, in.AdminUsers, func(mapCtx *direct.MapContext, p *pb.AttachedClusterUser) *string {
+		return direct.LazyPtr(p.GetUsername())
+	})
+	/*NOTYET
+	// MISSING: AdminGroups
+	*/
+	return out
+}
+
+func AttachedClustersAuthorization_ToProto(mapCtx *direct.MapContext, in *krm.AttachedClustersAuthorization) *pb.AttachedClustersAuthorization {
+	if in == nil {
+		return nil
+	}
+	out := &pb.AttachedClustersAuthorization{}
+	out.AdminUsers = direct.Slice_ToProto(mapCtx, in.AdminUsers, func(mapCtx *direct.MapContext, p *string) *pb.AttachedClusterUser {
+		return &pb.AttachedClusterUser{Username: direct.ValueOf(p)}
+	})
+	/*NOTYET
+	// MISSING: AdminGroups
+	*/
+	return out
+}
+
+func AttachedOidcConfig_FromProto(mapCtx *direct.MapContext, in *pb.AttachedOidcConfig) *krm.AttachedOidcConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.AttachedOidcConfig{}
+	out.IssuerURL = in.GetIssuerUrl()
+	out.Jwks = in.GetJwks()
+	return out
+}
+
+func AttachedOidcConfig_ToProto(mapCtx *direct.MapContext, in *krm.AttachedOidcConfig) *pb.AttachedOidcConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.AttachedOidcConfig{}
+	out.IssuerUrl = in.IssuerURL
+	out.Jwks = in.Jwks
+	return out
+}
+
+func ContainerAttachedClusterSpec_FromProto(mapCtx *direct.MapContext, in *pb.AttachedCluster) *krm.ContainerAttachedClusterSpec {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ContainerAttachedClusterSpec{}
+	out.Description = direct.LazyPtr(in.GetDescription())
+	out.OidcConfig = *AttachedOidcConfig_FromProto(mapCtx, in.GetOidcConfig())
+	out.PlatformVersion = in.GetPlatformVersion()
+	out.Distribution = in.GetDistribution()
+	out.Fleet = *Fleet_FromProto(mapCtx, in.GetFleet())
+	/*NOTYET
+	// MISSING: Etag
+	*/
+	out.Annotations = in.Annotations
+	out.LoggingConfig = LoggingConfig_FromProto(mapCtx, in.GetLoggingConfig())
+	out.Authorization = AttachedClustersAuthorization_FromProto(mapCtx, in.GetAuthorization())
+	out.MonitoringConfig = MonitoringConfig_FromProto(mapCtx, in.GetMonitoringConfig())
+	/*NOTYET
+	// MISSING: ProxyConfig
+	*/
+	out.BinaryAuthorization = BinaryAuthorization_FromProto(mapCtx, in.GetBinaryAuthorization())
+	return out
+}
+
+func ContainerAttachedClusterSpec_ToProto(mapCtx *direct.MapContext, in *krm.ContainerAttachedClusterSpec) *pb.AttachedCluster {
+	if in == nil {
+		return nil
+	}
+	out := &pb.AttachedCluster{}
+	out.Description = direct.ValueOf(in.Description)
+	out.OidcConfig = AttachedOidcConfig_ToProto(mapCtx, &in.OidcConfig)
+	out.PlatformVersion = in.PlatformVersion
+	out.Distribution = in.Distribution
+	out.Fleet = Fleet_ToProto(mapCtx, &in.Fleet)
+	/*NOTYET
+	// MISSING: Etag
+	*/
+	out.Annotations = in.Annotations
+	out.LoggingConfig = LoggingConfig_ToProto(mapCtx, in.LoggingConfig)
+	out.Authorization = AttachedClustersAuthorization_ToProto(mapCtx, in.Authorization)
+	out.MonitoringConfig = MonitoringConfig_ToProto(mapCtx, in.MonitoringConfig)
+	/*NOTYET
+	// MISSING: ProxyConfig
+	*/
+	out.BinaryAuthorization = BinaryAuthorization_ToProto(mapCtx, in.BinaryAuthorization)
+	return out
+}
+
+func LoggingComponentConfig_FromProto(mapCtx *direct.MapContext, in *pb.LoggingComponentConfig) *krm.LoggingComponentConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.LoggingComponentConfig{}
+	out.EnableComponents = slice_FromProto(mapCtx, in.EnableComponents, func(mapCtx *direct.MapContext, p pb.LoggingComponentConfig_Component) *string {
+		return direct.Enum_FromProto(mapCtx, p)
+	})
+	return out
+}
+
+func LoggingComponentConfig_ToProto(mapCtx *direct.MapContext, in *krm.LoggingComponentConfig) *pb.LoggingComponentConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.LoggingComponentConfig{}
+	out.EnableComponents = slice_ToProto(mapCtx, in.EnableComponents, func(mapCtx *direct.MapContext, s *string) pb.LoggingComponentConfig_Component {
+		ret := direct.Enum_ToProto[pb.LoggingComponentConfig_Component](mapCtx, s)
+		return ret
+	})
+	return out
+}
+
+func slice_ToProto[T, U any](mapCtx *direct.MapContext, in []T, mapper func(mapCtx *direct.MapContext, in *T) U) []U {
+	if in == nil {
+		return nil
+	}
+
+	outSlice := make([]U, 0, len(in))
+	for _, inItem := range in {
+		outItem := mapper(mapCtx, &inItem)
+		outSlice = append(outSlice, outItem)
+	}
+	return outSlice
+}
+
+func slice_FromProto[T, U any](mapCtx *direct.MapContext, in []T, mapper func(mapCtx *direct.MapContext, in T) *U) []U {
+	if in == nil {
+		return nil
+	}
+
+	outSlice := make([]U, 0, len(in))
+	for _, inItem := range in {
+		outItem := mapper(mapCtx, inItem)
+		outSlice = append(outSlice, *outItem)
+	}
+	return outSlice
+}

--- a/pkg/controller/direct/containerattached/mapper.generated.go
+++ b/pkg/controller/direct/containerattached/mapper.generated.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerattached
+
+import (
+	pb "cloud.google.com/go/gkemulticloud/apiv1/gkemulticloudpb"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/containerattached/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+func AttachedClusterError_FromProto(mapCtx *direct.MapContext, in *pb.AttachedClusterError) *krm.AttachedClusterError {
+	if in == nil {
+		return nil
+	}
+	out := &krm.AttachedClusterError{}
+	out.Message = direct.LazyPtr(in.GetMessage())
+	return out
+}
+func AttachedClusterError_ToProto(mapCtx *direct.MapContext, in *krm.AttachedClusterError) *pb.AttachedClusterError {
+	if in == nil {
+		return nil
+	}
+	out := &pb.AttachedClusterError{}
+	out.Message = direct.ValueOf(in.Message)
+	return out
+}
+
+/*
+NOTYET
+
+	func AttachedProxyConfig_FromProto(mapCtx *direct.MapContext, in *pb.AttachedProxyConfig) *krm.AttachedProxyConfig {
+		if in == nil {
+			return nil
+		}
+		out := &krm.AttachedProxyConfig{}
+		out.KubernetesSecret = KubernetesSecret_FromProto(mapCtx, in.GetKubernetesSecret())
+		return out
+	}
+
+	func AttachedProxyConfig_ToProto(mapCtx *direct.MapContext, in *krm.AttachedProxyConfig) *pb.AttachedProxyConfig {
+		if in == nil {
+			return nil
+		}
+		out := &pb.AttachedProxyConfig{}
+		out.KubernetesSecret = KubernetesSecret_ToProto(mapCtx, in.KubernetesSecret)
+		return out
+	}
+*/
+func BinaryAuthorization_FromProto(mapCtx *direct.MapContext, in *pb.BinaryAuthorization) *krm.BinaryAuthorization {
+	if in == nil {
+		return nil
+	}
+	out := &krm.BinaryAuthorization{}
+	out.EvaluationMode = direct.Enum_FromProto(mapCtx, in.GetEvaluationMode())
+	return out
+}
+func BinaryAuthorization_ToProto(mapCtx *direct.MapContext, in *krm.BinaryAuthorization) *pb.BinaryAuthorization {
+	if in == nil {
+		return nil
+	}
+	out := &pb.BinaryAuthorization{}
+	out.EvaluationMode = direct.Enum_ToProto[pb.BinaryAuthorization_EvaluationMode](mapCtx, in.EvaluationMode)
+	return out
+}
+
+/*NOTYET
+func KubernetesSecret_FromProto(mapCtx *direct.MapContext, in *pb.KubernetesSecret) *krm.KubernetesSecret {
+	if in == nil {
+		return nil
+	}
+	out := &krm.KubernetesSecret{}
+	out.Name = direct.LazyPtr(in.GetName())
+	out.Namespace = direct.LazyPtr(in.GetNamespace())
+	return out
+}
+func KubernetesSecret_ToProto(mapCtx *direct.MapContext, in *krm.KubernetesSecret) *pb.KubernetesSecret {
+	if in == nil {
+		return nil
+	}
+	out := &pb.KubernetesSecret{}
+	out.Name = KubernetesSecret_Name_ToProto(mapCtx, in.Name)
+	out.Namespace = KubernetesSecret_Namespace_ToProto(mapCtx, in.Namespace)
+	return out
+}
+*/
+
+func LoggingConfig_FromProto(mapCtx *direct.MapContext, in *pb.LoggingConfig) *krm.LoggingConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.LoggingConfig{}
+	out.ComponentConfig = LoggingComponentConfig_FromProto(mapCtx, in.GetComponentConfig())
+	return out
+}
+func LoggingConfig_ToProto(mapCtx *direct.MapContext, in *krm.LoggingConfig) *pb.LoggingConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.LoggingConfig{}
+	out.ComponentConfig = LoggingComponentConfig_ToProto(mapCtx, in.ComponentConfig)
+	return out
+}
+func ManagedPrometheusConfig_FromProto(mapCtx *direct.MapContext, in *pb.ManagedPrometheusConfig) *krm.ManagedPrometheusConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.ManagedPrometheusConfig{}
+	out.Enabled = direct.LazyPtr(in.GetEnabled())
+	return out
+}
+func ManagedPrometheusConfig_ToProto(mapCtx *direct.MapContext, in *krm.ManagedPrometheusConfig) *pb.ManagedPrometheusConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.ManagedPrometheusConfig{}
+	out.Enabled = direct.ValueOf(in.Enabled)
+	return out
+}
+func MonitoringConfig_FromProto(mapCtx *direct.MapContext, in *pb.MonitoringConfig) *krm.MonitoringConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.MonitoringConfig{}
+	out.ManagedPrometheusConfig = ManagedPrometheusConfig_FromProto(mapCtx, in.GetManagedPrometheusConfig())
+	return out
+}
+func MonitoringConfig_ToProto(mapCtx *direct.MapContext, in *krm.MonitoringConfig) *pb.MonitoringConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.MonitoringConfig{}
+	out.ManagedPrometheusConfig = ManagedPrometheusConfig_ToProto(mapCtx, in.ManagedPrometheusConfig)
+	return out
+}
+func WorkloadIdentityConfig_FromProto(mapCtx *direct.MapContext, in *pb.WorkloadIdentityConfig) *krm.WorkloadIdentityConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.WorkloadIdentityConfig{}
+	out.IssuerUri = direct.LazyPtr(in.GetIssuerUri())
+	out.WorkloadPool = direct.LazyPtr(in.GetWorkloadPool())
+	out.IdentityProvider = direct.LazyPtr(in.GetIdentityProvider())
+	return out
+}
+func WorkloadIdentityConfig_ToProto(mapCtx *direct.MapContext, in *krm.WorkloadIdentityConfig) *pb.WorkloadIdentityConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.WorkloadIdentityConfig{}
+	out.IssuerUri = direct.ValueOf(in.IssuerUri)
+	out.WorkloadPool = direct.ValueOf(in.WorkloadPool)
+	out.IdentityProvider = direct.ValueOf(in.IdentityProvider)
+	return out
+}

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -458,11 +458,11 @@ while clusters with private issuers need to provide both 'issuerUrl' and 'jwks'.
     <tr>
         <td>
             <p><code>projectRef</code></p>
-            <p><i>Optional</i></p>
+            <p><i>Required</i></p>
         </td>
         <td>
             <p><code class="apitype">object</code></p>
-            <p>{% verbatim %}The ID of the project in which the resource belongs. If it is not provided, the provider project is used.{% endverbatim %}</p>
+            <p>{% verbatim %}The ID of the project in which the resource belongs.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Followed step 3 of the Direct Controller migration guide.
Manually implemented functions which the generator was unable to handle on its own.
Since this is a migration for an existing resource, some `NOTYET`s are in the code for new, unimplemented fields.

Fix the change that made the required `ProjectRef` optional in the previous PR.
