### PR TITLE
Sort the AccessControlEntry slice in PrivilegedAccessManagerEntitlement before diffing

### DIFF
--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -308,36 +308,36 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 
 	updateMask := &fieldmaskpb.FieldMask{}
 
-	parsedAndSortedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
+	parsedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
 	if mapCtx.Err() != nil {
 		return fmt.Errorf("error generating update mask: %w", mapCtx.Err())
 	}
-	sortArrayFieldsInSpec(parsedAndSortedActual)
-	sortedDesired := a.desired.DeepCopy()
-	sortArrayFieldsInSpec(&sortedDesired.Spec)
+	sortArrayFieldsInSpec(parsedActual)
+	parsedDesired := a.desired.DeepCopy()
+	sortArrayFieldsInSpec(&parsedDesired.Spec)
 
-	if !reflect.DeepEqual(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets) {
-		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets))
+	if !reflect.DeepEqual(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets) {
+		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets))
 		updateMask.Paths = append(updateMask.Paths, "additional_notification_targets")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow) {
-		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow))
+	if !reflect.DeepEqual(parsedActual.ApprovalWorkflow, parsedDesired.Spec.ApprovalWorkflow) {
+		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedActual.ApprovalWorkflow, parsedDesired.Spec.ApprovalWorkflow))
 		updateMask.Paths = append(updateMask.Paths, "approval_workflow")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers) {
-		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers))
+	if !reflect.DeepEqual(parsedActual.EligibleUsers, parsedDesired.Spec.EligibleUsers) {
+		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedActual.EligibleUsers, parsedDesired.Spec.EligibleUsers))
 		updateMask.Paths = append(updateMask.Paths, "eligible_users")
 	}
-	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()) {
-		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()))
+	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, parsedDesired.Spec.MaxRequestDuration).AsDuration()) {
+		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, parsedDesired.Spec.MaxRequestDuration).AsDuration()))
 		updateMask.Paths = append(updateMask.Paths, "max_request_duration")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess) {
-		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess))
+	if !reflect.DeepEqual(parsedActual.PrivilegedAccess, parsedDesired.Spec.PrivilegedAccess) {
+		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedActual.PrivilegedAccess, parsedDesired.Spec.PrivilegedAccess))
 		updateMask.Paths = append(updateMask.Paths, "privileged_access")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig) {
-		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig))
+	if !reflect.DeepEqual(parsedActual.RequesterJustificationConfig, parsedDesired.Spec.RequesterJustificationConfig) {
+		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedActual.RequesterJustificationConfig, parsedDesired.Spec.RequesterJustificationConfig))
 		updateMask.Paths = append(updateMask.Paths, "requester_justification_config")
 	}
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -312,9 +312,9 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	if mapCtx.Err() != nil {
 		return fmt.Errorf("error generating update mask: %w", mapCtx.Err())
 	}
-	sortArrayFieldsInSpec(parsedActual)
+	sortPrincipalsInSpec(parsedActual)
 	parsedDesired := a.desired.DeepCopy()
-	sortArrayFieldsInSpec(&parsedDesired.Spec)
+	sortPrincipalsInSpec(&parsedDesired.Spec)
 
 	if !reflect.DeepEqual(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets) {
 		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets))

--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -308,32 +308,36 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 
 	updateMask := &fieldmaskpb.FieldMask{}
 
-	parsedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
+	parsedAndSortedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
 	if mapCtx.Err() != nil {
 		return fmt.Errorf("error generating update mask: %w", mapCtx.Err())
 	}
-	if !reflect.DeepEqual(parsedActual.AdditionalNotificationTargets, a.desired.Spec.AdditionalNotificationTargets) {
-		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedActual.AdditionalNotificationTargets, a.desired.Spec.AdditionalNotificationTargets))
+	sortArrayFieldsInSpec(parsedAndSortedActual)
+	sortedDesired := a.desired.DeepCopy()
+	sortArrayFieldsInSpec(&sortedDesired.Spec)
+
+	if !reflect.DeepEqual(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets) {
+		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets))
 		updateMask.Paths = append(updateMask.Paths, "additional_notification_targets")
 	}
