### PR TITLE
[DO NOT MERGE] Experiment diffing of AccessControlEntry slice using apimachinary sets

### DIFF
--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -308,36 +308,36 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 
 	updateMask := &fieldmaskpb.FieldMask{}
 
-	parsedAndSortedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
+	parsedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
 	if mapCtx.Err() != nil {
 		return fmt.Errorf("error generating update mask: %w", mapCtx.Err())
 	}
-	sortArrayFieldsInSpec(parsedAndSortedActual)
-	sortedDesired := a.desired.DeepCopy()
-	sortArrayFieldsInSpec(&sortedDesired.Spec)
+	sortArrayFieldsInSpec(parsedActual)
+	parsedDesired := a.desired.DeepCopy()
+	sortArrayFieldsInSpec(&parsedDesired.Spec)
 
-	if !reflect.DeepEqual(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets) {
-		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets))
+	if !reflect.DeepEqual(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets) {
+		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedActual.AdditionalNotificationTargets, parsedDesired.Spec.AdditionalNotificationTargets))
 		updateMask.Paths = append(updateMask.Paths, "additional_notification_targets")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow) {
-		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow))
+	if !reflect.DeepEqual(parsedActual.ApprovalWorkflow, parsedDesired.Spec.ApprovalWorkflow) {
+		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedActual.ApprovalWorkflow, parsedDesired.Spec.ApprovalWorkflow))
 		updateMask.Paths = append(updateMask.Paths, "approval_workflow")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers) {
-		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers))
+	if !reflect.DeepEqual(parsedActual.EligibleUsers, parsedDesired.Spec.EligibleUsers) {
+		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedActual.EligibleUsers, parsedDesired.Spec.EligibleUsers))
 		updateMask.Paths = append(updateMask.Paths, "eligible_users")
 	}
-	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()) {
-		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()))
+	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, parsedDesired.Spec.MaxRequestDuration).AsDuration()) {
+		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, parsedDesired.Spec.MaxRequestDuration).AsDuration()))
 		updateMask.Paths = append(updateMask.Paths, "max_request_duration")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess) {
-		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess))
+	if !reflect.DeepEqual(parsedActual.PrivilegedAccess, parsedDesired.Spec.PrivilegedAccess) {
+		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedActual.PrivilegedAccess, parsedDesired.Spec.PrivilegedAccess))
 		updateMask.Paths = append(updateMask.Paths, "privileged_access")
 	}
-	if !reflect.DeepEqual(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig) {
-		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig))
+	if !reflect.DeepEqual(parsedActual.RequesterJustificationConfig, parsedDesired.Spec.RequesterJustificationConfig) {
+		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedActual.RequesterJustificationConfig, parsedDesired.Spec.RequesterJustificationConfig))
 		updateMask.Paths = append(updateMask.Paths, "requester_justification_config")
 	}
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -308,32 +308,36 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 
 	updateMask := &fieldmaskpb.FieldMask{}
 
-	parsedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
+	parsedAndSortedActual := PrivilegedAccessManagerEntitlementSpec_FromProto(mapCtx, a.actual)
 	if mapCtx.Err() != nil {
 		return fmt.Errorf("error generating update mask: %w", mapCtx.Err())
 	}
