### PR TITLE
docs:fix: point to the right ref

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubmembership.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/gkehub/gkehubmembership.md
@@ -23,7 +23,7 @@ Note: GKE Hub REST documentation is under construction.
 </tr>
 <tr>
 <td>{{gcp_name_short}} Service Documentation</td>
-<td><a href="/anthos/multicluster-management/connect/overview">/anthos/multicluster-management/connect/overview</a></td>
+<td><a href="/kubernetes-engine/fleet-management/docs/manage-features">/kubernetes-engine/fleet-management/docs/manage-features</a></td>
 </tr>
 <tr>
 <td>{{gcp_name_short}} REST Resource Name</td>

--- a/scripts/generate-google3-docs/resource-reference/templates/gkehub_gkehubmembership.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/gkehub_gkehubmembership.tmpl
@@ -22,7 +22,7 @@ Note: GKE Hub REST documentation is under construction.
 </tr>
 <tr>
 <td>{{"{{gcp_name_short}}"}} Service Documentation</td>
-<td><a href="/anthos/multicluster-management/connect/overview">/anthos/multicluster-management/connect/overview</a></td>
+<td><a href="/kubernetes-engine/fleet-management/docs/manage-features">/kubernetes-engine/fleet-management/docs/manage-features</a></td>
 </tr>
 <tr>
 <td>{{"{{gcp_name_short}}"}} REST Resource Name</td>


### PR DESCRIPTION
This is a small fix to point to the right references docs. 