### PR TITLE
tests: increase timeout for lint job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-22.04
-    timeout-minutes: 12
+    timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
We seem to be hitting the timeout, particularly with the go update.
