### PR TITLE
fix: Remove underscores from generated type names

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -262,7 +262,7 @@ func goNameForProtoMessage(msg protoreflect.MessageDescriptor) string {
 
 	fullName = strings.TrimPrefix(fullName, string(msg.ParentFile().FullName()))
 	fullName = strings.TrimPrefix(fullName, ".")
-	fullName = strings.ReplaceAll(fullName, ".", "_")
+	fullName = strings.ReplaceAll(fullName, ".", "")
 	return fullName
 }
 


### PR DESCRIPTION
In general, go names should not contain underscores. Also, the names
(with underscores) start to look a bit strange when we start to use them
in conjunction with the "ObservedState" suffix. For example, this is not
ideal: `WorkstationConfig_HostObservedState`. Would prefer to just avoid
underscores altogether.