### PR TITLE
tool: simplify controller builder commands by removing redundant flags

### DIFF
--- a/dev/tools/controllerbuilder/README.md
+++ b/dev/tools/controllerbuilder/README.md
@@ -2,16 +2,22 @@ Examples:
 
 
 ```
-go run . generate-types  --proto-source-path ../proto-to-mapper/build/googleapis.pb \
-  --service google.bigtable.admin.v2 --version v1beta1 \
-  --output-api ~/kcc/k8s-config-connector
-  --kinds BigtableInstance
+# To generate Go types for BigtableInstance
+go run . generate-types \
+  --service google.bigtable.admin.v2 \
+  --api-version bigtable.cnrm.cloud.google.com/v1beta1 \
+  --resource BigtableInstance:Instance
 
+# To generate mapping function between KRM and proto for BigtableInstance
+go run . generate-mapper \
+  --output-dir ~/kcc/k8s-config-connector/pkg/controller/direct/ \
+  --service google.bigtable.admin.v2
 
-go run . generate-mapper --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-      --output-dir ~/kcc/k8s-config-connector/pkg/controller/direct/ \
-      --proto-source-path ../proto-to-mapper/build/googleapis.pb \
-      --service google.bigtable.admin.v2 \
-      --api-dir ~/kcc/k8s-config-connector/apis/
+# To scaffold generate the SecretManagerSecretVersion controller
+go run . generate-direct-reconciler \
+  --kind SecretManagerSecretVersion \
+  --proto-resource SecretVersion \
+  --api-version  "secretmanager.cnrm.cloud.google.com/v1beta1" \
+  --service "google.cloud.secretmanager.v1"
 
 ```

