### PR TITLE
lint: add depguard

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ issues:
 linters:
   disable-all: true
   enable:
+    - depguard
     - errcheck
     - errorlint
     # - exportloopref
@@ -60,3 +61,9 @@ linters-settings:
       - shadow
       - testinggoroutine
       - unusedwrite
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/ghodss/yaml"
+            desc: Use "sigs.k8s.io/yaml"

--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -36,7 +36,7 @@ import (
 	testyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/yaml"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/operator/pkg/test/controller/manifest.go
+++ b/operator/pkg/test/controller/manifest.go
@@ -22,7 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cluster"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"

--- a/operator/scripts/generate-image-configmap/main.go
+++ b/operator/scripts/generate-image-configmap/main.go
@@ -27,7 +27,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/operator/scripts/utils/yaml.go
+++ b/operator/scripts/utils/yaml.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	goyaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/pkg/cli/cmd/apply/yamlresource/yaml_to_unstructured_resource.go
+++ b/pkg/cli/cmd/apply/yamlresource/yaml_to_unstructured_resource.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/pkg/cli/cmd/printresources/printer/printer.go
+++ b/pkg/cli/cmd/printresources/printer/printer.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/cmd/printresources/resourcedescription"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/pkg/cli/outputsink/filename/filename.go
+++ b/pkg/cli/outputsink/filename/filename.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/resourceskeleton"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/servicemapping/servicemappingloader"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"github.com/gosimple/slug"
 	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/cli/outputsink/sink_test.go
+++ b/pkg/cli/outputsink/sink_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
 	tfprovider "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/tf/provider"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/cli/stream/yamlstream.go
+++ b/pkg/cli/stream/yamlstream.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/pkg/controller/dynamic/common_test_functions.go
+++ b/pkg/controller/dynamic/common_test_functions.go
@@ -21,7 +21,7 @@ import (
 
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/crd/crdloader/crdloader.go
+++ b/pkg/crd/crdloader/crdloader.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/text"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/snippet/snippetgeneration/snippetgeneration.go
+++ b/pkg/snippet/snippetgeneration/snippetgeneration.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/mapslice"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	goyaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/pkg/test/resourcefixture/resourcefixture.go
+++ b/pkg/test/resourcefixture/resourcefixture.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/pkg/test/unstructured.go
+++ b/pkg/test/unstructured.go
@@ -17,7 +17,7 @@ package test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/pkg/test/yaml/yaml.go
+++ b/pkg/test/yaml/yaml.go
@@ -21,7 +21,7 @@ import (
 
 	cnrmyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/yaml"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/scripts/generate-cnrm-cluster-roles/main.go
+++ b/scripts/generate-cnrm-cluster-roles/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/slice"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/scripts/generate-crds/main.go
+++ b/scripts/generate-crds/main.go
@@ -40,7 +40,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/slice"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdgen "sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/genall"

--- a/scripts/generate-gvks/main.go
+++ b/scripts/generate-gvks/main.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/scripts/parse-crds/parse-crds.go
+++ b/scripts/parse-crds/parse-crds.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/crdgeneration"
 	kccyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/yaml"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 

--- a/scripts/resource-autogen/servicemapping/servicemappingloader/servicemappingloader.go
+++ b/scripts/resource-autogen/servicemapping/servicemappingloader/servicemappingloader.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/resource-autogen/allowlist"
 	generatedembed "github.com/GoogleCloudPlatform/k8s-config-connector/scripts/resource-autogen/servicemapping/embed/generated"
 
-	"github.com/ghodss/yaml"
+	"github.com/ghodss/yaml" //nolint:depguard
 )
 
 var emptyIAMConfig v1alpha1.IAMConfig


### PR DESCRIPTION
Using `depguard` to highlight the imports we don't want to use. I will `//nolint` existing usages and this will prevent future imports.