### PR TITLE
Adding mocks for cloudidentity membership API

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -755,6 +755,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "cloudids.cnrm.cloud.google.com", Kind: "CloudIDSEndpoint"}:
 
 			case schema.GroupKind{Group: "cloudidentity.cnrm.cloud.google.com", Kind: "CloudIdentityGroup"}:
+			case schema.GroupKind{Group: "cloudidentity.cnrm.cloud.google.com", Kind: "CloudIdentityMembership"}:
 
 			case schema.GroupKind{Group: "containerattached.cnrm.cloud.google.com", Kind: "ContainerAttachedCluster"}:
 

--- a/mockgcp/mockcloudidentity/groups.go
+++ b/mockgcp/mockcloudidentity/groups.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/klog/v2"
 
@@ -131,19 +130,6 @@ func addAdditionalGroup(obj *pb.Group, entityKey *pb.EntityKey) {
 		}
 	}
 	obj.AdditionalGroupKeys = append(obj.AdditionalGroupKeys, entityKey)
-}
-
-func buildLRO(obj proto.Message) (*longrunning.Operation, error) {
-	responseAny, err := anypb.New(obj)
-	if err != nil {
-		return nil, fmt.Errorf("error building anypb for response: %w", err)
-	}
-	lro := &longrunning.Operation{}
-	lro.Done = true
-	lro.Result = &longrunning.Operation_Response{
-		Response: responseAny,
-	}
-	return lro, nil
 }
 
 func (s *groupsServer) PatchGroup(ctx context.Context, req *pb.PatchGroupRequest) (*longrunning.Operation, error) {

--- a/mockgcp/mockcloudidentity/groupsmembership.go
+++ b/mockgcp/mockcloudidentity/groupsmembership.go
@@ -1,0 +1,146 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockcloudidentity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/google/apps/cloudidentity/groups/v1beta1"
+)
+
+type groupsMembershipsServer struct {
+	*MockService
+	pb.UnimplementedGroupsMembershipsServerServer
+}
+
+func (s *groupsMembershipsServer) GetGroupsMembership(ctx context.Context, req *pb.GetGroupsMembershipRequest) (*pb.Membership, error) {
+	//GET https://cloudidentity.googleapis.com/v1/{name=groups/*/memberships/*}
+	name, err := s.parseMembershipName(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.Membership{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.PermissionDenied, "Error(2017): Permission denied for group resource '%s' (or it may not exist).", fqn)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *groupsMembershipsServer) CreateGroupsMembership(ctx context.Context, req *pb.CreateGroupsMembershipRequest) (*longrunning.Operation, error) {
+	// POST https://cloudidentity.googleapis.com/v1/{parent=groups/*}/memberships
+	groupName, err := s.parseGroupName(*req.Parent)
+	if err != nil {
+		return nil, err
+	}
+	reqName := fmt.Sprintf("%s/memberships/%x", groupName.String(), time.Now().UnixMilli())
+	name, err := s.parseMembershipName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	now := timestamppb.Now()
+
+	obj := proto.Clone(req.GroupsMembership).(*pb.Membership)
+	obj.Name = PtrTo(fmt.Sprintf("%s", name.String()))
+	obj.CreateTime = now
+	obj.UpdateTime = now
+
+	obj.Type = PtrTo("USER")              // TODO: logic for this value ?
+	obj.DeliverySetting = PtrTo("DIGEST") // TODO: logic for this value ?
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	// TODO: is this all for LRO ?
+	retObj := proto.Clone(obj).(*pb.Membership)
+	return buildLRO(retObj)
+}
+
+// No patch in mockgcp/generated/google/apps/cloudidentity/groups/v1beta1/service_grpc.pb.go
+// func (s *groupsMembershipsServer) PatchGroupsMembership(ctx context.Context, req *pb.PatchGroupsMembershipRequest) (*longrunning.Operation, error) {}
+
+// TODO: implement these from mockgcp/generated/google/apps/cloudidentity/groups/v1beta1/service_grpc.pb.go ?
+// Modifies the `MembershipRole`s of a `Membership`.
+// ModifyMembershipRolesGroupsMembership(ctx context.Context, in *ModifyMembershipRolesGroupsMembershipRequest, opts ...grpc.CallOption) (*ModifyMembershipRolesResponse, error)
+// Searches direct groups of a member.
+// SearchDirectGroupsGroupsMembership(ctx context.Context, in *SearchDirectGroupsGroupsMembershipRequest, opts ...grpc.CallOption) (*SearchDirectGroupsResponse, error)
+// Search transitive groups of a member. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterprise Plus, and Enterprise for Education; and Cloud Identity Premium accounts. A transitive group is any group that has a direct or indirect membership to the member. Actor must have view permissions all transitive groups.
+// SearchTransitiveGroupsGroupsMembership(ctx context.Context, in *SearchTransitiveGroupsGroupsMembershipRequest, opts ...grpc.CallOption) (*SearchTransitiveGroupsResponse, error)
+// Search transitive memberships of a group. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterprise Plus, and Enterprise for Education; and Cloud Identity Premium accounts. A transitive membership is any direct or indirect membership of a group. Actor must have view permissions to all transitive memberships.
+// SearchTransitiveMembershipsGroupsMembership(ctx context.Context, in *SearchTransitiveMembershipsGroupsMembershipRequest, opts ...grpc.CallOption) (*SearchTransitiveMembershipsResponse, error)
+
+func (s *groupsMembershipsServer) DeleteGroupsMembership(ctx context.Context, req *pb.DeleteGroupsMembershipRequest) (*longrunning.Operation, error) {
+	name, err := s.parseMembershipName(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.Membership{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	// Returns a non-standard LRO
+	lro := &longrunning.Operation{}
+	lro.Done = true
+	return lro, nil
+}
+
+type membershipName struct {
+	Group      string
+	Membership string
+}
+
+func (n *membershipName) String() string {
+	return fmt.Sprintf("groups/%s/memberships/%s", n.Group, n.Membership)
+}
+
+func (s *MockService) parseMembershipName(name string) (*membershipName, error) {
+	//From GET https://cloudidentity.googleapis.com/v1/{name=groups/*/memberships/*}
+	// name: groups/{group}/memberships/{membership}
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 4 && tokens[0] == "groups" && tokens[2] == "memberships" {
+		name := &membershipName{
+			Group:      tokens[1],
+			Membership: tokens[3],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockcloudidentity/service.go
+++ b/mockgcp/mockcloudidentity/service.go
@@ -52,11 +52,13 @@ func (s *MockService) ExpectedHosts() []string {
 
 func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterGroupsServerServer(grpcServer, &groupsServer{MockService: s})
+	pb.RegisterGroupsMembershipsServerServer(grpcServer, &groupsMembershipsServer{MockService: s})
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
 		pb.RegisterGroupsServerHandler,
+		pb.RegisterGroupsMembershipsServerHandler,
 		s.operations.RegisterOperationsPath("/v1beta1/operations/{name}"),
 	)
 	if err != nil {

--- a/mockgcp/mockcloudidentity/utils.go
+++ b/mockgcp/mockcloudidentity/utils.go
@@ -14,6 +14,14 @@
 
 package mockcloudidentity
 
+import (
+	"fmt"
+
+	"google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
 func PtrTo[T any](t T) *T {
 	return &t
 }
@@ -24,4 +32,17 @@ func ValueOf[T any](p *T) T {
 		v = *p
 	}
 	return v
+}
+
+func buildLRO(obj proto.Message) (*longrunning.Operation, error) {
+	responseAny, err := anypb.New(obj)
+	if err != nil {
+		return nil, fmt.Errorf("error building anypb for response: %w", err)
+	}
+	lro := &longrunning.Operation{}
+	lro.Done = true
+	lro.Result = &longrunning.Operation_Response{
+		Response: responseAny,
+	}
+	return lro, nil
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
@@ -1,0 +1,36 @@
+apiVersion: cloudidentity.cnrm.cloud.google.com/v1beta1
+kind: CloudIdentityMembership
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: cloudidentitymembership-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  groupRef:
+    name: cloudidentitygroup-${uniqueId}
+  preferredMemberKey:
+    id: test2@${ISOLATED_TEST_ORG_NAME}
+  resourceID: 19471824c77
+  roles:
+  - expiryDetail:
+      expireTime: "2222-10-02T15:01:23Z"
+    name: MEMBER
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  deliverySetting: DIGEST
+  observedGeneration: 3
+  type: USER
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
@@ -17,7 +17,7 @@ spec:
     name: cloudidentitygroup-${uniqueId}
   preferredMemberKey:
     id: test2@${ISOLATED_TEST_ORG_NAME}
-  resourceID: 19471824c77
+  resourceID: ${membershipID}
   roles:
   - expiryDetail:
       expireTime: "2222-10-02T15:01:23Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
@@ -1,0 +1,426 @@
+POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "parent": "customers/C00qzcxfe"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Group",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+    "displayName": "Cloud Identity Group Name",
+    "groupKey": {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "labels": {
+      "cloudidentity.googleapis.com/groups.discussion_forum": ""
+    },
+    "name": "groups/${groupID}",
+    "parent": "customers/C00qzcxfe",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    }
+  ]
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471824c77",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "name": "MEMBER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471824c77",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77:modifyMembershipRoles?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "addRoles": [],
+  "removeRoles": [],
+  "updateRolesParams": [
+    {
+      "fieldMask": "expiry_detail.expire_time",
+      "membershipRole": {
+        "expiryDetail": {
+          "expireTime": "2222-10-02T15:01:23Z"
+        },
+        "name": "MEMBER",
+        "restrictionEvaluations": null
+      }
+    }
+  ]
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "membership": {
+    "createTime": "2025-01-16T23:45:52.247648519Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471824c77",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "expiryDetail": {
+          "expireTime": "2222-10-02T15:01:23Z"
+        },
+        "name": "MEMBER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2025-01-16T23:45:52.247648519Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471824c77",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "expiryDetail": {
+        "expireTime": "2222-10-02T15:01:23Z"
+      },
+      "name": "MEMBER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471824c77' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
@@ -155,7 +155,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471824c77",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -171,7 +171,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -189,7 +189,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471824c77",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -204,7 +204,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77:modifyMembershipRoles?alt=json
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -238,9 +238,9 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-16T23:45:52.247648519Z",
+    "createTime": "2025-01-17T18:51:02.320337735Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471824c77",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -253,13 +253,13 @@ X-Xss-Protection: 0
       }
     ],
     "type": "USER",
-    "updateTime": "2025-01-16T23:45:52.247648519Z"
+    "updateTime": "2025-01-17T18:51:02.320337735Z"
   }
 }
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -277,7 +277,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471824c77",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -295,7 +295,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -316,7 +316,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471824c77?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -334,7 +334,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471824c77' (or it may not exist).",
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
     "status": "PERMISSION_DENIED"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
@@ -1,6 +1,6 @@
 POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 {
   "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
@@ -48,7 +48,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -85,7 +85,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -125,7 +125,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "preferredMemberKey": {
@@ -173,7 +173,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -206,7 +206,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "addRoles": [],
@@ -261,7 +261,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -297,7 +297,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -318,7 +318,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 403 Forbidden
 Cache-Control: private
@@ -343,7 +343,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -383,7 +383,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -404,7 +404,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 403 Forbidden
 Cache-Control: private

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
@@ -17,7 +17,7 @@ spec:
     name: cloudidentitygroup-${uniqueId}
   preferredMemberKey:
     id: test2@${ISOLATED_TEST_ORG_NAME}
-  resourceID: 19471803a55
+  resourceID: ${membershipID}
   roles:
   - name: MEMBER
   - name: MANAGER

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
@@ -1,0 +1,35 @@
+apiVersion: cloudidentity.cnrm.cloud.google.com/v1beta1
+kind: CloudIdentityMembership
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: cloudidentitymembership-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  groupRef:
+    name: cloudidentitygroup-${uniqueId}
+  preferredMemberKey:
+    id: test2@${ISOLATED_TEST_ORG_NAME}
+  resourceID: 19471803a55
+  roles:
+  - name: MEMBER
+  - name: MANAGER
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  deliverySetting: DIGEST
+  observedGeneration: 3
+  type: USER
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
@@ -155,7 +155,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471803a55",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -171,7 +171,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -189,7 +189,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471803a55",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -204,7 +204,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55:modifyMembershipRoles?alt=json
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -233,9 +233,9 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-16T23:43:36.533190184Z",
+    "createTime": "2025-01-17T18:51:02.320337735Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471803a55",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -248,13 +248,13 @@ X-Xss-Protection: 0
       }
     ],
     "type": "USER",
-    "updateTime": "2025-01-16T23:43:36.533190184Z"
+    "updateTime": "2025-01-17T18:51:02.320337735Z"
   }
 }
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -272,7 +272,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471803a55",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -290,7 +290,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -311,7 +311,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -329,7 +329,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471803a55' (or it may not exist).",
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
     "status": "PERMISSION_DENIED"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
@@ -1,6 +1,6 @@
 POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 {
   "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
@@ -48,7 +48,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -85,7 +85,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -125,7 +125,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "preferredMemberKey": {
@@ -173,7 +173,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -206,7 +206,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "addRoles": [
@@ -256,7 +256,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -292,7 +292,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -313,7 +313,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 403 Forbidden
 Cache-Control: private
@@ -338,7 +338,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -378,7 +378,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -399,7 +399,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 403 Forbidden
 Cache-Control: private

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
@@ -1,0 +1,421 @@
+POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "parent": "customers/C00qzcxfe"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Group",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+    "displayName": "Cloud Identity Group Name",
+    "groupKey": {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "labels": {
+      "cloudidentity.googleapis.com/groups.discussion_forum": ""
+    },
+    "name": "groups/${groupID}",
+    "parent": "customers/C00qzcxfe",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    }
+  ]
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471803a55",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "name": "MEMBER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471803a55",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55:modifyMembershipRoles?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "addRoles": [
+    {
+      "expiryDetail": null,
+      "name": "MANAGER",
+      "restrictionEvaluations": null
+    }
+  ],
+  "removeRoles": [],
+  "updateRolesParams": []
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "membership": {
+    "createTime": "2025-01-16T23:43:36.533190184Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471803a55",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "name": "MEMBER"
+      },
+      {
+        "name": "MANAGER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2025-01-16T23:43:36.533190184Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471803a55",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    },
+    {
+      "name": "MANAGER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471803a55?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471803a55' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
@@ -1,0 +1,34 @@
+apiVersion: cloudidentity.cnrm.cloud.google.com/v1beta1
+kind: CloudIdentityMembership
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: cloudidentitymembership-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  groupRef:
+    name: cloudidentitygroup-${uniqueId}
+  preferredMemberKey:
+    id: test2@${ISOLATED_TEST_ORG_NAME}
+  resourceID: "19471798744"
+  roles:
+  - name: MEMBER
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  deliverySetting: DIGEST
+  observedGeneration: 3
+  type: USER
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
@@ -17,7 +17,7 @@ spec:
     name: cloudidentitygroup-${uniqueId}
   preferredMemberKey:
     id: test2@${ISOLATED_TEST_ORG_NAME}
-  resourceID: "19471798744"
+  resourceID: ${membershipID}
   roles:
   - name: MEMBER
 status:

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
@@ -1,0 +1,420 @@
+POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+{
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "parent": "customers/C00qzcxfe"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Group",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+    "displayName": "Cloud Identity Group Name",
+    "groupKey": {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "labels": {
+      "cloudidentity.googleapis.com/groups.discussion_forum": ""
+    },
+    "name": "groups/${groupID}",
+    "parent": "customers/C00qzcxfe",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    },
+    {
+      "name": "MANAGER"
+    }
+  ]
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471798744",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "name": "MEMBER"
+      },
+      {
+        "name": "MANAGER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471798744",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    },
+    {
+      "name": "MANAGER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744:modifyMembershipRoles?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+{
+  "addRoles": [],
+  "removeRoles": [
+    "MANAGER"
+  ],
+  "updateRolesParams": []
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "membership": {
+    "createTime": "2025-01-16T23:36:17.476112624Z",
+    "deliverySetting": "DIGEST",
+    "name": "groups/${groupID}/memberships/19471798744",
+    "preferredMemberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
+    "roles": [
+      {
+        "name": "MEMBER"
+      }
+    ],
+    "type": "USER",
+    "updateTime": "2025-01-16T23:36:17.476112624Z"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deliverySetting": "DIGEST",
+  "name": "groups/${groupID}/memberships/19471798744",
+  "preferredMemberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "roles": [
+    {
+      "name": "MEMBER"
+    }
+  ],
+  "type": "USER",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+Content-Type: application/json
+User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471798744' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+
+403 Forbidden
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}' (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
@@ -158,7 +158,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471798744",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -177,7 +177,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -195,7 +195,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471798744",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -213,7 +213,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744:modifyMembershipRoles?alt=json
+POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -238,9 +238,9 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-16T23:36:17.476112624Z",
+    "createTime": "2025-01-17T18:51:02.320337735Z",
     "deliverySetting": "DIGEST",
-    "name": "groups/${groupID}/memberships/19471798744",
+    "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
     },
@@ -250,13 +250,13 @@ X-Xss-Protection: 0
       }
     ],
     "type": "USER",
