### PR TITLE
Use CEL rule to validate field immutability for direct Compute resources

### DIFF
--- a/apis/compute/v1beta1/firewallpolicyrule_types.go
+++ b/apis/compute/v1beta1/firewallpolicyrule_types.go
@@ -102,12 +102,14 @@ type ComputeFirewallPolicyRuleSpec struct {
 	// +optional
 	EnableLogging *bool `json:"enableLogging,omitempty"`
 
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="the field is immutable"
 	/* Immutable. */
 	FirewallPolicyRef *refs.ComputeFirewallPolicyRef `json:"firewallPolicyRef"`
 
 	/* A match condition that incoming traffic is evaluated against. If it evaluates to true, the corresponding 'action' is enforced. */
 	Match *FirewallPolicyRuleMatch `json:"match"`
 
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="the field is immutable"
 	/* Immutable. An integer indicating the priority of a rule in the list. The priority must be a positive value between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest prority. */
 	Priority int64 `json:"priority"`
 

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefirewallpolicyrules.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefirewallpolicyrules.compute.cnrm.cloud.google.com.yaml
@@ -112,6 +112,9 @@ spec:
                       resource.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: the field is immutable
+                  rule: self == oldSelf
               match:
                 description: A match condition that incoming traffic is evaluated
                   against. If it evaluates to true, the corresponding 'action' is
@@ -217,6 +220,9 @@ spec:
                   where 0 is the highest priority and 2147483647 is the lowest prority.
                 format: int64
                 type: integer
+                x-kubernetes-validations:
+                - message: the field is immutable
+                  rule: self == oldSelf
               targetResources:
                 items:
                   oneOf:


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

b/377531379

Checked all three direct compute resources(forwarding rule, firewall policy rule, target tcp proxy), added CEL rule on the immutable and required fields, following https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/docs/develop-resources/api-conventions/validations.md#option-2

Note: We haven't turned on direct reconciliation for those compute resources yet, instead, we use the "alpha.cnrm.cloud.google.com/reconciler: "direct"" annotation to opt-in. So they are still protected by the immutable webhook for now. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
