### PR TITLE
tests: fuzz DataExchange spec 

### DIFF
--- a/pkg/controller/direct/bigqueryanalyticshub/fuzzers.go
+++ b/pkg/controller/direct/bigqueryanalyticshub/fuzzers.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigqueryanalyticshub
+
+import (
+	bigqueryanalyticshubpb "cloud.google.com/go/bigquery/analyticshub/apiv1/analyticshubpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(fuzzDataExchange())
+}
+
+func fuzzDataExchange() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&bigqueryanalyticshubpb.DataExchange{},
+		BigQueryAnalyticsHubDataExchangeSpec_FromProto, BigQueryAnalyticsHubDataExchangeSpec_ToProto,
+		BigQueryAnalyticsHubDataExchangeObservedState_FromProto, BigQueryAnalyticsHubDataExchangeObservedState_ToProto,
+	)
+
+	f.UnimplementedFields.Insert([]string{
+		".discovery_type", // does not round trip as it is a pointer to a enum value
+		".sharing_environment_config",
+		".icon",
+		".name", // this is the same as our self reference
+	}...)
+
+	f.SpecFields.Insert([]string{
+		".description",
+		".documentation",
+		".display_name",
+		".primary_contact",
+		".discovery_type",
+	}...)
+
+	// status fields are only listing_count for now
+	f.StatusFields.Insert([]string{
+		".listing_count",
+	}...)
+
+	return f
+}

--- a/pkg/controller/direct/bigqueryanalyticshub/mapper.go
+++ b/pkg/controller/direct/bigqueryanalyticshub/mapper.go
@@ -30,6 +30,17 @@ func BigQueryAnalyticsHubDataExchangeObservedState_FromProto(mapCtx *direct.MapC
 	return out
 }
 
+func BigQueryAnalyticsHubDataExchangeObservedState_ToProto(mapCtx *direct.MapContext, in *krm.BigQueryAnalyticsHubDataExchangeObservedState) *pb.DataExchange {
+	if in == nil {
+		return nil
+	}
+
+	out := &pb.DataExchange{}
+	out.ListingCount = int32(direct.ValueOf(in.ListingCount))
+	// MISSING: SharingEnvironmentConfig // not yet
+	return out
+}
+
 func BigQueryAnalyticsHubDataExchangeSpec_FromProto(mapCtx *direct.MapContext, in *pb.DataExchange) *krm.BigQueryAnalyticsHubDataExchangeSpec {
 	if in == nil {
 		return nil

--- a/pkg/fuzztesting/fuzzkrm.go
+++ b/pkg/fuzztesting/fuzzkrm.go
@@ -141,6 +141,9 @@ func (f *FuzzTest[ProtoT, KRMType]) Fuzz(t *testing.T, seed int64) {
 		t.Fatalf("error mapping from krm to proto: %v", ctx.Err())
 	}
 
+	// This clear will remove any non roundtrippable fields
+	fuzz.Visit("", p2.ProtoReflect(), nil, clearFields)
+
 	if diff := cmp.Diff(p1, p2, protocmp.Transform()); diff != "" {
 		t.Logf("p1 = %v", prototext.Format(p1))
 		t.Logf("p2 = %v", prototext.Format(p2))


### PR DESCRIPTION
- Adds support for un roundtrippable fields like a pointer to a enum on the proto. 
- Adds fuzzer for DataExchange
