### PR TITLE
test: fix TestAcquire/bigquery/resourceid-userspecifiedresourceid

### DIFF
--- a/pkg/test/resourcefixture/testdata/resourceid/userspecifiedresourceid/create.yaml
+++ b/pkg/test/resourcefixture/testdata/resourceid/userspecifiedresourceid/create.yaml
@@ -20,3 +20,5 @@ spec:
   resourceID: bigquerydataset_${uniqueId}
   friendlyName: bigquerydataset-sample
   location: us-central1
+  projectRef:
+    external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/resourceid/userspecifiedresourceid/update.yaml
+++ b/pkg/test/resourcefixture/testdata/resourceid/userspecifiedresourceid/update.yaml
@@ -20,3 +20,5 @@ spec:
   resourceID: bigquerydataset_${uniqueId}
   friendlyName: bigquerydataset-sample-updated
   location: us-central1
+  projectRef:
+    external: ${projectId}


### PR DESCRIPTION
Add back the projectRef, which was likely removed unintentionally in a previous PR https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2814.

Fixes #3170