### PR TITLE
tests: set 0 llm

### DIFF
--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export0.yaml
@@ -1,0 +1,28 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  description: ""
+  disabled: false
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: STRING
+    launchStage: ""
+    metricKind: DELTA
+    unit: ""
+    valueType: DISTRIBUTION
+  projectRef:
+    external: ${projectId}
+  valueExtractor: EXTRACT(jsonPayload.response)

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export1.yaml
@@ -1,0 +1,28 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 0
+      - 1
+  description: ""
+  disabled: false
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: ""
+    labels:
+    - description: ""
+      key: testkey
+      valueType: STRING
+    launchStage: ""
+    metricKind: DELTA
+    unit: ""
+    valueType: DISTRIBUTION
+  projectRef:
+    external: ${projectId}
+  valueExtractor: EXTRACT(jsonPayload.response)

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log
@@ -1,0 +1,285 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log.real
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log.real
@@ -1,0 +1,296 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: Metric logginglogmetric-${uniqueId} does not exist. [google.rpc.error_details_ext] { message: \"Metric logginglogmetric-${uniqueId} does not exist.\" }"
+      }
+    ],
+    "message": "Metric logginglogmetric-${uniqueId} does not exist.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log
@@ -1,0 +1,168 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "metadata": {},
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log.real
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log.real
@@ -1,0 +1,172 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/controller-manager
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "metadata": {},
+    "metricKind": "DELTA",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        0,
+        1
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "labels": [
+      {
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "resourceName": "projects/${projectId}/metrics/logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_object00.yaml
@@ -1,0 +1,51 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: a concise name
+    labels:
+    - description: a label description
+      key: testkey
+      valueType: STRING
+    launchStage: EARLY_ACCESS
+    metadata:
+      ingestDelay: 1s
+      samplePeriod: 1s
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_object01.yaml
@@ -1,0 +1,51 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  name: logginglogmetric-${uniqueId}
+  namespace: ${projectId}
+spec:
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 0
+      - 1
+  filter: resource.type=gae_app AND severity<=ERROR
+  labelExtractors:
+    testkey: EXTRACT(jsonPayload.request)
+  metricDescriptor:
+    displayName: ""
+    labels:
+    - description: ""
+      key: testkey
+      valueType: STRING
+    launchStage: ""
+    metadata:
+      ingestDelay: ""
+      samplePeriod: ""
+    metricKind: DELTA
+    valueType: DISTRIBUTION
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-${uniqueId}
+  valueExtractor: EXTRACT(jsonPayload.response)
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
+  observedGeneration: 3
+  updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/script.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/script.yaml
@@ -1,0 +1,75 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  filter: "resource.type=gae_app AND severity<=ERROR"
+  metricDescriptor:
+    displayName: "a concise name"
+    launchStage: "EARLY_ACCESS"
+    metadata:
+      ingestDelay: "1s"
+      samplePeriod: "1s"
+    labels:
+    - description: "a label description"
+      key: "testkey"
+      valueType: "STRING"
+    metricKind: "DELTA"
+    valueType: "DISTRIBUTION"
+  valueExtractor: "EXTRACT(jsonPayload.response)"
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)"
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 1.5
+      - 4.5
+  projectRef:
+    external: "projects/${projectId}"
+---
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/state-into-spec: absent
+spec:
+  filter: "resource.type=gae_app AND severity<=ERROR" # cannot be empty
+  metricDescriptor:
+    displayName: ""
+    launchStage: ""
+    metadata:
+      ingestDelay: ""
+      samplePeriod: ""
+    labels:
+    - description: ""
+      key: "testkey" # cannot be empty
+      valueType: "STRING" # immutable
+    metricKind: "DELTA" # immutable
+    valueType: "DISTRIBUTION" # immutable
+  valueExtractor: "EXTRACT(jsonPayload.response)" # cannot be empty
+  labelExtractors:
+    testkey: "EXTRACT(jsonPayload.request)" # cannot be empty
+  bucketOptions:
+    explicitBuckets:
+      bounds:
+      - 0
+      - 1 # needs to be higher than the lower bound
+  projectRef:
+    external: "projects/${projectId}"


### PR DESCRIPTION
Adds a scenario test for setting 0 for native types for the LoggingLogMetric.

A few call outs
- test was hand written
- no issues were detected

Note in the future we will want tooling that can generate these tests for us and run against the direct controllers. To that end, both the filler mechanism in the random filler (https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3151) and the field analysis tool (https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2326/) will help.