### PR TITLE
Refactor CloudNetworkRef to use Ref / ID split pattern

### DIFF
--- a/pkg/controller/direct/dataflow/refs.go
+++ b/pkg/controller/direct/dataflow/refs.go
@@ -53,12 +53,8 @@ func (r *refNormalizer) VisitField(path string, v any) error {
 	}
 
 	if networkRef, ok := v.(*refs.ComputeNetworkRef); ok {
-		resolved, err := refs.ResolveComputeNetwork(r.ctx, r.kube, r.src, networkRef)
-		if err != nil {
+		if err := networkRef.Normalize(r.ctx, r.kube, r.src); err != nil {
 			return err
-		}
-		*networkRef = refs.ComputeNetworkRef{
-			External: resolved.String(),
 		}
 	}
 

--- a/pkg/controller/direct/networkconnectivity/refs.go
+++ b/pkg/controller/direct/networkconnectivity/refs.go
@@ -53,12 +53,8 @@ func (r *refNormalizer) VisitField(path string, v any) error {
 	}
 
 	if networkRef, ok := v.(*refs.ComputeNetworkRef); ok {
-		resolved, err := refs.ResolveComputeNetwork(r.ctx, r.kube, r.src, networkRef)
-		if err != nil {
+		if err := networkRef.Normalize(r.ctx, r.kube, r.src); err != nil {
 			return err
-		}
-		*networkRef = refs.ComputeNetworkRef{
-			External: resolved.String(),
 		}
 	}
 

--- a/pkg/controller/direct/redis/cluster/refs.go
+++ b/pkg/controller/direct/redis/cluster/refs.go
@@ -53,12 +53,8 @@ func (r *refNormalizer) VisitField(path string, v any) error {
 	}
 
 	if networkRef, ok := v.(*refs.ComputeNetworkRef); ok {
-		resolved, err := refs.ResolveComputeNetwork(r.ctx, r.kube, r.src, networkRef)
-		if err != nil {
+		if err := networkRef.Normalize(r.ctx, r.kube, r.src); err != nil {
 			return err
-		}
-		*networkRef = refs.ComputeNetworkRef{
-			External: resolved.String(),
 		}
 	}
 

--- a/pkg/controller/direct/sql/sqlinstance_resolverefs.go
+++ b/pkg/controller/direct/sql/sqlinstance_resolverefs.go
@@ -228,12 +228,11 @@ func resolvePrivateNetworkRef(ctx context.Context, kube client.Reader, obj *krm.
 		Name:      resRef.Name,
 		Namespace: resRef.Namespace,
 	}
-	net, err := refs.ResolveComputeNetwork(ctx, kube, obj, netRef)
-	if err != nil {
+	if err := netRef.Normalize(ctx, kube, obj); err != nil {
 		return err
 	}
 
-	obj.Spec.Settings.IpConfiguration.PrivateNetworkRef.External = net.String()
+	obj.Spec.Settings.IpConfiguration.PrivateNetworkRef.External = netRef.External
 
 	return nil
 }

--- a/pkg/controller/direct/workstations/workstationcluster_normalize.go
+++ b/pkg/controller/direct/workstations/workstationcluster_normalize.go
@@ -25,11 +25,9 @@ import (
 
 func NormalizeWorkstationCluster(ctx context.Context, kube client.Reader, obj *krm.WorkstationCluster) error {
 	// Resolve network.
-	network, err := refs.ResolveComputeNetwork(ctx, kube, obj, &obj.Spec.NetworkRef)
-	if err != nil {
+	if err := obj.Spec.NetworkRef.Normalize(ctx, kube, obj); err != nil {
 		return err
 	}
-	obj.Spec.NetworkRef.External = network.String()
 
 	// Resolve subnetwork.
 	subnet, err := refs.ResolveComputeSubnetwork(ctx, kube, obj, &obj.Spec.SubnetworkRef)

--- a/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudbuild/v1beta1/cloudbuildworkerpool/_http.log
@@ -582,6 +582,32 @@ X-Xss-Protection: 0
 
 ---
 
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: name=projects%2F${projectId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}",
+  "projectId": "${projectId}",
+  "state": 1
+}
+
+---
+
 GET https://cloudbuild.googleapis.com/v1/projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/controller-manager
@@ -619,7 +645,7 @@ x-goog-request-params: location=us-central1
   "privatePoolV1Config": {
     "networkConfig": {
       "egressOption": 1,
-      "peeredNetwork": "projects/${projectId}/global/networks/computenetwork-${uniqueId}",
+      "peeredNetwork": "projects/${projectNumber}/global/networks/computenetwork-${uniqueId}",
       "peeredNetworkIpRange": "/29"
     },
     "workerConfig": {
@@ -696,6 +722,32 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: name=projects%2F${projectId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}",
+  "projectId": "${projectId}",
+  "state": 1
 }
 
 ---
@@ -828,6 +880,136 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
+}
+
+---
+
+GET https://cloudbuild.googleapis.com/v1/projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: location=us-central1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "Updated CloudBuild WorkerPool",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
+  "privatePoolV1Config": {
+    "networkConfig": {
+      "egressOption": 2,
+      "peeredNetwork": "projects/${projectNumber}/global/networks/computenetwork-${uniqueId}",
+      "peeredNetworkIpRange": "/29"
+    },
+    "workerConfig": {
+      "diskSizeGb": "150",
+      "machineType": "e2-highmem-4"
+    }
+  },
+  "state": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: name=projects%2F${projectId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}",
+  "projectId": "${projectId}",
+  "state": 1
+}
+
+---
+
+GET https://cloudbuild.googleapis.com/v1/projects/${projectId}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: location=us-central1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "Updated CloudBuild WorkerPool",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}/locations/us-central1/workerPools/cloudbuildworkerpool-${uniqueId}",
+  "privatePoolV1Config": {
+    "networkConfig": {
+      "egressOption": 2,
+      "peeredNetwork": "projects/${projectNumber}/global/networks/computenetwork-${uniqueId}",
+      "peeredNetworkIpRange": "/29"
+    },
+    "workerConfig": {
+      "diskSizeGb": "150",
+      "machineType": "e2-highmem-4"
+    }
+  },
+  "state": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: name=projects%2F${projectId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}",
+  "projectId": "${projectId}",
+  "state": 1
 }
 
 ---


### PR DESCRIPTION
- **ComputeNetworkRef: split into ref and ID**
- **mockgcp: CloudBuildWorkerPool: normalize peered network link to use project number**
