### PR TITLE
chore: skip dcl code-generation in read-pr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,19 @@ vet:
 	make -C operator vet
 	go vet -tags integration ./pkg/... ./cmd/... ./config/tests/...
 
-# Generate code
-.PHONY: generate
+# Generate code including the dcl (legacy)
+.PHONY: generate-including-dcl
 generate:
-	# Don't run go generate on `pkg/clients/generated` in the normal development flow due to high latency.
-	# This path will be covered by `generate-go-client` target specifically.
 	go work vendor -o temp-vendor # So we can load DCL resources
 	go generate ./pkg/dcl/schema/...
 	rm -rf temp-vendor
+	go generate ./pkg/apis/...
+	make -C operator generate
+	make fmt
+
+# Generate code
+.PHONY: generate
+generate:
 	go generate ./pkg/apis/...
 	make -C operator generate
 	make fmt


### PR DESCRIPTION
Save us $$$ time on `make ready-pr` and `make manifests`