### PR TITLE
fix: update the compute image test yaml

### DIFF
--- a/config/samples/resources/computeimage/image-from-url-raw/compute_v1beta1_computeimage.yaml
+++ b/config/samples/resources/computeimage/image-from-url-raw/compute_v1beta1_computeimage.yaml
@@ -23,6 +23,6 @@ spec:
   family: ubuntu-custom
   licenses: ["https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"]
   rawDisk:
-    source: "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+    source: "https://storage.googleapis.com/config-connector-computeimage-raw/computeimage-raw.tar.gz"
     containerType: "TAR"
     sha1: 819b7e9c17423f4539f09687eaa13687afa2fe32

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeimage.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeimage.md
@@ -703,7 +703,7 @@ spec:
   family: ubuntu-custom
   licenses: ["https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"]
   rawDisk:
-    source: "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+    source: "https://storage.googleapis.com/config-connector-computeimage-raw/computeimage-raw.tar.gz"
     containerType: "TAR"
     sha1: 819b7e9c17423f4539f09687eaa13687afa2fe32
 ```


### PR DESCRIPTION
The bucket was deleted and rendered the test to fail. Updated the yaml with new bucket and tested locally.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
