### PR TITLE
chore: add a missing proto annotation

### DIFF
--- a/apis/alloydb/v1beta1/instance_types.go
+++ b/apis/alloydb/v1beta1/instance_types.go
@@ -117,6 +117,7 @@ type Instance_InstanceNetworkConfig struct {
 }
 
 // AlloyDBInstanceStatus defines the config connector machine state of AlloyDBInstance
+// +kcc:proto=google.cloud.alloydb.v1beta.Instance
 type AlloyDBInstanceStatus struct {
 	/* Conditions represent the latest available observations of the
 	   object's current state. */


### PR DESCRIPTION
Although this Go struct isn’t auto generated, let’s add the proto annotation to help various LLM tools.