### PR TITLE
chore: Rename v1alpa1/OrganizationRef to ApigeeOrganizationRef

### DIFF
--- a/apis/apigee/v1alpha1/environmentgroup_identity.go
+++ b/apis/apigee/v1alpha1/environmentgroup_identity.go
@@ -64,7 +64,7 @@ func NewEnvironmentGroupIdentity(ctx context.Context, reader client.Reader, obj 
 		return nil, fmt.Errorf("cannot resolve organization: %w", err)
 	}
 
-	org, err := refs.ParseOrganizationExternal(orgExternal)
+	org, err := refs.ParseApigeeOrganizationExternal(orgExternal)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse external organization: %w", err)
 	}

--- a/apis/apigee/v1alpha1/environmentgroup_types.go
+++ b/apis/apigee/v1alpha1/environmentgroup_types.go
@@ -24,7 +24,7 @@ var ApigeeEnvgroupGVK = GroupVersion.WithKind("ApigeeEnvgroup")
 
 type Parent struct {
 	// +required
-	OrganizationRef *refv1alpha1.OrganizationRef `json:"organizationRef"`
+	OrganizationRef *refv1alpha1.ApigeeOrganizationRef `json:"organizationRef"`
 }
 
 // ApigeeEnvgroupSpec defines the desired state of ApigeeEnvgroup

--- a/apis/apigee/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apigee/v1alpha1/zz_generated.deepcopy.go
@@ -234,7 +234,7 @@ func (in *Parent) DeepCopyInto(out *Parent) {
 	*out = *in
 	if in.OrganizationRef != nil {
 		in, out := &in.OrganizationRef, &out.OrganizationRef
-		*out = new(refsv1alpha1.OrganizationRef)
+		*out = new(refsv1alpha1.ApigeeOrganizationRef)
 		**out = **in
 	}
 }

--- a/apis/refs/v1alpha1/apigeeorganizationref.go
+++ b/apis/refs/v1alpha1/apigeeorganizationref.go
@@ -33,26 +33,26 @@ var (
 	ApigeeOrganizationGVK = GroupVersion.WithKind("ApigeeOrganization")
 )
 
-var _ refsv1beta1.ExternalNormalizer = &OrganizationRef{}
+var _ refsv1beta1.ExternalNormalizer = &ApigeeOrganizationRef{}
 
-type OrganizationRef struct {
-	/* The Organization selfLink, when not managed by Config Connector. */
+type ApigeeOrganizationRef struct {
+	/* The ApigeeOrganization selfLink, when not managed by Config Connector. */
 	External string `json:"external,omitempty"`
-	/* The `name` field of an `Organization` resource. */
+	/* The `name` field of an `ApigeeOrganization` resource. */
 	Name string `json:"name,omitempty"`
-	/* The `namespace` field of an `Organization` resource. */
+	/* The `namespace` field of an `ApigeeOrganization` resource. */
 	Namespace string `json:"namespace,omitempty"`
 }
 
-type Organization struct {
-	OrganizationName string
+type ApigeeOrganization struct {
+	Name string
 }
 
-func (o *Organization) FullyQualifiedName() string {
-	return "organizations/" + o.OrganizationName
+func (o *ApigeeOrganization) FullyQualifiedName() string {
+	return "organizations/" + o.Name
 }
 
-func (r *OrganizationRef) NormalizedExternal(ctx context.Context, reader client.Reader, otherNamespace string) (string, error) {
+func (r *ApigeeOrganizationRef) NormalizedExternal(ctx context.Context, reader client.Reader, otherNamespace string) (string, error) {
 	if r.External != "" && r.Name != "" {
 		return "", fmt.Errorf("cannot specify both name and external on %s reference", ApigeeOrganizationGVK.Kind)
 	}
@@ -96,7 +96,7 @@ func (r *OrganizationRef) NormalizedExternal(ctx context.Context, reader client.
 	return r.External, nil
 }
 
-func ParseOrganizationExternal(external string) (resourceID string, err error) {
+func ParseApigeeOrganizationExternal(external string) (resourceID string, err error) {
 	tokens := strings.Split(external, "/")
 
 	if len(tokens) != 2 || tokens[0] != "organizations" {

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_apigeeenvgroups.apigee.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_apigeeenvgroups.apigee.cnrm.cloud.google.com.yaml
@@ -81,14 +81,15 @@ spec:
                   - external
                 properties:
                   external:
-                    description: The Organization selfLink, when not managed by Config
-                      Connector.
+                    description: The ApigeeOrganization selfLink, when not managed
+                      by Config Connector.
                     type: string
                   name:
-                    description: The `name` field of an `Organization` resource.
+                    description: The `name` field of an `ApigeeOrganization` resource.
                     type: string
                   namespace:
-                    description: The `namespace` field of an `Organization` resource.
+                    description: The `namespace` field of an `ApigeeOrganization`
+                      resource.
                     type: string
                 type: object
               resourceID:

--- a/pkg/controller/direct/apigee/envgroup_controller.go
+++ b/pkg/controller/direct/apigee/envgroup_controller.go
@@ -220,7 +220,7 @@ func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error
 	if mapCtx.Err() != nil {
 		return nil, mapCtx.Err()
 	}
-	obj.Spec.Parent.OrganizationRef = &refs.OrganizationRef{External: a.id.Parent().String()}
+	obj.Spec.Parent.OrganizationRef = &refs.ApigeeOrganizationRef{External: a.id.Parent().String()}
 	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is to disambiguate Apigee organizations from GCP organizations.