### PR TITLE
fix: Fix SQLInstance authorizednetworks periodic

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-activationpolicy-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -406,7 +405,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-auditconfig-direct/_http.log
@@ -186,7 +186,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -590,7 +589,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-authorizednetworks-direct/_http.log
@@ -52,7 +52,9 @@ User-Agent: kcc/controller-manager
           "name": "all",
           "value": "0.0.0.0/0"
         }
-      ]
+      ],
+      "ipv4Enabled": true,
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {
@@ -409,7 +411,9 @@ User-Agent: kcc/controller-manager
           "name": "my-network",
           "value": "1.2.3.0/24"
         }
-      ]
+      ],
+      "ipv4Enabled": true,
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-binarylog-direct/_http.log
@@ -59,7 +59,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -604,7 +603,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-pitr-direct/_http.log
@@ -59,7 +59,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -428,7 +427,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_http.log
@@ -51,7 +51,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-connectorenforcement-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -406,7 +405,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-databaseflags-direct/_http.log
@@ -52,7 +52,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -434,7 +433,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_http.log
@@ -49,7 +49,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -595,7 +594,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE_PLUS",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-deletionprotection-direct/_http.log
@@ -47,7 +47,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -408,7 +407,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-denymaintenanceperiod-direct/_http.log
@@ -53,7 +53,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -434,7 +433,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-encryptionkey-direct/_http.log
@@ -1074,7 +1074,8 @@ User-Agent: kcc/controller-manager
     "ipConfiguration": {
       "ipv4Enabled": false,
       "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
-      "requireSsl": true
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     },
     "kind": "sql#settings",
     "locationPreference": {
@@ -1505,7 +1506,8 @@ User-Agent: kcc/controller-manager
     "ipConfiguration": {
       "ipv4Enabled": false,
       "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
-      "requireSsl": true
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     },
     "kind": "sql#settings",
     "locationPreference": {

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-insightsconfig-direct/_http.log
@@ -53,7 +53,6 @@ User-Agent: kcc/controller-manager
     },
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -428,7 +427,6 @@ User-Agent: kcc/controller-manager
     },
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-locationpreference-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -392,7 +391,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-maintenancewindow-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -424,7 +423,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-multithreading-direct/_http.log
@@ -50,7 +50,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -485,7 +484,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-direct/_http.log
@@ -47,7 +47,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -584,7 +583,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-mysql-minimal-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -810,7 +809,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-passwordvalidationpolicy-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -415,7 +414,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-postgres-minimal-direct/_http.log
@@ -46,7 +46,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -576,7 +575,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-direct/_http.log
@@ -1384,7 +1384,8 @@ User-Agent: kcc/controller-manager
       "allocatedIpRange": "computeaddress-${uniqueId}",
       "enablePrivatePathForGoogleCloudServices": true,
       "ipv4Enabled": false,
-      "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}"
+      "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {
@@ -1729,7 +1730,8 @@ User-Agent: kcc/controller-manager
       "allocatedIpRange": "computeaddress2-${uniqueId}",
       "enablePrivatePathForGoogleCloudServices": true,
       "ipv4Enabled": false,
-      "privateNetwork": "projects/${projectId}/global/networks/computenetwork2-${uniqueId}"
+      "privateNetwork": "projects/${projectId}/global/networks/computenetwork2-${uniqueId}",
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-privatenetwork-legacyref-direct/_http.log
@@ -1384,7 +1384,8 @@ User-Agent: kcc/controller-manager
       "allocatedIpRange": "computeaddress-${uniqueId}",
       "enablePrivatePathForGoogleCloudServices": true,
       "ipv4Enabled": false,
-      "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}"
+      "privateNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {
@@ -1729,7 +1730,8 @@ User-Agent: kcc/controller-manager
       "allocatedIpRange": "computeaddress2-${uniqueId}",
       "enablePrivatePathForGoogleCloudServices": true,
       "ipv4Enabled": false,
-      "privateNetwork": "projects/${projectId}/global/networks/computenetwork2-${uniqueId}"
+      "privateNetwork": "projects/${projectId}/global/networks/computenetwork2-${uniqueId}",
+      "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
     "locationPreference": {

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_http.log
@@ -51,7 +51,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -442,7 +441,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-direct/_http.log
@@ -48,7 +48,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-sqlserver-minimal-direct/_http.log
@@ -47,7 +47,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -649,7 +648,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/_http.log
@@ -45,7 +45,9 @@ User-Agent: kcc/controller-manager
     "dataDiskType": "PD_SSD",
     "edition": "ENTERPRISE",
     "ipConfiguration": {
-      "requireSsl": true
+      "ipv4Enabled": true,
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     },
     "kind": "sql#settings",
     "locationPreference": {
@@ -389,6 +391,7 @@ User-Agent: kcc/controller-manager
     "dataDiskType": "PD_SSD",
     "edition": "ENTERPRISE",
     "ipConfiguration": {
+      "ipv4Enabled": true,
       "requireSsl": false,
       "sslMode": "ENCRYPTED_ONLY"
     },

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl-direct/create.yaml
@@ -27,6 +27,7 @@ spec:
       # for docs about the different possible `sslMode` field values, and the limiations of the
       # `requireSsl` field.
       requireSsl: true
+      sslMode: "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone
     # preference based on availability. Therefore it could potentially vary if not

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/_http.log
@@ -44,7 +44,8 @@ User-Agent: google-api-go-client/0.5 Terraform/ (+https://www.terraform.io) Terr
     "ipConfiguration": {
       "enablePrivatePathForGoogleCloudServices": false,
       "ipv4Enabled": true,
-      "requireSsl": true
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     },
     "locationPreference": {
       "zone": "us-central1-a"

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-ssl/create.yaml
@@ -25,6 +25,7 @@ spec:
       # for docs about the different possible `sslMode` field values, and the limiations of the
       # `requireSsl` field.
       requireSsl: true
+      sslMode: "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone
     # preference based on availability. Therefore it could potentially vary if not

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-storage-direct/_http.log
@@ -47,7 +47,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",
@@ -407,7 +406,6 @@ User-Agent: kcc/controller-manager
     "edition": "ENTERPRISE",
     "ipConfiguration": {
       "ipv4Enabled": true,
-      "serverCaMode": "GOOGLE_MANAGED_INTERNAL_CA",
       "sslMode": "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
     },
     "kind": "sql#settings",


### PR DESCRIPTION
Turns out, we need to set a default value for the IpConfiguration fields for Ipv4Enabled and SslMode, even if some of the IpConfiguration is specified. And, we do not need to set a default for ServerCaMode.

Also, SslMode appears to have a different default value depending on which type of database is used.
