### PR TITLE
refactor: no refs for BigQueryDatasetRef

### DIFF
--- a/apis/bigquery/v1beta1/dataset_reference.go
+++ b/apis/bigquery/v1beta1/dataset_reference.go
@@ -71,9 +71,23 @@ func (r *DatasetRef) NormalizedExternal(ctx context.Context, reader client.Reade
 		return "", fmt.Errorf("reading referenced %s %s: %w", BigQueryDatasetGVK, key, err)
 	}
 	// Get external from status.externalRef. This is the most trustworthy place.
-	actualExternalRef, _, err := unstructured.NestedString(u.Object, "status", "externalRef")
+	actualExternalRef, found, err := unstructured.NestedString(u.Object, "status", "externalRef")
 	if err != nil {
 		return "", fmt.Errorf("reading status.externalRef: %w", err)
+	}
+	if !found {
+		// BigQueryDataset is still TF based so we resolve the reference from the object
+		projectID, err := refsv1beta1.ResolveProjectID(ctx, reader, u)
+		if err != nil {
+			return "", err
+		}
+		datasetID, err := refsv1beta1.GetResourceID(u)
+		if err != nil {
+			return "", err
+		}
+		actualExternal := fmt.Sprintf("projects/%s/datasets/%s", projectID, datasetID)
+		r.External = actualExternal
+		return r.External, nil
 	}
 	if actualExternalRef == "" {
 		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)

