### PR TITLE
wip:fix: don't assign external

### DIFF
--- a/apis/bigquery/v1beta1/dataset_reference.go
+++ b/apis/bigquery/v1beta1/dataset_reference.go
@@ -81,8 +81,7 @@ func (r *BigQueryDatasetRef) NormalizedExternal(ctx context.Context, reader clie
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a BigQueryDatasetRef from the Config Connector BigQueryDataset object.

--- a/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
@@ -81,8 +81,7 @@ func (r *BigQueryAnalyticsHubDataExchangeRef) NormalizedExternal(ctx context.Con
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a BigQueryAnalyticsHubDataExchangeRef from the Config Connector BigQueryAnalyticsHubDataExchange object.

--- a/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
@@ -82,8 +82,8 @@ func (r *BigQueryAnalyticsHubListingRef) NormalizedExternal(ctx context.Context,
 	if actualExternalRef == "" {
 		return "", fmt.Errorf("BigQueryAnalyticsHubListing is not ready yet")
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+
+	return actualExternalRef, nil
 }
 
 // New builds a BigQueryAnalyticsHubListingRef from the Config Connector BigQueryAnalyticsHubListing object.

--- a/apis/bigqueryconnection/v1alpha1/connection_reference.go
+++ b/apis/bigqueryconnection/v1alpha1/connection_reference.go
@@ -151,6 +151,5 @@ func (r *BigQueryConnectionConnectionRef) NormalizedExternal(ctx context.Context
 	if actualExternalRef == "" {
 		return "", fmt.Errorf("BigQueryConnectionConnection is not ready yet.")
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }

--- a/apis/bigqueryconnection/v1beta1/connection_reference.go
+++ b/apis/bigqueryconnection/v1beta1/connection_reference.go
@@ -151,6 +151,5 @@ func (r *BigQueryConnectionConnectionRef) NormalizedExternal(ctx context.Context
 	if actualExternalRef == "" {
 		return "", fmt.Errorf("BigQueryConnectionConnection is not ready yet.")
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }

--- a/apis/compute/v1beta1/computefirewallpolicyrule_reference.go
+++ b/apis/compute/v1beta1/computefirewallpolicyrule_reference.go
@@ -82,8 +82,7 @@ func (r *ComputeFirewallPolicyRuleRef) NormalizedExternal(ctx context.Context, r
 	if actualExternalRef == "" {
 		return "", fmt.Errorf("ComputeFirewallPolicyRule is not ready yet")
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a NewComputeFirewallPolicyRuleRef from the Config Connector ComputeFirewallPolicyRule object.

--- a/apis/compute/v1beta1/targettcpproxy_reference.go
+++ b/apis/compute/v1beta1/targettcpproxy_reference.go
@@ -84,8 +84,7 @@ func (r *ComputeTargetTCPProxyRef) NormalizedExternal(ctx context.Context, reade
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a ComputeTargetTCPProxyRef from the Config Connector ComputeTargetTCPProxy object.

--- a/apis/discoveryengine/v1alpha1/datastore_reference.go
+++ b/apis/discoveryengine/v1alpha1/datastore_reference.go
@@ -88,8 +88,7 @@ func (r *DiscoveryEngineDataStoreRef) NormalizedExternal(ctx context.Context, re
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a DiscoveryEngineDataStoreRef from the Config Connector DiscoveryEngineDataStore object.

--- a/apis/discoveryengine/v1alpha1/engine_reference.go
+++ b/apis/discoveryengine/v1alpha1/engine_reference.go
@@ -81,8 +81,7 @@ func (r *DiscoveryEngineEngineRef) NormalizedExternal(ctx context.Context, reade
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a DiscoveryEngineEngineRef from the Config Connector DiscoveryEngineEngine object.

--- a/apis/kms/v1alpha1/autokeyconfig_reference.go
+++ b/apis/kms/v1alpha1/autokeyconfig_reference.go
@@ -81,8 +81,7 @@ func (r *KMSAutokeyConfigRef) NormalizedExternal(ctx context.Context, reader cli
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a KMSAutokeyConfigRef from the Config Connector KMSAutokeyConfig object.

--- a/apis/kms/v1alpha1/keyhandle_reference.go
+++ b/apis/kms/v1alpha1/keyhandle_reference.go
@@ -81,8 +81,7 @@ func (r *KMSKeyHandleRef) NormalizedExternal(ctx context.Context, reader client.
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a KMSKeyHandleRef from the Config Connector KMSKeyHandle object.

--- a/apis/kms/v1beta1/autokeyconfig_reference.go
+++ b/apis/kms/v1beta1/autokeyconfig_reference.go
@@ -81,8 +81,7 @@ func (r *KMSAutokeyConfigRef) NormalizedExternal(ctx context.Context, reader cli
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a KMSAutokeyConfigRef from the Config Connector KMSAutokeyConfig object.

--- a/apis/memorystore/v1alpha1/instance_reference.go
+++ b/apis/memorystore/v1alpha1/instance_reference.go
@@ -81,8 +81,7 @@ func (r *MemorystoreInstanceRef) NormalizedExternal(ctx context.Context, reader 
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a MemorystoreInstanceRef from the Config Connector MemorystoreInstance object.

--- a/apis/secretmanager/v1beta1/secret_reference.go
+++ b/apis/secretmanager/v1beta1/secret_reference.go
@@ -79,8 +79,7 @@ func (r *SecretRef) NormalizedExternal(ctx context.Context, reader client.Reader
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 func ParseSecretExternal(external string) (*SecretIdentity, error) {

--- a/apis/secretmanager/v1beta1/secretversion_reference.go
+++ b/apis/secretmanager/v1beta1/secretversion_reference.go
@@ -79,8 +79,7 @@ func (r *SecretVersionRef) NormalizedExternal(ctx context.Context, reader client
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 func ParseSecretVersionExternal(external string) (*SecretVersionIdentity, error) {

--- a/apis/securesourcemanager/v1alpha1/repository_reference.go
+++ b/apis/securesourcemanager/v1alpha1/repository_reference.go
@@ -81,8 +81,7 @@ func (r *SecureSourceManagerRepositoryRef) NormalizedExternal(ctx context.Contex
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a SecureSourceManagerRepositoryRef from the Config Connector SecureSourceManagerRepository object.

--- a/apis/spanner/v1beta1/instance_reference.go
+++ b/apis/spanner/v1beta1/instance_reference.go
@@ -81,8 +81,7 @@ func (r *SpannerInstanceRef) NormalizedExternal(ctx context.Context, reader clie
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a SpannerInstanceRef from the Config Connector SpannerInstance object.

--- a/apis/workstations/v1alpha1/cluster_reference.go
+++ b/apis/workstations/v1alpha1/cluster_reference.go
@@ -79,8 +79,7 @@ func (r *WorkstationClusterRef) NormalizedExternal(ctx context.Context, reader c
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a WorkstationClusterRef from the Config Connector WorkstationCluster object.

--- a/apis/workstations/v1alpha1/config_reference.go
+++ b/apis/workstations/v1alpha1/config_reference.go
@@ -79,8 +79,7 @@ func (r *WorkstationConfigRef) NormalizedExternal(ctx context.Context, reader cl
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a WorkstationConfigRef from the Config Connector WorkstationConfig object.

--- a/apis/workstations/v1beta1/cluster_reference.go
+++ b/apis/workstations/v1beta1/cluster_reference.go
@@ -79,8 +79,7 @@ func (r *WorkstationClusterRef) NormalizedExternal(ctx context.Context, reader c
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+	return actualExternalRef, nil
 }
 
 // New builds a WorkstationClusterRef from the Config Connector WorkstationCluster object.

--- a/dev/tools/controllerbuilder/template/apis/refs.go
+++ b/dev/tools/controllerbuilder/template/apis/refs.go
@@ -80,7 +80,7 @@ func (r *{{.ProtoResource}}Ref) NormalizedExternal(ctx context.Context, reader c
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
 	}
-	r.External = actualExternalRef
-	return r.External, nil
+
+	return actualExternalRef, nil
 }
 `


### PR DESCRIPTION
The canonical example for reference handling is that we either pass in:

* the external format OR
* the name of the reference

Consider this example

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/bcf1e3e3fcce891e4ba56104533acb77e61ea0b3/pkg/test/resourcefixture/testdata/basic/bigqueryanalyticshub/v1alpha1/bigqueryanalyticshublisting-base/create.yaml#L23-L25

If the NormlizedExternal checks that only one of `r.External` or `r.Name` is set BUT assigns `r.External` at the end, future calls to this function will error out. IOW, the function is not idempotent and I think it should be because we may be calling this function repeatedly throughout the reconciliation of a resource.