--- a/dev/tools/controllerbuilder/cmd/root.go
+++ b/dev/tools/controllerbuilder/cmd/root.go
@@ -30,8 +30,10 @@ import (
 
 func Execute() {
 	var generateOptions options.GenerateOptions
-	generateOptions.InitDefaults()
-
+	if err := generateOptions.InitDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing defaults: %v\n", err)
+		os.Exit(1)
+	}
 	rootCmd := &cobra.Command{}
 	generateOptions.BindPersistentFlags(rootCmd)
 

--- a/dev/tools/controllerbuilder/generate.sh
+++ b/dev/tools/controllerbuilder/generate.sh
@@ -23,17 +23,11 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-APIS_DIR=${REPO_ROOT}/apis/
-OUTPUT_MAPPER=${REPO_ROOT}/pkg/controller/direct/
-
-PROTO_BUNDLE=${REPO_ROOT}/.build/googleapis.pb
 
 # DiscoveryEngine
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.discoveryengine.v1 \
     --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource DiscoveryEngineDataStore:DataStore \
     --resource DiscoveryEngineEngine:Engine
 
@@ -42,215 +36,134 @@ go run . generate-types \
 # EOF
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.discoveryengine.v1 \
-    --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1
 
 # DataFlow
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.dataflow.v1beta3 \
     --api-version dataflow.cnrm.cloud.google.com/v1beta1 \
-    --output-api ${APIS_DIR} \
     --resource DataflowFlexTemplateJob:FlexTemplateRuntimeEnvironment
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.dataflow.v1beta3 \
-    --api-version dataflow.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version dataflow.cnrm.cloud.google.com/v1alpha1
 
 # SecureSourceManagerInstance
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource SecureSourceManagerInstance:Instance
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.securesourcemanager.v1 \
-    --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1
 
 # RedisCluster
 go run . generate-types  \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
-    --api-version redis.cnrm.cloud.google.com/v1alpha1  \
-    --output-api ${APIS_DIR} \
+    --api-version redis.cnrm.cloud.google.com/v1alpha1 \
     --resource RedisCluster:Cluster
 
 go run . generate-types  \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1beta1  \
-    --output-api ${APIS_DIR} \
     --resource RedisCluster:Cluster
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.redis.cluster.v1 \
-    --api-version redis.cnrm.cloud.google.com/v1beta1  \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version redis.cnrm.cloud.google.com/v1beta1
 
 # Bigtable
 
 go run . generate-types  \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
-    --output-api ${APIS_DIR} \
     --resource BigtableInstance:Instance
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.bigtable.admin.v2 \
-    --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version bigtable.cnrm.cloud.google.com/v1beta1
 
 # NetworkConnectivity
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource NetworkConnectivityServiceConnectionPolicy:ServiceConnectionPolicy
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service mockgcp.cloud.networkconnectivity.v1 \
-    --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1
 
 # BigQueryDataset
 go run . generate-types  \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.v2 \
     --api-version bigquery.cnrm.cloud.google.com/v1beta1  \
-    --output-api ${APIS_DIR} \
     --resource BigQueryDataset:Dataset
 
 # go run . generate-mapper \
-#     --proto-source-path ${PROTO_BUNDLE} \
 #     --service google.cloud.bigquery.v2 \
-#     --api-version bigquery.cnrm.cloud.google.com/v1beta1 \
-#     --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-#     --output-dir ${OUTPUT_MAPPER} \
-#     --api-dir ${APIS_DIR}
+#     --api-version bigquery.cnrm.cloud.google.com/v1beta1
 
 # BigQueryDataTransferConfig
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.datatransfer.v1 \
     --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource BigQueryDataTransferConfig:TransferConfig
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.bigquery.datatransfer.v1 \
-    --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1
 
 # Firestore
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.firestore.admin.v1 \
     --api-version firestore.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource FirestoreDatabase:Database
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.firestore.admin.v1 \
-    --api-version firestore.cnrm.cloud.google.com/v1alpha1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version firestore.cnrm.cloud.google.com/v1alpha1
 
 # Certificate Manager DNSAuthorization
 go run . generate-types \
     --service google.cloud.certificatemanager.v1  \
-    --proto-source-path ${PROTO_BUNDLE} \
-    --output-api $REPO_ROOT/apis \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1"
 
 go run . generate-types \
     --service google.cloud.certificatemanager.v1  \
-    --proto-source-path ${PROTO_BUNDLE} \
-    --output-api $REPO_ROOT/apis \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1"
 
 # Workstations
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
-    --output-api ${APIS_DIR} \
     --resource WorkstationCluster:WorkstationCluster
 
 go run . generate-types \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1alpha1 \
-    --output-api ${APIS_DIR} \
     --resource WorkstationConfig:WorkstationConfig
 
 go run . generate-mapper \
-    --proto-source-path ${PROTO_BUNDLE} \
     --service google.cloud.workstations.v1 \
-    --api-version workstations.cnrm.cloud.google.com/v1beta1 \
-    --api-go-package-path github.com/GoogleCloudPlatform/k8s-config-connector/apis \
-    --output-dir ${OUTPUT_MAPPER} \
-    --api-dir ${APIS_DIR}
+    --api-version workstations.cnrm.cloud.google.com/v1beta1
 
 # SecretManager
 go run main.go generate-types \
      --service google.cloud.secretmanager.v1 \
-     --proto-source-path ${PROTO_BUNDLE} \
-     --output-api ${APIS_DIR} \
      --resource SecretManagerSecret:Secret \
      --api-version "secretmanager.cnrm.cloud.google.com/v1beta1"
 
 go run . generate-mapper \
-   --proto-source-path ${PROTO_BUNDLE} \
    --service google.cloud.secretmanager.v1 \
-   --api-version "secretmanager.cnrm.cloud.google.com/v1beta1" \
-   --api-go-package-path  $REPO_ROOT/apis/ \
-   --output-dir $REPO_ROOT/pkg/controller/direct/ \
-   --api-dir $REPO_ROOT/apis/
-
-# To scaffold generate the SecretManagerSecretVersion controller:
-# go run . generate-direct-reconciler \
-#    --kind SecretManagerSecretVersion \
-#    --proto-resource SecretVersion \
-#    --api-version  "secretmanager.cnrm.cloud.google.com/v1beta1" \
-#    --service "google.cloud.secretmanager.v1" \
-#    --proto-source-path ${PROTO_BUNDLE}
+   --api-version "secretmanager.cnrm.cloud.google.com/v1beta1"
 
 # Spanner
 go run main.go generate-types \
     --service google.spanner.admin.instance.v1 \
-    --proto-source-path ${PROTO_BUNDLE} \
     --output-api $REPO_ROOT/apis \
     --resource SpannerInstance:Instance \
     --api-version "spanner.cnrm.cloud.google.com/v1beta1"

--- a/dev/tools/controllerbuilder/pkg/commands/generatedirectreconciler/command.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatedirectreconciler/command.go
@@ -52,7 +52,6 @@ func (o *GenerateBasicReconcilerOptions) InitDefaults() error {
 	if err != nil {
 		return nil
 	}
-	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
 	o.APIGoPackagePath = "github.com/GoogleCloudPlatform/k8s-config-connector/apis/"
 	o.APIDirectory = root + "/apis/"
 	//	o.OutputAPIDirectory = root + "/apis/"

--- a/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
@@ -42,7 +42,6 @@ func (o *GenerateMapperOptions) InitDefaults() error {
 	if err != nil {
 		return nil
 	}
-	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
 	o.APIGoPackagePath = "github.com/GoogleCloudPlatform/k8s-config-connector/apis/"
 	o.APIDirectory = root + "/apis/"
 	o.OutputMapperDirectory = root + "/pkg/controller/direct/"

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -76,7 +76,6 @@ func (o *GenerateCRDOptions) InitDefaults() error {
 	if err != nil {
 		return nil
 	}
-	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
 	o.OutputAPIDirectory = root + "/apis/"
 	return nil
 }

--- a/dev/tools/controllerbuilder/pkg/commands/updatetypes/updatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/updatetypes/updatetypescommand.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/codegen"
@@ -47,11 +46,10 @@ type UpdateTypeOptions struct {
 }
 
 func (o *UpdateTypeOptions) InitDefaults() error {
-	root, err := getGitRepoRoot()
+	root, err := options.RepoRoot()
 	if err != nil {
 		return nil
 	}
-	o.ProtoSourcePath = root + "/dev/tools/proto-to-mapper/build/googleapis.pb"
 	o.apiDirectory = root + "/apis/"
 	o.goPackagePath = "github.com/GoogleCloudPlatform/k8s-config-connector/apis/"
 	return nil
@@ -247,16 +245,4 @@ func (u *TypeUpdater) generate() error {
 			})
 	}
 	return nil
-}
-
-func getGitRepoRoot() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-
-	// Convert the output to a string and trim any whitespace
-	repoRoot := strings.TrimSpace(string(output))
-	return repoRoot, nil
 }

