### PR TITLE
Configure pprof on controller-manager.

### DIFF
--- a/operator/config/crd/bases/customize.core.cnrm.cloud.google.com_controllerreconcilers.yaml
+++ b/operator/config/crd/bases/customize.core.cnrm.cloud.google.com_controllerreconcilers.yaml
@@ -41,6 +41,20 @@ spec:
           spec:
             description: ControllerReconcilerSpec is the specification of ControllerReconciler.
             properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
               rateLimit:
                 description: |-
                   RateLimit configures the token bucket rate limit to the kubernetes client used

--- a/operator/config/crd/bases/customize.core.cnrm.cloud.google.com_namespacedcontrollerreconcilers.yaml
+++ b/operator/config/crd/bases/customize.core.cnrm.cloud.google.com_namespacedcontrollerreconcilers.yaml
@@ -41,6 +41,20 @@ spec:
           spec:
             description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
             properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
               rateLimit:
                 description: |-
                   RateLimit configures the token bucket rate limit to the kubernetes client used

--- a/operator/pkg/apis/core/customize/v1alpha1/controllerreconciler_types.go
+++ b/operator/pkg/apis/core/customize/v1alpha1/controllerreconciler_types.go
@@ -41,6 +41,9 @@ type NamespacedControllerReconcilerSpec struct {
 	// If not specified, the default will be Token Bucket with qps 20, burst 30.
 	// +optional
 	RateLimit *RateLimit `json:"rateLimit,omitempty"`
+	// Configures the debug endpoint on the service.
+	// +optional
+	Pprof *PprofConfig `json:"pprof,omitempty"`
 }
 
 type RateLimit struct {
@@ -50,6 +53,16 @@ type RateLimit struct {
 	// The burst of the token bucket rate limit for all the requests to the kubernetes client.
 	// +optional
 	Burst int `json:"burst,omitempty"`
+}
+
+type PprofConfig struct {
+	// Control if pprof should be turned on and which types should be enabled.
+	// +kubebuilder:validation:Enum=none;all
+	// +optional
+	Support string `json:"support,omitempty"`
+	// The port that the pprof server binds to if enabled
+	// +optional
+	Port int `json:"port,omitempty"`
 }
 
 // NamespacedControllerReconcilerStatus defines the observed state of NamespacedControllerReconciler.
@@ -92,6 +105,9 @@ type ControllerReconcilerSpec struct {
 	// If not specified, the default will be Token Bucket with qps 20, burst 30.
 	// +optional
 	RateLimit *RateLimit `json:"rateLimit,omitempty"`
+	// Configures the debug endpoint on the service.
+	// +optional
+	Pprof *PprofConfig `json:"pprof,omitempty"`
 }
 
 // ControllerReconcilerStatus defines the observed state of ControllerReconciler.
@@ -113,6 +129,10 @@ type ControllerReconcilerList struct {
 }
 
 var ValidRateLimitControllers = []string{
+	"cnrm-controller-manager",
+}
+
+var SupportedPprofControllers = []string{
 	"cnrm-controller-manager",
 }
 

--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -861,6 +861,10 @@ func (r *Reconciler) applyControllerReconcilerCR(ctx context.Context, cr *custom
 		r.log.Error(err, errMsg)
 		return r.handleApplyControllerReconcilerFailed(ctx, cr, errMsg)
 	}
+	if err := controllers.ApplyContainerPprof(m, cr.Name, cr.Spec.Pprof); err != nil {
+		msg := fmt.Sprintf("failed to apply pprof customization %s: %v", cr.Name, err)
+		return r.handleApplyControllerReconcilerFailed(ctx, cr, msg)
+	}
 	return r.handleApplyControllerReconcilerSucceeded(ctx, cr)
 }
 

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -551,6 +551,10 @@ func (r *Reconciler) applyNamespacedControllerReconciler(ctx context.Context, cr
 		msg := fmt.Sprintf("failed to apply rate limit customization %s: %v", cr.Name, err)
 		return r.handleApplyNamespacedControllerReconcilerFailed(ctx, cr.Namespace, cr.Name, msg)
 	}
+	if err := controllers.ApplyContainerPprof(m, cr.Name, cr.Spec.Pprof); err != nil {
+		msg := fmt.Sprintf("failed to apply pprof customization %s: %v", cr.Name, err)
+		return r.handleApplyNamespacedControllerReconcilerFailed(ctx, cr.Namespace, cr.Name, msg)
+	}
 	return r.handleApplyNamespacedControllerReconcilerSucceeded(ctx, cr.Namespace, cr.Name)
 }
 

--- a/operator/pkg/preflight/upgrade.go
+++ b/operator/pkg/preflight/upgrade.go
@@ -31,7 +31,8 @@ import (
 )
 
 var (
-	ulog = ctrl.Log.WithName("UpgradeChecker")
+	ulog       = ctrl.Log.WithName("UpgradeChecker")
+	devVersion = semver.MustParse("0.0.0-dev")
 )
 
 // NewUpgradeChecker provides an implementation of declarative.Preflight that
@@ -95,6 +96,10 @@ func (u *UpgradeChecker) Preflight(ctx context.Context, o declarative.Declarativ
 }
 
 func compareMajorOnly(v, w semver.Version) int {
+	if v.Equals(devVersion) {
+		// If we are using a dev controller ignore semver drift.
+		return 0
+	}
 	if v.Major != w.Major {
 		if v.Major > w.Major {
 			return 1


### PR DESCRIPTION
Generated file.
Adding cluster mode changes.
Updated version for cluster mode.
Skipping version check on dev mode controllers.
Make pprof support case insensitive.

### Change description

Allows you to enable pprof and use it as follows.

apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
kind: NamespacedControllerReconciler
metadata:
  name: cnrm-controller-manager 
  namespace: kcc-test
spec:
  pprof:
    support: all
    port: 1234

kubectl port-forward cnrm-controller-manager-<id> -n cnrm-system 1234

curl http://localhost:1234/debug/pprof/heap > heap.outheap.out

Fixes #

### Tests you have done

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
