### PR TITLE
fix: Incorrect value of clientTLSPolicy from ComputeBackendService

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
@@ -1166,7 +1166,8 @@ spec:
                       - external
                     properties:
                       external:
-                        description: 'Allowed value: The `name` field of a `NetworkSecurityClientTLSPolicy`
+                        description: 'Allowed value: string of the format `//networksecurity.googleapis.com/projects/{{project}}/locations/{{location}}/clientTlsPolicies/{{value}}`,
+                          where {{value}} is the `name` field of a `NetworkSecurityClientTLSPolicy`
                           resource.'
                         type: string
                       name:

--- a/config/servicemappings/compute.yaml
+++ b/config/servicemappings/compute.yaml
@@ -172,6 +172,7 @@ spec:
             kind: NetworkSecurityClientTLSPolicy
             version: v1beta1
             group: networksecurity.cnrm.cloud.google.com
+          valueTemplate: "//networksecurity.googleapis.com/projects/{{project}}/locations/{{location}}/clientTlsPolicies/{{value}}"
           dclBasedResource: true
         - tfField: iap.oauth2_client_id
           description: OAuth2 Client ID for IAP.

--- a/pkg/krmtotf/templating.go
+++ b/pkg/krmtotf/templating.go
@@ -182,6 +182,16 @@ func expandFieldTemplate(template string, r *Resource, c client.Client, smLoader
 		if val, exists, _ := unstructured.NestedString(r.GetStatusOrObservedState(), strings.Split(path, ".")...); exists {
 			return val
 		}
+
+		// todo(yuhou): Special handling to resolve project from DCL-based resource
+		// Only used for fixtures/globalcomputebackendservicesecuritysettings test for now
+		if path == "project" {
+			dclPath := "projectRef.external"
+			if val, exists, _ := unstructured.NestedString(r.Spec, strings.Split(dclPath, ".")...); exists {
+				return val
+			}
+		}
+
 		if isRequired {
 			resolutionError = fmt.Errorf("unable to resolve missing value: %v", field)
 		}

--- a/pkg/krmtotf/templating.go
+++ b/pkg/krmtotf/templating.go
@@ -183,9 +183,10 @@ func expandFieldTemplate(template string, r *Resource, c client.Client, smLoader
 			return val
 		}
 
-		// todo(yuhou): Special handling to resolve project from DCL-based resource
-		// Only used for fixtures/globalcomputebackendservicesecuritysettings test for now
-		if path == "project" {
+		// Special handling to resolve project from DCL-based resource
+		// Only applied to a referenced NetworkSecurityClientTLSPolicy resource
+		// and tested by fixtures/globalcomputebackendservicesecuritysettings test for now
+		if path == "project" && r.Kind == "NetworkSecurityClientTLSPolicy" {
 			dclPath := "projectRef.external"
 			if val, exists, _ := unstructured.NestedString(r.Spec, strings.Split(dclPath, ".")...); exists {
 				return val

--- a/pkg/test/resourcefixture/contexts/compute_context.go
+++ b/pkg/test/resourcefixture/contexts/compute_context.go
@@ -30,6 +30,15 @@ func init() {
 		SkipUpdate:   true,
 	}
 
+	resourceContextMap["globalcomputebackendservicesecuritysettings"] = ResourceContext{
+		ResourceKind: "ComputeBackendService",
+		// Underlying API changes dependency resource's project id to number after successful creation.
+		// For now TF servicemapping does not have a way to resolve dependency DCL resources' project number.
+		// Skip checking no change after creation(testNoChangeAfterCreate) to bypass this temporarily.
+		// See https://buganizer.corp.google.com/issues/374166656#comment11 for details.
+		SkipNoChange: true,
+	}
+
 	resourceContextMap["computeexternalvpngateway"] = ResourceContext{
 		ResourceKind: "ComputeExternalVPNGateway",
 		SkipUpdate:   true,

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/create.yaml
@@ -22,7 +22,7 @@ spec:
   # global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED
   securitySettings:
     clientTLSPolicyRef:
-      name: clienttlspolicy-${uniqueId}
+      name: networksecurityclienttlspolicy-${uniqueId}
     subjectAltNames:
       - spiffe://junk.svc.id.goog/ns/test/sa/frontend
   timeoutSec: 10

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/create.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: computebackendservice-${uniqueId}
+spec:
+  loadBalancingScheme: INTERNAL_SELF_MANAGED
+  # The security settings that apply to this backend service. This field is applicable to
+  # global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED
+  securitySettings:
+    clientTLSPolicyRef:
+      name: clienttlspolicy-${uniqueId}
+    subjectAltNames:
+      - spiffe://junk.svc.id.goog/ns/test/sa/frontend
+  timeoutSec: 10
+  location: global

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/dependencies.yaml
@@ -15,7 +15,7 @@
 apiVersion: networksecurity.cnrm.cloud.google.com/v1beta1
 kind: NetworkSecurityClientTLSPolicy
 metadata:
-  name: clienttlspolicy-${uniqueId}
+  name: networksecurityclienttlspolicy-${uniqueId}
 spec:
   clientCertificate:
     certificateProviderInstance:

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/dependencies.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networksecurity.cnrm.cloud.google.com/v1beta1
+kind: NetworkSecurityClientTLSPolicy
+metadata:
+  name: clienttlspolicy-${uniqueId}
+spec:
+  clientCertificate:
+    certificateProviderInstance:
+      pluginInstance: google_cloud_private_spiffe
+  location: global
+  serverValidationCa:
+    - certificateProviderInstance:
+        pluginInstance: google_cloud_private_spiffe

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/update.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeBackendService
+metadata:
+  name: computebackendservice-${uniqueId}
+spec:
+  loadBalancingScheme: INTERNAL_SELF_MANAGED
+  # The security settings that apply to this backend service. This field is applicable to
+  # global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED
+  securitySettings:
+    clientTLSPolicyRef:
+      name: clienttlspolicy-${uniqueId}
+    subjectAltNames:
+      - spiffe://junk.svc.id.goog/ns/test/sa/frontend
+  timeoutSec: 5
+  location: global

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computebackendservice/globalcomputebackendservicesecuritysettings/update.yaml
@@ -22,7 +22,7 @@ spec:
   # global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED
   securitySettings:
     clientTLSPolicyRef:
-      name: clienttlspolicy-${uniqueId}
+      name: networksecurityclienttlspolicy-${uniqueId}
     subjectAltNames:
       - spiffe://junk.svc.id.goog/ns/test/sa/frontend
   timeoutSec: 5

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computebackendservice.md
@@ -2150,7 +2150,7 @@ service resource.{% endverbatim %}</p>
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Allowed value: The `name` field of a `NetworkSecurityClientTLSPolicy` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}Allowed value: string of the format `//networksecurity.googleapis.com/projects/{{project}}/locations/{{location}}/clientTlsPolicies/{{value}}`, where {{value}} is the `name` field of a `NetworkSecurityClientTLSPolicy` resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_backend_service.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_backend_service.go
@@ -4305,11 +4305,7 @@ func expandComputeBackendServiceSecuritySettings(v interface{}, d tpgresource.Te
 }
 
 func expandComputeBackendServiceSecuritySettingsClientTlsPolicy(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	f, err := tpgresource.ParseGlobalFieldValue("regions", v.(string), "project", d, config, true)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid value for client_tls_policy: %s", err)
-	}
-	return f.RelativeLink(), nil
+	return v, nil
 }
 
 func expandComputeBackendServiceSecuritySettingsSubjectAltNames(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes b/374166656

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->
Resource created successfully:
```
kubectl describe ComputeBackendService computebackendservice-yuhou1025
Spec:
  Load Balancing Scheme:  INTERNAL_SELF_MANAGED
  Location:               global
  Resource ID:            computebackendservice-yuhou1025
  Security Settings:
    Client TLS Policy Ref:
      Name:  clienttlspolicy-yuhou1025
    Subject Alt Names:
      spiffe://junk.svc.id.goog/ns/test/sa/frontend
  Timeout Sec:  10
Status:
  Conditions:
    Last Transition Time:  2024-10-25T19:18:09Z
    Message:               The resource is up to date
    Reason:                UpToDate
    Status:                True
    Type:                  Ready
  Creation Timestamp:      2024-10-25T12:03:28.186-07:00
  Fingerprint:             KkS0AHjQtyc=
  Generated Id:            2810711594725955000
  Observed Generation:     2
  Self Link:               https://www.googleapis.com/compute/v1/projects/cnrm-yuhou/global/backendServices/computebackendservice-yuhou1025
Events:
  Type     Reason              Age                  From                              Message
  ----     ------              ----                 ----                              -------
  Warning  DependencyNotReady  17m                  computebackendservice-controller  reference NetworkSecurityClientTLSPolicy default/clienttlspolicy-yuhou1025 is not ready
  Normal   Updating            2m40s (x4 over 17m)  computebackendservice-controller  Update in progress
  Normal   UpToDate            2m19s (x4 over 16m)  computebackendservice-controller  The resource is up to date
```

Dynamic test passed(after skipping testNoChangeAfterCreate):
```
--- PASS: TestCreateNoChangeUpdateDelete (0.17s)
    --- PASS: TestCreateNoChangeUpdateDelete/compute (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/compute/basic-globalcomputebackendservicesecuritysettings (154.81s)
PASS
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