-    "updateTime": "2025-01-16T23:36:17.476112624Z"
+    "updateTime": "2025-01-17T18:51:02.320337735Z"
   }
 }
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -274,7 +274,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deliverySetting": "DIGEST",
-  "name": "groups/${groupID}/memberships/19471798744",
+  "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
   },
@@ -289,7 +289,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -310,7 +310,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/19471798744?alt=json
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
 
@@ -328,7 +328,7 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/19471798744' (or it may not exist).",
+    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
     "status": "PERMISSION_DENIED"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
@@ -1,6 +1,6 @@
 POST https://cloudidentity.googleapis.com/v1beta1/groups?alt=json&initialGroupConfig=EMPTY
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 {
   "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
@@ -48,7 +48,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -85,7 +85,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -125,7 +125,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "preferredMemberKey": {
@@ -179,7 +179,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -215,7 +215,7 @@ X-Xss-Protection: 0
 
 POST https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}:modifyMembershipRoles?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 {
   "addRoles": [],
@@ -258,7 +258,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -291,7 +291,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 200 OK
 Cache-Control: private
@@ -312,7 +312,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/${membershipID}?alt=json
 Content-Type: application/json
-User-Agent: kcc/controller-manager DeclarativeClientLib/0.0.1
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
 403 Forbidden
 Cache-Control: private
@@ -337,7 +337,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -377,7 +377,7 @@ X-Xss-Protection: 0
 
 DELETE https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
 Cache-Control: private
@@ -398,7 +398,7 @@ X-Xss-Protection: 0
 
 GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
-User-Agent: Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-google-beta/kcc/controller-manager
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 403 Forbidden
 Cache-Control: private

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeature/mcifeature/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeature/mcifeature/_http.log
@@ -1240,7 +1240,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1265,7 +1265,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships?alt=json&membershipId=gkehubmembership1-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1306,7 +1306,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1356,7 +1356,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1395,7 +1395,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1420,7 +1420,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships?alt=json&membershipId=gkehubmembership2-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1461,7 +1461,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1511,7 +1511,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2297,7 +2297,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2336,7 +2336,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2367,7 +2367,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership2-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2392,7 +2392,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2431,7 +2431,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -2462,7 +2462,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/gkehubmembership1-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/mci-${uniqueId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicacmgkehubfeaturemembership/_http.log
@@ -1254,7 +1254,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1279,7 +1279,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-basic-acm-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1323,7 +1323,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1378,7 +1378,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1456,7 +1456,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1521,7 +1521,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "sourceFormat": "unstructured"
@@ -1560,7 +1560,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1585,7 +1585,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1662,7 +1662,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1712,7 +1712,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1748,7 +1748,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1807,7 +1807,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1819,7 +1819,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1863,7 +1863,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1894,7 +1894,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-basic-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basiccsaugkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basiccsaugkehubfeaturemembership/_http.log
@@ -1228,7 +1228,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1253,7 +1253,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships?alt=json&membershipId=gkehubmembership-basic-csau-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1297,7 +1297,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1352,7 +1352,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1430,7 +1430,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1495,7 +1495,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "sourceFormat": "unstructured"
@@ -1534,7 +1534,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "sourceFormat": "unstructured"
@@ -1559,7 +1559,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1635,7 +1635,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1684,7 +1684,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1719,7 +1719,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {}
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1778,7 +1778,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}": {}
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1790,7 +1790,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1834,7 +1834,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1865,7 +1865,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-basic-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicpocogkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/basicpocogkehubfeaturemembership/_http.log
@@ -1244,7 +1244,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1269,7 +1269,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships?alt=json&membershipId=gkehubmembership-basic-poco-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1313,7 +1313,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1368,7 +1368,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1446,7 +1446,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "10"
@@ -1511,7 +1511,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
         "policycontroller": {
           "policyControllerHubConfig": {
             "auditIntervalSeconds": "10"
@@ -1550,7 +1550,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "10"
@@ -1575,7 +1575,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "15",
@@ -1656,7 +1656,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
         "policycontroller": {
           "policyControllerHubConfig": {
             "auditIntervalSeconds": "15",
@@ -1710,7 +1710,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "15",
@@ -1750,7 +1750,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {}
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/policycontroller",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1809,7 +1809,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}": {}
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/policycontroller",
     "resourceState": {
@@ -1821,7 +1821,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1865,7 +1865,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1896,7 +1896,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-basic-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullacmgkehubfeaturemembership/_http.log
@@ -1254,7 +1254,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1279,7 +1279,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-full-acm-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1323,7 +1323,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1378,7 +1378,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1456,7 +1456,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1531,7 +1531,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1580,7 +1580,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1615,7 +1615,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1691,7 +1691,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1740,7 +1740,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1775,7 +1775,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1834,7 +1834,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1846,7 +1846,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1890,7 +1890,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1921,7 +1921,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-full-acm-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullcsaugkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullcsaugkehubfeaturemembership/_http.log
@@ -1228,7 +1228,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1253,7 +1253,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships?alt=json&membershipId=gkehubmembership-full-csau-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1297,7 +1297,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1352,7 +1352,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1430,7 +1430,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1505,7 +1505,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1554,7 +1554,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1589,7 +1589,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1665,7 +1665,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
         "configmanagement": {
           "configSync": {
             "git": {
@@ -1714,7 +1714,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {
       "configmanagement": {
         "configSync": {
           "git": {
@@ -1749,7 +1749,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {}
+    "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/configmanagement",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1808,7 +1808,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}": {}
+      "projects/example-project-01/locations/us-south1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/configmanagement",
     "resourceState": {
@@ -1820,7 +1820,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1864,7 +1864,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1895,7 +1895,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/gkehubmembership-full-csau-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-south1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullpocogkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/fullpocogkehubfeaturemembership/_http.log
@@ -1137,7 +1137,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1162,7 +1162,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships?alt=json&membershipId=gkehubmembership-full-poco-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1206,7 +1206,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1261,7 +1261,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1339,7 +1339,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "10",
@@ -1419,7 +1419,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
         "policycontroller": {
           "policyControllerHubConfig": {
             "auditIntervalSeconds": "10",
@@ -1473,7 +1473,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "10",
@@ -1513,7 +1513,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "15",
@@ -1597,7 +1597,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
         "policycontroller": {
           "policyControllerHubConfig": {
             "auditIntervalSeconds": "15",
@@ -1654,7 +1654,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {
       "policycontroller": {
         "policyControllerHubConfig": {
           "auditIntervalSeconds": "15",
@@ -1697,7 +1697,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {}
+    "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/policycontroller",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1756,7 +1756,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}": {}
+      "projects/example-project-01/locations/us-west1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/policycontroller",
     "resourceState": {
@@ -1768,7 +1768,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1812,7 +1812,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1843,7 +1843,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/gkehubmembership-full-poco-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-west1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubfeaturemembership/meshgkehubfeaturemembership/_http.log
@@ -1163,7 +1163,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1188,7 +1188,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=gkehubmembership-mesh-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1232,7 +1232,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1287,7 +1287,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1365,7 +1365,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "mesh": {
         "management": "MANAGEMENT_MANUAL"
       }
@@ -1427,7 +1427,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "mesh": {
           "management": "MANAGEMENT_MANUAL"
         }
@@ -1463,7 +1463,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "mesh": {
         "management": "MANAGEMENT_MANUAL"
       }
@@ -1485,7 +1485,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "mesh": {
         "management": "MANAGEMENT_AUTOMATIC"
       }
@@ -1548,7 +1548,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
         "mesh": {
           "management": "MANAGEMENT_AUTOMATIC"
         }
@@ -1584,7 +1584,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {
       "mesh": {
         "management": "MANAGEMENT_AUTOMATIC"
       }
@@ -1606,7 +1606,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/servicemesh",
   "updateTime": "2024-04-01T12:34:56.123456Z"
@@ -1665,7 +1665,7 @@ X-Xss-Protection: 0
       "managed-by-cnrm": "true"
     },
     "membershipSpecs": {
-      "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
+      "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
     },
     "name": "projects/example-project-01/locations/global/features/servicemesh",
     "resourceState": {
@@ -1677,7 +1677,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1721,7 +1721,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1752,7 +1752,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/example-project-01/locations/us-central1/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -1798,7 +1798,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "membershipSpecs": {
-    "projects/example-project-01/locations/us-central1/memberships/gkehubmembership-mesh-${uniqueId}": {}
+    "projects/example-project-01/locations/us-central1/memberships/${membershipID}": {}
   },
   "name": "projects/example-project-01/locations/global/features/servicemesh",
   "updateTime": "2024-04-01T12:34:56.123456Z"

--- a/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubmembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/gkehub/v1beta1/gkehubmembership/_http.log
@@ -383,7 +383,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -408,7 +408,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships?alt=json&membershipId=gkehubmembership-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -452,7 +452,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -507,7 +507,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -551,7 +551,7 @@ X-Xss-Protection: 0
 
 ---
 
-PATCH https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json&updateMask=description
+PATCH https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json&updateMask=description
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -595,7 +595,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -650,7 +650,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -694,7 +694,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+DELETE https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -725,7 +725,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -185,6 +185,10 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 	// Specific to SecretManager
 	visitor.replacePaths[".expireTime"] = "2024-04-01T12:34:56.123456Z"
 
+	// Specific to CloudIdentityMembership
+	visitor.replacePaths[".membership.createTime"] = "2025-01-17T18:51:02.320337735Z"
+	visitor.replacePaths[".membership.updateTime"] = "2025-01-17T18:51:02.320337735Z"
+
 	// Specific to BigQueryConnectionConnection.
 	visitor.replacePaths[".status.observedState.aws.accessRole.identity"] = "048077221682493034546"
 	visitor.replacePaths[".status.observedState.azure.identity"] = "117243083562690747295"
@@ -339,6 +343,11 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 			case schema.GroupVersionKind{Group: "cloudidentity.cnrm.cloud.google.com", Version: "v1beta1", Kind: "CloudIdentityGroup"}:
 				visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
 					return strings.ReplaceAll(s, resourceID, "${groupID}")
+				})
+
+			case schema.GroupVersionKind{Group: "cloudidentity.cnrm.cloud.google.com", Version: "v1beta1", Kind: "CloudIdentityMembership"}:
+				visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+					return strings.ReplaceAll(s, resourceID, "${membershipID}")
 				})
 			}
 		}

--- a/tests/e2e/replacements.go
+++ b/tests/e2e/replacements.go
@@ -134,6 +134,8 @@ func (r *Replacements) placeholderForGCPResource(resource string) string {
 		return "${firewallPolicyID}"
 	case "folders":
 		return "${folderID}"
+	case "memberships":
+		return "${membershipID}"
 	case "sslCertificates":
 		return "${sslCertificateID}"
 	case "serviceAttachments":

--- a/tests/e2e/testdata/scenarios/fields/management/gkehub/featuremembership/set_unset/_http02.log
+++ b/tests/e2e/testdata/scenarios/fields/management/gkehub/featuremembership/set_unset/_http02.log
@@ -1,4 +1,4 @@
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -23,7 +23,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -48,7 +48,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -73,7 +73,7 @@ X-Xss-Protection: 0
 
 ---
 
-POST https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships?alt=json&membershipId=gkehubmembership-${uniqueId}
+POST https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships?alt=json&membershipId=${membershipID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -116,7 +116,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}/operations/${operationID}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}/operations/${operationID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -170,7 +170,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -213,7 +213,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -256,7 +256,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -299,7 +299,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
@@ -342,7 +342,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/gkehubmembership-${uniqueId}?alt=json
+GET https://gkehub.googleapis.com/v1beta1/projects/${projectId}/locations/global/memberships/${membershipID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 


### PR DESCRIPTION
### Change description

Adding mocks for cloudidentity membership API

### Tests Run
The following tests passed:

E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures/addexpirydatecloudidentitymembership  2>&1 | tee log.cloudidentity
E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures/addrolecloudidentitymembership  2>&1 | tee log.cloudidentity
E2E_KUBE_TARGET=envtest RUN_E2E=1 E2E_GCP_TARGET=mock go test -test.count=1 -timeout 3600s -v ./tests/e2e -run TestAllInSeries/fixtures/removerolecloudidentitymembership  2>&1 | tee log.cloudidentity

