### PR TITLE
tool: fix the `types.go` template

### DIFF
--- a/apis/iap/v1alpha1/iapsettings_types.go
+++ b/apis/iap/v1alpha1/iapsettings_types.go
@@ -70,9 +70,8 @@ type IAPSettingsStatus struct {
 	// ObservedState *IAPSettingsObservedState `json:"observedState,omitempty"`
 }
 
-// IAPSettingsSpec defines the desired state of IAPSettings
-// +kcc:proto=google.cloud.iap.v1.IapSettings
 // IAPSettingsObservedState is the state of the IAPSettings resource as most recently observed in GCP.
+// +kcc:proto=google.cloud.iap.v1.IapSettings
 // NOTYET: there is no output only field
 // type IAPSettingsObservedState struct {
 // }

--- a/apis/managedkafka/v1alpha1/cluster_types.go
+++ b/apis/managedkafka/v1alpha1/cluster_types.go
@@ -125,7 +125,6 @@ type ManagedKafkaClusterStatus struct {
 	ObservedState *ManagedKafkaClusterObservedState `json:"observedState,omitempty"`
 }
 
-// ManagedKafkaClusterSpec defines the desired state of ManagedKafkaCluster
 // ManagedKafkaClusterObservedState is the state of the ManagedKafkaCluster resource as most recently observed in GCP.
 // +kcc:proto=google.cloud.managedkafka.v1.Cluster
 type ManagedKafkaClusterObservedState struct {

--- a/apis/managedkafka/v1alpha1/topic_types.go
+++ b/apis/managedkafka/v1alpha1/topic_types.go
@@ -75,9 +75,8 @@ type ManagedKafkaTopicStatus struct {
 	// ObservedState *ManagedKafkaTopicObservedState `json:"observedState,omitempty"`
 }
 
-// ManagedKafkaTopicSpec defines the desired state of ManagedKafkaTopic
-// +kcc:proto=google.cloud.managedkafka.v1.Topic
 // ManagedKafkaTopicObservedState is the state of the ManagedKafkaTopic resource as most recently observed in GCP.
+// +kcc:proto=google.cloud.managedkafka.v1.Topic
 // NOTYET: the resource does not have any output only fields
 // type ManagedKafkaTopicObservedState struct {
 // }

--- a/dev/tools/controllerbuilder/template/apis/types.go
+++ b/dev/tools/controllerbuilder/template/apis/types.go
@@ -57,11 +57,10 @@ type {{ .Kind }}Status struct {
 	ObservedState *{{ .Kind }}ObservedState ` + "`" + `json:"observedState,omitempty"` + "`" + `
 }
 
-// {{ .Kind }}Spec defines the desired state of {{ .Kind }}
+// {{ .Kind }}ObservedState is the state of the {{ .Kind }} resource as most recently observed in GCP.
 {{- if .KindProtoTag }}
 // +kcc:proto={{ .KindProtoTag }}
 {{- end }}
-// {{ .Kind }}ObservedState is the state of the {{ .Kind }} resource as most recently observed in GCP.
 type {{ .Kind }}ObservedState struct {
 }
 


### PR DESCRIPTION
Not sure if there was a merge error, but I noticed this while generating the new resources.