### PR TITLE
chore: hack to workaround broken go build

### DIFF
--- a/scripts/resource-autogen/servicemapping/embed/generated/main/assets_generate_fallback.go
+++ b/scripts/resource-autogen/servicemapping/embed/generated/main/assets_generate_fallback.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !integration
+// +build !integration
+
+package main
+
+// This function is needed so that we can `go build ./...`
+func main() {
+	panic("you must specify the integration build tag")
+}


### PR DESCRIPTION
We need a main even if the integration build tag is not specified.

This enables go build ./...

Our placeholder just panics if run.
