### PR TITLE
tool: use LLM to generate fuzzer

### DIFF
--- a/apis/managedkafka/v1alpha1/cluster_types.go
+++ b/apis/managedkafka/v1alpha1/cluster_types.go
@@ -126,8 +126,8 @@ type ManagedKafkaClusterStatus struct {
 }
 
 // ManagedKafkaClusterSpec defines the desired state of ManagedKafkaCluster
-// +kcc:proto=google.cloud.managedkafka.v1.Cluster
 // ManagedKafkaClusterObservedState is the state of the ManagedKafkaCluster resource as most recently observed in GCP.
+// +kcc:proto=google.cloud.managedkafka.v1.Cluster
 type ManagedKafkaClusterObservedState struct {
 	// Identifier. The name of the cluster. Structured like:
 	//  projects/{project_number}/locations/{location}/clusters/{cluster_id}

--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -45,10 +45,7 @@ type PromptOptions struct {
 }
 
 func (o *PromptOptions) InitDefaults() error {
-	root, err := options.RepoRoot()
-	if err != nil {
-		return err
-	}
+	root := os.Getenv("REPO_ROOT")
 	o.SrcDir = root
 	o.ProtoDir = root + "/.build/third_party/googleapis/"
 	return nil

--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -107,7 +107,12 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 	if err != nil {
 		return err
 	}
-	x, err := toolbot.NewCSVExporter(extractor, addProtoDefinition)
+	apiDir := o.SrcDir + "/apis/"
+	addGoStruct, err := toolbot.NewEnhanceWithGoStruct(apiDir)
+	if err != nil {
+		return err
+	}
+	x, err := toolbot.NewCSVExporter(extractor, addProtoDefinition, addGoStruct)
 	if err != nil {
 		return err
 	}

--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -44,6 +44,16 @@ type PromptOptions struct {
 	StrictInputColumnKeys []string
 }
 
+func (o *PromptOptions) InitDefaults() error {
+	root, err := options.RepoRoot()
+	if err != nil {
+		return err
+	}
+	o.SrcDir = root
+	o.ProtoDir = root + "/.build/third_party/googleapis/"
+	return nil
+}
+
 // BindFlags binds the flags to the command.
 func (o *PromptOptions) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.SrcDir, "src-dir", o.SrcDir, "base directory for source code")
@@ -56,6 +66,11 @@ func (o *PromptOptions) BindFlags(cmd *cobra.Command) {
 func BuildPromptCommand(baseOptions *options.GenerateOptions) *cobra.Command {
 	opt := &PromptOptions{
 		GenerateOptions: baseOptions,
+	}
+
+	if err := opt.InitDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing defaults: %v\n", err)
+		os.Exit(1)
 	}
 
 	cmd := &cobra.Command{

--- a/dev/tools/controllerbuilder/pkg/toolbot/enhancewithgostruct.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/enhancewithgostruct.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbot
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+type goStruct struct {
+	FilePath   string
+	Definition []string
+}
+
+// EnhanceWithGoStruct is an enhancer that finds Go structs with matching proto message annotation "// +kcc:proto=..."
+type EnhanceWithGoStruct struct {
+	srcDirectory string
+	structs      map[string][]*goStruct
+}
+
+// NewEnhanceWithGoStruct creates a new EnhanceWithGoStruct
+func NewEnhanceWithGoStruct(srcDirectory string) (*EnhanceWithGoStruct, error) {
+	x := &EnhanceWithGoStruct{
+		srcDirectory: srcDirectory,
+		structs:      make(map[string][]*goStruct),
+	}
+	if err := x.findGoStructs(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+var _ Enhancer = &EnhanceWithGoStruct{}
+
+// EnhanceDataPoint enhances the data point by adding matching Go struct definitions
+func (x *EnhanceWithGoStruct) EnhanceDataPoint(ctx context.Context, p *DataPoint) error {
+	if p.Type != "fuzz-gen" { // Only enhance if this is a fuzz-gen tool
+		return nil
+	}
+
+	protoMsg := p.Input["proto.message"]
+	if protoMsg == "" {
+		return nil
+	}
+
+	if goStructs := x.structs[protoMsg]; len(goStructs) > 0 {
+		// Combine all matching struct definitions with newlines between them
+		var definitions []string
+		for i, goStruct := range goStructs {
+			if i > 0 {
+				definitions = append(definitions, "") // Add blank line between structs
+			}
+			definitions = append(definitions, goStruct.Definition...)
+		}
+		p.SetInput("go.struct.definition", strings.Join(definitions, "\n"))
+	} else {
+		klog.Infof("unable to find Go struct for proto message %q", protoMsg)
+	}
+
+	return nil
+}
+
+// findGoStructs finds all Go structs with proto message annotations
+func (x *EnhanceWithGoStruct) findGoStructs() error {
+	return filepath.WalkDir(x.srcDirectory, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(p) != ".go" {
+			return nil
+		}
+
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("reading file %q: %w", p, err)
+		}
+		r := bytes.NewReader(b)
+		br := bufio.NewReader(r)
+
+		var lastComment string
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return fmt.Errorf("scanning file %q: %w", p, err)
+			}
+			line = strings.TrimSuffix(line, "\n")
+
+			// Track comments that might contain proto annotations
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				lastComment = strings.TrimSpace(line)
+				continue
+			}
+
+			// Look for struct definitions with matching proto annotation
+			if strings.HasPrefix(strings.TrimSpace(line), "type") && strings.Contains(line, "struct") {
+				if strings.Contains(lastComment, "// +kcc:proto=") {
+					protoMsg := strings.TrimPrefix(lastComment, "// +kcc:proto=")
+					goStruct := &goStruct{FilePath: p}
+
+					// Include the comment and struct definition
+					goStruct.Definition = append(goStruct.Definition, lastComment)
+
+					indent := 0
+					for {
+						goStruct.Definition = append(goStruct.Definition, line)
+						for _, r := range line {
+							if r == '{' {
+								indent++
+							}
+							if r == '}' {
+								indent--
+							}
+						}
+						if indent == 0 {
+							break
+						}
+						line, err = br.ReadString('\n')
+						if err != nil {
+							if err == io.EOF {
+								break
+							}
+							return fmt.Errorf("scanning file %q: %w", p, err)
+						}
+						line = strings.TrimSuffix(line, "\n")
+					}
+					x.structs[protoMsg] = append(x.structs[protoMsg], goStruct)
+				}
+			}
+			lastComment = ""
+		}
+		return nil
+	})
+}

