### PR TITLE
fix: Actually fix workstation docs

### DIFF
--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstation.md
@@ -26,7 +26,7 @@
 </tr>
 <tr>
 <td>{{gcp_name_short}} REST Resource Documentation</td>
-<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations>/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations"</a></td>
+<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations">/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations</a></td>
 </tr>
 <tr>
 <td>{{product_name_short}} Resource Short Names</td>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/workstations/workstationconfig.md
@@ -26,7 +26,7 @@
 </tr>
 <tr>
 <td>{{gcp_name_short}} REST Resource Documentation</td>
-<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs>/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs"</a></td>
+<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs">/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs</a></td>
 </tr>
 <tr>
 <td>{{product_name_short}} Resource Short Names</td>

--- a/scripts/generate-google3-docs/resource-reference/templates/workstations_workstation.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/workstations_workstation.tmpl
@@ -26,7 +26,7 @@
 </tr>
 <tr>
 <td>{{"{{gcp_name_short}}"}} REST Resource Documentation</td>
-<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations>/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations"</a></td>
+<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations">/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs.workstations</a></td>
 </tr>
 <tr>
 <td>{{"{{product_name_short}}"}} Resource Short Names</td>

--- a/scripts/generate-google3-docs/resource-reference/templates/workstations_workstationconfig.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/workstations_workstationconfig.tmpl
@@ -26,7 +26,7 @@
 </tr>
 <tr>
 <td>{{"{{gcp_name_short}}"}} REST Resource Documentation</td>
-<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs>/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs"</a></td>
+<td><a href="/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs">/workstations/docs/reference/rest/v1/projects.locations.workstationClusters.workstationConfigs</a></td>
 </tr>
 <tr>
 <td>{{"{{product_name_short}}"}} Resource Short Names</td>


### PR DESCRIPTION
Accidentally placed the quotation mark in the wrong position in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/3447
