### PR TITLE
chore: fix inconsistent tags on types

### DIFF
--- a/apis/bigqueryanalyticshub/v1alpha1/dataexchange_types.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/dataexchange_types.go
@@ -109,7 +109,6 @@ type BigQueryAnalyticsHubDataExchangeObservedState struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=gcp,shortName=gcpbigqueryanalyticshubdataexchange;gcpbigqueryanalyticshubdataexchanges
-// +kubebuilder:resource:categories=gcp
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true";"cnrm.cloud.google.com/system=true";"cnrm.cloud.google.com/stability-level=alpha"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date"


### PR DESCRIPTION
Looks like we don't consider CRD tags
per version.
