### PR TITLE
chore: Enable more SecretManagerSecret fields 

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_generated_object_fullsecretmanagersecret.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_generated_object_fullsecretmanagersecret.golden.yaml
@@ -19,6 +19,10 @@ spec:
     foo: secretmanagersecret
   expireTime: "2025-10-03T15:01:23Z"
   replication:
+    auto:
+      customerManagedEncryption:
+        kmsKeyRef:
+          name: kmscryptokey-${uniqueId}
     automatic: true
   rotation:
     nextRotationTime: "2025-10-03T15:01:23Z"

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_http.log
@@ -363,7 +363,7 @@ X-Xss-Protection: 0
   "done": true,
   "name": "operations/${operationID}",
   "response": {
-    "@type": "type.googleapis.com/mockgcp.api.serviceusage.v1beta1.ServiceIdentity",
+    "@type": "type.googleapis.com/google.api.serviceusage.v1beta1.ServiceIdentity",
     "email": "service-${projectNumber}@gcp-sa-secretmanager.iam.gserviceaccount.com",
     "uniqueId": "12345678"
   }
@@ -699,7 +699,11 @@ x-goog-request-params: parent=projects%2F${projectId}
     "managed-by-cnrm": "true"
   },
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-02T15:01:23Z",
@@ -737,7 +741,11 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-02T15:01:23Z",
@@ -782,7 +790,11 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-02T15:01:23Z",
@@ -816,7 +828,11 @@ x-goog-request-params: secret.name=projects%2F${projectId}%2Fsecrets%2Fsecretman
   },
   "name": "projects/${projectId}/secrets/secretmanagersecret-${uniqueId}",
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-03T15:01:23Z",
@@ -855,7 +871,11 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-03T15:01:23Z",
@@ -901,7 +921,11 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
   "replication": {
-    "automatic": {}
+    "automatic": {
+      "customerManagedEncryption": {
+        "kmsKeyName": "projects/${projectId}/locations/global/keyRings/kmskeyring-${uniqueId}/cryptoKeys/kmscryptokey-${uniqueId}"
+      }
+    }
   },
   "rotation": {
     "nextRotationTime": "2025-10-03T15:01:23Z",

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/_http.log
@@ -363,7 +363,7 @@ X-Xss-Protection: 0
   "done": true,
   "name": "operations/${operationID}",
   "response": {
-    "@type": "type.googleapis.com/google.api.serviceusage.v1beta1.ServiceIdentity",
+    "@type": "type.googleapis.com/mockgcp.api.serviceusage.v1beta1.ServiceIdentity",
     "email": "service-${projectNumber}@gcp-sa-secretmanager.iam.gserviceaccount.com",
     "uniqueId": "12345678"
   }

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/create.yaml
@@ -25,10 +25,10 @@ spec:
     automatic: true
   # TF-based resource is broken, got the error even if not changing this field 
   # "cannot make changes to immutable field(s): [Field Name: replication.0.auto.#, Got: 1, Wanted: 0]"
-  #   auto:
-  #     customerManagedEncryption:
-  #       kmsKeyRef:
-  #         name: kmscryptokey-${uniqueId}
+    auto:
+      customerManagedEncryption:
+        kmsKeyRef:
+          name: kmscryptokey-${uniqueId}
   topics:
     - topicRef:
         name: topic-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/dependencies.yaml
@@ -22,6 +22,8 @@ apiVersion: kms.cnrm.cloud.google.com/v1beta1
 kind: KMSCryptoKey
 metadata:
   name: kmscryptokey-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
 spec:
   keyRingRef:
     name: kmskeyring-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/secretmanager/v1beta1/fullsecretmanagersecret/update.yaml
@@ -23,12 +23,12 @@ metadata:
 spec:
   replication:
     automatic: true
-  # TF-based resource is broken, got the error even if not changing this field 
-  # "cannot make changes to immutable field(s): [Field Name: replication.0.auto.#, Got: 1, Wanted: 0]"
-  #   auto:
-  #     customerManagedEncryption:
-  #       kmsKeyRef:
-  #         name: kmscryptokey-${uniqueId}
+    # TF-based resource is broken, got the error even if not changing this field 
+    # "cannot make changes to immutable field(s): [Field Name: replication.0.auto.#, Got: 1, Wanted: 0]"
+    auto:
+      customerManagedEncryption:
+        kmsKeyRef:
+          name: kmscryptokey-${uniqueId}
   topics:
     - topicRef:
         name: topic-2-${uniqueId}


### PR DESCRIPTION
This PR adds back the test coverage for those fields that is previously broken in the TF-based approach.
1st git-commit is running agaisnt real GCP, and the second is against mockgcp.  

This also verified https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/3051 is fixed in the direct approach