### PR TITLE
fix: add version

### DIFF
--- a/pkg/controller/direct/gkehub/mappings.go
+++ b/pkg/controller/direct/gkehub/mappings.go
@@ -68,6 +68,7 @@ func ConfigManagementMembershipSpec_FromProto(mapCtx *direct.MapContext, r *api.
 		Binauthz:   FeaturemembershipBinauthz_FromProto(mapCtx, r.Binauthz),
 		ConfigSync: ConfigSyncMembershipSpec_FromProto(mapCtx, r.ConfigSync),
 		Management: direct.LazyPtr(r.Management),
+		Version:    direct.LazyPtr(r.Version),
 	}
 }
 


### PR DESCRIPTION
Super small fix to add the `Version` field to the FromProto conversion.