### PR TITLE
tool: add annotation to the generated Go fields with their corresponding proto fields

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -226,6 +226,7 @@ func WriteField(out io.Writer, field protoreflect.FieldDescriptor, msg protorefl
 		}
 	}
 
+	fmt.Fprintf(out, "\t// +kcc:proto=%s\n", field.FullName())
 	fmt.Fprintf(out, "\t%s %s `json:\"%s,omitempty\"`\n",
 		goFieldName,
 		goType,


### PR DESCRIPTION
This provides an easier way to track the mapping between generate Go fields and their corresponding proto fields. I think we should start tracking this information.

/cc @jasonvigil @yuwenma 