### PR TITLE
Fix permanent diff caused by default GPU driver installation in GKE node pools

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/node_config.go
@@ -108,6 +108,7 @@ func schemaNodeConfig() *schema.Schema {
 								Type:        schema.TypeList,
 								MaxItems:    1,
 								Optional:    true,
+								Computed:    true,
 								ForceNew:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: `Configuration for auto installation of GPU driver.`,


### PR DESCRIPTION
Pick up the fix in https://github.com/GoogleCloudPlatform/magic-modules/pull/11152.

Default driver installation was enabled with release R17 on 5/24 in GKE 1.30.1-gke.1156000, which causes permanent diff in our test case.

Original error:
```
{"severity":"error","timestamp":"2024-10-22T19:34:52.878Z","msg":"Reconciler error","controller":"containernodepool-controller","controllerGroup":"container.cnrm.cloud.google.com","controllerKind":"ContainerNodePool","ContainerNodePool":{"name":"duxakctmptrllzcmjraupzbigsicqv","namespace":"cnrm-jingyih-test"},"namespace":"cnrm-jingyih-test","name":"duxakctmptrllzcmjraupzbigsicqv","reconcileID":"6adda282-8f22-471d-9635-a185a3963b49","error":"Update call failed: cannot make changes to immutable field(s): [Field Name: nodeConfig.0.GuestAccelerator.0.GpuDriverInstallationConfig.0.GpuDriverVersion, Got: , Wanted: DEFAULT Field Name: nodeConfig.0.GuestAccelerator.0.GpuDriverInstallationConfig.#, Got: 0, Wanted: 1]; please refer to our troubleshooting doc: https://cloud.google.com/config-connector/docs/troubleshooting"}

{"severity":"error","timestamp":"2024-10-22T19:35:09.636Z","msg":"Reconciler error","controller":"containernodepool-controller","controllerGroup":"container.cnrm.cloud.google.com","controllerKind":"ContainerNodePool","ContainerNodePool":{"name":"duxakctmptrllzcmjraupzbigsicqv","namespace":"cnrm-jingyih-test"},"namespace":"cnrm-jingyih-test","name":"duxakctmptrllzcmjraupzbigsicqv","reconcileID":"987e435a-6e08-4b90-aa23-8fb26b78f017","error":"Update call failed: cannot make changes to immutable field(s): [Field Name: nodeConfig.0.GuestAccelerator.0.GpuDriverInstallationConfig.#, Got: 0, Wanted: 1 Field Name: nodeConfig.0.GuestAccelerator.0.GpuDriverInstallationConfig.0.GpuDriverVersion, Got: , Wanted: DEFAULT]; please refer to our troubleshooting doc: https://cloud.google.com/config-connector/docs/troubleshooting"}
```

Locally tested:
```
$ go test -v --timeout 3600s -tags=integration ./config/tests/samples/create/ -run-tests basic-node-pool
```

Fixes b/374873592