### PR TITLE
chore: improvements around Direct identity and external  

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -189,6 +189,14 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 				return fmt.Errorf("add refs file %s: %w", scaffolder.PathToRefsFile(kind, resource.ProtoName), err)
 			}
 		}
+		if scaffolder.IdentityFileExist(kind, resource.ProtoName) {
+			fmt.Printf("file %s already exists, skipping\n", scaffolder.PathToIdentityFile(kind, resource.ProtoName))
+		} else {
+			err := scaffolder.AddIdentityFile(kind, resource.ProtoName)
+			if err != nil {
+				return fmt.Errorf("add identity file %s: %w", scaffolder.PathToIdentityFile(kind, resource.ProtoName), err)
+			}
+		}
 	}
 
 	if err := typeGenerator.WriteVisitedMessages(); err != nil {

--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -56,7 +56,7 @@ func generateController(service, kind string, cArgs *ccTemplate.ControllerArgs) 
 		return err
 	}
 
-	controllerFilePath, err := buildControllerPath(service, kind)
+	controllerFilePath, err := buildControllerPath(service, cArgs.ProtoResource)
 	if err != nil {
 		return err
 	}
@@ -99,8 +99,8 @@ func buildResourcePath(service, filename string) (string, error) {
 	return "", fmt.Errorf("file %s already exist", resourceFilePath)
 }
 
