### PR TITLE
fix: fix the update diff in ManagedKaflaCluster

### DIFF
--- a/pkg/controller/direct/managedkafka/cluster_controller.go
+++ b/pkg/controller/direct/managedkafka/cluster_controller.go
@@ -181,6 +181,10 @@ func (a *ClusterAdapter) Update(ctx context.Context, updateOp *directbase.Update
 		return mapCtx.Err()
 	}
 
+	// Set the name field to ensure the GCP API can identity the resource during UpdateCluster().
+	// This also prevents incorrect diffs, as the name field is not populated by ManagedKafkaClusterSpec_ToProto.
+	desiredPb.Name = a.id.String()
+
 	paths, err := common.CompareProtoMessage(desiredPb, a.actual, common.BasicDiff)
 	if err != nil {
 		return err
@@ -195,13 +199,11 @@ func (a *ClusterAdapter) Update(ctx context.Context, updateOp *directbase.Update
 		}
 		return updateOp.UpdateStatus(ctx, status, nil)
 	}
-	updateMask := &fieldmaskpb.FieldMask{
-		Paths: sets.List(paths)}
 
-	desiredPb.Name = a.id.String() // populate the name field so that the GCP API can identify the resource
 	req := &pb.UpdateClusterRequest{
-		UpdateMask: updateMask,
-		Cluster:    desiredPb,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: sets.List(paths)},
+		Cluster: desiredPb,
 	}
 	op, err := a.gcpClient.UpdateCluster(ctx, req)
 	if err != nil {

--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-basic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-basic/_http.log
@@ -818,7 +818,7 @@ X-Xss-Protection: 0
 
 ---
 
-PATCH https://managedkafka.googleapis.com/v1/projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=capacityConfig.memoryBytes%2CcapacityConfig.vcpuCount%2CgcpConfig.accessConfig.networkConfigs%2Cname%2CrebalanceConfig.mode
+PATCH https://managedkafka.googleapis.com/v1/projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=capacityConfig.memoryBytes%2CcapacityConfig.vcpuCount%2CgcpConfig.accessConfig.networkConfigs%2CrebalanceConfig.mode
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 X-Goog-Request-Params: cluster.name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fclusters%2Fmanagedkafkacluster-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-cmek/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-cmek/_http.log
@@ -796,7 +796,7 @@ X-Xss-Protection: 0
 
 ---
 
-PATCH https://managedkafka.googleapis.com/v1/projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=capacityConfig.memoryBytes%2CcapacityConfig.vcpuCount%2Cname%2CrebalanceConfig.mode
+PATCH https://managedkafka.googleapis.com/v1/projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=capacityConfig.memoryBytes%2CcapacityConfig.vcpuCount%2CrebalanceConfig.mode
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 X-Goog-Request-Params: cluster.name=projects%2F${projectId}%2Flocations%2Fus-central1%2Fclusters%2Fmanagedkafkacluster-${uniqueId}


### PR DESCRIPTION
Fix the update diff on the `name` field in `ManagedKaflaCluster`, similar to how it's handled for `ManagedKaflaTopic` in #3585.