### PR TITLE
fix: listing ref

### DIFF
--- a/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
@@ -117,7 +117,8 @@ func NewBigQueryAnalyticsHubListingRef(ctx context.Context, reader client.Reader
 		return nil, fmt.Errorf("cannot parse dataExchangeRef for listing ref: %w", err)
 	}
 
-	id.parent = &BigQueryAnalyticsHubListingParent{ProjectID: projectID, Location: location, DataExchangeID: dataExchangeID.ID()}
+	deID := dataExchangeID.ID()
+	id.parent = &BigQueryAnalyticsHubListingParent{ProjectID: projectID, Location: location, DataExchangeID: deID}
 
 	// Get desired ID
 	resourceID := valueOf(obj.Spec.ResourceID)
@@ -126,6 +127,9 @@ func NewBigQueryAnalyticsHubListingRef(ctx context.Context, reader client.Reader
 	}
 	if resourceID == "" {
 		return nil, fmt.Errorf("cannot resolve resource ID")
+	}
+	if deID == "" {
+		return nil, fmt.Errorf("cannot resolve dataExchange ID")
 	}
 
 	// Use approved External
@@ -150,8 +154,12 @@ func NewBigQueryAnalyticsHubListingRef(ctx context.Context, reader client.Reader
 		return nil, fmt.Errorf("cannot reset `metadata.name` or `spec.resourceID` to %s, since it has already assigned to %s",
 			resourceID, actualResourceID)
 	}
+	if actualParent.DataExchangeID != deID {
+		return nil, fmt.Errorf("spec.dataExchangeRef changed, expect %s, got %s", actualParent.DataExchangeID, deID)
+	}
+
 	id.External = externalRef
-	id.parent = &BigQueryAnalyticsHubListingParent{ProjectID: projectID, Location: location}
+	id.parent = &BigQueryAnalyticsHubListingParent{ProjectID: projectID, Location: location, DataExchangeID: deID}
 	return id, nil
 }
 


### PR DESCRIPTION
Forgot to actually record the dataExchangeID in a parent for the listing reference. The dynamic post submit caught this but only in `testDriftDetection` for some reason.

```
$     go test -v -tags=integration ./pkg/controller/dynamic/ -timeout 1600s -test.count=1 -test.run 'TestCreateNoChangeUpdateDelete/bigqueryanalyticshub/basic-bigqueryanalyticshublisting-base'  2>&1 

...

testreconciler.go:187: reconcile for BigQueryDataset:67ynb4sojpz6wri/bigquerydataset67ynb4sojpz6wri took 493.033563ms, result was ({false 5m48.428911865s}, <nil>)
--- PASS: TestCreateNoChangeUpdateDelete (0.23s)
    --- PASS: TestCreateNoChangeUpdateDelete/bigqueryanalyticshub (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/bigqueryanalyticshub/basic-bigqueryanalyticshublisting-base (83.60s)
PASS
...
ok      github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dynamic      93.940s
```