### PR TITLE
chore: add presubmit check for generated types for direct resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,3 +400,13 @@ operator-e2e-tests:
 	export TEST_ORG_ID=${ORG_ID}
 	export TEST_BILLING_ACCOUNT_ID=${BILLING_ACCOUNT}
 	cd operator/tests/e2e/ && go test --project-id=${PROJECT_ID}
+
+# Generate Go types for direct resources specified in the config files located under `dev/tools/controllerbuilder/config`.
+.PHONY: generate-types
+generate-types:
+	cd dev/tools/controllerbuilder && \
+	./generate-proto.sh && \
+	for config in config/*.yaml; do \
+		go run . generate-types --config $$config; \
+	done
+	dev/tasks/fix-gofmt 

--- a/dev/tools/controllerbuilder/generate-proto.sh
+++ b/dev/tools/controllerbuilder/generate-proto.sh
@@ -61,6 +61,7 @@ fi
 
 
 protoc --include_imports --include_source_info \
+    --experimental_allow_proto3_optional \
     -I ${THIRD_PARTY}/googleapis/ \
     -I ${REPO_ROOT}/mockgcp/apis \
     ${REPO_ROOT}/mockgcp/apis/mockgcp/cloud/apigee/*/*.proto \


### PR DESCRIPTION
Follow up of #3375.

This PR adds a presubmit check to prevent accidental manual edits to the generated types for direct resources, ensuring the tools can be safely rerun. (Diff in copyright year within the generated file is ignored)

To ***opt-in*** the check, create a configuration YAML file and place it in the `dev/tools/controllerbuilder/config` directory. Here’s an example configuration file:

```
service: google.cloud.bigquery.datatransfer.v1
apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
generateMapper: true
resources:
  - kind: BigQueryDataTransferConfig
    protoName: TransferConfig
    skipScaffoldFiles: true # files were scaffolded using a previous template, making them incompatible with the new scaffolding template.
```