### PR TITLE
tool: rename flags for type updater

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/updatetypes/updatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/updatetypes/updatetypescommand.go
@@ -29,7 +29,7 @@ type UpdateTypeOptions struct {
 	*options.GenerateOptions
 
 	parentNessage string // The fully qualified name of the parent prroto message of the field to be inserted
-	fieldToInsert string
+	insertField   string
 	ignoredFields string // TODO: could be part of GenerateOptions
 	apiDirectory  string
 	goPackagePath string
@@ -46,8 +46,8 @@ func (o *UpdateTypeOptions) InitDefaults() error {
 }
 
 func (o *UpdateTypeOptions) BindFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.parentNessage, "parent-message", o.parentNessage, "Fully qualified name of the proto message holding the new field. e.g. `google.cloud.bigquery.datatransfer.v1.TransferConfig`")
-	cmd.Flags().StringVar(&o.fieldToInsert, "field-to-insert", o.fieldToInsert, "Name of the new field to be inserted, e.g. `schedule_options_v2`")
+	cmd.Flags().StringVar(&o.parentNessage, "parent", o.parentNessage, "Fully qualified name of the proto message holding the new field. e.g. `google.cloud.bigquery.datatransfer.v1.TransferConfig`")
+	cmd.Flags().StringVar(&o.insertField, "insert-field", o.insertField, "Name of the new field to be inserted, e.g. `schedule_options_v2`")
 	// TODO: Update this flag to accept a file path pointing to the ignored fields YAML file.
 	cmd.Flags().StringVar(&o.ignoredFields, "ignored-fields", o.ignoredFields, "Comma-separated list of fields to ignore")
 	cmd.Flags().StringVar(&o.apiDirectory, "api-dir", o.apiDirectory, "Base directory for APIs")
@@ -89,7 +89,7 @@ func runTypeUpdater(ctx context.Context, opt *UpdateTypeOptions) error {
 	typeUpdaterOpts := &typeupdater.UpdaterOptions{
 		ProtoSourcePath:       opt.GenerateOptions.ProtoSourcePath,
 		ParentMessageFullName: opt.parentNessage,
-		FieldToInsert:         opt.fieldToInsert,
+		FieldToInsert:         opt.insertField,
 		IgnoredFields:         opt.ignoredFields,
 		APIDirectory:          opt.apiDirectory,
 		GoPackagePath:         opt.goPackagePath,

--- a/dev/tools/controllerbuilder/update.sh
+++ b/dev/tools/controllerbuilder/update.sh
@@ -22,7 +22,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 # example usage
 go run . update-types \
-    --parent-message "google.monitoring.dashboard.v1.Dashboard" \
-    --field-to-insert "row_layout" \
+    --parent "google.monitoring.dashboard.v1.Dashboard" \
+    --insert-field "row_layout" \
     --api-dir ${REPO_ROOT}/apis/monitoring/v1beta1 \
     --ignored-fields "google.monitoring.dashboard.v1.PickTimeSeriesFilter.interval"

--- a/docs/develop-resources/scenarios/new-field.md
+++ b/docs/develop-resources/scenarios/new-field.md
@@ -11,8 +11,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd $REPO_ROOT/dev/tools/controllerbuilder
 
 go run . update-types \
-    --parent-message "google.monitoring.dashboard.v1.Dashboard" \
-    --field-to-insert "row_layout" \
+    --parent "google.monitoring.dashboard.v1.Dashboard" \
+    --insert-field "row_layout" \
     --api-dir ${REPO_ROOT}/apis/monitoring/v1beta1
 ```
 


### PR DESCRIPTION
Following up the discussion in #3337, renaming some of the flags in the type updater.