### PR TITLE
tests: clearer log when waiting for webhook

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -660,7 +660,7 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 		if err == nil {
 			break
 		}
-		t.Logf("error waiting for webhook to start: %v", err)
+		t.Logf("waiting for webhook to start (%v)", err)
 		time.Sleep(100 * time.Millisecond)
 	}
 


### PR DESCRIPTION
It isn't (normally) an error, we're just waiting
for the webhook to start.
