### PR TITLE
fix: don't include unmanageddetector in base

### DIFF
--- a/config/installbundle/base/kustomization.yaml
+++ b/config/installbundle/base/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - ../components/roles
   - ../components/rolebindings
   - ../components/recorder
-  - ../components/unmanageddetector
   - ../components/webhook
+  # Note: unmanageddetector is only used in namespaced mode
+  #- ../components/unmanageddetector


### PR DESCRIPTION
This causes it to be included twice, which is an error.
