### PR TITLE
fix: mark "node_config[0].kubelet_config" as "computed"

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
@@ -482,6 +482,7 @@ func schemaNodeConfig() *schema.Schema {
 				"kubelet_config": {
 					Type:        schema.TypeList,
 					Optional:    true,
+					Computed:    true,
 					MaxItems:    1,
 					Description: `Node kubelet configs.`,
 					Elem: &schema.Resource{


### PR DESCRIPTION
Cherry pick the fix in https://github.com/GoogleCloudPlatform/magic-modules/pull/11971.

This resolves the reconciliation error that occurs when `kubeletConfig` is empty in the user's configuration, but a subfield under kubeletConfig is set externally outside of KCC.

```
{"severity":"error","timestamp":"2024-10-21T23:33:23.865Z","logger":"containernodepool-controller","msg":"error applying desired state","resource":{"name":"test-b-374795345-10212024-pool","namespace":"default"},"error":"summary: googleapi: Error 400: At least one of ['node_version', 'image_type', 'updated_node_pool', 'locations', 'workload_metadata_config', 'upgrade_settings', 'kubelet_config', 'linux_node_config', 'tags', 'taints', 'labels', 'node_network_config', 'gcfs_config', 'gvnic', 'confidential_nodes', 'logging_config', 'fast_socket', 'resource_labels', 'accelerators', 'windows_node_config', 'machine_type', 'disk_type', 'disk_size_gb', 'storage_pools', 'containerd_config', 'resource_manager_tags', 'performance_monitoring_unit', 'queued_provisioning', 'max_run_duration'] must be specified.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.RequestInfo\",\n    \"requestId\": \"0x19bb67b615f44eff\"\n  }\n]\n, badRequest"}
```

Tested locally in b/374795345.