### PR TITLE
test: generate fuzzer for ManagedKafkaTopic

### DIFF
--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -52,7 +52,6 @@ go run main.go prompt \
   <<EOF > $REPO_ROOT/pkg/controller/direct/managedkafka/cluster_fuzzer.go
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Cluster
-// krm.kind: ManagedKafkaCluster
 EOF
 ```
 

--- a/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/cluster_fuzzer.go
@@ -14,7 +14,6 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Cluster
-// krm.kind: ManagedKafkaCluster
 
 package managedkafka
 
@@ -24,16 +23,16 @@ import (
 )
 
 func init() {
-	fuzztesting.RegisterKRMFuzzer(managedKafkaClusterFuzzer())
+	fuzztesting.RegisterKRMFuzzer(managedkafkaClusterFuzzer())
 }
 
-func managedKafkaClusterFuzzer() fuzztesting.KRMFuzzer {
+func managedkafkaClusterFuzzer() fuzztesting.KRMFuzzer {
 	f := fuzztesting.NewKRMTypedFuzzer(&pb.Cluster{},
 		ManagedKafkaClusterSpec_FromProto, ManagedKafkaClusterSpec_ToProto,
 		ManagedKafkaClusterObservedState_FromProto, ManagedKafkaClusterObservedState_ToProto,
 	)
 
-	f.UnimplementedFields.Insert(".name")
+	f.UnimplementedFields.Insert(".name") // Identifier
 	f.UnimplementedFields.Insert(".satisfies_pzi")
 	f.UnimplementedFields.Insert(".satisfies_pzs")
 

--- a/pkg/controller/direct/managedkafka/topic_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/topic_fuzzer.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,20 +23,15 @@ import (
 )
 
 func init() {
-	fuzztesting.RegisterKRMFuzzer(managedKafkaTopicFuzzer())
+	fuzztesting.RegisterKRMSpecFuzzer(managedKafkaTopicFuzzer())
 }
 
 func managedKafkaTopicFuzzer() fuzztesting.KRMFuzzer {
-	f := fuzztesting.NewKRMTypedFuzzer(&pb.Topic{},
+	f := fuzztesting.NewKRMTypedSpecFuzzer(&pb.Topic{},
 		ManagedKafkaTopicSpec_FromProto, ManagedKafkaTopicSpec_ToProto,
-		nil, nil,
 	)
 
 	f.UnimplementedFields.Insert(".name") // Special Field
-
-	f.SpecFields.Insert(".partition_count")
-	f.SpecFields.Insert(".replication_factor")
-	f.SpecFields.Insert(".configs")
 
 	return f
 }

--- a/pkg/controller/direct/managedkafka/topic_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/topic_fuzzer.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.managedkafka.v1.Topic
+
+package managedkafka
+
+import (
+	pb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(managedKafkaTopicFuzzer())
+}
+
+func managedKafkaTopicFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Topic{},
+		ManagedKafkaTopicSpec_FromProto, ManagedKafkaTopicSpec_ToProto,
+		nil, nil,
+	)
+
+	f.UnimplementedFields.Insert(".name") // Special Field
+
+	f.SpecFields.Insert(".partition_count")
+	f.SpecFields.Insert(".replication_factor")
+	f.SpecFields.Insert(".configs")
+
+	return f
+}


### PR DESCRIPTION
Had to manually fix this resource because it doesn't have "ObservedState." Hopefully, the results improve as more similar examples are added.

I also updated the documentation since the tool was enhanced to prompt with the matching go type, making the "// krm.kind" marker no longer necessary.