### PR TITLE
controllerbuilder: strict mode to catch inconsistent training examples

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/datapoint.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/datapoint.go
@@ -25,9 +25,19 @@ import (
 
 // DataPoint holds the input and output for a tool.
 type DataPoint struct {
-	Type   string
-	Input  map[string]string
-	Output string
+	Description string
+	Type        string
+	Input       map[string]string
+	Output      string
+}
+
+// InputColumnKeys returns a set of the input column names
+func (p *DataPoint) InputColumnKeys() sets.Set[string] {
+	keys := sets.New[string]()
+	for k := range p.Input {
+		keys.Insert(k)
+	}
+	return keys
 }
 
 // SetInput sets an input value for the data point.

--- a/dev/tools/controllerbuilder/pkg/toolbot/extracttoolmarkers.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/extracttoolmarkers.go
@@ -29,8 +29,10 @@ import (
 type ExtractToolMarkers struct {
 }
 
+var _ Extractor = &ExtractToolMarkers{}
+
 // Extract extracts tool markers from source code.
-func (x *ExtractToolMarkers) Extract(ctx context.Context, src []byte) ([]*DataPoint, error) {
+func (x *ExtractToolMarkers) Extract(ctx context.Context, description string, src []byte) ([]*DataPoint, error) {
 	var dataPoints []*DataPoint
 
 	r := bytes.NewReader(src)
@@ -52,8 +54,9 @@ func (x *ExtractToolMarkers) Extract(ctx context.Context, src []byte) ([]*DataPo
 				klog.V(2).Infof("found tool line %q", comment)
 				toolName := strings.TrimPrefix(comment, "+tool:")
 				dataPoint := &DataPoint{
-					Type:   toolName,
-					Output: string(src),
+					Description: description,
+					Type:        toolName,
+					Output:      string(src),
 				}
 
 				for {
@@ -85,7 +88,8 @@ func (x *ExtractToolMarkers) Extract(ctx context.Context, src []byte) ([]*DataPo
 				klog.V(2).Infof("found tool line %q", comment)
 				toolName := "kcc-proto"
 				dataPoint := &DataPoint{
-					Type: toolName,
+					Description: description,
+					Type:        toolName,
 				}
 
 				proto := strings.TrimPrefix(comment, "+kcc:proto=")

--- a/mockgcp/mockdiscoveryengine/datastore.go
+++ b/mockgcp/mockdiscoveryengine/datastore.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: discoveryengine.cnrm.cloud.google.com/v1alpha1
-// krm.kind: DiscoveryEngineDataStore
 // proto.service: google.cloud.discoveryengine.v1.DataStoreService
-// proto.resource: DataStore
+// proto.message: google.cloud.discoveryengine.v1.DataStore
 
 package mockdiscoveryengine
 

--- a/mockgcp/mockedgecontainer/service.go
+++ b/mockgcp/mockedgecontainer/service.go
@@ -14,6 +14,10 @@
 
 package mockedgecontainer
 
+// +tool:mockgcp-service
+// http.host: edgecontainer.googleapis.com
+// proto.service: google.cloud.edgecontainer.v1.EdgeContainer
+
 import (
 	"context"
 	"net/http"

--- a/mockgcp/mockfirestore/service.go
+++ b/mockgcp/mockfirestore/service.go
@@ -14,6 +14,10 @@
 
 package mockfirestore
 
+// +tool:mockgcp-service
+// http.host: firestore.googleapis.com
+// proto.service: google.firestore.admin.v1.FirestoreAdmin
+
 import (
 	"context"
 	"net/http"

--- a/mockgcp/mockgkehub/service.go
+++ b/mockgcp/mockgkehub/service.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:mockgcp-service
+// http.host: gkehub.googleapis.com
+// proto.service: google.cloud.gkehub.v1beta.GkeHub
+// proto.service: google.cloud.gkehub.v1beta1.GkeHubMembershipService
+
 package mockgkehub
 
 import (

--- a/mockgcp/mockiam/service.go
+++ b/mockgcp/mockiam/service.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:mockgcp-service
+// http.host: iam.googleapis.com
+// proto.service: google.iam.admin.v1.IAM
+
 package mockiam
 
 import (

--- a/mockgcp/mockkms/autokeyconfig.go
+++ b/mockgcp/mockkms/autokeyconfig.go
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +mockgcp-support
-// apiVersion: kms.cnrm.cloud.google.com/v1beta1
-// kind: KMSAutokeyConfig
-// service: google.cloud.kms.v1.AutokeyAdmin
-// resource: AutokeyConfig
+// +tool:mockgcp-support
+// proto.service: google.cloud.kms.v1.AutokeyAdmin
+// proto.message: google.cloud.kms.v1.AutokeyConfig
 
 package mockkms
 

--- a/mockgcp/mockkms/cryptokey.go
+++ b/mockgcp/mockkms/cryptokey.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: kms.cnrm.cloud.google.com/v1beta1
-// krm.kind: KMSCryptoKey
 // proto.service: google.cloud.kms.v1.KeyManagementService
-// proto.resource: CryptoKey
+// proto.message: google.cloud.kms.v1.CryptoKey
 
 package mockkms
 

--- a/mockgcp/mockkms/cryptokeyversion.go
+++ b/mockgcp/mockkms/cryptokeyversion.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: kms.cnrm.cloud.google.com/v1beta1
-// krm.kind: KMSCryptoKeyVersion
 // proto.service: google.cloud.kms.v1.KeyManagementService
-// proto.resource: CryptoKeyVersion
+// proto.message: google.cloud.kms.v1.CryptoKeyVersion
 
 package mockkms
 

--- a/mockgcp/mockkms/keyhandle.go
+++ b/mockgcp/mockkms/keyhandle.go
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +mockgcp-support
-// apiVersion: kms.cnrm.cloud.google.com/v1alpha1
-// kind: KMSKeyHandle
-// service: google.cloud.kms.v1.AutokeyServer
-// resource: KeyHandle
+// +tool:mockgcp-support
+// proto.service: google.cloud.kms.v1.Autokey
+// proto.message: google.cloud.kms.v1.KeyHandle
 
 package mockkms
 

--- a/mockgcp/mockkms/keyring.go
+++ b/mockgcp/mockkms/keyring.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: kms.cnrm.cloud.google.com/v1beta1
-// krm.kind: KMSKeyRing
 // proto.service: google.cloud.kms.v1.KeyManagementService
-// proto.resource: KeyRing
+// proto.message: google.cloud.kms.v1.KeyRing
 
 package mockkms
 

--- a/mockgcp/mocklogging/logbucket.go
+++ b/mockgcp/mocklogging/logbucket.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: logging.cnrm.cloud.google.com/v1beta1
-// krm.kind: LoggingLogBucket
 // proto.service: google.logging.v2.ConfigServiceV2
-// proto.resource: LogBucket
+// proto.message: google.logging.v2.LogBucket
 
 package mocklogging
 

--- a/mockgcp/mocklogging/logmetric.go
+++ b/mockgcp/mocklogging/logmetric.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: logging.cnrm.cloud.google.com/v1beta1
-// krm.kind: LoggingLogMetric
 // proto.service: google.logging.v2.MetricsServiceV2
-// proto.resource: LogMetric
+// proto.message: google.logging.v2.LogMetric
 
 package mocklogging
 

--- a/mockgcp/mocklogging/logsink.go
+++ b/mockgcp/mocklogging/logsink.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// apiVersion: logging.cnrm.cloud.google.com/v1beta1
-// kind: LoggingLogSink
-// service: google.logging.v2.ConfigServiceV2
-// resource: LogSink
+// proto.service: google.logging.v2.ConfigServiceV2
+// proto.message: google.logging.v2.LogSink
 
 package mocklogging
 

--- a/mockgcp/mocklogging/logview.go
+++ b/mockgcp/mocklogging/logview.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: logging.cnrm.cloud.google.com/v1beta1
-// krm.kind: LoggingLogView
 // proto.service: google.logging.v2.ConfigServiceV2
-// proto.resource: LogView
+// proto.message: google.logging.v2.LogView
 
 package mocklogging
 

--- a/mockgcp/mockmonitoring/servicelevelobjective.go
+++ b/mockgcp/mockmonitoring/servicelevelobjective.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
-// krm.kind: MonitoringServiceLevelObjective
 // proto.service: google.monitoring.v3.ServiceMonitoringService
-// proto.resource: ServiceLevelObjective
+// proto.message: google.monitoring.v3.ServiceLevelObjective
 
 package mockmonitoring
 

--- a/mockgcp/mockpubsublite/reservation.go
+++ b/mockgcp/mockpubsublite/reservation.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: pubsublite.cnrm.cloud.google.com/v1beta1
-// krm.kind: PubSubLiteReservation
 // proto.service: google.cloud.pubsublite.v1.AdminService
-// proto.resource: Reservation
+// proto.message: google.cloud.pubsublite.v1.Reservation
 
 package mockpubsublite
 

--- a/mockgcp/mockpubsublite/subscription.go
+++ b/mockgcp/mockpubsublite/subscription.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: pubsublite.cnrm.cloud.google.com/v1beta1
-// krm.kind: PubSubLiteSubscription
 // proto.service: google.cloud.pubsublite.v1.AdminService
-// proto.resource: Subscription
+// proto.message: google.cloud.pubsublite.v1.Subscription
 
 package mockpubsublite
 

--- a/mockgcp/mockpubsublite/topic.go
+++ b/mockgcp/mockpubsublite/topic.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: pubsublite.cnrm.cloud.google.com/v1beta1
-// krm.kind: PubSubLiteTopic
 // proto.service: google.cloud.pubsublite.v1.AdminService
-// proto.resource: Topic
+// proto.message: google.cloud.pubsublite.v1.Topic
 
 package mockpubsublite
 

--- a/mockgcp/mockvpcaccess/connector.go
+++ b/mockgcp/mockvpcaccess/connector.go
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 // +tool:mockgcp-support
-// krm.apiVersion: vpcaccess.cnrm.cloud.google.com/v1beta1
-// krm.kind: VPCAccessConnector
 // proto.service: google.cloud.vpcaccess.v1.VpcAccessService
-// proto.resource: Connector
+// proto.message: google.cloud.vpcaccess.v1.Connector
 
 package mockvpcaccess
 


### PR DESCRIPTION
- **mockgcp: clean up the tool annotations**
- **controllerbuilder: strict mode to catch inconsistent training examples**
- **controllerbuilder: precompute proto service definitions**
