### PR TITLE
regen: fix head

### DIFF
--- a/apis/bigqueryanalyticshub/v1beta1/dataexchange_reference.go
+++ b/apis/bigqueryanalyticshub/v1beta1/dataexchange_reference.go
@@ -33,7 +33,7 @@ var _ refsv1beta1.ExternalNormalizer = &BigQueryAnalyticsHubDataExchangeRef{}
 // holds the GCP identifier for the KRM object.
 type BigQueryAnalyticsHubDataExchangeRef struct {
 	// A reference to an externally managed BigQueryAnalyticsHubDataExchange resource.
-	// Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}}".
 	External string `json:"external,omitempty"`
 
 	// The name of a BigQueryAnalyticsHubDataExchange resource.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
@@ -85,7 +85,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed BigQueryAnalyticsHubDataExchange
-                      resource. Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}}".
                     type: string
                   name:
                     description: The name of a BigQueryAnalyticsHubDataExchange resource.
@@ -413,7 +413,7 @@ spec:
                 properties:
                   external:
                     description: A reference to an externally managed BigQueryAnalyticsHubDataExchange
-                      resource. Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".
+                      resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}}".
                     type: string
                   name:
                     description: The name of a BigQueryAnalyticsHubDataExchange resource.

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigqueryanalyticshub/bigqueryanalyticshublisting.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigqueryanalyticshub/bigqueryanalyticshublisting.md
@@ -149,7 +149,7 @@ source:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}A reference to an externally managed BigQueryAnalyticsHubDataExchange resource. Should be in the format "projects/{{projectID}}/locations/{{ocation}}/dataexchanges/{{dataexchangeID}}".{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed BigQueryAnalyticsHubDataExchange resource. Should be in the format "projects/{{projectID}}/locations/{{location}}/dataexchanges/{{dataexchangeID}}".{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
I think https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3398 upset the `make manifest` for this resource.