--- a/dev/tools/controllerbuilder/pkg/options/generateoptions.go
+++ b/dev/tools/controllerbuilder/pkg/options/generateoptions.go
@@ -27,7 +27,13 @@ type GenerateOptions struct {
 	APIVersion      string
 }
 
-func (o *GenerateOptions) InitDefaults() {
+func (o *GenerateOptions) InitDefaults() error {
+	root, err := RepoRoot()
+	if err != nil {
+		return nil
+	}
+	o.ProtoSourcePath = root + "/.build/googleapis.pb"
+	return nil
 }
 
 func (o *GenerateOptions) BindPersistentFlags(cmd *cobra.Command) {

--- a/docs/develop-resources/deep-dives/2-define-apis.md
+++ b/docs/develop-resources/deep-dives/2-define-apis.md
@@ -4,17 +4,17 @@ Config Connector builds the API using the Google Cloud Client proto.
 
 ## 2.1 Build the Google Cloud Proto (one-off step)
 
-This step generates the Google Cloud Client proto in a single file under ./dev/tools/proto-to-mapper/build. This should be a one-off command only when you need to update the proto or the first time you develop the direct resource.
+This step generates the Google Cloud Client proto in a single file under ".build" folder. This should be a one-off command only when you need to update the proto or the first time you develop the direct resource.
 
-Make sure the` generate-pb` rule in [proto-to-mapper/Makefile](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/dev/tools/proto-to-mapper/Makefile#L2) contains your proto. If not, add one using the file path in [https://github.com/googleapis/googleapis/tree/master](https://github.com/googleapis/googleapis/tree/master). [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/6ce31faf38dfaf6f44dd964802f43f9228d5a869/dev/tools/proto-to-mapper/Makefile#L16)
+Make sure the [generate-proto.sh](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/dev/tools/controllerbuilder/generate-proto.sh) script contains the proto you are working with. If not, add one using the file path in [https://github.com/googleapis/googleapis/tree/master](https://github.com/googleapis/googleapis/tree/master). [example](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/cf8e50caff716d95a94412c6038ede2589669c95/dev/tools/controllerbuilder/generate-proto.sh#L44)
 
 Run the following command to generate the Google proto.
 
 
 ```
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd $REPO_ROOT/dev/tools/proto-to-mapper
-make generate-pb
+cd $REPO_ROOT/dev/tools/controllerbuilder
+./generate-proto.sh
 ```
 
 ## 2.2 Generate the Config Connector Types (repeat-run safe) 
@@ -28,7 +28,6 @@ cd $REPO_ROOT/dev/tools/controllerbuilder
 
 go run main.go generate-types \
      --service google.storage.v1 \
-     --proto-source-path ../proto-to-mapper/build/googleapis.pb \
      --api-version "storage.cnrm.cloud.google.com/v1beta1" \
      --resource StorageNotification:Notification
 ```
@@ -36,11 +35,6 @@ go run main.go generate-types \
 * `--service`
 
 The proto name of the GCP service, you can find them in [https://github.com/googleapis/googleapis.git](https://github.com/googleapis/googleapis.git). For example, the SQL service is [https://github.com/googleapis/googleapis/tree/master/google/cloud/sql/v1beta4](https://github.com/googleapis/googleapis/tree/master/google/cloud/sql/v1beta4). The `–service` should be `google.cloud.sql.v1beta4`
-
-
-* `--proto-source-path`
-
-The path to the one-off file we generated in 2.1
 
 * `--output-api`
 

--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -9,12 +9,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd $REPO_ROOT/dev/tools/controllerbuilder
 
 go run . generate-mapper \
-   --proto-source-path ../proto-to-mapper/build/googleapis.pb \
    --service google.storage.v1  \
-   --api-version "storage.cnrm.cloud.google.com/v1beta1" \
-   --api-go-package-path  $REPO_ROOT/apis \
-   --output-dir $REPO_ROOT/pkg/controller/direct/ \
-   --api-dir $REPO_ROOT/apis 
+   --api-version "storage.cnrm.cloud.google.com/v1beta1"
 ```
 
 **Note**: We suggest using the same proto for your mock GCP and for you type-generation tool to generate the Config Connector API and mapper to avoid mismatch in schema definitions. There are some exceptions where you need to [replace the proto go package](https://github.com/xiaoweim/k8s-config-connector/blob/master/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go#L132).


### PR DESCRIPTION
 - Set a new default for the `--proto-source-path` flag.
 - Remove redundant flags with default values for simpler commands.
 - Update the contributor guide to reflect these changes.