### PR TITLE
Fix format validation for SecretManagerSecretRef and SecretManagerSecretVersionRef

### DIFF
--- a/apis/refs/v1beta1/secretmanagerrefs.go
+++ b/apis/refs/v1beta1/secretmanagerrefs.go
@@ -57,7 +57,7 @@ func ResolveSecretManagerSecretRef(ctx context.Context, reader client.Reader, sr
 	// External should be in the "projects/*/secrets/*" format
 	if ref.External != "" {
 		tokens := strings.Split(ref.External, "/")
-		if len(tokens) == 4 && tokens[0] == "project" && tokens[2] == "secrets" {
+		if len(tokens) == 4 && tokens[0] == "projects" && tokens[2] == "secrets" {
 			ref = &SecretManagerSecretRef{
 				External: fmt.Sprintf("projects/%s/secrets/%s", tokens[1], tokens[3]),
 			}
@@ -146,7 +146,7 @@ func ResolveSecretManagerSecretVersionRef(ctx context.Context, reader client.Rea
 	// External should be in the "projects/*/secrets/*/versions/*" format
 	if ref.External != "" {
 		tokens := strings.Split(ref.External, "/")
-		if len(tokens) == 6 && tokens[0] == "project" && tokens[2] == "secrets" && tokens[4] == "versions" {
+		if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "secrets" && tokens[4] == "versions" {
 			ref = &SecretManagerSecretVersionRef{
 				External: fmt.Sprintf("projects/%s/secrets/%s/versions/%s", tokens[1], tokens[3], tokens[5]),
 			}

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_generated_object_dataformrepository-full.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_generated_object_dataformrepository-full.golden.yaml
@@ -10,6 +10,11 @@ metadata:
   name: dataformrepository-${uniqueId}
   namespace: ${uniqueId}
 spec:
+  gitRemoteSettings:
+    authenticationTokenSecretVersionRef:
+      external: projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1
+    defaultBranch: main
+    url: https://github.com/GoogleCloudPlatform/k8s-config-connector
   projectRef:
     external: ${projectId}
   region: us-west2

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/_http.log
@@ -1,3 +1,105 @@
+GET https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}
+
+404 Not Found
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Secret [projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}] not found.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets?%24alt=json%3Benum-encoding%3Dint&secretId=secretmanagersecret-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "replication": {
+    "automatic": {}
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
+  "replication": {
+    "automatic": {}
+  }
+}
+
+---
+
+POST https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}:addVersion?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}
+
+{
+  "parent": "projects/${projectId}/secrets/secretmanagersecret-${uniqueId}",
+  "payload": {
+    "data": "SSBhbHdheXMgbG92ZWQgc3BhcnJpbmcgd2l0aCBnaWFudCBjYW5keSBzd29yZHMsIGJ1dCBJIGhhZCBubyBpZGVhIHRoYXQgd2FzIG15IHN1cGVyIHNlY3JldCBpbmZvcm1hdGlvbiE="
+  }
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+  "replicationStatus": {
+    "automatic": {}
+  },
+  "state": 1
+}
+
+---
+
 GET https://dataform.googleapis.com/v1beta1/projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
@@ -19,7 +121,13 @@ Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-west2
 
-{}
+{
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  }
+}
 
 200 OK
 Content-Type: application/json
@@ -27,7 +135,13 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "displayName": "",
-  "gitRemoteSettings": null,
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "sshAuthenticationConfig": null,
+    "tokenStatus": "TOKEN_STATUS_UNSPECIFIED",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  },
   "labels": {},
   "name": "projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}",
   "npmrcEnvironmentVariablesSecretVersion": "",
@@ -49,7 +163,13 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "displayName": "",
-  "gitRemoteSettings": null,
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "sshAuthenticationConfig": null,
+    "tokenStatus": "TOKEN_STATUS_UNSPECIFIED",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  },
   "labels": {},
   "name": "projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}",
   "npmrcEnvironmentVariablesSecretVersion": "",
@@ -60,12 +180,17 @@ Grpc-Metadata-Content-Type: application/grpc
 
 ---
 
-PATCH https://dataform.googleapis.com/v1beta1/projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=workspaceCompilationOverrides
+PATCH https://dataform.googleapis.com/v1beta1/projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=gitRemoteSettings%2CworkspaceCompilationOverrides
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 X-Goog-Request-Params: repository.name=projects%2F${projectId}%2Flocations%2Fus-west2%2Frepositories%2Fdataformrepository-${uniqueId}
 
 {
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  },
   "name": "projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}",
   "workspaceCompilationOverrides": {
     "defaultDatabase": "database",
@@ -80,7 +205,13 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "displayName": "",
-  "gitRemoteSettings": null,
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "sshAuthenticationConfig": null,
+    "tokenStatus": "TOKEN_STATUS_UNSPECIFIED",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  },
   "labels": {},
   "name": "projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}",
   "npmrcEnvironmentVariablesSecretVersion": "",
@@ -106,7 +237,13 @@ Grpc-Metadata-Content-Type: application/grpc
 
 {
   "displayName": "",
-  "gitRemoteSettings": null,
+  "gitRemoteSettings": {
+    "authenticationTokenSecretVersion": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+    "defaultBranch": "main",
+    "sshAuthenticationConfig": null,
+    "tokenStatus": "TOKEN_STATUS_UNSPECIFIED",
+    "url": "https://github.com/GoogleCloudPlatform/k8s-config-connector"
+  },
   "labels": {},
   "name": "projects/${projectId}/locations/us-west2/repositories/dataformrepository-${uniqueId}",
   "npmrcEnvironmentVariablesSecretVersion": "",
@@ -130,5 +267,118 @@ X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-west2%2Frep
 Content-Type: application/json
 Grpc-Metadata-Content-Type: application/grpc
 Grpc-Metadata-X-Http-Code: 204
+
+{}
+
+---
+
+GET https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}/versions/1?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}%2Fversions%2F1
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+  "replicationStatus": {
+    "automatic": {}
+  },
+  "state": 1
+}
+
+---
+
+POST https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}/versions/1:destroy?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}%2Fversions%2F1
+
+{
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/secrets/secretmanagersecret-${uniqueId}/versions/1"
+}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "destroyTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1",
+  "replicationStatus": {
+    "automatic": {}
+  },
+  "state": 3
+}
+
+---
+
+GET https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}",
+  "replication": {
+    "automatic": {}
+  }
+}
+
+---
+
+DELETE https://secretmanager.googleapis.com/v1/projects/${projectId}/secrets/secretmanagersecret-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Fsecrets%2Fsecretmanagersecret-${uniqueId}
+
+200 OK
+Cache-Control: private
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
 
 {}

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/create.yaml
@@ -20,3 +20,8 @@ spec:
   projectRef:
     external: ${projectId}
   region: us-west2
