### PR TITLE
test: increase timeout for scenarios tests

### DIFF
--- a/scripts/github-actions/tests-e2e-scenarios.sh
+++ b/scripts/github-actions/tests-e2e-scenarios.sh
@@ -26,4 +26,4 @@ export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-en
 
 echo "Running scenarios tests..."
 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock RUN_E2E=1 \
-  go test -test.count=1 -timeout 360s -v ./tests/e2e -run TestE2EScript/scenarios/fields
+  go test -test.count=1 -timeout 600s -v ./tests/e2e -run TestE2EScript/scenarios/fields


### PR DESCRIPTION
I'm seeing a test timeout on one of my PRs. Let's bump up the timeout from `6 min` to `10 min` to reduce flakiness.

https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/13144550223/job/36679496601?pr=3585#step:4:2110