### PR TITLE
fix: Specify missing fields in clone backup configuration

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_generated_object_sqlinstance-clone-minimal-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_generated_object_sqlinstance-clone-minimal-direct.golden.yaml
@@ -21,8 +21,14 @@ spec:
   region: us-central1
   settings:
     backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: 3
+        retentionUnit: COUNT
       enabled: true
+      location: us-central1
       pointInTimeRecoveryEnabled: true
+      startTime: "00:00"
+      transactionLogRetentionDays: 2
     locationPreference:
       zone: us-central1-a
     tier: db-custom-1-3840

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/_http.log
@@ -42,9 +42,16 @@ User-Agent: kcc/controller-manager
     "activationPolicy": "ALWAYS",
     "availabilityType": "ZONAL",
     "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 3,
+        "retentionUnit": "COUNT"
+      },
       "enabled": true,
       "kind": "sql#backupConfiguration",
-      "pointInTimeRecoveryEnabled": true
+      "location": "us-central1",
+      "pointInTimeRecoveryEnabled": true,
+      "startTime": "12:00",
+      "transactionLogRetentionDays": 2
     },
     "connectorEnforcement": "NOT_REQUIRED",
     "dataDiskType": "PD_SSD",
@@ -189,15 +196,16 @@ X-Xss-Protection: 0
     "availabilityType": "ZONAL",
     "backupConfiguration": {
       "backupRetentionSettings": {
-        "retainedBackups": 7,
+        "retainedBackups": 3,
         "retentionUnit": "COUNT"
       },
       "enabled": true,
       "kind": "sql#backupConfiguration",
+      "location": "us-central1",
       "pointInTimeRecoveryEnabled": true,
       "replicationLogArchivingEnabled": false,
       "startTime": "12:00",
-      "transactionLogRetentionDays": 7,
+      "transactionLogRetentionDays": 2,
       "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
@@ -425,15 +433,16 @@ X-Xss-Protection: 0
     "availabilityType": "ZONAL",
     "backupConfiguration": {
       "backupRetentionSettings": {
-        "retainedBackups": 7,
+        "retainedBackups": 3,
         "retentionUnit": "COUNT"
       },
       "enabled": true,
       "kind": "sql#backupConfiguration",
+      "location": "us-central1",
       "pointInTimeRecoveryEnabled": true,
       "replicationLogArchivingEnabled": false,
       "startTime": "12:00",
-      "transactionLogRetentionDays": 7,
+      "transactionLogRetentionDays": 2,
       "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
@@ -592,15 +601,16 @@ X-Xss-Protection: 0
     "availabilityType": "ZONAL",
     "backupConfiguration": {
       "backupRetentionSettings": {
-        "retainedBackups": 7,
+        "retainedBackups": 3,
         "retentionUnit": "COUNT"
       },
       "enabled": true,
       "kind": "sql#backupConfiguration",
+      "location": "us-central1",
       "pointInTimeRecoveryEnabled": true,
       "replicationLogArchivingEnabled": false,
       "startTime": "12:00",
-      "transactionLogRetentionDays": 7,
+      "transactionLogRetentionDays": 2,
       "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/create.yaml
@@ -26,8 +26,14 @@ spec:
   region: us-central1
   settings:
     backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: 3
+        retentionUnit: COUNT
       enabled: true
+      location: us-central1
       pointInTimeRecoveryEnabled: true
+      startTime: 00:00
+      transactionLogRetentionDays: 2
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone
     # preference based on availability. Therefore it could potentially vary if not

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-clone-minimal-direct/dependencies.yaml
@@ -23,8 +23,14 @@ spec:
   region: us-central1
   settings:
     backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: 3
+        retentionUnit: COUNT
       enabled: true
+      location: us-central1
       pointInTimeRecoveryEnabled: true
+      startTime: 00:00
+      transactionLogRetentionDays: 2
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone
     # preference based on availability. Therefore it could potentially vary if not


### PR DESCRIPTION
This way, the test will not need to re-reconcile after cloning in order to update the backup configuration.
