### PR TITLE
chore: controllergen uses pinned googleapi version

### DIFF
--- a/dev/tools/controllerbuilder/generate-proto.sh
+++ b/dev/tools/controllerbuilder/generate-proto.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/dev/tools/controllerbuilder
+
+THIRD_PARTY=${REPO_ROOT}/.build/third_party
+mkdir -p ${THIRD_PARTY}/
+
+# We share the version with mockgcp, which is maybe a boundary violation, but is convenient.
+# (It would be confusing if these were out of sync!)
+GOOGLEAPI_VERSION=$(grep https://github.com/googleapis/googleapis ${REPO_ROOT}/mockgcp/git.versions | awk '{print $2}' )
+
+cd ${REPO_ROOT}/.build/third_party
+git clone https://github.com/googleapis/googleapis.git ${THIRD_PARTY}/googleapis || (cd ${THIRD_PARTY}/googleapis && git reset --hard ${GOOGLEAPI_VERSION})
+
+which protoc || sudo apt install -y protobuf-compiler
+# On mac:
+# sudo brew install protobuf
+
+protoc --include_imports --include_source_info \
+    -I ${THIRD_PARTY}/googleapis/ \
+    -I ${REPO_ROOT}/mockgcp/apis \
+    ${REPO_ROOT}/mockgcp/apis/mockgcp/cloud/networkconnectivity/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/api/*.proto \
+    ${THIRD_PARTY}/googleapis/google/api/*/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/bigtable/*/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/cloud/bigquery/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/cloud/*/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/cloud/*/*/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/dataflow/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/firestore/admin/v1/*.proto \
+    ${THIRD_PARTY}/googleapis/google/iam/v1/*.proto \
+    ${THIRD_PARTY}/googleapis/google/logging/v2/*.proto \
+    ${THIRD_PARTY}/googleapis/google/monitoring/v3/*.proto \
+    ${THIRD_PARTY}/googleapis/google/monitoring/dashboard/v1/*.proto \
+    ${THIRD_PARTY}/googleapis/google/devtools/cloudbuild/*/*.proto \
+    ${THIRD_PARTY}/googleapis/google/spanner/admin/instance/v1/*.proto \
+    -o ${REPO_ROOT}/.build/googleapis.pb

--- a/dev/tools/controllerbuilder/generate.sh
+++ b/dev/tools/controllerbuilder/generate.sh
@@ -21,33 +21,28 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-make -C ../proto-to-mapper generate-pb
+./generate-proto.sh
 
 APIS_DIR=${REPO_ROOT}/apis/
 OUTPUT_MAPPER=${REPO_ROOT}/pkg/controller/direct/
 
+PROTO_BUNDLE=${REPO_ROOT}/.build/googleapis.pb
+
 # DiscoveryEngine
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.discoveryengine.v1 \
     --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
-    --resource DiscoveryEngineDataStore:DataStore
-
-go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
-    --service google.cloud.discoveryengine.v1 \
-    --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
-    --kind DiscoveryEngineEngine \
-    --proto-resource Engine
+    --resource DiscoveryEngineDataStore:DataStore \
+    --resource DiscoveryEngineEngine:Engine
 
 # go run . prompt --src-dir ~/kcc/k8s-config-connector --proto-dir ~/kcc/k8s-config-connector/dev/tools/proto-to-mapper/third_party/googleapis/ <<EOF
 # // +kcc:proto=google.cloud.discoveryengine.v1.Engine
 # EOF
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.discoveryengine.v1 \
     --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -56,14 +51,14 @@ go run . generate-mapper \
 
 # DataFlow
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.dataflow.v1beta3 \
     --api-version dataflow.cnrm.cloud.google.com/v1beta1 \
     --output-api ${APIS_DIR} \
     --resource DataflowFlexTemplateJob:FlexTemplateRuntimeEnvironment
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.dataflow.v1beta3 \
     --api-version dataflow.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -72,14 +67,14 @@ go run . generate-mapper \
 
 # SecureSourceManagerInstance
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --resource SecureSourceManagerInstance:Instance
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -88,21 +83,21 @@ go run . generate-mapper \
 
 # RedisCluster
 go run . generate-types  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1alpha1  \
     --output-api ${APIS_DIR} \
     --resource RedisCluster:Cluster
 
 go run . generate-types  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1beta1  \
     --output-api ${APIS_DIR} \
     --resource RedisCluster:Cluster
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1beta1  \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -112,14 +107,14 @@ go run . generate-mapper \
 # Bigtable
 
 go run . generate-types  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --output-api ${APIS_DIR} \
     --resource BigtableInstance:Instance
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -128,14 +123,14 @@ go run . generate-mapper \
 
 # NetworkConnectivity
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --resource NetworkConnectivityServiceConnectionPolicy:ServiceConnectionPolicy
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -144,14 +139,14 @@ go run . generate-mapper \
 
 # BigQueryDataset
 go run . generate-types  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.v2 \
     --api-version bigquery.cnrm.cloud.google.com/v1beta1  \
     --output-api ${APIS_DIR} \
     --resource BigQueryDataset:Dataset
 
 # go run . generate-mapper \
-#     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+#     --proto-source-path ${PROTO_BUNDLE} \
 #     --service google.cloud.bigquery.v2 \
 #     --api-version bigquery.cnrm.cloud.google.com/v1beta1 \
 #     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -160,14 +155,14 @@ go run . generate-types  \
 
 # BigQueryDataTransferConfig
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.datatransfer.v1 \
     --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --resource BigQueryDataTransferConfig:TransferConfig
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.datatransfer.v1 \
     --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -176,14 +171,14 @@ go run . generate-mapper \
 
 # Firestore
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.firestore.admin.v1 \
     --api-version firestore.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --resource FirestoreDatabase:Database
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.firestore.admin.v1 \
     --api-version firestore.cnrm.cloud.google.com/v1alpha1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -193,35 +188,35 @@ go run . generate-mapper \
 # Certificate Manager DNSAuthorization
 go run . generate-types \
     --service google.cloud.certificatemanager.v1  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --output-api $REPO_ROOT/apis \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1"
 
 go run . generate-types \
     --service google.cloud.certificatemanager.v1  \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --output-api $REPO_ROOT/apis \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1"
 
 # Workstations
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
     --output-api ${APIS_DIR} \
     --resource WorkstationCluster:WorkstationCluster
 
 go run . generate-types \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1alpha1 \
     --output-api ${APIS_DIR} \
     --resource WorkstationConfig:WorkstationConfig
 
 go run . generate-mapper \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
@@ -231,30 +226,31 @@ go run . generate-mapper \
 # SecretManager
 go run main.go generate-types \
      --service google.cloud.secretmanager.v1 \
-     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+     --proto-source-path ${PROTO_BUNDLE} \
      --output-api ${APIS_DIR} \
      --resource SecretManagerSecret:Secret \
      --api-version "secretmanager.cnrm.cloud.google.com/v1beta1"
 
 go run . generate-mapper \
-   --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+   --proto-source-path ${PROTO_BUNDLE} \
    --service google.cloud.secretmanager.v1 \
    --api-version "secretmanager.cnrm.cloud.google.com/v1beta1" \
    --api-go-package-path  $REPO_ROOT/apis/ \
    --output-dir $REPO_ROOT/pkg/controller/direct/ \
    --api-dir $REPO_ROOT/apis/
 
-go run . generate-direct-reconciler \
-   --kind SecretManagerSecretVersion \
-   --proto-resource SecretVersion \
-   --api-version  "secretmanager.cnrm.cloud.google.com/v1beta1" \
-   --service "google.cloud.secretmanager.v1" \
-   --proto-source-path ../proto-to-mapper/build/googleapis.pb
+# To scaffold generate the SecretManagerSecretVersion controller:
+# go run . generate-direct-reconciler \
+#    --kind SecretManagerSecretVersion \
+#    --proto-resource SecretVersion \
+#    --api-version  "secretmanager.cnrm.cloud.google.com/v1beta1" \
+#    --service "google.cloud.secretmanager.v1" \
+#    --proto-source-path ${PROTO_BUNDLE}
 
 # Spanner
 go run main.go generate-types \
     --service google.spanner.admin.instance.v1 \
-    --proto-source-path ../proto-to-mapper/build/googleapis.pb \
+    --proto-source-path ${PROTO_BUNDLE} \
     --output-api $REPO_ROOT/apis \
     --resource SpannerInstance:Instance \
     --api-version "spanner.cnrm.cloud.google.com/v1beta1"


### PR DESCRIPTION
This ensures that we have one version of the googleapis, which would otherwise get confusing,  for example if the mocks had  fields that the clients did not.