### PR TITLE
fix: Remove whitespace from docs command

### DIFF
--- a/docs/develop-resources/deep-dives/2-define-apis.md
+++ b/docs/develop-resources/deep-dives/2-define-apis.md
@@ -30,7 +30,7 @@ go run main.go generate-types \
      --service google.storage.v1  \
      --proto-source-path ../proto-to-mapper/build/googleapis.pb \
      --output-api $REPO_ROOT/apis \
-     --kind StorageNotification  \ 
+     --kind StorageNotification  \
      --proto-resource Notification \
      --api-version "storage.cnrm.cloud.google.com/v1beta1"
 ```


### PR DESCRIPTION
Super minor, but this caused an issue for me when copy/pasting the command into my terminal, editing, and attempting to run it.

The error I got was:
```
`--proto-resource` is required
exit status 1
```
