### PR TITLE
tests: don't set up gcloud in github actions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -53,8 +53,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
       - name: "Run unit tests"
         run: |
           ./scripts/github-actions/ga-unit-test.sh

--- a/scripts/github-actions/ga-unit-test.sh
+++ b/scripts/github-actions/ga-unit-test.sh
@@ -23,8 +23,6 @@ source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \
 	setup_envs
 
 echo "Running unit tests..."
-# A dummy default project id is required for a few unit test cases
-gcloud config set project foobar
 
 GITHUB_ACTION=1 \
 make test


### PR DESCRIPTION
This should not be needed, and was giving a warning because we don't have credentials.
