### PR TITLE
tests: Only load the CRDs we are using

### DIFF
--- a/pkg/crd/crdloader/crdloader.go
+++ b/pkg/crd/crdloader/crdloader.go
@@ -136,6 +136,7 @@ func isMatch(group, version, kind string, crd apiextensions.CustomResourceDefini
 			return false
 		}
 	}
+
 	if version != "" {
 		foundVersion := false
 		for i := range crd.Spec.Versions {

--- a/pkg/k8s/crds.go
+++ b/pkg/k8s/crds.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var scoreForVersion = map[string]int{
@@ -42,6 +43,14 @@ func PreferredVersion(crd *apiextensions.CustomResourceDefinition) *apiextension
 
 	}
 	return preferredVersion
+}
+
+// GetGroupKindFromCRD returns the GroupKind that the CRD defines.
+func GetGroupKindFromCRD(crd *apiextensions.CustomResourceDefinition) schema.GroupKind {
+	return schema.GroupKind{
+		Group: crd.Spec.Group,
+		Kind:  crd.Spec.Names.Kind,
+	}
 }
 
 func GetAPIVersionFromCRD(crd *apiextensions.CustomResourceDefinition) string {


### PR DESCRIPTION
Speeds up tests a little, but also keeps the logs much more focused.