--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -40,6 +40,22 @@ If you have a lot of fields that need to be manually written, you can split the 
 * Follow the naming convention as the auto-generated code. You shall have two methods `<field>_ToProto` and` <field>_FromProto`
 * Remove the `MISSING` comment
 
+## 3.3 (Optional) Add fuzzer test
+
+Note: For Beta resources, a fuzzer test is required for both the `Spec` and `Status` / `ObservedState`. To generate a fuzzer test, modify the following example and run it:
+
+```
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd $REPO_ROOT/dev/tools/controllerbuilder
+
+go run main.go prompt \
+  <<EOF > $REPO_ROOT/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+// +tool:fuzz-gen
+// proto.message: google.cloud.managedkafka.v1.Cluster
+// krm.kind: ManagedKafkaCluster
+EOF
+```
+
 
 ## Exit Criteria
 

--- a/pkg/controller/direct/discoveryengine/datastoretargetsite_fuzzer.go
+++ b/pkg/controller/direct/discoveryengine/datastoretargetsite_fuzzer.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:fuzz-gen
+// proto.message: google.cloud.discoveryengine.v1.TargetSite
+
 package discoveryengine
 
 import (

--- a/pkg/controller/direct/discoveryengine/engine_fuzzer.go
+++ b/pkg/controller/direct/discoveryengine/engine_fuzzer.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:fuzz-gen
+// proto.message: google.cloud.discoveryengine.v1.Engine
+
 package discoveryengine
 
 import (

--- a/pkg/controller/direct/discoveryengine/fuzzers.go
+++ b/pkg/controller/direct/discoveryengine/fuzzers.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:fuzz-gen
+// proto.message: google.cloud.discoveryengine.v1.DataStore
+
 package discoveryengine
 
 import (

--- a/pkg/controller/direct/iap/iapsettings_fuzzer.go
+++ b/pkg/controller/direct/iap/iapsettings_fuzzer.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:fuzz-gen
+// proto.message: google.cloud.iap.v1.IapSettings
+
 package iap
 
 import (

--- a/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/cluster_fuzzer.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.managedkafka.v1.Cluster
+// krm.kind: ManagedKafkaCluster
+
+package managedkafka
+
+import (
+	pb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(managedKafkaClusterFuzzer())
+}
+
+func managedKafkaClusterFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Cluster{},
+		ManagedKafkaClusterSpec_FromProto, ManagedKafkaClusterSpec_ToProto,
+		ManagedKafkaClusterObservedState_FromProto, ManagedKafkaClusterObservedState_ToProto,
+	)
+
+	f.UnimplementedFields.Insert(".name")
+	f.UnimplementedFields.Insert(".satisfies_pzi")
+	f.UnimplementedFields.Insert(".satisfies_pzs")
+
+	f.SpecFields.Insert(".labels")
+	f.SpecFields.Insert(".gcp_config")
+	f.SpecFields.Insert(".capacity_config")
+	f.SpecFields.Insert(".rebalance_config")
+
+	f.StatusFields.Insert(".create_time")
+	f.StatusFields.Insert(".update_time")
+	f.StatusFields.Insert(".state")
+
+	return f
+}

--- a/pkg/controller/direct/privilegedaccessmanager/fuzzers.go
+++ b/pkg/controller/direct/privilegedaccessmanager/fuzzers.go
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.privilegedaccessmanager.v1.Entitlement
+
 package privilegedaccessmanager
 
 import (


### PR DESCRIPTION
This PR:  
- Enhances the "prompt" tool by incorporating matching Go structs. For example, when generating the fuzzer for the `ManagedKafkaCluster` resource, the enhancer will identify the corresponding Go structs, `ManagedKafkaClusterSpec` and `ManagedKafkaClusterObservedState`, and include them in the prompt.
- Adds the `// +tool:fuzz-gen` annotation to existing fuzzers in the codebase as data points.  
- Adds default values to the "prompt" command flags for developer convenience, accommodating their various source code locations.  
- Generates the fuzzer for `ManagedKafkaCluster` using the following command, with **no** manual edits (besides updating the year in the license).

```
$ controllerbuilder prompt <<EOF > cluster_fuzzer.go
// +tool:fuzz-gen
// proto.message: google.cloud.managedkafka.v1.Cluster
// krm.kind: ManagedKafkaCluster
EOF
```