-func buildControllerPath(service, kind string) (string, error) {
-	return buildResourcePath(service, strings.ToLower(kind)+"_controller.go")
+func buildControllerPath(service, protoResource string) (string, error) {
+	return buildResourcePath(service, strings.ToLower(protoResource)+"_controller.go")
 }
 
 func FormatImports(path string, out []byte) error {

--- a/dev/tools/controllerbuilder/template/apis/identity.go
+++ b/dev/tools/controllerbuilder/template/apis/identity.go
@@ -1,0 +1,124 @@
+package apis
+
+const IdentityTemplate = `// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package {{ .Version }}
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// {{.ProtoResource}}Identity defines the resource reference to {{.Kind}}, which "External" field
+// holds the GCP identifier for the KRM object.
+type {{.ProtoResource}}Identity struct {
+	parent *{{.ProtoResource}}Parent
+	id string
+}
+
+func (i *{{.ProtoResource}}Identity) String() string {
+	return  p.parent.String() + "/{{.ProtoResource | toLower}s/" + p.id
+}
+
+func (i *{{.ProtoResource}}Identity) ID() string {
+	return p.id
+}
+
+func (i *{{.ProtoResource}}Identity) Parent() *{{.ProtoResource}}Parent {
+	return  i.parent
+}
+
+type {{.ProtoResource}}Parent struct {
+	ProjectID string
+	Location  string
+}
+
+func (p *{{.ProtoResource}}Parent) String() string {
+	return "projects/" + p.ProjectID + "/locations/" + p.Location
+}
+
+
+// New builds a {{.ProtoResource}}Identity from the Config Connector {{.ProtoResource}} object.
+func New{{.ProtoResource}}Identity(ctx context.Context, reader client.Reader, obj *{{.ProtoResource}}) (*{{.ProtoResource}}Identity, error) {
+
+	// Get Parent
+	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj, obj.Spec.ProjectRef)
+	if err != nil {
+		return nil, err
+	}
+	projectID := projectRef.ProjectID
+	if projectID == "" {
+		return nil, fmt.Errorf("cannot resolve project")
+	}
+	location := obj.Spec.Location
+
+	// Get desired ID
+	resourceID := common.ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("cannot resolve resource ID")
+	}
+
+	// Use approved External
+	externalRef := common.ValueOf(obj.Status.ExternalRef)
+	if externalRef != "" {
+		// Validate desired with actual
+		actualParent, actualResourceID, err := Parse{{.ProtoResource}}External(externalRef)
+		if err != nil {
+			return nil, err
+		}
+		if actualParent.ProjectID != projectID {
+			return nil, fmt.Errorf("spec.projectRef changed, expect %s, got %s", actualParent.ProjectID, projectID)
+		}
+		if actualParent.Location != location {
+			return nil, fmt.Errorf("spec.location changed, expect %s, got %s", actualParent.Location, location)
+		}
+		if actualResourceID != resourceID {
+			return nil, fmt.Errorf("cannot reset ` + "`" + `metadata.name` + "`" + ` or ` + "`" + `spec.resourceID` + "`" + ` to %s, since it has already assigned to %s",
+				resourceID, actualResourceID)
+		}
+	}
+	return &{{.ProtoResource}}Identity{
+		parent: &{{.ProtoResource}}Parent{
+			ProjectID: projectID,
+			Location:  location,
+		},
+		id: resourceID,
+	}, nil
+}
+
+func Parse{{.ProtoResource}}External(external string) (parent *{{.ProtoResource}}Parent, resourceID string, err error) {
+	tokens := strings.Split(external, "/")
+	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "{{.ProtoResource | ToLower }}s" {
+		return nil, "", fmt.Errorf("format of {{.Kind}} external=%q was not known (use projects/<projectId>/locations/<location>/{{.ProtoResource | ToLower }}s/<{{.ProtoResource | ToLower }}ID>)", external)
+	}
+	parent = &{{.ProtoResource}}Parent{
+		ProjectID: tokens[1],
+		Location:  tokens[3],
+	}
+	resourceID = tokens[5]
+	return parent, resourceID, nil
+}
+`

--- a/dev/tools/controllerbuilder/template/apis/refs.go
+++ b/dev/tools/controllerbuilder/template/apis/refs.go
@@ -29,11 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ refsv1beta1.ExternalNormalizer = &{{.Kind}}Ref{}
+var _ refsv1beta1.ExternalNormalizer = &{{.ProtoResource}}Ref{}
 
-// {{.Kind}}Ref defines the resource reference to {{.Kind}}, which "External" field
+// {{.ProtoResource}}Ref defines the resource reference to {{.Kind}}, which "External" field
 // holds the GCP identifier for the KRM object.
-type {{.Kind}}Ref struct {
+type {{.ProtoResource}}Ref struct {
 	// A reference to an externally managed {{.Kind}} resource.
 	// Should be in the format "projects/<projectID>/locations/<location>/{{.ProtoResource | ToLower }}s/<{{.ProtoResource | ToLower }}ID>".
 	External string ` + "`" + `json:"external,omitempty"` + "`" + `
@@ -43,20 +43,18 @@ type {{.Kind}}Ref struct {
 
 	// The namespace of a {{.Kind}} resource.
 	Namespace string ` + "`" + `json:"namespace,omitempty"` + "`" + `
-
-	parent *{{.Kind}}Parent
 }
 
 // NormalizedExternal provision the "External" value for other resource that depends on {{.Kind}}.
 // If the "External" is given in the other resource's spec.{{.Kind}}Ref, the given value will be used.
 // Otherwise, the "Name" and "Namespace" will be used to query the actual {{.Kind}} object from the cluster.
-func (r *{{.Kind}}Ref) NormalizedExternal(ctx context.Context, reader client.Reader, otherNamespace string) (string, error) {
+func (r *{{.ProtoResource}}Ref) NormalizedExternal(ctx context.Context, reader client.Reader, otherNamespace string) (string, error) {
 	if r.External != "" && r.Name != "" {
 		return "", fmt.Errorf("cannot specify both name and external on %s reference", {{.Kind}}GVK.Kind)
 	}
 	// From given External
 	if r.External != "" {
-		if _, _, err := parse{{.Kind}}External(r.External); err != nil {
+		if _, err := Parse{{.ProtoResource}}External(r.External); err != nil {
 			return "", err
 		}
 		return r.External, nil
@@ -85,106 +83,5 @@ func (r *{{.Kind}}Ref) NormalizedExternal(ctx context.Context, reader client.Rea
 	}
 	r.External = actualExternalRef
 	return r.External, nil
-}
-
-// New builds a {{.Kind}}Ref from the Config Connector {{.Kind}} object.
-func New{{.Kind}}Ref(ctx context.Context, reader client.Reader, obj *{{.Kind}}) (*{{.Kind}}Ref, error) {
-	id := &{{.Kind}}Ref{}
-
-	// Get Parent
-	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj, obj.Spec.ProjectRef)
-	if err != nil {
-		return nil, err
-	}
-	projectID := projectRef.ProjectID
-	if projectID == "" {
-		return nil, fmt.Errorf("cannot resolve project")
-	}
-	location := obj.Spec.Location
-	id.parent = &{{.Kind}}Parent{ProjectID: projectID, Location: location}
-
-	// Get desired ID
-	resourceID := valueOf(obj.Spec.ResourceID)
-	if resourceID == "" {
-		resourceID = obj.GetName()
-	}
-	if resourceID == "" {
-		return nil, fmt.Errorf("cannot resolve resource ID")
-	}
-
-	// Use approved External
-	externalRef := valueOf(obj.Status.ExternalRef)
-	if externalRef == "" {
-		id.External = as{{.Kind}}External(id.parent, resourceID)
-		return id, nil
-	}
-
-	// Validate desired with actual
-	actualParent, actualResourceID, err := parse{{.Kind}}External(externalRef)
-	if err != nil {
-		return nil, err
-	}
-	if actualParent.ProjectID != projectID {
-		return nil, fmt.Errorf("spec.projectRef changed, expect %s, got %s", actualParent.ProjectID, projectID)
-	}
-	if actualParent.Location != location {
-		return nil, fmt.Errorf("spec.location changed, expect %s, got %s", actualParent.Location, location)
-	}
-	if actualResourceID != resourceID {
-		return nil, fmt.Errorf("cannot reset ` + "`" + `metadata.name` + "`" + ` or ` + "`" + `spec.resourceID` + "`" + ` to %s, since it has already assigned to %s",
-			resourceID, actualResourceID)
-	}
-	id.External = externalRef
-	id.parent = &{{.Kind}}Parent{ProjectID: projectID, Location: location}
-	return id, nil
-}
-
-func (r *{{.Kind}}Ref) Parent() (*{{.Kind}}Parent, error) {
-	if r.parent != nil {
-		return r.parent, nil
-	}
-	if r.External != "" {
-		parent, _, err := parse{{.Kind}}External(r.External)
-		if err != nil {
-			return nil, err
-		}
-		return parent, nil
-	}
-	return nil, fmt.Errorf("{{.Kind}}Ref not initialized from ` + "`" + `New{{.Kind}}Ref` + "`" + ` or ` + "`" + `NormalizedExternal` + "`" + `")
-}
-
-type {{.Kind}}Parent struct {
-	ProjectID string
-	Location  string
-}
-
-func (p *{{.Kind}}Parent) String() string {
-	return "projects/" + p.ProjectID + "/locations/" + p.Location
-}
-
-func as{{.Kind}}External(parent *{{.Kind}}Parent, resourceID string) (external string) {
-	return parent.String() + "/{{.ProtoResource | ToLower }}s/" + resourceID
-}
-
-func parse{{.Kind}}External(external string) (parent *{{.Kind}}Parent, resourceID string, err error) {
-	external = strings.TrimPrefix(external, "/")
-	tokens := strings.Split(external, "/")
-	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "{{.ProtoResource | ToLower }}" {
-		return nil, "", fmt.Errorf("format of {{.Kind}} external=%q was not known (use projects/<projectId>/locations/<location>/{{.ProtoResource | ToLower }}s/<{{.ProtoResource | ToLower }}ID>)", external)
-	}
-	parent = &{{.Kind}}Parent{
-		ProjectID: tokens[1],
-		Location:  tokens[3],
-	}
-	resourceID = tokens[5]
-	return parent, resourceID, nil
-}
-
-func valueOf[T any](t *T) T {
-	var zeroVal T
-	if t == nil {
-		return zeroVal
-	}
-	return *t
 }
 `


### PR DESCRIPTION
Improvements:
- Separate resource Identity and external Ref
- Added in-line comments to guide the contributors on the functionality and expected behaviors. 
- Make the variable names shorter. e.g. `SecretManagerSecretVersion` --> `SecretVersion`
- Applied some best practice like introducing the CompareProtoMessage

Fixes:
- Remove `parent` from the reference API to avoid the json tag hack, and potential client-go unstructured parsing issues.  
- Parent and Identity should be read-only for adapter. 