-	if !reflect.DeepEqual(parsedActual.ApprovalWorkflow, a.desired.Spec.ApprovalWorkflow) {
-		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedActual.ApprovalWorkflow, a.desired.Spec.ApprovalWorkflow))
+	if !reflect.DeepEqual(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow) {
+		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow))
 		updateMask.Paths = append(updateMask.Paths, "approval_workflow")
 	}
-	if !reflect.DeepEqual(parsedActual.EligibleUsers, a.desired.Spec.EligibleUsers) {
-		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedActual.EligibleUsers, a.desired.Spec.EligibleUsers))
+	if !reflect.DeepEqual(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers) {
+		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers))
 		updateMask.Paths = append(updateMask.Paths, "eligible_users")
 	}
-	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, a.desired.Spec.MaxRequestDuration).AsDuration()) {
-		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, a.desired.Spec.MaxRequestDuration).AsDuration()))
+	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()) {
+		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()))
 		updateMask.Paths = append(updateMask.Paths, "max_request_duration")
 	}
-	if !reflect.DeepEqual(parsedActual.PrivilegedAccess, a.desired.Spec.PrivilegedAccess) {
-		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedActual.PrivilegedAccess, a.desired.Spec.PrivilegedAccess))
+	if !reflect.DeepEqual(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess) {
+		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess))
 		updateMask.Paths = append(updateMask.Paths, "privileged_access")
 	}
-	if !reflect.DeepEqual(parsedActual.RequesterJustificationConfig, a.desired.Spec.RequesterJustificationConfig) {
-		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedActual.RequesterJustificationConfig, a.desired.Spec.RequesterJustificationConfig))
+	if !reflect.DeepEqual(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig) {
+		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig))
 		updateMask.Paths = append(updateMask.Paths, "requester_justification_config")
 	}
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -21,7 +21,13 @@ import (
 )
 
 func sortArrayFieldsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
+	if spec == nil {
+		return
+	}
 	sortAccessControlEntrySlice(spec.EligibleUsers)
+	if spec.ApprovalWorkflow == nil || spec.ApprovalWorkflow.ManualApprovals == nil {
+		return
+	}
 	for _, step := range spec.ApprovalWorkflow.ManualApprovals.Steps {
 		sortAccessControlEntrySlice(step.Approvers)
 	}

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -17,7 +17,7 @@ package privilegedaccessmanager
 import (
 	"sort"
 
-	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1beta1"
 )
 
 func sortPrincipalsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privilegedaccessmanager
+
+import (
+	"sort"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+)
+
+func sortArrayFieldsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
+	sortAccessControlEntrySlice(spec.EligibleUsers)
+	for _, step := range spec.ApprovalWorkflow.ManualApprovals.Steps {
+		sortAccessControlEntrySlice(step.Approvers)
+	}
+}
+
+func sortAccessControlEntrySlice(accessControlEntries []krm.AccessControlEntry) {
+	for _, eu := range accessControlEntries {
+		sort.Strings(eu.Principals)
+	}
+	sort.Slice(accessControlEntries, func(i, j int) bool {
+		lenA := len(accessControlEntries[i].Principals)
+		lenB := len(accessControlEntries[j].Principals)
+		if lenA != lenB || lenA == 0 {
+			return lenA < lenB
+		}
+		for x := 0; x < lenA; x++ {
+			pA := accessControlEntries[i].Principals[x]
+			pB := accessControlEntries[j].Principals[x]
+			if pA != pB {
+				return pA < pB
+			}
+		}
+		return lenA < lenB
+	})
+}

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -20,36 +20,22 @@ import (
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
 )
 
-func sortArrayFieldsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
+func sortPrincipalsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
 	if spec == nil {
 		return
 	}
-	sortAccessControlEntrySlice(spec.EligibleUsers)
+
+	sortPrincipals(spec.EligibleUsers)
 	if spec.ApprovalWorkflow == nil || spec.ApprovalWorkflow.ManualApprovals == nil {
 		return
 	}
 	for _, step := range spec.ApprovalWorkflow.ManualApprovals.Steps {
-		sortAccessControlEntrySlice(step.Approvers)
+		sortPrincipals(step.Approvers)
 	}
 }
 
