### PR TITLE
fix: Remove wait after SQLInstance periodic test steps

### DIFF
--- a/pkg/controller/dynamic/dynamic_controller_integration_test.go
+++ b/pkg/controller/dynamic/dynamic_controller_integration_test.go
@@ -503,7 +503,7 @@ func testDriftCorrection(ctx context.Context, t *testing.T, testContext testrunn
 
 	// Underlying APIs may not have strongly-consistent reads due to caching. Sleep before attempting a re-reconcile, to
 	// give the underlying system some time to propagate the deletion info.
-	time.Sleep(resourceContext.RecreateDelay)
+	time.Sleep(time.Second * 10)
 
 	// get the current state
 	t.Logf("reconcile with %v\r", testUnstruct)

--- a/pkg/test/resourcefixture/contexts/register.go
+++ b/pkg/test/resourcefixture/contexts/register.go
@@ -63,10 +63,6 @@ type ResourceContext struct {
 	// services in GCP that claim to be done with creating / updating the resource before it is actually available.
 	PostModifyDelay time.Duration
 
-	// Time to delay before recreating the resource as part of the drift detection test.
-	// The default wait time is 10 seconds. However, some resources appear to need to
-	// wait longer before recreating, so this value is customizable.
-	RecreateDelay time.Duration
 	// If true, skip drift detection test.
 	SkipDriftDetection bool
 
@@ -90,12 +86,6 @@ func GetResourceContext(fixture resourcefixture.ResourceFixture, serviceMetadata
 
 	if rc.ResourceGVK == emptyGVK {
 		rc.ResourceGVK = fixture.GVK
-	}
-
-	if rc.RecreateDelay == 0 {
-		// By default, wait for 10 seconds before recreating resource as part of drift detection test.
-		// Some resources appear to need to wait longer than 10 seconds, so this value is customizable.
-		rc.RecreateDelay = time.Second * 10
 	}
 
 	// If CRD has DCL controller label, fetch DCL schema.

--- a/pkg/test/resourcefixture/contexts/sql_context.go
+++ b/pkg/test/resourcefixture/contexts/sql_context.go
@@ -14,8 +14,6 @@
 
 package contexts
 
-import "time"
-
 func init() {
 	resourceContextMap["sqlinstance-activationpolicy"] = ResourceContext{
 		// TODO: After switching to use direct controller, we can update the direct controller
@@ -23,10 +21,7 @@ func init() {
 		// can enable this test. The TF based controller does not support creating
 		// SQLInstances with `activationPolicy: "NEVER"`.
 		SkipDriftDetection: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind:       "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-activationpolicy-direct"] = ResourceContext{
@@ -35,416 +30,43 @@ func init() {
 		// can enable this test. The TF based controller does not support creating
 		// SQLInstances with `activationPolicy: "NEVER"`.
 		SkipDriftDetection: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-activedirectoryconfig"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-activedirectoryconfig-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-auditconfig"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-auditconfig-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-authorizednetworks"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-authorizednetworks-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind:       "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-backupconfiguration-binarylog"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-backupconfiguration-binarylog-direct"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-backupconfiguration-pitr"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-backupconfiguration-pitr-direct"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	/* Note: Terraform-based controller does not support create from clone.
-	resourceContextMap["sqlinstance-clone-minimal"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-	*/
-
-	resourceContextMap["sqlinstance-clone-minimal-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-connectorenforcement"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-connectorenforcement-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-databaseflags"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-databaseflags-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-datacacheconfig"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqlinstance-datacacheconfig-direct"] = ResourceContext{
 		// TODO: Remove after switching to use direct controller.
 		SkipNoChange: true,
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-deletionprotection"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-deletionprotection-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-denymaintenanceperiod"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-denymaintenanceperiod-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-encryptionkey"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-encryptionkey-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-insightsconfig"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-insightsconfig-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-locationpreference"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-locationpreference-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-maintenancewindow"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-maintenancewindow-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-multithreading"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-multithreading-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-mysql"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-mysql-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-mysql-minimal"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-mysql-minimal-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-passwordvalidationpolicy"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-passwordvalidationpolicy-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-postgres"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-postgres-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-postgres-minimal"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-postgres-minimal-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-privatenetwork"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-privatenetwork-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-privatenetwork-legacyref"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-privatenetwork-legacyref-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-replica"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-replica-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-sqlserver"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-sqlserver-direct"] = ResourceContext{
-		// SQL instances appear to need a bit of additional time before attempting to recreate
-		// with the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-sqlserver-minimal"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-sqlserver-minimal-direct"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-ssl"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-ssl-direct"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-storage"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
-	}
-
-	resourceContextMap["sqlinstance-storage-direct"] = ResourceContext{
-		// SQL instances need a bit of additional time before attempting to recreate with
-		// the exact same name. Otherwise, the GCP API returns "unknown error".
-		RecreateDelay: time.Second * 60,
-		ResourceKind:  "SQLInstance",
+		ResourceKind: "SQLInstance",
 	}
 
 	resourceContextMap["sqldatabase"] = ResourceContext{


### PR DESCRIPTION
This is should longer be necessary after waiting for LRO completion: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3034/commits/d9baf0bcffb932e8c8516117aec591c54790d437