+  gitRemoteSettings:
+    defaultBranch: main
+    url: https://github.com/GoogleCloudPlatform/k8s-config-connector
+    authenticationTokenSecretVersionRef:
+      external: projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/dependencies.yaml
@@ -1,0 +1,48 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-${uniqueId}
+data:
+  secretData: SSBhbHdheXMgbG92ZWQgc3BhcnJpbmcgd2l0aCBnaWFudCBjYW5keSBzd29yZHMsIGJ1dCBJIGhhZCBubyBpZGVhIHRoYXQgd2FzIG15IHN1cGVyIHNlY3JldCBpbmZvcm1hdGlvbiE=
+---
+apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+kind: SecretManagerSecret
+metadata:
+  name: secretmanagersecret-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    alpha.cnrm.cloud.google.com/reconciler: direct
+spec:
+  replication:
+    automatic: true
+---
+apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+kind: SecretManagerSecretVersion
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    alpha.cnrm.cloud.google.com/reconciler: direct
+  name: secretmanagersecretversion-${uniqueId}
+spec:
+  enabled: true
+  secretData:
+    valueFrom:
+      secretKeyRef:
+        key: secretData
+        name: secret-${uniqueId}
+  secretRef:
+    name: secretmanagersecret-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataform/v1beta1/dataformrepository-full/update.yaml
@@ -20,6 +20,11 @@ spec:
   projectRef:
     external: ${projectId}
   region: us-west2
+  gitRemoteSettings:
+    defaultBranch: main
+    url: https://github.com/GoogleCloudPlatform/k8s-config-connector
+    authenticationTokenSecretVersionRef:
+      external: projects/${projectNumber}/secrets/secretmanagersecret-${uniqueId}/versions/1
   workspaceCompilationOverrides:
     defaultDatabase: "database"
     schemaSuffix: "_suffix"

--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -1566,11 +1566,8 @@
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.stagingLocation" is not set in unstructured objects
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.tempLocation" is not set in unstructured objects
 [missing_field] crd=dataflowjobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.additionalExperiments[]" is not set in unstructured objects
-[missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.authenticationTokenSecretVersionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.defaultBranch" is not set in unstructured objects
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.sshAuthenticationConfig.hostPublicKey" is not set in unstructured objects
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.sshAuthenticationConfig.userPrivateKeySecretVersionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.url" is not set in unstructured objects
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.npmrcEnvironmentVariablesSecretVersionRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.setAuthenticatedUserAdmin" is not set in unstructured objects
 [missing_field] crd=datafusioninstances.datafusion.cnrm.cloud.google.com version=v1beta1: field ".spec.version" is not set in unstructured objects


### PR DESCRIPTION
Fix error
```
{"severity":"error","timestamp":"2025-01-22T07:00:49.994Z","msg":"Reconciler error","controller":"dataformrepository-controller","controllerGroup":"dataform.cnrm.cloud.google.com","controllerKind":"DataformRepository","DataformRepository":{"name":"dataformrepository-2tmq7a3ku34xkma","namespace":"2tmq7a3ku34xkma"},"namespace":"2tmq7a3ku34xkma","name":"dataformrepository-2tmq7a3ku34xkma","reconcileID":"645ec9cc-8246-42bb-ad57-b3ded07f6cd1","error":"Update call failed: failed to resolve resource references format of secretManagerSecretVersionRef external=\"projects/518915279/secrets/secretmanagersecret-2tmq7a3ku34xkma/versions/1\" was not known (use projects/<projectId>/secrets/<secretID>/versions/<versionID>)"}
```