### PR TITLE
tests: warn, don't panic, if we can't read spec.resourceID

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -221,9 +221,9 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					for _, create := range opt.Create {
 						resourceID, _, err := unstructured.NestedString(create.Object, "spec", "resourceID")
 						if err != nil {
-							t.Fatalf("error reading spec.resourceID: %v", err)
-						}
-						if strings.Contains(resourceID, "${resourceId}") {
+							j, _ := json.Marshal(create.Object)
+							t.Logf("error reading spec.resourceID, can't check for acquisition test: %v.  object is %v", err, string(j))
+						} else if strings.Contains(resourceID, "${resourceId}") {
 							t.Skipf("test has ${resourceId} placeholder in spec.resource, indicating an acquisition test.  Not currently supported here; skipping")
 						}
 					}


### PR DESCRIPTION
This shouldn't happen, but we need to know why it happens if it does.
