### PR TITLE
fix: Fix potential nil pointer issue in ComputeTargetTCPProxy direct update operation

### DIFF
--- a/pkg/controller/direct/compute/targettcpproxy/targettcpproxy_controller.go
+++ b/pkg/controller/direct/compute/targettcpproxy/targettcpproxy_controller.go
@@ -266,6 +266,14 @@ func (a *targetTCPProxyAdapter) Update(ctx context.Context, updateOp *directbase
 		if err != nil {
 			return fmt.Errorf("updating ComputeTargetTCPProxy backend service %s: %w", a.id.External, err)
 		}
+		if !op.Done() {
+			err = op.Wait(ctx)
+			if err != nil {
+				return fmt.Errorf("waiting ComputeTargetTCPProxy backend service %s update failed: %w", a.id.External, err)
+			}
+		}
+		log.V(2).Info("successfully updated ComputeTargetTCPProxy backend service", "name", a.id.External)
+
 	}
 	if !reflect.DeepEqual(targetTCPProxy.ProxyHeader, a.actual.ProxyHeader) && region == "global" {
 		setProxyHeaderReq := &computepb.SetProxyHeaderTargetTcpProxyRequest{
@@ -277,15 +285,14 @@ func (a *targetTCPProxyAdapter) Update(ctx context.Context, updateOp *directbase
 		if err != nil {
 			return fmt.Errorf("updating ComputeTargetTCPProxy proxy header %s: %w", a.id.External, err)
 		}
-	}
-
-	if !op.Done() {
-		err = op.Wait(ctx)
-		if err != nil {
-			return fmt.Errorf("waiting ComputeTargetTCPProxy %s update failed: %w", a.id.External, err)
+		if !op.Done() {
+			err = op.Wait(ctx)
+			if err != nil {
+				return fmt.Errorf("waiting ComputeTargetTCPProxy proxy header %s update failed: %w", a.id.External, err)
+			}
 		}
+		log.V(2).Info("successfully updated ComputeTargetTCPProxy proxy header", "name", a.id.External)
 	}
-	log.V(2).Info("successfully updated ComputeTargetTCPProxy", "name", a.id.External)
 
 	// Get the updated resource
 	updated, err = a.get(ctx)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Refactor the direct controller code, to prevent nil pointer issue when there's no UPDATE call. Surprisingly the presubmit tests didn't catch this...

error message:
```
dynamic_controller_integration_test.go:353: reconcile for ComputeTargetTCPProxy:ytcsjujcrrraiyy/computetargettcpproxy-ytcsjujcrrraiyy took 231.481942ms, result was ({false 0s}, INTERNAL ERROR: panic: observed a panic: runtime error: invalid memory address or nil pointer dereference
        	/home/prow/go/src/cnrm.googlesource.com/cnrm/pkg/execution/builtin.go:40 +0x45
        	panic({0x5fbf340?, 0xb0ea990?})
        		/home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/panic.go:770 +0x132
        	cloud.google.com/go/compute/apiv1.(*Operation).Done(...)
        		/home/prow/go/pkg/mod/cloud.google.com/go/compute@v1.28.1/apiv1/operations.go:37
        	github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/compute/targettcpproxy.(*targetTCPProxyAdapter).Update(0xc007c5d4c0, {0x778f1b8, 0xc03fec4fc0}, 0xc03c5bfe00)
        		/home/prow/go/src/cnrm.googlesource.com/cnrm/pkg/controller/direct/compute/targettcpproxy/targettcpproxy_controller.go:282 +0xa48
```

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->
Tests passed locally:
```
--- PASS: TestCreateNoChangeUpdateDelete (0.16s)
    --- PASS: TestCreateNoChangeUpdateDelete/compute (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/compute/basic-globalcomputetargettcpproxy-basic-direct (157.68s)
PASS
```
```
--- PASS: TestCreateNoChangeUpdateDelete (0.19s)
    --- PASS: TestCreateNoChangeUpdateDelete/compute (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/compute/basic-regionalcomputetargettcpproxy-direct (133.99s)
PASS
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
