### PR TITLE
feat: Add capability to replace proto contents in patch-proto

### DIFF
--- a/mockgcp/apply-proto-patches.sh
+++ b/mockgcp/apply-proto-patches.sh
@@ -67,3 +67,14 @@ cd tools/patch-proto
 #   // Optional. The configuration for Private Service Connect (PSC) for the cluster.
 #   PscConfig psc_config = 31 [(google.api.field_behavior) = OPTIONAL];
 # EOF
+
+go run . --file ${REPO_ROOT}/mockgcp/apis/mockgcp/cloud/apigee/v1/service.proto --service "ProjectsServer" --mode "replace" <<EOF
+
+  // Provisions a new Apigee organization with a functioning runtime. This is the standard way to create trial organizations for a free Apigee trial.
+  rpc ProvisionOrganizationProject(ProvisionOrganizationProjectRequest) returns (.google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1/{name=projects/*}:provisionOrganization"
+      body: "project"
+    };
+  };
+EOF

--- a/mockgcp/tools/patch-proto/go.mod
+++ b/mockgcp/tools/patch-proto/go.mod
@@ -14,4 +14,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/thediveo/enumflag/v2 v2.0.5 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 )

--- a/mockgcp/tools/patch-proto/go.sum
+++ b/mockgcp/tools/patch-proto/go.sum
@@ -20,6 +20,10 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/thediveo/enumflag/v2 v2.0.5 h1:VJjvlAqUb6m6mxOrB/0tfBJI0Kvi9wJ8ulh38xK87i8=
+github.com/thediveo/enumflag/v2 v2.0.5/go.mod h1:0NcG67nYgwwFsAvoQCmezG0J0KaIxZ0f7skg9eLq1DA=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Use this new capability to codify the Apigee proto hack that was originally made (manually) in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3183.

This addresses the suggested changes in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3183#pullrequestreview-2447281185 and https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3262#discussion_r1861004371.