### PR TITLE
chore: enable disco api for tests

### DIFF
--- a/scripts/shared-vars-public.sh
+++ b/scripts/shared-vars-public.sh
@@ -63,6 +63,7 @@ SUPPORTED_SERVICES=(
   dataflow.googleapis.com
   datafusion.googleapis.com
   dataproc.googleapis.com
+  discoveryengine.googleapis.com
   dlp.googleapis.com
   dns.googleapis.com
   edgenetwork.googleapis.com


### PR DESCRIPTION
Currently the post submits are failing for discovery engine with:

"
> dynamic_controller_integration_test.go:235: reconcile for DiscoveryEngineDataStore:4pvzd6wll2p7dby/datastore-4pvzd6wll2p7dby took 364.66735ms, result was ({false 0s}, Update call failed: getting discoveryengine datastore "projects/<REDACTED>" from gcp: googleapi: Error 403: Discovery Engine API has not been used in project <REDACTED> before or it is disabled. Enable it by visiting ...

"