### PR TITLE
fix: update to use new ResolveProject func

### DIFF
--- a/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
@@ -90,7 +90,7 @@ func NewBigQueryAnalyticsHubDataExchangeRef(ctx context.Context, reader client.R
 	id := &BigQueryAnalyticsHubDataExchangeRef{}
 
 	// Get Parent
-	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj, obj.Spec.ProjectRef)
+	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj.GetNamespace(), obj.Spec.ProjectRef)
 	if err != nil {
 		return nil, err
 	}

--- a/apis/memorystore/v1alpha1/instance_reference.go
+++ b/apis/memorystore/v1alpha1/instance_reference.go
@@ -90,7 +90,7 @@ func NewMemorystoreInstanceRef(ctx context.Context, reader client.Reader, obj *M
 	id := &MemorystoreInstanceRef{}
 
 	// Get Parent
-	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj, obj.Spec.ProjectRef)
+	projectRef, err := refsv1beta1.ResolveProject(ctx, reader, obj.GetNamespace(), obj.Spec.ProjectRef)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I think https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3233 wasn't synced to the most recent changes and we forgot one old reference to the an old style `ResolveProject`