### PR TITLE
feat: migrate the problematic go-client

### DIFF
--- a/pkg/clients/generated/README.md
+++ b/pkg/clients/generated/README.md
@@ -1,0 +1,12 @@
+# 🎉 Config Connector Go Client: A Fresh Start!
+
+We're excited to share that the Config Connector Go client is getting a major upgrade! We're moving to a more direct approach using `sigs.k8s.io/controller-runtime` and popular tools like `controller-gen` and `kubebuilder`. This means simpler, more reliable interactions with Config Connector resources.
+
+Find the new APIs in the `./apis` directory and use the [Kubernetes dynamic client](https://pkg.go.dev/k8s.io/client-go/dynamic) for API calls.
+
+We're excited about this new chapter for the Go client and believe it will significantly improve your workflow. Happy coding!  
+
+## Regarding the existing `./pkg/clients/generated` directory
+
+* It will remain in place for now, but please note it's an Alpha library and future plans may change (track progress in issue #3037).
+* It's currently up-to-date with the 1.125 release, but won't receive further updates.

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -18,7 +18,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 make -C operator test
-UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/... ./scripts/generate-go-crd-clients/... ./scripts/resource-autogen/... ./tests/... ./mockgcp/... | grep -v tests/e2e)
+UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/...  ./scripts/resource-autogen/... ./tests/... ./mockgcp/... | grep -v tests/e2e)
 if [ -z ${GITHUB_ACTION+x} ]; then
     go run gotest.tools/gotestsum@latest --format testname -- ${UNIT_TEST_PACKAGES} -coverprofile cover.out -count=1
 else

--- a/scripts/validate-prereqs.sh
+++ b/scripts/validate-prereqs.sh
@@ -50,6 +50,8 @@ if [[ "${changed_file_count}" != "0" ]] || [[ "${added_config_file_count}" != "0
     git ls-files --others --exclude-standard config/
     exit 1
 fi
+
+<<'###issues/3037: Drop problematic go-client check from PRESUBMIT'
 make generate-go-client
 changed_file_count=$(git diff --name-only | wc -l)
 added_go_client_file_count=$(git ls-files --others --exclude-standard pkg/clients/generated/ | wc -l)
@@ -64,6 +66,8 @@ if [[ "${changed_file_count}" != "0" ]] || [[ "${added_go_client_file_count}" !=
     git diff | head -n100
     exit 1
 fi
+###issues/3037: Drop problematic go-client check from PRESUBMIT
+
 make ensure
 if [[ $? -ne 0 ]]; then
   echo "'make ensure' failed. Please validate the override patch files."


### PR DESCRIPTION
This PR does two things
-  add a announcement to guide users using the direct api and dynamic client instead of the problematic one. 
-  skip the old lib from the KCC presubmit and stop updating it since then.


Discussed with Walter and Justin separately offlilne.  I think this is the agreement we get (correct me if I missed anything).  

More context in #3037 