-func sortAccessControlEntrySlice(accessControlEntries []krm.AccessControlEntry) {
+func sortPrincipals(accessControlEntries []krm.AccessControlEntry) {
 	for _, eu := range accessControlEntries {
 		sort.Strings(eu.Principals)
 	}
-	sort.Slice(accessControlEntries, func(i, j int) bool {
-		lenA := len(accessControlEntries[i].Principals)
-		lenB := len(accessControlEntries[j].Principals)
-		if lenA != lenB || lenA == 0 {
-			return lenA < lenB
-		}
-		for x := 0; x < lenA; x++ {
-			pA := accessControlEntries[i].Principals[x]
-			pB := accessControlEntries[j].Principals[x]
-			if pA != pB {
-				return pA < pB
-			}
-		}
-		return lenA < lenB
-	})
 }

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -1,0 +1,330 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privilegedaccessmanager
+
+import (
+	"reflect"
+	"testing"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortAccessControlEntrySlice(t *testing.T) {
+	tests := []struct {
+		testName string
+		unsorted []krm.AccessControlEntry
+		expected []krm.AccessControlEntry
+	}{
+		{
+			testName: "nil input",
+			unsorted: nil,
+			expected: nil,
+		},
+		{
+			testName: "empty slice",
+			unsorted: []krm.AccessControlEntry{},
+			expected: []krm.AccessControlEntry{},
+		},
+		{
+			testName: "empty principal slice in single access control entry",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{},
+				},
+			},
+		},
+		{
+			testName: "sort single entry",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort single entry containing duplicate principals",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort multiple entries",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort multiple entries",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			sortAccessControlEntrySlice(tc.unsorted)
+			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
+				t.Fatalf("unexpected diff running sortAccessControlEntrySlice (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+			}
+		})
+	}
+}
+
+func TestSortArrayFieldsInSpec(t *testing.T) {
+	tests := []struct {
+		testName string
+		unsorted *krm.PrivilegedAccessManagerEntitlementSpec
+		expected *krm.PrivilegedAccessManagerEntitlementSpec
+	}{
+		{
+			testName: "EligibleUsers and ApprovalWorkflow.ManualApprovals.Steps.Approvers are sorted",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+					{
+						Principals: []string{
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz2@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{
+						Steps: []krm.Step{
+							{
+								Approvers: []krm.AccessControlEntry{
+									{
+										Principals: []string{
+											"user:abc@test.com",
+											"serviceAccount:xyz@gservicaccount.com",
+										},
+									},
+									{
+										Principals: []string{
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"user:abc@test.com",
+											"serviceAccount:xyz2@gservicaccount.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"serviceAccount:xyz2@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{
+						Steps: []krm.Step{
+							{
+								Approvers: []krm.AccessControlEntry{
+									{
+										Principals: []string{
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"serviceAccount:xyz2@gservicaccount.com",
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"serviceAccount:xyz@gservicaccount.com",
+											"user:abc@test.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			sortArrayFieldsInSpec(tc.unsorted)
+			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
+				t.Fatalf("unexpected diff running sortArrayFieldsInSpec (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+			}
+		})
+	}
+}

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -220,6 +220,70 @@ func TestSortArrayFieldsInSpec(t *testing.T) {
 		expected *krm.PrivilegedAccessManagerEntitlementSpec
 	}{
 		{
+			testName: "nil spec",
+			unsorted: nil,
+			expected: nil,
+		},
+		{
+			testName: "empty spec with no EligibleUsers nor ApprovalWorkflow",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{},
+		},
+		{
+			testName: "nil ApprovalWorkflow.ManualApprovals",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{},
+			},
+		},
+		{
+			testName: "nil ApprovalWorkflow.ManualApprovals.Steps",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{},
+				},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{},
+				},
+			},
+		},
+		{
 			testName: "EligibleUsers and ApprovalWorkflow.ManualApprovals.Steps.Approvers are sorted",
 			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
 				EligibleUsers: []krm.AccessControlEntry{

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -123,59 +123,10 @@ func TestSortAccessControlEntrySlice(t *testing.T) {
 			expected: []krm.AccessControlEntry{
 				{
 					Principals: []string{
-						"user:abc@test.com",
-					},
-				},
-				{
-					Principals: []string{
-						"serviceAccount:xyz2@gservicaccount.com",
-						"user:abc@test.com",
-					},
-				},
-				{
-					Principals: []string{
 						"serviceAccount:xyz@gservicaccount.com",
 						"user:abc@test.com",
 					},
 				},
-				{
-					Principals: []string{
-						"serviceAccount:xyz2@gservicaccount.com",
-						"serviceAccount:xyz@gservicaccount.com",
-						"user:abc@test.com",
-					},
-				},
-			},
-		},
-		{
-			testName: "sort multiple entries",
-			unsorted: []krm.AccessControlEntry{
-				{
-					Principals: []string{
-						"user:abc@test.com",
-						"serviceAccount:xyz@gservicaccount.com",
-					},
-				},
-				{
-					Principals: []string{
-						"user:abc@test.com",
-					},
-				},
-				{
-					Principals: []string{
-						"user:abc@test.com",
-						"serviceAccount:xyz2@gservicaccount.com",
-					},
-				},
-				{
-					Principals: []string{
-						"user:abc@test.com",
-						"serviceAccount:xyz@gservicaccount.com",
-						"serviceAccount:xyz2@gservicaccount.com",
-					},
-				},
-			},
-			expected: []krm.AccessControlEntry{
 				{
 					Principals: []string{
 						"user:abc@test.com",
@@ -184,12 +135,6 @@ func TestSortAccessControlEntrySlice(t *testing.T) {
 				{
 					Principals: []string{
 						"serviceAccount:xyz2@gservicaccount.com",
-						"user:abc@test.com",
-					},
-				},
-				{
-					Principals: []string{
-						"serviceAccount:xyz@gservicaccount.com",
 						"user:abc@test.com",
 					},
 				},
@@ -205,9 +150,9 @@ func TestSortAccessControlEntrySlice(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.testName, func(t *testing.T) {
-			sortAccessControlEntrySlice(tc.unsorted)
+			sortPrincipals(tc.unsorted)
 			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
-				t.Fatalf("unexpected diff running sortAccessControlEntrySlice (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+				t.Fatalf("unexpected diff running sortPrincipals (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
 			}
 		})
 	}
@@ -337,18 +282,18 @@ func TestSortArrayFieldsInSpec(t *testing.T) {
 				EligibleUsers: []krm.AccessControlEntry{
 					{
 						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
 							"user:abc@test.com",
 						},
 					},
 					{
 						Principals: []string{
 							"serviceAccount:xyz2@gservicaccount.com",
-							"user:abc@test.com",
-						},
-					},
-					{
-						Principals: []string{
-							"serviceAccount:xyz@gservicaccount.com",
 							"user:abc@test.com",
 						},
 					},
@@ -360,18 +305,18 @@ func TestSortArrayFieldsInSpec(t *testing.T) {
 								Approvers: []krm.AccessControlEntry{
 									{
 										Principals: []string{
+											"serviceAccount:xyz@gservicaccount.com",
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
 											"user:abc@test.com",
 										},
 									},
 									{
 										Principals: []string{
 											"serviceAccount:xyz2@gservicaccount.com",
-											"user:abc@test.com",
-										},
-									},
-									{
-										Principals: []string{
-											"serviceAccount:xyz@gservicaccount.com",
 											"user:abc@test.com",
 										},
 									},
@@ -385,9 +330,9 @@ func TestSortArrayFieldsInSpec(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.testName, func(t *testing.T) {
-			sortArrayFieldsInSpec(tc.unsorted)
+			sortPrincipalsInSpec(tc.unsorted)
 			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
-				t.Fatalf("unexpected diff running sortArrayFieldsInSpec (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+				t.Fatalf("unexpected diff running sortPrincipalsInSpec (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
 			}
 		})
 	}


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
AccessControlEntry.Principals slices in PrivilegedAccessManagerEntitlement will be returned with an unexpected, random order, and reflect.DeepEqual() will take entry order into consideration when doing comparison. So we need to sort the AccessControlEntry.Principals slices before compare the actual state and the desired state of a PrivilegedAccessManagerEntitlement.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.

Verified that the change of order of principals in EligibleUsers and ApprovalWorkflow.ManualApprovals.Steps.Approvers won't trigger an update call to the API.