### PR TITLE
chore: turn on readOnlyRootFilesystem for GKE add-on release'

### DIFF
--- a/operator/config/gke-addon/manager_patch.yaml
+++ b/operator/config/gke-addon/manager_patch.yaml
@@ -30,3 +30,6 @@
     postStart:
       exec:
         command: ["./gke_addon_poststart"]
+- op: add
+  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
+  value: true


### PR DESCRIPTION
This is required by GKE add-on