### PR TITLE
feat: change UUID to user-specified ID in bqcc

### DIFF
--- a/apis/bigqueryconnection/v1beta1/connection_types.go
+++ b/apis/bigqueryconnection/v1beta1/connection_types.go
@@ -38,8 +38,8 @@ type Parent struct {
 type BigQueryConnectionConnectionSpec struct {
 	Parent `json:",inline"`
 
-	// The BigQuery ConnectionID. This is a server-generated ID in the UUID format.
-	// If not provided, ConfigConnector will create a new Connection and store the UUID in `status.serviceGeneratedID` field.
+	// The BigQuery ConnectionID. If not given, the metadata.name is used.
+	// To acquire a service-generated connection which ID is in UUID format, you can only use this field.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// User provided display name for the connection.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryconnectionconnections.bigqueryconnection.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryconnectionconnections.bigqueryconnection.cnrm.cloud.google.com.yaml
@@ -800,10 +800,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: The BigQuery ConnectionID. This is a server-generated
-                  ID in the UUID format. If not provided, ConfigConnector will create
-                  a new Connection and store the UUID in `status.serviceGeneratedID`
-                  field.
+                description: The BigQuery ConnectionID. If not given, the metadata.name
+                  is used. To acquire a service-generated connection which ID is in
+                  UUID format, you can only use this field.
                 type: string
               spark:
                 description: Spark properties.

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/_generated_object_bigqueryconnectionconnectionfull.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/_generated_object_bigqueryconnectionconnectionfull.golden.yaml
@@ -25,7 +25,7 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  externalRef: projects/${projectId}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be
+  externalRef: projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}
   observedGeneration: 2
   observedState:
     cloudResource:

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/_http.log
@@ -1,4 +1,30 @@
-POST https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections?%24alt=json%3Benum-encoding%3Dint
+GET https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2Fbigqueryconnectionconnection-${uniqueId}
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Not found: Connection projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections?%24alt=json%3Benum-encoding%3Dint&connectionId=bigqueryconnectionconnection-${uniqueId}
 Content-Type: application/json
 User-Agent: kcc/controller-manager
 x-goog-request-params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
@@ -28,15 +54,15 @@ X-Xss-Protection: 0
   "description": "test connection for cloud resource",
   "friendlyName": "cloud-resource-connection",
   "lastModifiedTime": "123456789",
-  "name": "projects/${projectNumber}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be"
+  "name": "projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}"
 }
 
 ---
 
-GET https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be?%24alt=json%3Benum-encoding%3Dint
+GET https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/controller-manager
-x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2F71389360-831c-431d-8975-837aee2153be
+x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2Fbigqueryconnectionconnection-${uniqueId}
 
 200 OK
 Cache-Control: private
@@ -57,21 +83,21 @@ X-Xss-Protection: 0
   "description": "test connection for cloud resource",
   "friendlyName": "cloud-resource-connection",
   "lastModifiedTime": "123456789",
-  "name": "projects/${projectNumber}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be"
+  "name": "projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}"
 }
 
 ---
 
-PATCH https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be?%24alt=json%3Benum-encoding%3Dint&updateMask=description%2CfriendlyName
+PATCH https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=description%2CfriendlyName
 Content-Type: application/json
 User-Agent: kcc/controller-manager
-x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2F71389360-831c-431d-8975-837aee2153be
+x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2Fbigqueryconnectionconnection-${uniqueId}
 
 {
   "cloudResource": {},
   "description": "updated connection for cloud resource",
   "friendlyName": "cloud-resource-connection-updated",
-  "name": "projects/${projectNumber}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be"
+  "name": "projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}"
 }
 
 200 OK
@@ -93,15 +119,15 @@ X-Xss-Protection: 0
   "description": "updated connection for cloud resource",
   "friendlyName": "cloud-resource-connection-updated",
   "lastModifiedTime": "123456789",
-  "name": "projects/${projectNumber}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be"
+  "name": "projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}"
 }
 
 ---
 
-GET https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be?%24alt=json%3Benum-encoding%3Dint
+GET https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/controller-manager
-x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2F71389360-831c-431d-8975-837aee2153be
+x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2Fbigqueryconnectionconnection-${uniqueId}
 
 200 OK
 Cache-Control: private
@@ -122,15 +148,15 @@ X-Xss-Protection: 0
   "description": "updated connection for cloud resource",
   "friendlyName": "cloud-resource-connection-updated",
   "lastModifiedTime": "123456789",
-  "name": "projects/${projectNumber}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be"
+  "name": "projects/${projectNumber}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}"
 }
 
 ---
 
-DELETE https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/71389360-831c-431d-8975-837aee2153be?%24alt=json%3Benum-encoding%3Dint
+DELETE https://bigqueryconnection.googleapis.com/v1/projects/${projectId}/locations/us-central1/connections/bigqueryconnectionconnection-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/controller-manager
-x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2F71389360-831c-431d-8975-837aee2153be
+x-goog-request-params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fconnections%2Fbigqueryconnectionconnection-${uniqueId}
 
 200 OK
 Cache-Control: private

--- a/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigqueryconnection/v1alpha1/bigqueryconnectionconnection/bigqueryconnectionconnectionfull/create.yaml
@@ -17,9 +17,6 @@ kind: BigQueryConnectionConnection
 metadata:
   name: bigqueryconnectionconnection-${uniqueId}
 spec:
-  # This is a service-generated-ID resource. Specifying the resource ID
-  # breaks the dynamic test.
-  # resourceID: 71389360-831c-431d-8975-837aee2153be
   friendlyName: "cloud-resource-connection"
   description: "test connection for cloud resource"
   location: us-central1


### PR DESCRIPTION
This change overrides the BQCC server behavior a little bit, that it no longer uses the service-generated UUID, instead, it always uses a user-specified ID. Another option that is more close to the BQC server behavior is that only `spec.resourceID`  configures the user created connectionID, if not given, KCC lets BQC assigns a default connection ID (UUID). The downside is that user may be confused due to the slightly different use of this resource's `metadata.name` and `spec.resourceID` compared to other resources. @jingyih  WDYT?   