--- a/apis/bigqueryanalyticshub/v1alpha1/listing_types.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/listing_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	v1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigqueryanalyticshub/v1beta1"
 
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
@@ -37,7 +38,7 @@ type BigQueryDatasetSource struct {
 	// +required
 	// Resource name of the dataset source for this listing.
 	//  e.g. `projects/myproject/datasets/123`
-	DatasetRef *refv1beta1.BigQueryDatasetRef `json:"datasetRef,omitempty"`
+	DatasetRef *bigquery.DatasetRef `json:"datasetRef,omitempty"`
 
 	// Optional. Resources in this dataset that are selectively shared.
 	//  If this field is empty, then the entire dataset (all resources) are

--- a/apis/bigqueryanalyticshub/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/bigqueryanalyticshub/v1alpha1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1alpha1
 
 import (
+	bigqueryv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	bigqueryanalyticshubv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigqueryanalyticshub/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
@@ -458,7 +459,7 @@ func (in *BigQueryDatasetSource) DeepCopyInto(out *BigQueryDatasetSource) {
 	*out = *in
 	if in.DatasetRef != nil {
 		in, out := &in.DatasetRef, &out.DatasetRef
-		*out = new(v1beta1.BigQueryDatasetRef)
+		*out = new(bigqueryv1beta1.DatasetRef)
 		**out = **in
 	}
 	if in.SelectedResources != nil {

--- a/apis/bigqueryanalyticshub/v1beta1/listing_types.go
+++ b/apis/bigqueryanalyticshub/v1beta1/listing_types.go
@@ -15,6 +15,7 @@
 package v1beta1
 
 import (
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ type BigQueryDatasetSource struct {
 	// +required
 	// Resource name of the dataset source for this listing.
 	//  e.g. `projects/myproject/datasets/123`
-	DatasetRef *refv1beta1.BigQueryDatasetRef `json:"datasetRef,omitempty"`
+	DatasetRef *bigquery.DatasetRef `json:"datasetRef,omitempty"`
 
 	// Optional. Resources in this dataset that are selectively shared.
 	//  If this field is empty, then the entire dataset (all resources) are

--- a/apis/bigqueryanalyticshub/v1beta1/zz_generated.deepcopy.go
+++ b/apis/bigqueryanalyticshub/v1beta1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1beta1
 
 import (
+	bigqueryv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -437,7 +438,7 @@ func (in *BigQueryDatasetSource) DeepCopyInto(out *BigQueryDatasetSource) {
 	*out = *in
 	if in.DatasetRef != nil {
 		in, out := &in.DatasetRef, &out.DatasetRef
-		*out = new(refsv1beta1.BigQueryDatasetRef)
+		*out = new(bigqueryv1beta1.DatasetRef)
 		**out = **in
 	}
 	if in.SelectedResources != nil {

--- a/apis/bigquerydatatransfer/v1alpha1/config_types.go
+++ b/apis/bigquerydatatransfer/v1alpha1/config_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +50,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	// The BigQuery target dataset id.
 	// +required
-	DatasetRef *refv1beta1.BigQueryDatasetRef `json:"datasetRef,omitempty"`
+	DatasetRef *bigquery.DatasetRef `json:"datasetRef,omitempty"`
 
 	// Is this config disabled. When set to true, no runs will be scheduled for
 	//  this transfer config.

--- a/apis/bigquerydatatransfer/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/bigquerydatatransfer/v1alpha1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1alpha1
 
 import (
+	bigqueryv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -148,7 +149,7 @@ func (in *BigQueryDataTransferConfigSpec) DeepCopyInto(out *BigQueryDataTransfer
 	}
 	if in.DatasetRef != nil {
 		in, out := &in.DatasetRef, &out.DatasetRef
-		*out = new(v1beta1.BigQueryDatasetRef)
+		*out = new(bigqueryv1beta1.DatasetRef)
 		**out = **in
 	}
 	if in.Disabled != nil {

--- a/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
@@ -15,6 +15,7 @@
 package v1beta1
 
 import (
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +80,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	// The BigQuery target dataset id.
 	// +required
-	DatasetRef *refv1beta1.BigQueryDatasetRef `json:"datasetRef,omitempty"`
+	DatasetRef *bigquery.DatasetRef `json:"datasetRef,omitempty"`
 
 	// Is this config disabled. When set to true, no runs will be scheduled for
 	//  this transfer config.

--- a/apis/bigquerydatatransfer/v1beta1/zz_generated.deepcopy.go
+++ b/apis/bigquerydatatransfer/v1beta1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1beta1
 
 import (
+	bigqueryv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -178,7 +179,7 @@ func (in *BigQueryDataTransferConfigSpec) DeepCopyInto(out *BigQueryDataTransfer
 	}
 	if in.DatasetRef != nil {
 		in, out := &in.DatasetRef, &out.DatasetRef
-		*out = new(refsv1beta1.BigQueryDatasetRef)
+		*out = new(bigqueryv1beta1.DatasetRef)
 		**out = **in
 	}
 	if in.Disabled != nil {

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com.yaml
@@ -217,15 +217,14 @@ spec:
                           - external
                         properties:
                           external:
-                            description: If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.
+                            description: A reference to an externally managed BigQueryDataset
+                              resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".
                             type: string
                           name:
-                            description: The `metadata.name` field of a `BigQueryDataset`
-                              resource.
+                            description: The name of a BigQueryDataset resource.
                             type: string
                           namespace:
-                            description: The `metadata.namespace` field of a `BigQueryDataset`
-                              resource.
+                            description: The namespace of a BigQueryDataset resource.
                             type: string
                         type: object
                       restrictedExportPolicy:
@@ -545,15 +544,14 @@ spec:
                           - external
                         properties:
                           external:
-                            description: If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.
+                            description: A reference to an externally managed BigQueryDataset
+                              resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".
                             type: string
                           name:
-                            description: The `metadata.name` field of a `BigQueryDataset`
-                              resource.
+                            description: The name of a BigQueryDataset resource.
                             type: string
                           namespace:
-                            description: The `metadata.namespace` field of a `BigQueryDataset`
-                              resource.
+                            description: The namespace of a BigQueryDataset resource.
                             type: string
                         type: object
                       restrictedExportPolicy:

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
@@ -95,15 +95,14 @@ spec:
                   - external
                 properties:
                   external:
-                    description: If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.
+                    description: A reference to an externally managed BigQueryDataset
+                      resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".
                     type: string
                   name:
-                    description: The `metadata.name` field of a `BigQueryDataset`
-                      resource.
+                    description: The name of a BigQueryDataset resource.
                     type: string
                   namespace:
-                    description: The `metadata.namespace` field of a `BigQueryDataset`
-                      resource.
+                    description: The namespace of a BigQueryDataset resource.
                     type: string
                 type: object
               disabled:
@@ -481,15 +480,14 @@ spec:
                   - external
                 properties:
                   external:
-                    description: If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.
+                    description: A reference to an externally managed BigQueryDataset
+                      resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".
                     type: string
                   name:
-                    description: The `metadata.name` field of a `BigQueryDataset`
-                      resource.
+                    description: The name of a BigQueryDataset resource.
                     type: string
                   namespace:
-                    description: The `metadata.namespace` field of a `BigQueryDataset`
-                      resource.
+                    description: The namespace of a BigQueryDataset resource.
                     type: string
                 type: object
               disabled:

--- a/pkg/controller/direct/bigqueryanalyticshub/listing_controller.go
+++ b/pkg/controller/direct/bigqueryanalyticshub/listing_controller.go
@@ -97,11 +97,10 @@ func (m *modelListing) AdapterForObject(ctx context.Context, reader client.Reade
 func resolveOptionalReferences(ctx context.Context, reader client.Reader, obj *krm.BigQueryAnalyticsHubListing) error {
 	if obj.Spec.Source != nil && obj.Spec.Source.BigQueryDatasetSource != nil {
 		if ref := obj.Spec.Source.BigQueryDatasetSource.DatasetRef; ref != nil {
-			datasetID, err := refs.ResolveBigQueryDataset(ctx, reader, obj, ref)
+			_, err := obj.Spec.Source.BigQueryDatasetSource.DatasetRef.NormalizedExternal(ctx, reader, obj.GetNamespace())
 			if err != nil {
 				return err
 			}
-			obj.Spec.Source.BigQueryDatasetSource.DatasetRef.External = datasetID.String()
 
 			for _, selectedResource := range obj.Spec.Source.BigQueryDatasetSource.SelectedResources {
 				if ref := selectedResource.TableRef; ref != nil {

--- a/pkg/controller/direct/bigqueryanalyticshub/mapper.go
+++ b/pkg/controller/direct/bigqueryanalyticshub/mapper.go
@@ -16,6 +16,7 @@ package bigqueryanalyticshub
 
 import (
 	pb "cloud.google.com/go/bigquery/analyticshub/apiv1/analyticshubpb"
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigqueryanalyticshub/v1beta1"
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
@@ -111,7 +112,7 @@ func Listing_BigQueryDatasetSource_FromProto(mapCtx *direct.MapContext, in *pb.L
 	}
 	out := &krm.BigQueryDatasetSource{}
 	if out.DatasetRef != nil {
-		out.DatasetRef = &refs.BigQueryDatasetRef{
+		out.DatasetRef = &bigquery.DatasetRef{
 			External: in.Dataset,
 		}
 	}

--- a/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransfer_mappings.go
+++ b/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransfer_mappings.go
@@ -16,6 +16,7 @@ package bigquerydatatransfer
 
 import (
 	pb "cloud.google.com/go/bigquery/datatransfer/apiv1/datatransferpb"
+	bigquery "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquery/v1beta1"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigquerydatatransfer/v1beta1"
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
@@ -60,7 +61,7 @@ func BigQueryDataTransferConfigSpec_FromProto(mapCtx *direct.MapContext, in *pb.
 	}
 	out := &krm.BigQueryDataTransferConfigSpec{}
 	if in.GetDestinationDatasetId() != "" {
-		out.DatasetRef = &refv1beta1.BigQueryDatasetRef{External: in.GetDestinationDatasetId()}
+		out.DatasetRef = &bigquery.DatasetRef{External: in.GetDestinationDatasetId()}
 	}
 	out.DisplayName = direct.LazyPtr(in.GetDisplayName())
 	out.DataSourceID = direct.LazyPtr(in.GetDataSourceId())

--- a/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransferconfig_controller.go
+++ b/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransferconfig_controller.go
@@ -111,11 +111,10 @@ func (m *model) AdapterForObject(ctx context.Context, reader client.Reader, u *u
 
 	// Resolve BigQueryDataSet Ref
 	if obj.Spec.DatasetRef != nil {
-		dataset, err := refv1beta1.ResolveBigQueryDataset(ctx, reader, obj, obj.Spec.DatasetRef)
+		_, err := obj.Spec.DatasetRef.NormalizedExternal(ctx, reader, obj.GetNamespace())
 		if err != nil {
 			return nil, err
 		}
-		obj.Spec.DatasetRef.External = dataset.GetDatasetID() // the GCP API only takes datasetID
 	}
 
 	// Resolve KMSCryptoKey Ref

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigqueryanalyticshub/bigqueryanalyticshublisting.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigqueryanalyticshub/bigqueryanalyticshublisting.md
@@ -399,7 +399,7 @@ source:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed BigQueryDataset resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -409,7 +409,7 @@ source:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `metadata.name` field of a `BigQueryDataset` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}The name of a BigQueryDataset resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -419,7 +419,7 @@ source:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `metadata.namespace` field of a `BigQueryDataset` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}The namespace of a BigQueryDataset resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
@@ -157,7 +157,7 @@ serviceAccountRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}If provided must be in the format `projects/[project_id]/datasets/[dataset_id]`.{% endverbatim %}</p>
+            <p>{% verbatim %}A reference to an externally managed BigQueryDataset resource. Should be in the format "projects/<projectID>/datasets/<datasetID>".{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -167,7 +167,7 @@ serviceAccountRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `metadata.name` field of a `BigQueryDataset` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}The name of a BigQueryDataset resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@ serviceAccountRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The `metadata.namespace` field of a `BigQueryDataset` resource.{% endverbatim %}</p>
+            <p>{% verbatim %}The namespace of a BigQueryDataset resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR gets rid of the "old" refs. usage for BigQueryDatasetRef. It doesn't get rid of it just yet; that will be in a separate PR when I change the `ResolveBigQueryTable` behavior