### PR TITLE
Remove the CEL rule for resourceID in the template

### DIFF
--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -37,8 +37,6 @@ var {{ .Kind }}GVK = GroupVersion.WithKind("{{ .Kind }}")
 // +kcc:proto={{ .KindProtoTag }}
 {{- end }}
 type {{ .Kind }}Spec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `
 }


### PR DESCRIPTION
Context: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3281#discussion_r1886826560

`spec.resourceID` is mutable because we want users to be able to:
1. Set the correct resource ID even if it was previously unset.
2. Unset the field when needed.
3. Update the value when it was set to an incorrect resource ID.
