### PR TITLE
Remove map field if it is externally-managed using the powertool

### DIFF
--- a/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_cli-2-stderr.log
+++ b/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_cli-2-stderr.log
@@ -1,2 +1,2 @@
 skipping field removal of array field ".spec.lifecycleRule" (may be an indication of undetermined ownership)
-skipping field removal of map field ".spec.softDeletePolicy" (may be an indication of undetermined ownership)
+deleting map field ".spec.softDeletePolicy" (all the subfields are considered managed)

--- a/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_cli-2-stdout.log
+++ b/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_cli-2-stdout.log
@@ -6,8 +6,7 @@
           cnrm.cloud.google.com/state-into-spec: merge -> absent
       spec:
         publicAccessPrevention: inherited -> <nil>
-        softDeletePolicy:
-          retentionDurationSeconds: 604800 -> <nil>
+        softDeletePolicy: map[retentionDurationSeconds:604800] -> <nil>
         storageClass: STANDARD -> <nil>
 
 

--- a/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_object03.yaml
+++ b/tests/e2e/testdata/scenarios/powertool/storagebucket_clear_state_into_spec/_object03.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket
 metadata:
@@ -36,7 +22,6 @@ spec:
       withState: ANY
   location: US
   resourceID: storagebucket-merge-${uniqueId}
-  softDeletePolicy: {}
   versioning:
     enabled: false
 status:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
This PR fixes the powertool behavior when the non-leaf object field is externally-managed: This means all the subfields are also externally-managed and should be removed after switching to `state-into-spec: absent`.

Fixes b/356413432

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
