### PR TITLE
fix: Log error when update is not supported for regional TCP Proxy

### DIFF
--- a/apis/compute/v1beta1/targettcpproxy_reference.go
+++ b/apis/compute/v1beta1/targettcpproxy_reference.go
@@ -97,12 +97,12 @@ func NewComputeTargetTCPProxyRef(ctx context.Context, reader client.Reader, obj 
 		return nil, fmt.Errorf("cannot resolve project")
 	}
 
-	// Get Region
+	// Get Location
 	if obj.Spec.Location == nil {
-		id.parent = &ComputeTargetTCPProxyParent{ProjectID: projectID, Region: "global"}
+		id.parent = &ComputeTargetTCPProxyParent{ProjectID: projectID, Location: "global"}
 	} else {
-		region := common.ValueOf(obj.Spec.Location)
-		id.parent = &ComputeTargetTCPProxyParent{ProjectID: projectID, Region: region}
+		location := common.ValueOf(obj.Spec.Location)
+		id.parent = &ComputeTargetTCPProxyParent{ProjectID: projectID, Location: location}
 	}
 
 	// Get desired ID
@@ -154,14 +154,14 @@ func (r *ComputeTargetTCPProxyRef) Parent() (*ComputeTargetTCPProxyParent, error
 
 type ComputeTargetTCPProxyParent struct {
 	ProjectID string
-	Region    string
+	Location  string
 }
 
 func (p *ComputeTargetTCPProxyParent) String() string {
-	if p.Region == "global" {
+	if p.Location == "global" {
 		return "projects/" + p.ProjectID + "/global"
 	} else {
-		return "projects/" + p.ProjectID + "/regions/" + p.Region
+		return "projects/" + p.ProjectID + "/regions/" + p.Location
 	}
 }
 
@@ -172,16 +172,17 @@ func asComputeTargetTCPProxyExternal(parent *ComputeTargetTCPProxyParent, resour
 func parseComputeTargetTCPProxyExternal(external string) (parent *ComputeTargetTCPProxyParent, resourceID string, err error) {
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
-	if len(tokens) == 5 && tokens[0] == "projects" && tokens[3] == "targetTcpProxies" {
+	if len(tokens) == 5 && tokens[0] == "projects" && tokens[2] == "global" && tokens[3] == "targetTcpProxies" {
 		parent = &ComputeTargetTCPProxyParent{
 			ProjectID: tokens[1],
+			Location:  "global",
 		}
 		resourceID = tokens[4]
 		return parent, resourceID, nil
 	} else if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "targetTcpProxies" {
 		parent = &ComputeTargetTCPProxyParent{
 			ProjectID: tokens[1],
-			Region:    tokens[3],
+			Location:  tokens[3],
 		}
 		resourceID = tokens[5]
 		return parent, resourceID, nil


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Fixes b/380362493

Address https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3236#discussion_r1853057354

Log error when update is not supported(by API), but fields get updated by user. However, if this happens, the resource will remain in error state. The only way to fix it might be to delete the resource and recreate a new one. Users won't be able to just revert the change.

I should also add a warning message that in our public doc, this will be done in #3227 

As mentioned in above discussion, there're several other ways to handle this:
1. GCP approach: do nothing on our side, and let the GCP API to handle the potential error(Users won't be able to revert the change too)
2. TF approach: trigger a `forceNew` feature to delete the old resource and create a new one with updated fields
3. Immutable check: Mark all fields in resource as immutable if the API doesn't support update. But it won't work for this case because global and regional share the CRD, global resource can be updated

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

Tried to update `proxyHeader` field in regional tcp proxy and the error looks like:
```
{"severity":"info","timestamp":"2024-11-25T21:26:49.428Z","msg":"resource is not ready","kind":"ComputeTargetTCPProxy","name":"computetargettcpproxy-hcmu7thn7lt2pmq","conditions":[{"lastTransitionTime":"2024-11-25T21:26:40Z","message":"Update call failed: error updating: update operation not supported for resource ComputeTargetTCPProxy hcmu7thn7lt2pmq/computetargettcpproxy-hcmu7thn7lt2pmq: projects/mock-project/regions/europe-west4/targetTcpProxies/computetargettcpproxy-hcmu7thn7lt2pmq","reason":"UpdateFailed","status":"False","type":"Ready"}]}
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
