### PR TITLE
dev:tools: mockgcp, api contexts

### DIFF
--- a/dev/tools/controllerbuilder/cmd/codebot/examples/apis/1-create-apis.md
+++ b/dev/tools/controllerbuilder/cmd/codebot/examples/apis/1-create-apis.md
@@ -1,0 +1,14 @@
+### Operator set up
+
+```bash
+$ export MOCKGCP_PATH = <absolute_path>
+$ export APIS_PATH = <absolute_path>
+$ export GEMINI_API_KEY = <your_key>
+# run from main
+$ go run main.go --apis-dir=$APIs_PATH --mockgcp-dir=$MOCKGCP_PATH
+```
+
+Prompt 1:
+>>> Generate an APIs folder (with all the files broken down by file name) for the ApigeeEnvgroupAttachment resource
+...
+...

--- a/dev/tools/controllerbuilder/cmd/ctf/main.go
+++ b/dev/tools/controllerbuilder/cmd/ctf/main.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/codebot"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/codebot/repocontext"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/codebot/ui"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/llm"
 	"k8s.io/klog/v2"
@@ -55,7 +56,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 
-	contextFiles := make(map[string]*codebot.FileInfo)
+	contextFiles := make(map[string]*repocontext.FileInfo)
 
 	{
 		// main.go
@@ -73,7 +74,7 @@ func run(ctx context.Context) error {
 	}
 	`
 
-		contextFiles["main.go"] = &codebot.FileInfo{
+		contextFiles["main.go"] = &repocontext.FileInfo{
 			Content: s,
 			Path:    "main.go",
 		}
@@ -92,7 +93,7 @@ module mymodule
 go 1.21
 	`
 
-		contextFiles["go.mod"] = &codebot.FileInfo{
+		contextFiles["go.mod"] = &repocontext.FileInfo{
 			Content: s,
 			Path:    "go.mod",
 		}
@@ -122,7 +123,7 @@ go 1.21
 
 	u := ui.NewTerminalUI()
 
-	chat, err := codebot.NewChat(ctx, llmClient, tmpDir, contextFiles, u)
+	chat, err := codebot.NewChat(ctx, llmClient, u, &codebot.Options{BaseDir: tmpDir, ContextFiles: contextFiles})
 	if err != nil {
 		return err
 	}

--- a/dev/tools/controllerbuilder/pkg/codebot/repocontext/apis.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/repocontext/apis.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repocontext
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func GatherAPIContents(apisPath string, examples int) ([]string, error) {
+	var exampleAPIsContents []string
+	var exampleAPIsDirPaths []string
+
+	// Walk through the apis directory.
+	err := filepath.Walk(apisPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Index on beta resources only for now
+		if info.IsDir() && strings.HasSuffix(info.Name(), "v1beta1") && len(exampleAPIsDirPaths) < examples {
+			exampleAPIsDirPaths = append(exampleAPIsDirPaths, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("walking apis directory: %w", err)
+	}
+
+	// Read up to "examples" files from each directory.
+	for _, dirPath := range exampleAPIsDirPaths {
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading directory %s: %w", dirPath, err)
+		}
+
+		for _, file := range files {
+			if !file.IsDir() && strings.HasSuffix(file.Name(), ".go") {
+				filePath := filepath.Join(dirPath, file.Name())
+				fileContent, err := os.ReadFile(filePath)
+				if err != nil {
+					return nil, fmt.Errorf("reading file %s: %w", filePath, err)
+				}
+				exampleAPIsContents = append(exampleAPIsContents, string(fileContent))
+			}
+		}
+	}
+
+	return exampleAPIsContents, nil
+}

--- a/dev/tools/controllerbuilder/pkg/codebot/repocontext/files.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/repocontext/files.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repocontext
+
+// todo acpana remove by refactoring
+type FileInfo struct {
+	Path    string
+	Content string
+}

--- a/dev/tools/controllerbuilder/pkg/codebot/repocontext/mockgcp.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/repocontext/mockgcp.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repocontext
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// gathers example mock content from multiple directories.
+func GatherMockContents(mockgcpPath string, examples int) ([]string, error) {
+	var exampleMockContents []string
+	var exampleMockDirPaths []string
+
+	// Walk through the mockgcp directory.
+	err := filepath.Walk(mockgcpPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Look for directories that might contain mocks
+		if info.IsDir() && strings.HasPrefix(info.Name(), "mock") && info.Name() != "mockgcp" && len(exampleMockDirPaths) < examples {
+			exampleMockDirPaths = append(exampleMockDirPaths, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("walking mockgcp directory: %w", err)
+	}
+
+	// Read up to "examples" files from each directory.
+	for _, dirPath := range exampleMockDirPaths {
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading directory %s: %w", dirPath, err)
+		}
+
+		for _, file := range files {
+			if !file.IsDir() && strings.HasSuffix(file.Name(), ".go") {
+				filePath := filepath.Join(dirPath, file.Name())
+				fileContent, err := os.ReadFile(filePath)
+				if err != nil {
+					return nil, fmt.Errorf("reading file %s: %w", filePath, err)
+				}
+				exampleMockContents = append(exampleMockContents, string(fileContent))
+			}
+		}
+	}
+
+	return exampleMockContents, nil
+}

--- a/dev/tools/controllerbuilder/pkg/codebot/rules/rules.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/rules/rules.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// holds code style and guidance coding
+package rules
+
+import "strings"
+
+var (
+	NoNakedReturns = Rule("Never use naked returns.")
+	CRDShortNames = Rule (`
+	For API type generation it is very important to add the right shortname labels. Good example:
+	// +kubebuilder:resource:categories=gcp,shortName=gcpapigeeenvgroup;gcpapigeeenvgroups
+
+	Figure out the right pluralization for your resources!
+	`)
+)
+
+type Rule string
+
+func ApplyRule(prompt string, rule Rule) string {
+	trimmedRule := strings.TrimSpace(string(rule))
+	if trimmedRule != "" {
+		return prompt + "\n" + string(rule)
+	}
+	return prompt
+}
+
+// ApplyRules applies multiple rules to a system prompt.
+func ApplyRules(prompt string, rules []Rule) string {
+    modifiedPrompt := prompt
+	modifiedPrompt += "\n Here are a few rules to keep in mind as you code in this codebase" + 
+	"in order to match the style and other coding conventions"
+    for _, rule := range rules {
+        modifiedPrompt = ApplyRule(modifiedPrompt, rule)
+    }
+    return modifiedPrompt
+}


### PR DESCRIPTION
A bit of a rougher PR:

- adds context around mockgcp files (add separates this addition from other files)
- ditto for api files

A lot of this work revolves still around prompt engineering but I figured it's worth showcasing it and adding in some of the changes I made. We can continue down this road a bit by adding "notable examples" beyond just raw numbers for mockgco or apis that we think are the gold standard.

Also check out the rules. We can enforce some of our codestyle in prompt. Another direction is to run the crds_test.go or other important linters and make the codebot iterate on its output accordingly.