### PR TITLE
fix: Fix g3doc for refs

### DIFF
--- a/apis/bigquery/v1beta1/dataset_reference.go
+++ b/apis/bigquery/v1beta1/dataset_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryDatasetRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryDatasetRef struct {
 	// A reference to an externally managed BigQueryDataset resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/datasets/<datasetID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/datasets/{{datasetID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a BigQueryDataset resource.
@@ -164,7 +164,7 @@ func ParseBigQueryDatasetExternal(external string) (parent *BigQueryDatasetParen
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 4 || tokens[0] != "projects" || tokens[2] != "datasets" {
-		return nil, "", fmt.Errorf("format of BigQueryDataset external=%q was not known (use projects/<projectId>/datasets/<datasetID>)", external)
+		return nil, "", fmt.Errorf("format of BigQueryDataset external=%q was not known (use projects/{{projectID}}/datasets/{{datasetID}})", external)
 	}
 	parent = &BigQueryDatasetParent{
 		ProjectID: tokens[1],

--- a/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/dataexchange_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryAnalyticsHubDataExchangeRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryAnalyticsHubDataExchangeRef struct {
 	// A reference to an externally managed BigQueryAnalyticsHubDataExchange resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/dataexchanges/<dataexchangeID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a BigQueryAnalyticsHubDataExchange resource.
@@ -168,7 +168,7 @@ func parseBigQueryAnalyticsHubDataExchangeExternal(external string) (parent *Big
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "dataexchange" {
-		return nil, "", fmt.Errorf("format of BigQueryAnalyticsHubDataExchange external=%q was not known (use projects/<projectId>/locations/<location>/dataexchanges/<dataexchangeID>)", external)
+		return nil, "", fmt.Errorf("format of BigQueryAnalyticsHubDataExchange external=%q was not known (use projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}})", external)
 	}
 	parent = &BigQueryAnalyticsHubDataExchangeParent{
 		ProjectID: tokens[1],

--- a/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/listing_reference.go
@@ -34,7 +34,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryAnalyticsHubListingRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryAnalyticsHubListingRef struct {
 	// A reference to an externally managed BigQueryAnalyticsHubListing resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/listings/<listingID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/listings/{{listingID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a BigQueryAnalyticsHubListing resource.
@@ -187,7 +187,7 @@ func parseBigQueryAnalyticsHubListingExternal(external string) (parent *BigQuery
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 8 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "dataExchanges" || tokens[6] != "listings" {
-		return nil, "", fmt.Errorf("format of BigQueryAnalyticsHubListing external=%q was not known (use projects/<projectID>/locations/<location>/dataExchanges/<dataExchangeID>/listings/<listingID>)", external)
+		return nil, "", fmt.Errorf("format of BigQueryAnalyticsHubListing external=%q was not known (use projects/{{projectID}}/locations/{{location}}/dataExchanges/{{dataExchangeID}}/listings/{{listingID}})", external)
 	}
 	parent = &BigQueryAnalyticsHubListingParent{
 		ProjectID:      tokens[1],

--- a/apis/bigqueryanalyticshub/v1beta1/dataexchange_reference.go
+++ b/apis/bigqueryanalyticshub/v1beta1/dataexchange_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryAnalyticsHubDataExchangeRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryAnalyticsHubDataExchangeRef struct {
 	// A reference to an externally managed BigQueryAnalyticsHubDataExchange resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/dataexchanges/<dataexchangeID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a BigQueryAnalyticsHubDataExchange resource.
@@ -87,7 +87,7 @@ func ParseDataExchangeIdentity(external string) (identity *DataExchangeIdentity,
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "dataExchanges" {
-		return nil, fmt.Errorf("format of BigQueryAnalyticsHubDataExchange external=%q was not known (use projects/<projectId>/locations/<location>/dataExchanges/<dataExchangeID>)", external)
+		return nil, fmt.Errorf("format of BigQueryAnalyticsHubDataExchange external=%q was not known (use projects/{{projectId}}/locations/{{location}}/dataExchanges/{{dataExchangeID}})", external)
 	}
 
 	return &DataExchangeIdentity{

--- a/apis/bigqueryconnection/v1alpha1/connection_reference.go
+++ b/apis/bigqueryconnection/v1alpha1/connection_reference.go
@@ -58,7 +58,7 @@ func NewBigQueryConnectionConnectionRef(ctx context.Context, reader client.Reade
 		tokens := strings.Split(externalRef, "/")
 
 		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "connections" {
-			return nil, fmt.Errorf("externalRef should be projects/<project>/locations/<location>/connections/<Connection>, got %s", externalRef)
+			return nil, fmt.Errorf("externalRef should be projects/{{project}}/locations/{{location}}/connections/{{Connection}}, got %s", externalRef)
 		}
 		id.parent = "projects/" + tokens[1] + "/locations/" + tokens[3]
 
@@ -93,7 +93,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryConnectionConnectionRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryConnectionConnectionRef struct {
 	// A reference to an externally managed BigQueryConnectionConnection resource.
-	// Should be in the format `projects/<projectID>/locations/<location>/connections/<connectionID>`.
+	// Should be in the format `projects/{{projectID}}/locations/{{location}}/connections/{{connectionID}}`.
 	External string `json:"external,omitempty"`
 
 	// The `name` of a `BigQueryConnectionConnection` resource.
@@ -112,7 +112,7 @@ func (r *BigQueryConnectionConnectionRef) Parent() (string, error) {
 		r.External = strings.TrimPrefix(r.External, "/")
 		tokens := strings.Split(r.External, "/")
 		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "connections" {
-			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/<projectId>/locations/<location>/connections/<connectionID>)", r.External)
+			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/{{projectId}}/locations/{{location}}/connections/{{connectionID}})", r.External)
 		}
 		r.parent = "projects/" + tokens[1] + "/locations/" + tokens[3]
 		return r.parent, nil
@@ -130,7 +130,7 @@ func (r *BigQueryConnectionConnectionRef) NormalizedExternal(ctx context.Context
 		r.External = strings.TrimPrefix(r.External, "/")
 		tokens := strings.Split(r.External, "/")
 		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "connections" {
-			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/<projectId>/locations/<location>/connections/<connectionID>)", r.External)
+			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/{{projectId}}/locations/{{location}}/connections/{{connectionID}})", r.External)
 		}
 		return r.External, nil
 	}

--- a/apis/bigqueryconnection/v1beta1/connection_reference.go
+++ b/apis/bigqueryconnection/v1beta1/connection_reference.go
@@ -79,7 +79,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryConnectionConnectionRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryConnectionConnectionRef struct {
 	// A reference to an externally managed BigQueryConnectionConnection resource.
-	// Should be in the format `projects/<projectID>/locations/<location>/connections/<connectionID>`.
+	// Should be in the format `projects/{{projectID}}/locations/{{location}}/connections/{{connectionID}}`.
 	External string `json:"external,omitempty"`
 
 	// The `name` of a `BigQueryConnectionConnection` resource.
@@ -91,7 +91,7 @@ type BigQueryConnectionConnectionRef struct {
 func parseExternal(external string) (string, string, string, error) {
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "connections" {
-		return "", "", "", fmt.Errorf("external should be projects/<project>/locations/<location>/connections/<Connection>, got %s", external)
+		return "", "", "", fmt.Errorf("external should be projects/{{project}}/locations/{{location}}/connections/{{Connection}}, got %s", external)
 	}
 	return tokens[1], tokens[3], tokens[5], nil
 }
@@ -130,7 +130,7 @@ func (r *BigQueryConnectionConnectionRef) NormalizedExternal(ctx context.Context
 		r.External = strings.TrimPrefix(r.External, "/")
 		tokens := strings.Split(r.External, "/")
 		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "connections" {
-			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/<projectId>/locations/<location>/connections/<connectionID>)", r.External)
+			return "", fmt.Errorf("format of BigQueryConnectionConnection external=%q was not known (use projects/{{projectId}}/locations/{{location}}/connections/{{connectionID}})", r.External)
 		}
 		return r.External, nil
 	}

--- a/apis/compute/v1beta1/computefirewallpolicyrule_reference.go
+++ b/apis/compute/v1beta1/computefirewallpolicyrule_reference.go
@@ -34,7 +34,7 @@ var _ refsv1beta1.ExternalNormalizer = &ComputeFirewallPolicyRuleRef{}
 // holds the GCP identifier for the KRM object.
 type ComputeFirewallPolicyRuleRef struct {
 	// A reference to an externally managed ComputeFirewallPolicyRule resource.
-	// Should be in the format "locations/global/firewallPolicies/<firewallPolicy>/rules/<priority>".
+	// Should be in the format "locations/global/firewallPolicies/{{firewallPolicy}}/rules/{{priority}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a ComputeFirewallPolicyRule resource.
@@ -158,7 +158,7 @@ func asComputeFirewallPolicyRuleExternal(parent *ComputeFirewallPolicyRuleParent
 func parseComputeFirewallPolicyRuleExternal(external string) (parent *ComputeFirewallPolicyRuleParent, priority int64, err error) {
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "locations" || tokens[2] != "firewallPolicies" || tokens[4] != "rules" {
-		return nil, -1, fmt.Errorf("format of ComputeFirewallPolicyRule external=%q was not known (use firewallPolicies/<firewallPolicy>/rules/<priority>)", external)
+		return nil, -1, fmt.Errorf("format of ComputeFirewallPolicyRule external=%q was not known (use firewallPolicies/{{firewallPolicy}}/rules/{{priority}})", external)
 	}
 	parent = &ComputeFirewallPolicyRuleParent{
 		FirewallPolicy: tokens[3],

--- a/apis/compute/v1beta1/targettcpproxy_reference.go
+++ b/apis/compute/v1beta1/targettcpproxy_reference.go
@@ -34,8 +34,8 @@ var _ refsv1beta1.ExternalNormalizer = &ComputeTargetTCPProxyRef{}
 // holds the GCP identifier for the KRM object.
 type ComputeTargetTCPProxyRef struct {
 	// A reference to an externally managed ComputeTargetTCPProxy resource.
-	// Should be in the format "projects/<projectID>/global/targetTcpProxies/<targettcpproxyID>"
-	// or "projects/<projectID>/regions/<region>/targetTcpProxies/<targettcpproxyID>".
+	// Should be in the format "projects/{{projectID}}/global/targetTcpProxies/{{targettcpproxyID}}"
+	// or "projects/{{projectID}}/regions/{{region}}/targetTcpProxies/{{targettcpproxyID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a ComputeTargetTCPProxy resource.

--- a/apis/discoveryengine/v1alpha1/datastore_reference.go
+++ b/apis/discoveryengine/v1alpha1/datastore_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &DiscoveryEngineDataStoreRef{}
 // holds the GCP identifier for the KRM object.
 type DiscoveryEngineDataStoreRef struct {
 	// A reference to an externally managed DiscoveryEngineDataStore resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/datastores/<datastoreID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/datastores/{{datastoreID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a DiscoveryEngineDataStore resource.
@@ -190,7 +190,7 @@ func ParseDiscoveryEngineDataStoreExternal(external string) (*DiscoveryEngineDat
 			DataStore:      tokens[7],
 		}, nil
 	}
-	return nil, fmt.Errorf("format of DiscoveryEngineDataStore external=%q was not known (use projects/<projectId>/locations/<location>/collections/<collectionID>/dataStores/<dataStoreID>)", external)
+	return nil, fmt.Errorf("format of DiscoveryEngineDataStore external=%q was not known (use projects/{{projectId}}/locations/{{location}}/collections/{{collectionID}}/dataStores/{{dataStoreID}})", external)
 }
 
 func valueOf[T any](t *T) T {

--- a/apis/discoveryengine/v1alpha1/engine_reference.go
+++ b/apis/discoveryengine/v1alpha1/engine_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &DiscoveryEngineEngineRef{}
 // holds the GCP identifier for the KRM object.
 type DiscoveryEngineEngineRef struct {
 	// A reference to an externally managed DiscoveryEngineEngine resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/engines/<engineID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/engines/{{engineID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a DiscoveryEngineEngine resource.
@@ -189,5 +189,5 @@ func parseDiscoveryEngineEngineExternal(external string) (*DiscoveryEngineEngine
 			DataStore:      tokens[7],
 		}, nil
 	}
-	return nil, fmt.Errorf("format of DiscoveryEngineEngine external=%q was not known (use projects/<projectId>/locations/<location>/collections/<collectionID>/engines/<engineID>)", external)
+	return nil, fmt.Errorf("format of DiscoveryEngineEngine external=%q was not known (use projects/{{projectId}}/locations/{{location}}/collections/{{collectionID}}/engines/{{engineID}})", external)
 }

--- a/apis/kms/v1alpha1/autokeyconfig_reference.go
+++ b/apis/kms/v1alpha1/autokeyconfig_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &KMSAutokeyConfigRef{}
 // holds the GCP identifier for the KRM object.
 type KMSAutokeyConfigRef struct {
 	// A reference to an externally managed KMSAutokeyConfig resource.
-	// Should be in the format "folders/<folderID>/autokeyConfig".
+	// Should be in the format "folders/{{folderID}}/autokeyConfig".
 	External string `json:"external,omitempty"`
 
 	// The name of a KMSAutokeyConfig resource.
@@ -150,7 +150,7 @@ func ParseKMSAutokeyConfigExternal(external string) (parent *KMSAutokeyConfigPar
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 3 || tokens[0] != "folders" || tokens[2] != "autokeyConfig" {
-		return nil, fmt.Errorf("format of KMSAutokeyConfig external=%q was not known (use folders/<folderID>/autokeyConfig)", external)
+		return nil, fmt.Errorf("format of KMSAutokeyConfig external=%q was not known (use folders/{{folderID}}/autokeyConfig)", external)
 	}
 	parent = &KMSAutokeyConfigParent{
 		FolderID: tokens[1],

--- a/apis/kms/v1alpha1/keyhandle_reference.go
+++ b/apis/kms/v1alpha1/keyhandle_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &KMSKeyHandleRef{}
 // holds the GCP identifier for the KRM object.
 type KMSKeyHandleRef struct {
 	// A reference to an externally managed KMSKeyHandle resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/keyHandles/<keyhandleID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/keyHandles/{{keyhandleID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a KMSKeyHandle resource.
@@ -106,7 +106,7 @@ func NewKMSKeyHandleRef(ctx context.Context, reader client.Reader, obj *KMSKeyHa
 
 	// At this point we are expecting desiredHandleID to be either empty or valid uuid
 	// 1. if desiredHandleID empty:
-	// id.external will be projects/<pid>/locations/<loc>/keyHandles/. i.e without resourceID.
+	// id.external will be projects/{{pid}}/locations/{{loc}}/keyHandles/. i.e without resourceID.
 	// A call will be made to find() with invalid externalID which will return false.
 	// 2. if desiredHandleID is a valid UUID: id.external will be valid.
 
@@ -178,7 +178,7 @@ func ParseKMSKeyHandleExternal(external string) (parent *KMSKeyHandleParent, res
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "keyHandles" {
-		return nil, "", fmt.Errorf("format of KMSKeyHandle external=%q was not known (use projects/<projectId>/locations/<location>/keyHandles/<keyhandleID>)", external)
+		return nil, "", fmt.Errorf("format of KMSKeyHandle external=%q was not known (use projects/{{projectId}}/locations/{{location}}/keyHandles/{{keyhandleID}})", external)
 	}
 	parent = &KMSKeyHandleParent{
 		ProjectID: tokens[1],
@@ -192,7 +192,7 @@ func AsKMSKeyHandleExternal_FromSpec(spec *KMSKeyHandleSpec) (parent *KMSKeyHand
 	external := strings.TrimPrefix(spec.ProjectRef.External, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 2 || tokens[0] != "projects" {
-		return nil, "", fmt.Errorf("invalid projectRef found in KMSKeyHandle=%q was not known (use projects/<projectId>)", external)
+		return nil, "", fmt.Errorf("invalid projectRef found in KMSKeyHandle=%q was not known (use projects/{{projectId}})", external)
 	}
 	parent = &KMSKeyHandleParent{
 		ProjectID: tokens[1],

--- a/apis/kms/v1beta1/keyhandle_reference.go
+++ b/apis/kms/v1beta1/keyhandle_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &KMSKeyHandleRef{}
 // holds the GCP identifier for the KRM object.
 type KMSKeyHandleRef struct {
 	// A reference to an externally managed KMSKeyHandle resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/keyHandles/<keyhandleID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/keyHandles/{{keyhandleID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a KMSKeyHandle resource.
@@ -106,7 +106,7 @@ func NewKMSKeyHandleRef(ctx context.Context, reader client.Reader, obj *KMSKeyHa
 
 	// At this point we are expecting desiredHandleID to be either empty or valid uuid
 	// 1. if desiredHandleID empty:
-	// id.external will be projects/<pid>/locations/<loc>/keyHandles/. i.e without resourceID.
+	// id.external will be projects/{{pid}}/locations/{{loc}}/keyHandles/. i.e without resourceID.
 	// A call will be made to find() with invalid externalID which will return false.
 	// 2. if desiredHandleID is a valid UUID: id.external will be valid.
 
@@ -178,7 +178,7 @@ func ParseKMSKeyHandleExternal(external string) (parent *KMSKeyHandleParent, res
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "keyHandles" {
-		return nil, "", fmt.Errorf("format of KMSKeyHandle external=%q was not known (use projects/<projectId>/locations/<location>/keyHandles/<keyhandleID>)", external)
+		return nil, "", fmt.Errorf("format of KMSKeyHandle external=%q was not known (use projects/{{projectId}}/locations/{{location}}/keyHandles/{{keyhandleID}})", external)
 	}
 	parent = &KMSKeyHandleParent{
 		ProjectID: tokens[1],
@@ -192,7 +192,7 @@ func AsKMSKeyHandleExternal_FromSpec(spec *KMSKeyHandleSpec) (parent *KMSKeyHand
 	external := strings.TrimPrefix(spec.ProjectRef.External, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 2 || tokens[0] != "projects" {
-		return nil, "", fmt.Errorf("invalid projectRef found in KMSKeyHandle=%q was not known (use projects/<projectId>)", external)
+		return nil, "", fmt.Errorf("invalid projectRef found in KMSKeyHandle=%q was not known (use projects/{{projectId}})", external)
 	}
 	parent = &KMSKeyHandleParent{
 		ProjectID: tokens[1],

--- a/apis/memorystore/v1alpha1/instance_reference.go
+++ b/apis/memorystore/v1alpha1/instance_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &MemorystoreInstanceRef{}
 // holds the GCP identifier for the KRM object.
 type MemorystoreInstanceRef struct {
 	// A reference to an externally managed MemorystoreInstance resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/instances/<instanceID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/instances/{{instanceID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a MemorystoreInstance resource.
@@ -168,7 +168,7 @@ func parseMemorystoreInstanceExternal(external string) (parent *MemorystoreInsta
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "instance" {
-		return nil, "", fmt.Errorf("format of MemorystoreInstance external=%q was not known (use projects/<projectId>/locations/<location>/instances/<instanceID>)", external)
+		return nil, "", fmt.Errorf("format of MemorystoreInstance external=%q was not known (use projects/{{projectId}}/locations/{{location}}/instances/{{instanceID}})", external)
 	}
 	parent = &MemorystoreInstanceParent{
 		ProjectID: tokens[1],

--- a/apis/refs/v1beta1/computerefs.go
+++ b/apis/refs/v1beta1/computerefs.go
@@ -41,7 +41,7 @@ func fixStaleExternalFormat(external string) string {
 
 type ComputeNetworkRef struct {
 	// A reference to an externally managed Compute Network resource.
-	// Should be in the format `projects/<projectID>/global/networks/<network>`.
+	// Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
 	External string `json:"external,omitempty"`
 	/* The `name` field of a `ComputeNetwork` resource. */
 	Name string `json:"name,omitempty"`

--- a/apis/secretmanager/v1beta1/secret_reference.go
+++ b/apis/secretmanager/v1beta1/secret_reference.go
@@ -34,7 +34,7 @@ var _ refsv1beta1.ExternalNormalizer = &SecretRef{}
 // holds the GCP identifier for the KRM object.
 type SecretRef struct {
 	// A reference to an externally managed SecretManagerSecret resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/secrets/<secretID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/secrets/{{secretID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a SecretManagerSecret resource.
@@ -97,7 +97,7 @@ func ParseSecretExternal(external string) (*SecretIdentity, error) {
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 4 || tokens[0] != "projects" || tokens[2] != "secrets" {
-		return nil, fmt.Errorf("format of SecretManagerSecret external=%q was not known (use projects/<projectId>/secrets/<secretID>)", external)
+		return nil, fmt.Errorf("format of SecretManagerSecret external=%q was not known (use projects/{{projectId}}/secrets/{{secretID}})", external)
 	}
 	return &SecretIdentity{
 		parent: &SecretParent{ProjectID: tokens[1]},

--- a/apis/secretmanager/v1beta1/secretversion_reference.go
+++ b/apis/secretmanager/v1beta1/secretversion_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &SecretVersionRef{}
 // holds the GCP identifier for the KRM object.
 type SecretVersionRef struct {
 	// A reference to an externally managed SecretManagerSecretVersion resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/secretversions/<secretversionID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/secretversions/{{secretversionID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a SecretManagerSecretVersion resource.
@@ -90,7 +90,7 @@ func ParseSecretVersionExternal(external string) (*SecretVersionIdentity, error)
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "secrets" || tokens[4] != "versions" {
-		return nil, fmt.Errorf("format of SecretManagerSecretVersion external=%q was not known (use projects/<projectId>/secrets/<secretID>/versions/<versionID>)", external)
+		return nil, fmt.Errorf("format of SecretManagerSecretVersion external=%q was not known (use projects/{{projectId}}/secrets/{{secretID}}/versions/{{versionID}})", external)
 	}
 	return &SecretVersionIdentity{
 		parent: &SecretVersionParent{ProjectID: tokens[1], SecretID: tokens[3]},

--- a/apis/securesourcemanager/v1alpha1/instance_reference.go
+++ b/apis/securesourcemanager/v1alpha1/instance_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &SecureSourceManagerInstanceRef{}
 // holds the GCP identifier for the KRM object.
 type SecureSourceManagerInstanceRef struct {
 	// A reference to an externally managed SecureSourceManagerInstance resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/instances/<instanceID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/instances/{{instanceID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a SecureSourceManagerInstance resource.
@@ -67,7 +67,7 @@ func parseSecureSourceManagerExternal(external string) (*ProjectIDAndLocation, s
 		return parent, resourceID, nil
 	}
 
-	return nil, "", fmt.Errorf("format of SecureSourceManagerInstance external=%q was not known (use projects/<projectId>/locations/<location>/instances/<instanceID>)", external)
+	return nil, "", fmt.Errorf("format of SecureSourceManagerInstance external=%q was not known (use projects/{{projectId}}/locations/{{location}}/instances/{{instanceID}})", external)
 }
 
 // NormalizedExternal provision the "External" value for other resource that depends on SecureSourceManagerInstance.

--- a/apis/securesourcemanager/v1alpha1/repository_reference.go
+++ b/apis/securesourcemanager/v1alpha1/repository_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &SecureSourceManagerRepositoryRef{}
 // holds the GCP identifier for the KRM object.
 type SecureSourceManagerRepositoryRef struct {
 	// A reference to an externally managed SecureSourceManagerRepository resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/repositories/<repositoryID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/repositories/{{repositoryID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a SecureSourceManagerRepository resource.
@@ -180,7 +180,7 @@ func parseSecureSourceManagerRepositoryExternal(external string) (parent *Secure
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "repositories" {
-		return nil, "", fmt.Errorf("format of SecureSourceManagerRepository external=%q was not known (use projects/<projectId>/locations/<location>/repositories/<repositoryID>)", external)
+		return nil, "", fmt.Errorf("format of SecureSourceManagerRepository external=%q was not known (use projects/{{projectId}}/locations/{{location}}/repositories/{{repositoryID}})", external)
 	}
 	parent = &SecureSourceManagerRepositoryParent{
 		ProjectID: tokens[1],

--- a/apis/spanner/v1beta1/instance_reference.go
+++ b/apis/spanner/v1beta1/instance_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &SpannerInstanceRef{}
 // holds the GCP identifier for the KRM object.
 type SpannerInstanceRef struct {
 	// A reference to an externally managed SpannerInstance resource.
-	// Should be in the format "projects/<projectID>/instances/<instanceID>".
+	// Should be in the format "projects/{{projectID}}/instances/{{instanceID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a SpannerInstance resource.
@@ -159,7 +159,7 @@ func parseSpannerInstanceExternal(external string) (parent *SpannerInstanceParen
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 4 || tokens[0] != "projects" || tokens[2] != "instances" {
-		return nil, "", fmt.Errorf("format of SpannerInstance external=%q was not known (use projects/<projectId>/instances/<instanceID>)", external)
+		return nil, "", fmt.Errorf("format of SpannerInstance external=%q was not known (use projects/{{projectId}}/instances/{{instanceID}})", external)
 	}
 	parent = &SpannerInstanceParent{
 		ProjectID: tokens[1],

--- a/apis/workstations/v1alpha1/cluster_reference.go
+++ b/apis/workstations/v1alpha1/cluster_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &WorkstationClusterRef{}
 // holds the GCP identifier for the KRM object.
 type WorkstationClusterRef struct {
 	// A reference to an externally managed WorkstationCluster resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a WorkstationCluster resource.
@@ -165,7 +165,7 @@ func parseWorkstationClusterExternal(external string) (parent *WorkstationCluste
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "workstationClusters" {
-		return nil, "", fmt.Errorf("format of WorkstationCluster external=%q was not known (use projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>)", external)
+		return nil, "", fmt.Errorf("format of WorkstationCluster external=%q was not known (use projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}})", external)
 	}
 	parent = &WorkstationClusterParent{
 		ProjectID: tokens[1],

--- a/apis/workstations/v1alpha1/config_reference.go
+++ b/apis/workstations/v1alpha1/config_reference.go
@@ -32,7 +32,7 @@ var _ refsv1beta1.ExternalNormalizer = &WorkstationConfigRef{}
 // holds the GCP identifier for the KRM object.
 type WorkstationConfigRef struct {
 	// A reference to an externally managed WorkstationConfig resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>/workstationConfigs/<workstationconfigID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}/workstationConfigs/{{workstationconfigID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a WorkstationConfig resource.

--- a/apis/workstations/v1alpha1/workstation_reference.go
+++ b/apis/workstations/v1alpha1/workstation_reference.go
@@ -32,7 +32,7 @@ var _ refsv1beta1.ExternalNormalizer = &WorkstationRef{}
 // holds the GCP identifier for the KRM object.
 type WorkstationRef struct {
 	// A reference to an externally managed Workstation resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>/workstationConfigs/<workstationconfigID>/workstations/<workstationID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}/workstationConfigs/{{workstationconfigID}}/workstations/{{workstationID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a Workstation resource.

--- a/apis/workstations/v1beta1/cluster_reference.go
+++ b/apis/workstations/v1beta1/cluster_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &WorkstationClusterRef{}
 // holds the GCP identifier for the KRM object.
 type WorkstationClusterRef struct {
 	// A reference to an externally managed WorkstationCluster resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a WorkstationCluster resource.
@@ -165,7 +165,7 @@ func parseWorkstationClusterExternal(external string) (parent *WorkstationCluste
 	external = strings.TrimPrefix(external, "/")
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "workstationClusters" {
-		return nil, "", fmt.Errorf("format of WorkstationCluster external=%q was not known (use projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>)", external)
+		return nil, "", fmt.Errorf("format of WorkstationCluster external=%q was not known (use projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}})", external)
 	}
 	parent = &WorkstationClusterParent{
 		ProjectID: tokens[1],

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
@@ -85,7 +85,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed BigQueryAnalyticsHubDataExchange
-                      resource. Should be in the format "projects/<projectID>/locations/<location>/dataexchanges/<dataexchangeID>".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".
                     type: string
                   name:
                     description: The name of a BigQueryAnalyticsHubDataExchange resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudbuildworkerpools.cloudbuild.cnrm.cloud.google.com.yaml
@@ -71,7 +71,7 @@ spec:
                         properties:
                           external:
                             description: A reference to an externally managed Compute
-                              Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                              Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.
@@ -279,7 +279,7 @@ spec:
                         properties:
                           external:
                             description: A reference to an externally managed Compute
-                              Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                              Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefirewallpolicyrules.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefirewallpolicyrules.compute.cnrm.cloud.google.com.yaml
@@ -236,7 +236,7 @@ spec:
                   properties:
                     external:
                       description: A reference to an externally managed Compute Network
-                        resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                        resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                       type: string
                     name:
                       description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeforwardingrules.compute.cnrm.cloud.google.com.yaml
@@ -306,7 +306,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed Compute Network
-                      resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                      resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com.yaml
@@ -143,7 +143,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed Compute Network
-                      resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                      resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryengineengines.discoveryengine.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryengineengines.discoveryengine.cnrm.cloud.google.com.yaml
@@ -158,7 +158,7 @@ spec:
                   properties:
                     external:
                       description: A reference to an externally managed DiscoveryEngineDataStore
-                        resource. Should be in the format "projects/<projectID>/locations/<location>/datastores/<datastoreID>".
+                        resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/datastores/{{datastoreID}}".
                       type: string
                     name:
                       description: The name of a DiscoveryEngineDataStore resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_memorystoreinstances.memorystore.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_memorystoreinstances.memorystore.cnrm.cloud.google.com.yaml
@@ -173,7 +173,7 @@ spec:
                       properties:
                         external:
                           description: A reference to an externally managed Compute
-                            Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                            Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                           type: string
                         name:
                           description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_networkconnectivityserviceconnectionpolicies.networkconnectivity.cnrm.cloud.google.com.yaml
@@ -79,7 +79,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed Compute Network
-                      resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                      resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_redisclusters.redis.cnrm.cloud.google.com.yaml
@@ -159,7 +159,7 @@ spec:
                       properties:
                         external:
                           description: A reference to an externally managed Compute
-                            Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                            Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                           type: string
                         name:
                           description: The `name` field of a `ComputeNetwork` resource.
@@ -498,7 +498,7 @@ spec:
                       properties:
                         external:
                           description: A reference to an externally managed Compute
-                            Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                            Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                           type: string
                         name:
                           description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecretversions.secretmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecretversions.secretmanager.cnrm.cloud.google.com.yaml
@@ -136,7 +136,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed SecretManagerSecret
-                      resource. Should be in the format "projects/<projectID>/locations/<location>/secrets/<secretID>".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/secrets/{{secretID}}".
                     type: string
                   name:
                     description: The name of a SecretManagerSecret resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
@@ -223,7 +223,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed SecureSourceManagerInstance
-                      resource. Should be in the format "projects/<projectID>/locations/<location>/instances/<instanceID>".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/instances/{{instanceID}}".
                     type: string
                   name:
                     description: The name of a SecureSourceManagerInstance resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_sqlinstances.sql.cnrm.cloud.google.com.yaml
@@ -546,7 +546,7 @@ spec:
                         properties:
                           external:
                             description: A reference to an externally managed Compute
-                              Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                              Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                             type: string
                           name:
                             description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
@@ -109,7 +109,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed Compute Network
-                      resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                      resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.
@@ -455,7 +455,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed Compute Network
-                      resource. Should be in the format `projects/<projectID>/global/networks/<network>`.
+                      resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.
                     type: string
                   name:
                     description: The `name` field of a `ComputeNetwork` resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
@@ -418,7 +418,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed WorkstationCluster
-                      resource. Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}".
                     type: string
                   name:
                     description: The name of a WorkstationCluster resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
@@ -108,7 +108,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed WorkstationConfig
-                      resource. Should be in the format "projects/<projectID>/locations/<location>/workstationClusters/<workstationclusterID>/workstationConfigs/<workstationconfigID>".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/workstationClusters/{{workstationclusterID}}/workstationConfigs/{{workstationconfigID}}".
                     type: string
                   name:
                     description: The name of a WorkstationConfig resource.

--- a/dev/tools/controllerbuilder/template/apis/identity.go
+++ b/dev/tools/controllerbuilder/template/apis/identity.go
@@ -109,7 +109,7 @@ func New{{.ProtoResource}}Identity(ctx context.Context, reader client.Reader, ob
 func Parse{{.ProtoResource}}External(external string) (parent *{{.ProtoResource}}Parent, resourceID string, err error) {
 	tokens := strings.Split(external, "/")
 	if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "{{.ProtoResource | ToLower }}s" {
-		return nil, "", fmt.Errorf("format of {{.Kind}} external=%q was not known (use projects/<projectId>/locations/<location>/{{.ProtoResource | ToLower }}s/<{{.ProtoResource | ToLower }}ID>)", external)
+		return nil, "", fmt.Errorf("format of {{.Kind}} external=%q was not known (use projects/{{"{{"}}projectID{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/{{.ProtoResource | ToLower }}s/{{"{{"}}{{.ProtoResource | ToLower }}ID{{"}}"}})", external)
 	}
 	parent = &{{.ProtoResource}}Parent{
 		ProjectID: tokens[1],

--- a/dev/tools/controllerbuilder/template/apis/refs.go
+++ b/dev/tools/controllerbuilder/template/apis/refs.go
@@ -34,7 +34,7 @@ var _ refsv1beta1.ExternalNormalizer = &{{.ProtoResource}}Ref{}
 // holds the GCP identifier for the KRM object.
 type {{.ProtoResource}}Ref struct {
 	// A reference to an externally managed {{.Kind}} resource.
-	// Should be in the format "projects/<projectID>/locations/<location>/{{.ProtoResource | ToLower }}s/<{{.ProtoResource | ToLower }}ID>".
+	// Should be in the format "projects/{{"{{"}}projectID{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/{{.ProtoResource | ToLower }}s/{{"{{"}}{{.ProtoResource | ToLower }}ID{{"}}"}}".
 	External string ` + "`" + `json:"external,omitempty"` + "`" + `
 
 	// The name of a {{.Kind}} resource.

--- a/pkg/controller/direct/firestore/firestoredatabase_externalresource.go
+++ b/pkg/controller/direct/firestore/firestoredatabase_externalresource.go
@@ -50,7 +50,7 @@ func asID(externalRef string) (*FirestoreDatabaseIdentity, error) {
 	tokens := strings.Split(path, "/")
 
 	if len(tokens) != 4 || tokens[0] != "projects" || tokens[2] != "databases" {
-		return nil, fmt.Errorf("externalRef should be %s/projects/<project>/databases/<firestoredatabase>, got %s",
+		return nil, fmt.Errorf("externalRef should be %s/projects/{{projectID}}/databases/{{firestoredatabase}}, got %s",
 			serviceDomain, externalRef)
 	}
 	return &FirestoreDatabaseIdentity{

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudbuild/cloudbuildworkerpool.md
@@ -168,7 +168,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computefirewallpolicyrule.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computefirewallpolicyrule.md
@@ -501,7 +501,7 @@ targetServiceAccounts:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeforwardingrule.md
@@ -536,7 +536,7 @@ provided metadata. Possible values: ["MATCH_ANY", "MATCH_ALL"].{% endverbatim %}
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataflow/dataflowflextemplatejob.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/dataflow/dataflowflextemplatejob.md
@@ -275,7 +275,7 @@ transformNameMapping: {}
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/redis/rediscluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/redis/rediscluster.md
@@ -299,7 +299,7 @@ zoneDistributionConfig:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
@@ -203,7 +203,7 @@ secretRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed SecretManagerSecret resource. Should be in the format "projects/<projectID>/locations/<location>/secrets/<secretID>".{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed SecretManagerSecret resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/secrets/{{secretID}}".{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/sql/sqlinstance.md
@@ -1243,7 +1243,7 @@ settings:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
@@ -216,7 +216,7 @@ subnetworkRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/<projectID>/global/networks/<network>`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed Compute Network resource. Should be in the format `projects/{{projectID}}/global/networks/{{network}}`.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
We are using `projects/<projectID>/global/networks/<network>` in template but that will cause issues in our g3doc, screenshot: https://screenshot.googleplex.com/5Hg3goroSATbXDF.png. I changed the template to escape braces `{{` and `}}` during Golang Template rendering: `projects/{{projectID}}/global/networks/{{network}}`.

I noticed there are other refs using `[[` and `]]`. Other than consistency I don't see doc issues, so I skip them for now.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
