### PR TITLE
Fix the unexpected diff in runservicemulticontainer test

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicemulticontainer/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicemulticontainer/create.yaml
@@ -18,7 +18,7 @@ metadata:
   name: runservice-${uniqueId}
 spec:
   ingress: "INGRESS_TRAFFIC_ALL"
-  launchStage: "BETA"
+  launchStage: "GA"
   location: "us-central1"
   projectRef:
     external: "projects/${projectId}"

--- a/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicemulticontainer/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicemulticontainer/update.yaml
@@ -18,7 +18,7 @@ metadata:
   name: runservice-${uniqueId}
 spec:
   ingress: "INGRESS_TRAFFIC_ALL"
-  launchStage: "BETA"
+  launchStage: "GA"
   location: "us-central1"
   projectRef:
     external: "projects/${projectId}"


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes the failed runservicemulticontainer test (b/375678794).

When getting the underlying Cloud Run service resource in runservicemulticontainer test, `launchStage` value was updated to `GA` in the GET response. (https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services) So during the reconciliation of the testNoChange step(s) in dynamic test, the value of `launchStage` is `GA` in the live state and is `BETA` in the desired state, and this caused an unexpected diff and triggers an unexpected API call.

This behavior comes from the underlying Cloud Run API so we can't really fix it. To resolve the failed test, the workaround is to match the `launchStage` in the test case with the `launchStage` returned by the Cloud Run API. 


### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
