### PR TITLE
ci: lint more yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,3 +67,7 @@ linters-settings:
         deny:
           - pkg: "github.com/ghodss/yaml"
             desc: Use "sigs.k8s.io/yaml"
+          - pkg: "yaml/v2"
+            desc: Use "sigs.k8s.io/yaml"
+          - pkg: "yaml/v3"
+            desc: Use "sigs.k8s.io/yaml"


### PR DESCRIPTION
Now that we have depguard we can further lint packages we'd rather avoid using in our project(s).

Fixes https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/2389