### PR TITLE
fix: fix merge error on golden test file

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-cmek/_generated_object_managedkafkacluster-cmek.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-cmek/_generated_object_managedkafkacluster-cmek.golden.yaml
@@ -36,6 +36,5 @@ status:
   observedGeneration: 2
   observedState:
     createTime: "1970-01-01T00:00:00Z"
-    name: projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}
     state: ACTIVE
     updateTime: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
There was an error when merging my branches locally. I'm fixing it in this PR.

```
2025-02-06T06:10:23.9221606Z {"severity":"info","timestamp":"2025-02-06T06:10:23.921Z","msg":"resource is ready","kind":"ManagedKafkaCluster","name":"managedkafkacluster-mfv2jaejjrs6hsq"}
2025-02-06T06:10:23.9252813Z     utils.go:235: FAIL: unexpected diff in /home/runner/work/k8s-config-connector/k8s-config-connector/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkacluster/managedkafkacluster-cmek/_generated_object_managedkafkacluster-cmek.golden.yaml:   map[string]any{
2025-02-06T06:10:23.9254576Z           	... // 2 identical entries
2025-02-06T06:10:23.9256735Z           	"metadata": map[string]any{"finalizers": []any{string("cnrm.cloud.google.com/finalizer"), string("cnrm.cloud.google.com/deletion-defender")}, "generation": float64(2), "labels": map[string]any{"cnrm-test": string("true")}, "name": string("managedkafkacluster-${uniqueId}"), ...},
2025-02-06T06:10:23.9261752Z           	"spec":     map[string]any{"capacityConfig": map[string]any{"memoryBytes": float64(4.294967296e+09), "vcpuCount": float64(4)}, "gcpConfig": map[string]any{"accessConfig": map[string]any{"networkConfigs": []any{map[string]any{"subnetworkRef": map[string]any{"name": string("computesubnetwork-${uniqueId}")}}}}, "kmsKeyRef": map[string]any{"name": string("kmscryptokey-${uniqueId}")}}, "location": string("us-central1"), "projectRef": map[string]any{"external": string("${projectId}")}, ...},
2025-02-06T06:10:23.9263539Z           	"status": map[string]any{
2025-02-06T06:10:23.9265001Z           		"conditions":         []any{map[string]any{"lastTransitionTime": string("1970-01-01T00:00:00Z"), "message": string("The resource is up to date"), "reason": string("UpToDate"), "status": string("True"), ...}},
2025-02-06T06:10:23.9266228Z           		"externalRef":        string("projects/${projectId}/locations/us-central1/clusters/managedkafk"...),
2025-02-06T06:10:23.9267244Z           		"observedGeneration": float64(2),
2025-02-06T06:10:23.9267913Z           		"observedState": map[string]any{
2025-02-06T06:10:23.9268692Z           			"createTime": string("1970-01-01T00:00:00Z"),
2025-02-06T06:10:23.9269996Z         - 			"name":       string("projects/${projectId}/locations/us-central1/clusters/managedkafkacluster-${uniqueId}"),
2025-02-06T06:10:23.9271254Z           			"state":      string("ACTIVE"),
2025-02-06T06:10:23.9272038Z           			"updateTime": string("1970-01-01T00:00:00Z"),
2025-02-06T06:10:23.9272515Z           		},
2025-02-06T06:10:23.9273037Z           	},
2025-02-06T06:10:23.9273353Z           }
```