### PR TITLE
Avoid misleading error message when a string contains colon and followed by only env vars

### DIFF
--- a/config/samples/resources/iampolicy/external-project-level-policy/iam_v1beta1_iampolicy.yaml
+++ b/config/samples/resources/iampolicy/external-project-level-policy/iam_v1beta1_iampolicy.yaml
@@ -32,7 +32,7 @@ spec:
         # Replace ${GSA_EMAIL?} with the Config Connector service account's
         # email address. This ensures that the Config Connector service account
         # can continue to manage the referenced project.
-        - serviceAccount:${GSA_EMAIL?}
+        - "serviceAccount:${GSA_EMAIL?}"
       role: roles/owner
     - members:
         - serviceAccount:iampolicy-dep-external-project@iampolicy-dep-external-project.iam.gserviceaccount.com

--- a/config/samples/resources/iampolicy/project-level-policy/iam_v1beta1_iampolicy.yaml
+++ b/config/samples/resources/iampolicy/project-level-policy/iam_v1beta1_iampolicy.yaml
@@ -32,7 +32,7 @@ spec:
         # Replace ${GSA_EMAIL?} with the Config Connector service account's
         # email address. This ensures that the Config Connector service account
         # can continue to manage the referenced project.
-        - serviceAccount:${GSA_EMAIL?}
+        - "serviceAccount:${GSA_EMAIL?}"
       role: roles/owner
     - members:
         - serviceAccount:iampolicy-dep-project@iampolicy-dep-project.iam.gserviceaccount.com

--- a/config/samples/resources/privilegedaccessmanagerentitlement/folder-level-entitlement/privilegedaccessmanager_v1beta1_privilegedaccessmanagerentitlement.yaml
+++ b/config/samples/resources/privilegedaccessmanagerentitlement/folder-level-entitlement/privilegedaccessmanager_v1beta1_privilegedaccessmanagerentitlement.yaml
@@ -52,4 +52,4 @@ spec:
           approvers:
             - principals:
                 # Replace ${GROUP_EMAIL?} with your group email.
-                - group:${GROUP_EMAIL?}
+                - "group:${GROUP_EMAIL?}"

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/iam/iampolicy.md
@@ -931,7 +931,7 @@ spec:
         # Replace ${GSA_EMAIL?} with the Config Connector service account's
         # email address. This ensures that the Config Connector service account
         # can continue to manage the referenced project.
-        - serviceAccount:${GSA_EMAIL?}
+        - "serviceAccount:${GSA_EMAIL?}"
       role: roles/owner
     - members:
         - serviceAccount:iampolicy-dep-external-project@iampolicy-dep-external-project.iam.gserviceaccount.com
@@ -1044,7 +1044,7 @@ spec:
         # Replace ${GSA_EMAIL?} with the Config Connector service account's
         # email address. This ensures that the Config Connector service account
         # can continue to manage the referenced project.
-        - serviceAccount:${GSA_EMAIL?}
+        - "serviceAccount:${GSA_EMAIL?}"
       role: roles/owner
     - members:
         - serviceAccount:iampolicy-dep-project@iampolicy-dep-project.iam.gserviceaccount.com

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privilegedaccessmanager/privilegedaccessmanagerentitlement.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privilegedaccessmanager/privilegedaccessmanagerentitlement.md
@@ -756,7 +756,7 @@ spec:
           approvers:
             - principals:
                 # Replace ${GROUP_EMAIL?} with your group email.
-                - group:${GROUP_EMAIL?}
+                - "group:${GROUP_EMAIL?}"
 ---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
In sample yamls, quote the strings that contain colon (':') followed by only env var(s). This is to avoid misleading error messages like below:

```
error creating resource: PrivilegedAccessManagerEntitlement.privilegedaccessmanager.cnrm.cloud.google.com 
"uwewbiibxqnycqcqinjtavlwhssvbdgloygejrxlbolmhkgx" is invalid: 
spec.approvalWorkflow.manualApprovals.step.approvers.principals: Invalid value: "object": 
spec.approvalWorkflow.manualApprovals.step.approvers.principals in body must be of type string: "object"
```

In the folder-level-entitlement sample, while the principals list was correctly configured, because the value of `GROUP_EMAIL` was empty, the value of `spec.approvalWorkflow.manualApprovals.step.approvers.principals` became `- group:`, and APIserver considered it an object instead of a string, thus we received this confusing error message.

To avoid such error message, we should just quote string values like that.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
