### PR TITLE
tool: use a different annotation prefix for go fields

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -30,6 +30,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// KCCProtoMessageAnnotation is used for go structs that map to proto messages
+	KCCProtoMessageAnnotation = "+kcc:proto"
+
+	// KCCProtoFieldAnnotation is used for go struct fields that map to proto fields
+	KCCProtoFieldAnnotation = "+kcc:proto:field"
+)
+
 // Some special-case values that are not obvious how to map in KRM
 var protoMessagesNotMappedToGoStruct = map[string]string{
 	"google.protobuf.Timestamp":   "string",
@@ -154,7 +162,7 @@ func WriteMessage(out io.Writer, msg protoreflect.MessageDescriptor) {
 	goType := goNameForProtoMessage(msg)
 
 	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "// +kcc:proto=%s\n", msg.FullName())
+	fmt.Fprintf(out, "// %s=%s\n", KCCProtoMessageAnnotation, msg.FullName())
 	fmt.Fprintf(out, "type %s struct {\n", goType)
 	for i := 0; i < msg.Fields().Len(); i++ {
 		field := msg.Fields().Get(i)
@@ -226,7 +234,7 @@ func WriteField(out io.Writer, field protoreflect.FieldDescriptor, msg protorefl
 		}
 	}
 
-	fmt.Fprintf(out, "\t// +kcc:proto=%s\n", field.FullName())
+	fmt.Fprintf(out, "\t// %s=%s\n", KCCProtoFieldAnnotation, field.FullName())
 	fmt.Fprintf(out, "\t%s %s `json:\"%s,omitempty\"`\n",
 		goFieldName,
 		goType,


### PR DESCRIPTION
Use distinct annotation prefixes for proto messages vs fields.

The special case is that when a proto message is also a field of another proto message.

Before this PR
```
// +kcc:proto=google.cloud.bigquery.datatransfer.v1.ScheduleOptionsV2
type ScheduleOptionsV2 struct {
    // ... fields ...
}

type TransferConfig struct {
    // +kcc:proto=google.cloud.bigquery.datatransfer.v1.TransferConfig.schedule_options_v2
    ScheduleOptionsV2 *ScheduleOptionsV2 `json:"scheduleOptionsV2,omitempty"`
}
```

After this PR
```
// +kcc:proto=google.cloud.bigquery.datatransfer.v1.ScheduleOptionsV2
type ScheduleOptionsV2 struct {
    // ... fields ...
}

type TransferConfig struct {
    // +kcc:proto:field=google.cloud.bigquery.datatransfer.v1.TransferConfig.schedule_options_v2
    ScheduleOptionsV2 *ScheduleOptionsV2 `json:"scheduleOptionsV2,omitempty"`
}
```