-	if !reflect.DeepEqual(parsedActual.AdditionalNotificationTargets, a.desired.Spec.AdditionalNotificationTargets) {
-		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedActual.AdditionalNotificationTargets, a.desired.Spec.AdditionalNotificationTargets))
+	sortArrayFieldsInSpec(parsedAndSortedActual)
+	sortedDesired := a.desired.DeepCopy()
+	sortArrayFieldsInSpec(&sortedDesired.Spec)
+
+	if !reflect.DeepEqual(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets) {
+		log.V(2).Info("'spec.additionalNotificationTargets' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.AdditionalNotificationTargets, sortedDesired.Spec.AdditionalNotificationTargets))
 		updateMask.Paths = append(updateMask.Paths, "additional_notification_targets")
 	}
-	if !reflect.DeepEqual(parsedActual.ApprovalWorkflow, a.desired.Spec.ApprovalWorkflow) {
-		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedActual.ApprovalWorkflow, a.desired.Spec.ApprovalWorkflow))
+	if !reflect.DeepEqual(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow) {
+		log.V(2).Info("'spec.approvalWorkflow' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.ApprovalWorkflow, sortedDesired.Spec.ApprovalWorkflow))
 		updateMask.Paths = append(updateMask.Paths, "approval_workflow")
 	}
-	if !reflect.DeepEqual(parsedActual.EligibleUsers, a.desired.Spec.EligibleUsers) {
-		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedActual.EligibleUsers, a.desired.Spec.EligibleUsers))
+	if !reflect.DeepEqual(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers) {
+		log.V(2).Info("'spec.eligibleUsers' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.EligibleUsers, sortedDesired.Spec.EligibleUsers))
 		updateMask.Paths = append(updateMask.Paths, "eligible_users")
 	}
-	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, a.desired.Spec.MaxRequestDuration).AsDuration()) {
-		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, a.desired.Spec.MaxRequestDuration).AsDuration()))
+	if !reflect.DeepEqual(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()) {
+		log.V(2).Info("'spec.maxRequestDuration' field is updated (-old +new)", cmp.Diff(a.actual.MaxRequestDuration.AsDuration(), direct.StringDuration_ToProto(mapCtx, sortedDesired.Spec.MaxRequestDuration).AsDuration()))
 		updateMask.Paths = append(updateMask.Paths, "max_request_duration")
 	}
-	if !reflect.DeepEqual(parsedActual.PrivilegedAccess, a.desired.Spec.PrivilegedAccess) {
-		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedActual.PrivilegedAccess, a.desired.Spec.PrivilegedAccess))
+	if !reflect.DeepEqual(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess) {
+		log.V(2).Info("'spec.privilegedAccess' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.PrivilegedAccess, sortedDesired.Spec.PrivilegedAccess))
 		updateMask.Paths = append(updateMask.Paths, "privileged_access")
 	}
-	if !reflect.DeepEqual(parsedActual.RequesterJustificationConfig, a.desired.Spec.RequesterJustificationConfig) {
-		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedActual.RequesterJustificationConfig, a.desired.Spec.RequesterJustificationConfig))
+	if !reflect.DeepEqual(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig) {
+		log.V(2).Info("'spec.requesterJustificationConfig' field is updated (-old +new)", cmp.Diff(parsedAndSortedActual.RequesterJustificationConfig, sortedDesired.Spec.RequesterJustificationConfig))
 		updateMask.Paths = append(updateMask.Paths, "requester_justification_config")
 	}
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -21,7 +21,13 @@ import (
 )
 
 func sortArrayFieldsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
+	if spec == nil {
+		return
+	}
 	sortAccessControlEntrySlice(spec.EligibleUsers)
+	if spec.ApprovalWorkflow == nil || spec.ApprovalWorkflow.ManualApprovals == nil {
+		return
+	}
 	for _, step := range spec.ApprovalWorkflow.ManualApprovals.Steps {
 		sortAccessControlEntrySlice(step.Approvers)
 	}

