### PR TITLE
tests: wait for the webhook server to start

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -652,6 +652,18 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 		}
 	}()
 
+	// Wait for the webhook server to start (mgr.Start runs asynchronously)
+	for {
+		webhookStarted := mgr.GetWebhookServer().StartedChecker()
+		req := &http.Request{}
+		err := webhookStarted(req)
+		if err == nil {
+			break
+		}
+		t.Logf("error waiting for webhook to start: %v", err)
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	return h
 }
 


### PR DESCRIPTION
Because we start the manager in a goroutine, there is a race where the
webhook may not have started yet.  We were observing some test
failures because of this.
