### PR TITLE
fix: duplicate cnrm in image path

### DIFF
--- a/dev/tasks/build-release-bundle
+++ b/dev/tasks/build-release-bundle
@@ -51,7 +51,7 @@ echo ${VERSION} > ${BUNDLE_DIR}/version
 CRDS_FILE=$(mktemp -t crds.XXXXXXXX.yaml)
 
 # Update container registry for kustomize
-IMAGE_PREFIX=${IMAGE_PREFIX:-"gcr.io/gke-release/cnrm/"}
+IMAGE_PREFIX=${IMAGE_PREFIX:-"gcr.io/gke-release/"}
 IMAGE_TAG=${IMAGE_TAG:-${VERSION}}
 
 RECORDER_IMG=${RECORDER_IMG:-"${IMAGE_PREFIX}recorder:${IMAGE_TAG}"}


### PR DESCRIPTION
Fix the duplicate cnrm in image path. Issue Reference: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3164/commits/295914cae9d5f087ec130df19ed4bdfc5b648e7b


- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
