### PR TITLE
fix: controller-gen crd to allow unexported field

### DIFF
--- a/dev/tasks/generate-crds
+++ b/dev/tasks/generate-crds
@@ -26,7 +26,7 @@ cd ${REPO_ROOT}
 cd ${REPO_ROOT}/apis
 go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3 \
   object:headerFile=${REPO_ROOT}/hack/boilerplate.go.txt \
-  crd:crdVersions=v1,allowDangerousTypes=true \
+  crd:crdVersions=v1,allowDangerousTypes=true,ignoreUnexportedFields=true \
   output:crd:artifacts:config=config/crd/ \
   paths="./..."
 


### PR DESCRIPTION
We added a "parent" field in the type "_reference.go" template, which does not intended to have [json tags](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/dev/tools/controllerbuilder/template/apis/refs.go#L47) to hide it from the CRD. 

This PR adjusts the `dev/tasks/generate-crds` to let it skip that "parent" field.