### PR TITLE
test: fix dynamic tests for BigQueryDataTransferConfig

### DIFF
--- a/pkg/test/resourcefixture/contexts/bigquerydatatransfer_context.go
+++ b/pkg/test/resourcefixture/contexts/bigquerydatatransfer_context.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contexts
+
+func init() {
+	resourceContextMap["bigquerydatatransferconfig-salesforce"] = ResourceContext{
+		ResourceKind:       "BigQueryDataTransferConfig", // this direct resource has service-generated ID
+		SkipDriftDetection: true,
+	}
+	resourceContextMap["bigquerydatatransferconfig-scheduledquery"] = ResourceContext{
+		ResourceKind:       "BigQueryDataTransferConfig", // this direct resource has service-generated ID
+		SkipDriftDetection: true,
+	}
+}


### PR DESCRIPTION
This PR includes:

 - Skipped the "drift correction test" for this resource because it has a service-generated ID.
 - Added functionality in the dynamic e2e test to ignore sensitive fields (masked by the GCP API) during "update test".

Tested
```
$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests bigquerydatatransferconfig-salesforce

$ go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests bigquerydatatransferconfig-scheduledquery
```

For reference, the original error in "update test":
```
    dynamic_controller_integration_test.go:820: unexpected diff:   string(
        -       "AKfZ4pamHD_459mErG-pofG1xFFX1F3JRWRCh8nULWvFVHa1U3ZG1vFywgzDKR8",
        +       "client-id2",
          )
```