### PR TITLE
chore: add apt-get update to install-tools

### DIFF
--- a/dev/tasks/install-tools
+++ b/dev/tasks/install-tools
@@ -33,10 +33,12 @@ fi
 
 if ! command -v jq; then
   echo "jq not found; installing (assuming we are running in a container)"
+  apt-get update
   apt-get install --yes jq
 fi
 
 if ! command -v zip; then
   echo "zip not found; installing (assuming we are running in a container)"
+  apt-get update
   apt-get install --yes zip
 fi


### PR DESCRIPTION
Otherwise if the docker container has not been updated in a while,
the installation fails.
