### PR TITLE
fix: Make ResourceID field "mutable"

### DIFF
--- a/apis/bigquerydatatransfer/v1alpha1/config_types.go
+++ b/apis/bigquerydatatransfer/v1alpha1/config_types.go
@@ -83,6 +83,7 @@ type BigQueryDataTransferConfigSpec struct {
 	Parent `json:",inline"`
 
 	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Data transfer schedule.

--- a/apis/bigquerydatatransfer/v1alpha1/config_types.go
+++ b/apis/bigquerydatatransfer/v1alpha1/config_types.go
@@ -82,8 +82,6 @@ type BigQueryDataTransferConfigSpec struct {
 
 	Parent `json:",inline"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
@@ -108,8 +108,6 @@ type BigQueryDataTransferConfigSpec struct {
 
 	Parent `json:",inline"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
@@ -109,6 +109,7 @@ type BigQueryDataTransferConfigSpec struct {
 	Parent `json:",inline"`
 
 	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Data transfer schedule.

--- a/apis/certificatemanager/v1alpha1/dnsauthorization_types.go
+++ b/apis/certificatemanager/v1alpha1/dnsauthorization_types.go
@@ -41,6 +41,7 @@ type CertificateManagerDNSAuthorizationSpec struct {
 	ProjectRef refs.ProjectRef `json:"projectRef"`
 
 	/* Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/apis/certificatemanager/v1alpha1/dnsauthorization_types.go
+++ b/apis/certificatemanager/v1alpha1/dnsauthorization_types.go
@@ -40,8 +40,7 @@ type CertificateManagerDNSAuthorizationSpec struct {
 	// +required
 	ProjectRef refs.ProjectRef `json:"projectRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
+	/* Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/apis/certificatemanager/v1beta1/dnsauthorization_types.go
+++ b/apis/certificatemanager/v1beta1/dnsauthorization_types.go
@@ -44,8 +44,7 @@ type CertificateManagerDNSAuthorizationSpec struct {
 	// +optional
 	Location string `json:"location"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	/* Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
+	/* Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/apis/certificatemanager/v1beta1/dnsauthorization_types.go
+++ b/apis/certificatemanager/v1beta1/dnsauthorization_types.go
@@ -45,6 +45,7 @@ type CertificateManagerDNSAuthorizationSpec struct {
 	Location string `json:"location"`
 
 	/* Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/apis/compute/v1beta1/targettcpproxy_types.go
+++ b/apis/compute/v1beta1/targettcpproxy_types.go
@@ -54,6 +54,7 @@ type ComputeTargetTCPProxySpec struct {
 	ProxyHeader *string `json:"proxyHeader,omitempty"`
 
 	// The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 }
 

--- a/apis/compute/v1beta1/targettcpproxy_types.go
+++ b/apis/compute/v1beta1/targettcpproxy_types.go
@@ -53,8 +53,7 @@ type ComputeTargetTCPProxySpec struct {
 	// the backend. Default value: "NONE" Possible values: ["NONE", "PROXY_V1"].
 	ProxyHeader *string `json:"proxyHeader,omitempty"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID is immutable"
-	// Immutable. The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.
+	// The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 }
 

--- a/apis/containerattached/v1beta1/cluster_types.go
+++ b/apis/containerattached/v1beta1/cluster_types.go
@@ -30,6 +30,7 @@ type ContainerAttachedClusterSpec struct {
 
 	// Optional.
 	// The ContainerAttachedCluster name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Location field is immutable"

--- a/apis/containerattached/v1beta1/cluster_types.go
+++ b/apis/containerattached/v1beta1/cluster_types.go
@@ -28,8 +28,7 @@ type ContainerAttachedClusterSpec struct {
 	/* The ID of the project in which the resource belongs.*/
 	ProjectRef *refs.ProjectRef `json:"projectRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable, Optional.
+	// Optional.
 	// The ContainerAttachedCluster name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/discoveryengine/v1alpha1/discoveryenginedatastore_types.go
+++ b/apis/discoveryengine/v1alpha1/discoveryenginedatastore_types.go
@@ -26,6 +26,7 @@ var DiscoveryEngineDataStoreGVK = GroupVersion.WithKind("DiscoveryEngineDataStor
 // +kcc:proto=google.cloud.discoveryengine.v1.DataStore
 type DiscoveryEngineDataStoreSpec struct {
 	// The DiscoveryEngineDataStore name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Required. The data store display name.

--- a/apis/discoveryengine/v1alpha1/discoveryenginedatastore_types.go
+++ b/apis/discoveryengine/v1alpha1/discoveryenginedatastore_types.go
@@ -25,8 +25,6 @@ var DiscoveryEngineDataStoreGVK = GroupVersion.WithKind("DiscoveryEngineDataStor
 // DiscoveryEngineDataStoreSpec defines the desired state of DiscoveryEngineDataStore
 // +kcc:proto=google.cloud.discoveryengine.v1.DataStore
 type DiscoveryEngineDataStoreSpec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The DiscoveryEngineDataStore name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/kms/v1alpha1/keyhandle_types.go
+++ b/apis/kms/v1alpha1/keyhandle_types.go
@@ -30,6 +30,7 @@ type KMSKeyHandleSpec struct {
 	// The KMS Key Handle ID used for resource creation or acquisition.
 	// For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID.
 	// For acquisition: This field must be provided to identify the key handle resource to acquire.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Project hosting KMSKeyHandle

--- a/apis/kms/v1alpha1/keyhandle_types.go
+++ b/apis/kms/v1alpha1/keyhandle_types.go
@@ -27,8 +27,6 @@ var KMSKeyHandleGVK = GroupVersion.WithKind("KMSKeyHandle")
 // KMSKeyHandleSpec defines the desired state of KMSKeyHandle
 // +kcc:proto=google.cloud.kms.v1.KeyHandle
 type KMSKeyHandleSpec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The KMS Key Handle ID used for resource creation or acquisition.
 	// For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID.
 	// For acquisition: This field must be provided to identify the key handle resource to acquire.

--- a/apis/kms/v1beta1/keyhandle_types.go
+++ b/apis/kms/v1beta1/keyhandle_types.go
@@ -30,6 +30,7 @@ type KMSKeyHandleSpec struct {
 	// The KMS Key Handle ID used for resource creation or acquisition.
 	// For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID.
 	// For acquisition: This field must be provided to identify the key handle resource to acquire.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Project hosting KMSKeyHandle

--- a/apis/kms/v1beta1/keyhandle_types.go
+++ b/apis/kms/v1beta1/keyhandle_types.go
@@ -27,8 +27,6 @@ var KMSKeyHandleGVK = SchemeGroupVersion.WithKind("KMSKeyHandle")
 // KMSKeyHandleSpec defines the desired state of KMSKeyHandle
 // +kcc:proto=google.cloud.kms.v1.KeyHandle
 type KMSKeyHandleSpec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The KMS Key Handle ID used for resource creation or acquisition.
 	// For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID.
 	// For acquisition: This field must be provided to identify the key handle resource to acquire.

--- a/apis/privilegedaccessmanager/v1alpha1/entitlement_types.go
+++ b/apis/privilegedaccessmanager/v1alpha1/entitlement_types.go
@@ -48,10 +48,8 @@ type PrivilegedAccessManagerEntitlementSpec struct {
 	// +required
 	Location *string `json:"location"`
 
-	// Immutable.
 	// The PrivilegedAccessManagerEntitlement name. If not given, the
 	// 'metadata.name' will be used.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/privilegedaccessmanager/v1alpha1/entitlement_types.go
+++ b/apis/privilegedaccessmanager/v1alpha1/entitlement_types.go
@@ -50,6 +50,7 @@ type PrivilegedAccessManagerEntitlementSpec struct {
 
 	// The PrivilegedAccessManagerEntitlement name. If not given, the
 	// 'metadata.name' will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement_types.go
+++ b/apis/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement_types.go
@@ -51,7 +51,6 @@ type PrivilegedAccessManagerEntitlementSpec struct {
 	// Immutable.
 	// The PrivilegedAccessManagerEntitlement name. If not given, the
 	// 'metadata.name' will be used.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement_types.go
+++ b/apis/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement_types.go
@@ -51,6 +51,7 @@ type PrivilegedAccessManagerEntitlementSpec struct {
 	// Immutable.
 	// The PrivilegedAccessManagerEntitlement name. If not given, the
 	// 'metadata.name' will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/secretmanager/v1beta1/secret_types.go
+++ b/apis/secretmanager/v1beta1/secret_types.go
@@ -29,6 +29,7 @@ var SecretManagerSecretGVK = GroupVersion.WithKind("SecretManagerSecret")
 // +kcc:proto=google.cloud.secretmanager.v1.Secret
 type SecretManagerSecretSpec struct {
 	// The SecretManagerSecret name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Immutable. The replication policy of the secret data attached to

--- a/apis/secretmanager/v1beta1/secret_types.go
+++ b/apis/secretmanager/v1beta1/secret_types.go
@@ -28,8 +28,6 @@ var SecretManagerSecretGVK = GroupVersion.WithKind("SecretManagerSecret")
 // SecretManagerSecretSpec defines the desired state of SecretManagerSecret
 // +kcc:proto=google.cloud.secretmanager.v1.Secret
 type SecretManagerSecretSpec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The SecretManagerSecret name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/securesourcemanager/v1alpha1/repository_types.go
+++ b/apis/securesourcemanager/v1alpha1/repository_types.go
@@ -35,8 +35,6 @@ type SecureSourceManagerRepositorySpec struct {
 	// +required
 	Location string `json:"location"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The SecureSourceManagerRepository name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/securesourcemanager/v1alpha1/repository_types.go
+++ b/apis/securesourcemanager/v1alpha1/repository_types.go
@@ -36,6 +36,7 @@ type SecureSourceManagerRepositorySpec struct {
 	Location string `json:"location"`
 
 	// The SecureSourceManagerRepository name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// The name of the instance in which the repository is hosted, formatted as

--- a/apis/spanner/v1beta1/instance_types.go
+++ b/apis/spanner/v1beta1/instance_types.go
@@ -45,8 +45,6 @@ type SpannerInstanceSpec struct {
 	// +optional
 	ProcessingUnits *int32 `json:"processingUnits,omitempty"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The SpannerInstance name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/apis/spanner/v1beta1/instance_types.go
+++ b/apis/spanner/v1beta1/instance_types.go
@@ -46,6 +46,7 @@ type SpannerInstanceSpec struct {
 	ProcessingUnits *int32 `json:"processingUnits,omitempty"`
 
 	// The SpannerInstance name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 }
 

--- a/apis/workstations/v1alpha1/cluster_types.go
+++ b/apis/workstations/v1alpha1/cluster_types.go
@@ -36,8 +36,6 @@ type WorkstationClusterSpec struct {
 	// The location of the cluster.
 	Location string `json:"location,omitempty"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The WorkstationCluster name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1alpha1/cluster_types.go
+++ b/apis/workstations/v1alpha1/cluster_types.go
@@ -37,6 +37,7 @@ type WorkstationClusterSpec struct {
 	Location string `json:"location,omitempty"`
 
 	// The WorkstationCluster name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation cluster.

--- a/apis/workstations/v1alpha1/config_types.go
+++ b/apis/workstations/v1alpha1/config_types.go
@@ -275,6 +275,7 @@ type WorkstationConfigSpec struct {
 	Parent *WorkstationClusterRef `json:"parentRef"`
 
 	// The WorkstationConfig name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation configuration.

--- a/apis/workstations/v1alpha1/config_types.go
+++ b/apis/workstations/v1alpha1/config_types.go
@@ -274,8 +274,6 @@ type WorkstationConfigSpec struct {
 	// Parent is a reference to the parent WorkstationCluster for this WorkstationConfig.
 	Parent *WorkstationClusterRef `json:"parentRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The WorkstationConfig name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1alpha1/workstation_types.go
+++ b/apis/workstations/v1alpha1/workstation_types.go
@@ -27,8 +27,6 @@ type WorkstationSpec struct {
 	// Parent is a reference to the parent WorkstationConfig for this Workstation.
 	Parent *WorkstationConfigRef `json:"parentRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The Workstation name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1alpha1/workstation_types.go
+++ b/apis/workstations/v1alpha1/workstation_types.go
@@ -28,6 +28,7 @@ type WorkstationSpec struct {
 	Parent *WorkstationConfigRef `json:"parentRef"`
 
 	// The Workstation name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation.

--- a/apis/workstations/v1beta1/cluster_types.go
+++ b/apis/workstations/v1beta1/cluster_types.go
@@ -36,8 +36,6 @@ type WorkstationClusterSpec struct {
 	// The location of the cluster.
 	Location string `json:"location,omitempty"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The WorkstationCluster name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1beta1/cluster_types.go
+++ b/apis/workstations/v1beta1/cluster_types.go
@@ -37,6 +37,7 @@ type WorkstationClusterSpec struct {
 	Location string `json:"location,omitempty"`
 
 	// The WorkstationCluster name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation cluster.

--- a/apis/workstations/v1beta1/config_types.go
+++ b/apis/workstations/v1beta1/config_types.go
@@ -275,6 +275,7 @@ type WorkstationConfigSpec struct {
 	Parent *WorkstationClusterRef `json:"parentRef"`
 
 	// The WorkstationConfig name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation configuration.

--- a/apis/workstations/v1beta1/config_types.go
+++ b/apis/workstations/v1beta1/config_types.go
@@ -274,8 +274,6 @@ type WorkstationConfigSpec struct {
 	// Parent is a reference to the parent WorkstationCluster for this WorkstationConfig.
 	Parent *WorkstationClusterRef `json:"parentRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The WorkstationConfig name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1beta1/workstation_types.go
+++ b/apis/workstations/v1beta1/workstation_types.go
@@ -27,8 +27,6 @@ type WorkstationSpec struct {
 	// Parent is a reference to the parent WorkstationConfig for this Workstation.
 	Parent *WorkstationConfigRef `json:"parentRef"`
 
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The Workstation name. If not given, the metadata.name will be used.
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/apis/workstations/v1beta1/workstation_types.go
+++ b/apis/workstations/v1beta1/workstation_types.go
@@ -28,6 +28,7 @@ type WorkstationSpec struct {
 	Parent *WorkstationConfigRef `json:"parentRef"`
 
 	// The Workstation name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Optional. Human-readable name for this workstation.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
@@ -233,7 +233,8 @@ spec:
                 type: object
               resourceID:
                 description: The BigQueryDataTransferConfig name. If not given, the
-                  metadata.name will be used.
+                  metadata.name will be used. Cannot be changed after create, except
+                  for updating from empty string to the actual resource ID.
                 type: string
               schedule:
                 description: |-
@@ -619,7 +620,8 @@ spec:
                 type: object
               resourceID:
                 description: The BigQueryDataTransferConfig name. If not given, the
-                  metadata.name will be used.
+                  metadata.name will be used. Cannot be changed after create, except
+                  for updating from empty string to the actual resource ID.
                 type: string
               schedule:
                 description: |-

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
@@ -232,12 +232,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The BigQueryDataTransferConfig name. If not
-                  given, the metadata.name will be used.
+                description: The BigQueryDataTransferConfig name. If not given, the
+                  metadata.name will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               schedule:
                 description: |-
                   Data transfer schedule.
@@ -621,12 +618,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The BigQueryDataTransferConfig name. If not
-                  given, the metadata.name will be used.
+                description: The BigQueryDataTransferConfig name. If not given, the
+                  metadata.name will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               schedule:
                 description: |-
                   Data transfer schedule.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagerdnsauthorizations.certificatemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagerdnsauthorizations.certificatemanager.cnrm.cloud.google.com.yaml
@@ -107,13 +107,10 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. Optional. The name of the resource. Used for
-                  creation and acquisition. When unset, the value of `metadata.name`
-                  is used as the default.
+                description: Optional. The name of the resource. Used for creation
+                  and acquisition. When unset, the value of `metadata.name` is used
+                  as the default.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - domain
             - projectRef
@@ -270,13 +267,10 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. Optional. The name of the resource. Used for
-                  creation and acquisition. When unset, the value of `metadata.name`
-                  is used as the default.
+                description: Optional. The name of the resource. Used for creation
+                  and acquisition. When unset, the value of `metadata.name` is used
+                  as the default.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - domain
             - projectRef

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagerdnsauthorizations.certificatemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_certificatemanagerdnsauthorizations.certificatemanager.cnrm.cloud.google.com.yaml
@@ -109,7 +109,8 @@ spec:
               resourceID:
                 description: Optional. The name of the resource. Used for creation
                   and acquisition. When unset, the value of `metadata.name` is used
-                  as the default.
+                  as the default. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - domain
@@ -269,7 +270,8 @@ spec:
               resourceID:
                 description: Optional. The name of the resource. Used for creation
                   and acquisition. When unset, the value of `metadata.name` is used
-                  as the default.
+                  as the default. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - domain

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
@@ -116,12 +116,9 @@ spec:
                   ["NONE", "PROXY_V1"].'
                 type: string
               resourceID:
-                description: Immutable. The ComputeTargetTCPProxy name. If not given,
-                  the metadata.name will be used.
+                description: The ComputeTargetTCPProxy name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID is immutable
-                  rule: self == oldSelf
             required:
             - backendServiceRef
             type: object

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computetargettcpproxies.compute.cnrm.cloud.google.com.yaml
@@ -117,7 +117,8 @@ spec:
                 type: string
               resourceID:
                 description: The ComputeTargetTCPProxy name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - backendServiceRef

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
@@ -271,7 +271,8 @@ spec:
                 type: object
               resourceID:
                 description: Optional. The ContainerAttachedCluster name. If not given,
-                  the metadata.name will be used.
+                  the metadata.name will be used. Cannot be changed after create,
+                  except for updating from empty string to the actual resource ID.
                 type: string
             required:
             - distribution

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerattachedclusters.containerattached.cnrm.cloud.google.com.yaml
@@ -270,12 +270,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable, Optional. The ContainerAttachedCluster name.
-                  If not given, the metadata.name will be used.
+                description: Optional. The ContainerAttachedCluster name. If not given,
+                  the metadata.name will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - distribution
             - fleet

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryenginedatastores.discoveryengine.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryenginedatastores.discoveryengine.cnrm.cloud.google.com.yaml
@@ -121,12 +121,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The DiscoveryEngineDataStore name. If not
-                  given, the metadata.name will be used.
+                description: The DiscoveryEngineDataStore name. If not given, the
+                  metadata.name will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               solutionTypes:
                 description: |-
                   The solutions that the data store enrolls. Available solutions for each

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryenginedatastores.discoveryengine.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_discoveryenginedatastores.discoveryengine.cnrm.cloud.google.com.yaml
@@ -122,7 +122,8 @@ spec:
                 type: object
               resourceID:
                 description: The DiscoveryEngineDataStore name. If not given, the
-                  metadata.name will be used.
+                  metadata.name will be used. Cannot be changed after create, except
+                  for updating from empty string to the actual resource ID.
                 type: string
               solutionTypes:
                 description: |-

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_kmskeyhandles.kms.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_kmskeyhandles.kms.cnrm.cloud.google.com.yaml
@@ -100,7 +100,9 @@ spec:
                   acquisition. For creation: If specified, this value is used as the
                   key handle ID. If not provided, a UUID will be generated and assigned
                   as the key handle ID. For acquisition: This field must be provided
-                  to identify the key handle resource to acquire.'
+                  to identify the key handle resource to acquire. Cannot be changed
+                  after create, except for updating from empty string to the actual
+                  resource ID.'
                 type: string
               resourceTypeSelector:
                 description: Indicates the resource type that the resulting [CryptoKey][]
@@ -240,7 +242,9 @@ spec:
                   acquisition. For creation: If specified, this value is used as the
                   key handle ID. If not provided, a UUID will be generated and assigned
                   as the key handle ID. For acquisition: This field must be provided
-                  to identify the key handle resource to acquire.'
+                  to identify the key handle resource to acquire. Cannot be changed
+                  after create, except for updating from empty string to the actual
+                  resource ID.'
                 type: string
               resourceTypeSelector:
                 description: Indicates the resource type that the resulting [CryptoKey][]

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_kmskeyhandles.kms.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_kmskeyhandles.kms.cnrm.cloud.google.com.yaml
@@ -96,15 +96,12 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: 'Immutable. The KMS Key Handle ID used for resource creation
-                  or acquisition. For creation: If specified, this value is used as
-                  the key handle ID. If not provided, a UUID will be generated and
-                  assigned as the key handle ID. For acquisition: This field must
-                  be provided to identify the key handle resource to acquire.'
+                description: 'The KMS Key Handle ID used for resource creation or
+                  acquisition. For creation: If specified, this value is used as the
+                  key handle ID. If not provided, a UUID will be generated and assigned
+                  as the key handle ID. For acquisition: This field must be provided
+                  to identify the key handle resource to acquire.'
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               resourceTypeSelector:
                 description: Indicates the resource type that the resulting [CryptoKey][]
                   is meant to protect, e.g. `{SERVICE}.googleapis.com/{TYPE}`. See
@@ -239,15 +236,12 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: 'Immutable. The KMS Key Handle ID used for resource creation
-                  or acquisition. For creation: If specified, this value is used as
-                  the key handle ID. If not provided, a UUID will be generated and
-                  assigned as the key handle ID. For acquisition: This field must
-                  be provided to identify the key handle resource to acquire.'
+                description: 'The KMS Key Handle ID used for resource creation or
+                  acquisition. For creation: If specified, this value is used as the
+                  key handle ID. If not provided, a UUID will be generated and assigned
+                  as the key handle ID. For acquisition: This field must be provided
+                  to identify the key handle resource to acquire.'
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               resourceTypeSelector:
                 description: Indicates the resource type that the resulting [CryptoKey][]
                   is meant to protect, e.g. `{SERVICE}.googleapis.com/{TYPE}`. See

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com.yaml
@@ -304,7 +304,8 @@ spec:
                 type: object
               resourceID:
                 description: The PrivilegedAccessManagerEntitlement name. If not given,
-                  the 'metadata.name' will be used.
+                  the 'metadata.name' will be used. Cannot be changed after create,
+                  except for updating from empty string to the actual resource ID.
                 type: string
             required:
             - eligibleUsers
@@ -668,7 +669,9 @@ spec:
                 type: object
               resourceID:
                 description: Immutable. The PrivilegedAccessManagerEntitlement name.
-                  If not given, the 'metadata.name' will be used.
+                  If not given, the 'metadata.name' will be used. Cannot be changed
+                  after create, except for updating from empty string to the actual
+                  resource ID.
                 type: string
             required:
             - eligibleUsers

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com.yaml
@@ -303,12 +303,9 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               resourceID:
-                description: Immutable. The PrivilegedAccessManagerEntitlement name.
-                  If not given, the 'metadata.name' will be used.
+                description: The PrivilegedAccessManagerEntitlement name. If not given,
+                  the 'metadata.name' will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - eligibleUsers
             - location
@@ -673,9 +670,6 @@ spec:
                 description: Immutable. The PrivilegedAccessManagerEntitlement name.
                   If not given, the 'metadata.name' will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - eligibleUsers
             - location

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
@@ -240,7 +240,8 @@ spec:
                 type: object
               resourceID:
                 description: The SecretManagerSecret name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
               rotation:
                 description: Optional. Rotation policy attached to the [Secret][google.cloud.secretmanager.v1.Secret].

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_secretmanagersecrets.secretmanager.cnrm.cloud.google.com.yaml
@@ -239,12 +239,9 @@ spec:
                     type: object
                 type: object
               resourceID:
-                description: Immutable. The SecretManagerSecret name. If not given,
-                  the metadata.name will be used.
+                description: The SecretManagerSecret name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               rotation:
                 description: Optional. Rotation policy attached to the [Secret][google.cloud.secretmanager.v1.Secret].
                   May be excluded if there is no rotation policy.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
@@ -268,12 +268,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The SecureSourceManagerRepository name. If
-                  not given, the metadata.name will be used.
+                description: The SecureSourceManagerRepository name. If not given,
+                  the metadata.name will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - instanceRef
             - location

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_securesourcemanagerrepositories.securesourcemanager.cnrm.cloud.google.com.yaml
@@ -269,7 +269,8 @@ spec:
                 type: object
               resourceID:
                 description: The SecureSourceManagerRepository name. If not given,
-                  the metadata.name will be used.
+                  the metadata.name will be used. Cannot be changed after create,
+                  except for updating from empty string to the actual resource ID.
                 type: string
             required:
             - instanceRef

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
@@ -84,7 +84,8 @@ spec:
                 type: integer
               resourceID:
                 description: The SpannerInstance name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - config

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerinstances.spanner.cnrm.cloud.google.com.yaml
@@ -83,12 +83,9 @@ spec:
                 format: int32
                 type: integer
               resourceID:
-                description: Immutable. The SpannerInstance name. If not given, the
-                  metadata.name will be used.
+                description: The SpannerInstance name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - config
             - displayName

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
@@ -202,12 +202,9 @@ spec:
                 - message: ResourceID field is immutable
                   rule: self == oldSelf
               resourceID:
-                description: Immutable. The WorkstationCluster name. If not given,
-                  the metadata.name will be used.
+                description: The WorkstationCluster name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               subnetworkRef:
                 description: Immutable. Reference to the Compute Engine subnetwork
                   in which instances associated with this workstation cluster will
@@ -548,12 +545,9 @@ spec:
                 - message: ResourceID field is immutable
                   rule: self == oldSelf
               resourceID:
-                description: Immutable. The WorkstationCluster name. If not given,
-                  the metadata.name will be used.
+                description: The WorkstationCluster name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               subnetworkRef:
                 description: Immutable. Reference to the Compute Engine subnetwork
                   in which instances associated with this workstation cluster will

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationclusters.workstations.cnrm.cloud.google.com.yaml
@@ -203,7 +203,8 @@ spec:
                   rule: self == oldSelf
               resourceID:
                 description: The WorkstationCluster name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
               subnetworkRef:
                 description: Immutable. Reference to the Compute Engine subnetwork
@@ -546,7 +547,8 @@ spec:
                   rule: self == oldSelf
               resourceID:
                 description: The WorkstationCluster name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
               subnetworkRef:
                 description: Immutable. Reference to the Compute Engine subnetwork

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
@@ -507,7 +507,8 @@ spec:
                 type: array
               resourceID:
                 description: The WorkstationConfig name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
               runningTimeout:
                 description: |-
@@ -1134,7 +1135,8 @@ spec:
                 type: array
               resourceID:
                 description: The WorkstationConfig name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
               runningTimeout:
                 description: |-

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstationconfigs.workstations.cnrm.cloud.google.com.yaml
@@ -506,12 +506,9 @@ spec:
                   type: string
                 type: array
               resourceID:
-                description: Immutable. The WorkstationConfig name. If not given,
-                  the metadata.name will be used.
+                description: The WorkstationConfig name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               runningTimeout:
                 description: |-
                   Optional. Number of seconds that a workstation can run until it is
@@ -1136,12 +1133,9 @@ spec:
                   type: string
                 type: array
               resourceID:
-                description: Immutable. The WorkstationConfig name. If not given,
-                  the metadata.name will be used.
+                description: The WorkstationConfig name. If not given, the metadata.name
+                  will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
               runningTimeout:
                 description: |-
                   Optional. Number of seconds that a workstation can run until it is

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
@@ -118,12 +118,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The Workstation name. If not given, the metadata.name
+                description: The Workstation name. If not given, the metadata.name
                   will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - parentRef
             type: object
@@ -310,12 +307,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. The Workstation name. If not given, the metadata.name
+                description: The Workstation name. If not given, the metadata.name
                   will be used.
                 type: string
-                x-kubernetes-validations:
-                - message: ResourceID field is immutable
-                  rule: self == oldSelf
             required:
             - parentRef
             type: object

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_workstations.workstations.cnrm.cloud.google.com.yaml
@@ -119,7 +119,8 @@ spec:
                 type: object
               resourceID:
                 description: The Workstation name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - parentRef
@@ -308,7 +309,8 @@ spec:
                 type: object
               resourceID:
                 description: The Workstation name. If not given, the metadata.name
-                  will be used.
+                  will be used. Cannot be changed after create, except for updating
+                  from empty string to the actual resource ID.
                 type: string
             required:
             - parentRef

--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -38,6 +38,7 @@ var {{ .Kind }}GVK = GroupVersion.WithKind("{{ .Kind }}")
 {{- end }}
 type {{ .Kind }}Spec struct {
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
+	// Cannot be changed after create, except for updating from empty string to the actual resource ID.
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `
 }
 

--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -37,8 +37,6 @@ var {{ .Kind }}GVK = GroupVersion.WithKind("{{ .Kind }}")
 // +kcc:proto={{ .KindProtoTag }}
 {{- end }}
 type {{ .Kind }}Spec struct {
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ResourceID field is immutable"
-	// Immutable.
 	// The {{ .Kind }} name. If not given, the metadata.name will be used.
 	ResourceID *string ` + "`" + `json:"resourceID,omitempty"` + "`" + `
 }

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
@@ -387,7 +387,7 @@ serviceAccountRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The BigQueryDataTransferConfig name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquerydatatransfer/bigquerydatatransferconfig.md
@@ -387,7 +387,7 @@ serviceAccountRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagerdnsauthorization.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagerdnsauthorization.md
@@ -168,7 +168,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.{% endverbatim %}</p>
+            <p>{% verbatim %}Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagerdnsauthorization.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/certificatemanager/certificatemanagerdnsauthorization.md
@@ -168,7 +168,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.{% endverbatim %}</p>
+            <p>{% verbatim %}Optional. The name of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computetargettcpproxy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computetargettcpproxy.md
@@ -182,7 +182,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetTCPProxy name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computetargettcpproxy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computetargettcpproxy.md
@@ -182,7 +182,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The ComputeTargetTCPProxy name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -512,7 +512,7 @@ while clusters with private issuers need to provide both 'issuerUrl' and 'jwks'.
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable, Optional. The ContainerAttachedCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}Optional. The ContainerAttachedCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/containerattached/containerattachedcluster.md
@@ -512,7 +512,7 @@ while clusters with private issuers need to provide both 'issuerUrl' and 'jwks'.
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Optional. The ContainerAttachedCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}Optional. The ContainerAttachedCluster name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmskeyhandle.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmskeyhandle.md
@@ -147,7 +147,7 @@ resourceTypeSelector: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The KMS Key Handle ID used for resource creation or acquisition. For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID. For acquisition: This field must be provided to identify the key handle resource to acquire.{% endverbatim %}</p>
+            <p>{% verbatim %}The KMS Key Handle ID used for resource creation or acquisition. For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID. For acquisition: This field must be provided to identify the key handle resource to acquire. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmskeyhandle.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/kms/kmskeyhandle.md
@@ -147,7 +147,7 @@ resourceTypeSelector: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The KMS Key Handle ID used for resource creation or acquisition. For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID. For acquisition: This field must be provided to identify the key handle resource to acquire.{% endverbatim %}</p>
+            <p>{% verbatim %}The KMS Key Handle ID used for resource creation or acquisition. For creation: If specified, this value is used as the key handle ID. If not provided, a UUID will be generated and assigned as the key handle ID. For acquisition: This field must be provided to identify the key handle resource to acquire.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privilegedaccessmanager/privilegedaccessmanagerentitlement.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/privilegedaccessmanager/privilegedaccessmanagerentitlement.md
@@ -562,7 +562,7 @@ https://cloud.google.com/iam/docs/conditions-overview#attributes.{% endverbatim 
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The PrivilegedAccessManagerEntitlement name. If not given, the 'metadata.name' will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}Immutable. The PrivilegedAccessManagerEntitlement name. If not given, the 'metadata.name' will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
@@ -395,7 +395,7 @@ versionAliases:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The SecretManagerSecret name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The SecretManagerSecret name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecret.md
@@ -395,7 +395,7 @@ versionAliases:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The SecretManagerSecret name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The SecretManagerSecret name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerinstance.md
@@ -159,7 +159,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The SpannerInstance name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The SpannerInstance name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerinstance.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/spanner/spannerinstance.md
@@ -159,7 +159,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The SpannerInstance name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The SpannerInstance name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
@@ -219,7 +219,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The Workstation name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The Workstation name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
@@ -219,7 +219,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The Workstation name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The Workstation name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
@@ -376,7 +376,7 @@ subnetworkRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The WorkstationCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The WorkstationCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationcluster.md
@@ -376,7 +376,7 @@ subnetworkRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The WorkstationCluster name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The WorkstationCluster name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
@@ -955,7 +955,7 @@ runningTimeout: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. The WorkstationConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The WorkstationConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
@@ -955,7 +955,7 @@ runningTimeout: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The WorkstationConfig name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}The WorkstationConfig name. If not given, the metadata.name will be used. Cannot be changed after create, except for updating from empty string to the actual resource ID.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
In practice, due to in-controller enforcement, the only valid change is to set from empty string -> actual resource ID.
