### PR TITLE
mockgcp: tolerate deprecated field in swagger

### DIFF
--- a/mockgcp/tools/gapic/main.go
+++ b/mockgcp/tools/gapic/main.go
@@ -61,7 +61,7 @@ func run(ctx context.Context) error {
 	decoder := json.NewDecoder(bytes.NewReader(b))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(doc); err != nil {
-		return fmt.Errorf("parsing json %q: %w", p, err)
+		return fmt.Errorf("parsing json %q (with DisallowUnknownFields): %w", p, err)
 	}
 
 	c := protogen.NewOpenAPIConverter(protoPackage, doc)

--- a/mockgcp/tools/gapic/pkg/openapi/openapi.go
+++ b/mockgcp/tools/gapic/pkg/openapi/openapi.go
@@ -61,6 +61,7 @@ type Resource struct {
 
 // Method is a REST endpoint; a specific method against a resource.
 type Method struct {
+	Deprecated  bool   `json:"deprecated"`
 	Description string `json:"description"`
 	FlatPath    string `json:"flatPath"`
 


### PR DESCRIPTION
We're parsing "strictly" (errors for unknown fields),
and we hadn't encountered this field before.
