### PR TITLE
fix: duplicate cnrm in image path

### DIFF
--- a/dev/tasks/propose-tag
+++ b/dev/tasks/propose-tag
@@ -100,7 +100,7 @@ done
 # Swap container registry
 # TODO: This is only needed for release bundles that we didn't build with our scripts here (i.e. only needed for release bundles built with the legacy process)
 for channeldir in channels autopilot-channels; do
-  find ${REPO_ROOT}/operator/${channeldir}/packages -type f -name "*.yaml" | xargs sed -i -e "s@gcr.io/cnrm-eap/@gcr.io/gke-release/cnrm/@g"
+  find ${REPO_ROOT}/operator/${channeldir}/packages -type f -name "*.yaml" | xargs sed -i -e "s@gcr.io/cnrm-eap/@gcr.io/gke-release/@g"
 done
 
 # Generate operator/config/gke-addon/image_configmap.yaml

--- a/operator/scripts/update-kcc-manifest/main.go
+++ b/operator/scripts/update-kcc-manifest/main.go
@@ -459,7 +459,7 @@ func swapContainerRegistry(manifestPath string) error {
 		return fmt.Errorf("error reading manifestPath: %w", err)
 	}
 	manifest := string(content)
-	updatedManifest := strings.ReplaceAll(manifest, "gcr.io/cnrm-eap/", "gcr.io/gke-release/cnrm/")
+	updatedManifest := strings.ReplaceAll(manifest, "gcr.io/cnrm-eap/", "gcr.io/gke-release/")
 	fileMode := os.FileMode(0644) // -rw-r--r--
 	return ioutil.WriteFile(manifestPath, []byte(updatedManifest), fileMode)
 }


### PR DESCRIPTION
Fix duplicate cnrm/ in image path, reference: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3164/commits/295914cae9d5f087ec130df19ed4bdfc5b648e7b

More investigations and details are in the Issue link: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/3336.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