--- a/pkg/controller/direct/privilegedaccessmanager/util.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privilegedaccessmanager
+
+import (
+	"sort"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+)
+
+func sortArrayFieldsInSpec(spec *krm.PrivilegedAccessManagerEntitlementSpec) {
+	sortAccessControlEntrySlice(spec.EligibleUsers)
+	for _, step := range spec.ApprovalWorkflow.ManualApprovals.Steps {
+		sortAccessControlEntrySlice(step.Approvers)
+	}
+}
+
+func sortAccessControlEntrySlice(accessControlEntries []krm.AccessControlEntry) {
+	for _, eu := range accessControlEntries {
+		sort.Strings(eu.Principals)
+	}
+	sort.Slice(accessControlEntries, func(i, j int) bool {
+		lenA := len(accessControlEntries[i].Principals)
+		lenB := len(accessControlEntries[j].Principals)
+		if lenA != lenB || lenA == 0 {
+			return lenA < lenB
+		}
+		for x := 0; x < lenA; x++ {
+			pA := accessControlEntries[i].Principals[x]
+			pB := accessControlEntries[j].Principals[x]
+			if pA != pB {
+				return pA < pB
+			}
+		}
+		return lenA < lenB
+	})
+}

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -1,0 +1,330 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privilegedaccessmanager
+
+import (
+	"reflect"
+	"testing"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/privilegedaccessmanager/v1alpha1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortAccessControlEntrySlice(t *testing.T) {
+	tests := []struct {
+		testName string
+		unsorted []krm.AccessControlEntry
+		expected []krm.AccessControlEntry
+	}{
+		{
+			testName: "nil input",
+			unsorted: nil,
+			expected: nil,
+		},
+		{
+			testName: "empty slice",
+			unsorted: []krm.AccessControlEntry{},
+			expected: []krm.AccessControlEntry{},
+		},
+		{
+			testName: "empty principal slice in single access control entry",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{},
+				},
+			},
+		},
+		{
+			testName: "sort single entry",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort single entry containing duplicate principals",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort multiple entries",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+		{
+			testName: "sort multiple entries",
+			unsorted: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+				{
+					Principals: []string{
+						"user:abc@test.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"serviceAccount:xyz2@gservicaccount.com",
+					},
+				},
+			},
+			expected: []krm.AccessControlEntry{
+				{
+					Principals: []string{
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+				{
+					Principals: []string{
+						"serviceAccount:xyz2@gservicaccount.com",
+						"serviceAccount:xyz@gservicaccount.com",
+						"user:abc@test.com",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			sortAccessControlEntrySlice(tc.unsorted)
+			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
+				t.Fatalf("unexpected diff running sortAccessControlEntrySlice (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+			}
+		})
+	}
+}
+
+func TestSortArrayFieldsInSpec(t *testing.T) {
+	tests := []struct {
+		testName string
+		unsorted *krm.PrivilegedAccessManagerEntitlementSpec
+		expected *krm.PrivilegedAccessManagerEntitlementSpec
+	}{
+		{
+			testName: "EligibleUsers and ApprovalWorkflow.ManualApprovals.Steps.Approvers are sorted",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+					{
+						Principals: []string{
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz2@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{
+						Steps: []krm.Step{
+							{
+								Approvers: []krm.AccessControlEntry{
+									{
+										Principals: []string{
+											"user:abc@test.com",
+											"serviceAccount:xyz@gservicaccount.com",
+										},
+									},
+									{
+										Principals: []string{
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"user:abc@test.com",
+											"serviceAccount:xyz2@gservicaccount.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"serviceAccount:xyz2@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{
+						Steps: []krm.Step{
+							{
+								Approvers: []krm.AccessControlEntry{
+									{
+										Principals: []string{
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"serviceAccount:xyz2@gservicaccount.com",
+											"user:abc@test.com",
+										},
+									},
+									{
+										Principals: []string{
+											"serviceAccount:xyz@gservicaccount.com",
+											"user:abc@test.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			sortArrayFieldsInSpec(tc.unsorted)
+			if !reflect.DeepEqual(tc.unsorted, tc.expected) {
+				t.Fatalf("unexpected diff running sortArrayFieldsInSpec (-want +got): \n%v", cmp.Diff(tc.expected, tc.unsorted))
+			}
+		})
+	}
+}

--- a/pkg/controller/direct/privilegedaccessmanager/util_test.go
+++ b/pkg/controller/direct/privilegedaccessmanager/util_test.go
@@ -220,6 +220,70 @@ func TestSortArrayFieldsInSpec(t *testing.T) {
 		expected *krm.PrivilegedAccessManagerEntitlementSpec
 	}{
 		{
+			testName: "nil spec",
+			unsorted: nil,
+			expected: nil,
+		},
+		{
+			testName: "empty spec with no EligibleUsers nor ApprovalWorkflow",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{},
+		},
+		{
+			testName: "nil ApprovalWorkflow.ManualApprovals",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{},
+			},
+		},
+		{
+			testName: "nil ApprovalWorkflow.ManualApprovals.Steps",
+			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"user:abc@test.com",
+							"serviceAccount:xyz@gservicaccount.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{},
+				},
+			},
+			expected: &krm.PrivilegedAccessManagerEntitlementSpec{
+				EligibleUsers: []krm.AccessControlEntry{
+					{
+						Principals: []string{
+							"serviceAccount:xyz@gservicaccount.com",
+							"user:abc@test.com",
+						},
+					},
+				},
+				ApprovalWorkflow: &krm.ApprovalWorkflow{
+					ManualApprovals: &krm.ManualApprovals{},
+				},
+			},
+		},
+		{
 			testName: "EligibleUsers and ApprovalWorkflow.ManualApprovals.Steps.Approvers are sorted",
 			unsorted: &krm.PrivilegedAccessManagerEntitlementSpec{
 				EligibleUsers: []krm.AccessControlEntry{

--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -616,11 +616,11 @@ func testReconcileCreateNoChangeUpdateDelete(ctx context.Context, t *testing.T, 
 	resourceCleanup := systemContext.Reconciler.BuildCleanupFunc(ctx, testContext.CreateUnstruct, getResourceCleanupPolicy())
 	defer resourceCleanup()
 	testCreate(ctx, t, testContext, systemContext, resourceContext)
-	testNoChangeAfterCreate(ctx, t, testContext, systemContext, resourceContext)
+	//testNoChangeAfterCreate(ctx, t, testContext, systemContext, resourceContext)
 	testUpdate(ctx, t, testContext, systemContext, resourceContext)
-	testNoChangeAfterUpdate(ctx, t, testContext, systemContext, resourceContext)
-	testDriftCorrection(ctx, t, testContext, systemContext, resourceContext)
-	testDelete(ctx, t, testContext, systemContext, resourceContext)
+	//testNoChangeAfterUpdate(ctx, t, testContext, systemContext, resourceContext)
+	//testDriftCorrection(ctx, t, testContext, systemContext, resourceContext)
+	//testDelete(ctx, t, testContext, systemContext, resourceContext)
 }
 
 func checkComputeNetworkUpdate(t *testing.T, updateUnstruct *unstructured.Unstructured, gcpUnstruct *unstructured.Unstructured) {

--- a/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1alpha1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementbasicproject/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1alpha1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementbasicproject/create.yaml
@@ -30,3 +30,4 @@ spec:
   eligibleUsers:
     - principals:
         - serviceAccount:gsa-1-${uniqueId}@${projectId}.iam.gserviceaccount.com
+        - user:[REDACT]

--- a/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1alpha1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementbasicproject/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1alpha1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementbasicproject/update.yaml
@@ -20,14 +20,14 @@ spec:
   projectRef:
     external: projects/${projectId}
   location: global
-  # Use format hhmmss to pass assertObjectContains check.
-  maxRequestDuration: 1h0m0s
+  maxRequestDuration: 1800s
   privilegedAccess:
     gcpIAMAccess:
       roleBindings:
-        - role: roles/storage.admin
+        - role: roles/pubsub.admin
   requesterJustificationConfig:
     notMandatory: {}
   eligibleUsers:
     - principals:
-        - serviceAccount:gsa-2-${uniqueId}@${projectId}.iam.gserviceaccount.com
+        - user:[REDACT]
+        - serviceAccount:gsa-1-${uniqueId}@${projectId}.iam.gserviceaccount.com


### PR DESCRIPTION
Experiment code: e30a721c23faef14b5b8f2e6b3ab5ad9a778ea9b

Diff found when the order of items in the principals list is updated:
```
'spec.eligibleUsers' field is updated (-old +new):   []v1alpha1.AccessControlEntry{
- 	{
- 		Principals: []string{
- 			"serviceAccount:gsa-1-ixi2dbo2qmsgwgi@[REDACT].iam.gser"...,
- 			"user:[REDACT]",
- 		},
- 	},
+ 	{
+ 		Principals: []string{
+ 			"user:[REDACT]",
+ 			"serviceAccount:gsa-1-ixi2dbo2qmsgwgi@[REDACT].iam.gser"...,
+ 		},
+ 	},
  }
```
