### PR TITLE
Add warning log to clean up orphaned CRDs

### DIFF
--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -194,7 +194,9 @@ func doRecord(ctx context.Context, c client.Client, gvks []schema.GroupVersionKi
 
 func forEach(c client.Client, gvk schema.GroupVersionKind, listOptions *client.ListOptions, fn func(unstructured.Unstructured) error) error {
 	for ok := true; ok; ok = listOptions.Continue != "" {
-		if _, ok := opk8s.IgnoredCRDList[gvkToCRDName(gvk)]; ok {
+		crdName := gvkToCRDName(gvk)
+		if _, ok := opk8s.IgnoredCRDList[crdName]; ok {
+			logger.Info(fmt.Sprintf("Orphaned CRD %s found, you should delete it using 'kubectl delete crd %s'", crdName, crdName))
 			continue
 		}
 		list := unstructured.UnstructuredList{}

--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -198,8 +198,9 @@ func forEach(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, 
 		crdName := gvkToCRDName(gvk)
 		if _, ok := opk8s.IgnoredCRDList[crdName]; ok {
 			logger.Error(fmt.Errorf("unexpected CRD %s", crdName),
-				fmt.Sprintf("Orphaned CRD %s found, you should delete "+
-					"it using 'kubectl delete crd %s'", crdName, crdName))
+				fmt.Sprintf("please run `kubectl delete crd %s` to "+
+					"delete the orphaned CRD", crdName),
+				"crd", crdName)
 			continue
 		}
 		list := unstructured.UnstructuredList{}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Follow up on #2972 .

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Verified that the error showed up in the log when orphaned CRD existed, and disappeared after the orphaned CRD was deleted.
