### PR TITLE
test: Improve fuzzer test

### DIFF
--- a/pkg/controller/direct/discoveryengine/datastoretargetsite_fuzzer.go
+++ b/pkg/controller/direct/discoveryengine/datastoretargetsite_fuzzer.go
@@ -20,30 +20,39 @@ package discoveryengine
 import (
 	pb "cloud.google.com/go/discoveryengine/apiv1/discoveryenginepb"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func init() {
-	fuzztesting.RegisterKRMFuzzer(dataStoreTargetSiteFuzzer())
+	fuzztesting.RegisterFuzzer(dataStoreTargetSiteSpecFuzzer().FuzzSpec)
+	fuzztesting.RegisterFuzzer(dataStoreTargetSiteObservedStateFuzzer().FuzzObservedState)
 }
 
-func dataStoreTargetSiteFuzzer() fuzztesting.KRMFuzzer {
+var dataStoreTargetSiteKrmFields = fuzztesting.KRMFields{
+	UnimplementedFields: sets.New(".name"),
+	SpecFields: sets.New(".exact_match",
+		".provided_uri_pattern",
+		".type"),
+	ObservedStateFields: sets.New(".generated_uri_pattern",
+		".root_domain_uri",
+		".site_verification_info",
+		".indexing_status",
+		".update_time",
+		".failure_reason"),
+}
+
+func dataStoreTargetSiteSpecFuzzer() fuzztesting.KRMFuzzer {
 	f := fuzztesting.NewKRMTypedFuzzer(&pb.TargetSite{},
 		DiscoveryEngineDataStoreTargetSiteSpec_FromProto, DiscoveryEngineDataStoreTargetSiteSpec_ToProto,
+	)
+	f.KRMFields = dataStoreTargetSiteKrmFields
+	return f
+}
+
+func dataStoreTargetSiteObservedStateFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.TargetSite{},
 		DiscoveryEngineDataStoreTargetSiteObservedState_FromProto, DiscoveryEngineDataStoreTargetSiteObservedState_ToProto,
 	)
-
-	f.UnimplementedFields.Insert(".name") // special field
-
-	f.SpecFields.Insert(".exact_match")
-	f.SpecFields.Insert(".provided_uri_pattern")
-	f.SpecFields.Insert(".type")
-
-	f.StatusFields.Insert(".generated_uri_pattern")
-	f.StatusFields.Insert(".root_domain_uri")
-	f.StatusFields.Insert(".site_verification_info")
-	f.StatusFields.Insert(".indexing_status")
-	f.StatusFields.Insert(".update_time")
-	f.StatusFields.Insert(".failure_reason")
-
+	f.KRMFields = dataStoreTargetSiteKrmFields
 	return f
 }

--- a/pkg/controller/direct/discoveryengine/engine_fuzzer.go
+++ b/pkg/controller/direct/discoveryengine/engine_fuzzer.go
@@ -20,35 +20,36 @@ package discoveryengine
 import (
 	pb "cloud.google.com/go/discoveryengine/apiv1/discoveryenginepb"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func init() {
-	fuzztesting.RegisterKRMFuzzer(engineFuzzer())
+	fuzztesting.RegisterFuzzer(engineSpecFuzzer().FuzzSpec)
 }
 
-func engineFuzzer() fuzztesting.KRMFuzzer {
+var engineKrmFields = fuzztesting.KRMFields{
+	UnimplementedFields: sets.New(
+		".chat_engine_metadata", // Could be status
+		".name",                 // special field
+		".create_time",          // Could be status
+		".update_time"),         // Could be status
+	SpecFields: sets.New(".display_name",
+		".common_config",
+		".chat_engine_config",
+		".search_engine_config",
+		".solution_type",
+		".data_store_ids",
+		".industry_vertical",
+		".disable_analytics"),
+	//ObservedStateFields: sets.New(
+	//".create_time",
+	//".update_time"),
+}
+
+func engineSpecFuzzer() fuzztesting.KRMFuzzer {
 	f := fuzztesting.NewKRMTypedFuzzer(&pb.Engine{},
 		DiscoveryEngineEngineSpec_FromProto, DiscoveryEngineEngineSpec_ToProto,
-		DiscoveryEngineEngineObservedState_FromProto, DiscoveryEngineEngineObservedState_ToProto,
 	)
-
-	f.UnimplementedFields.Insert(".chat_engine_metadata") // Could be status
-	f.UnimplementedFields.Insert(".create_time")          // Could be status
-	f.UnimplementedFields.Insert(".update_time")          // Could be status
-
-	f.UnimplementedFields.Insert(".name") // special field
-
-	f.SpecFields.Insert(".display_name")
-	f.SpecFields.Insert(".common_config")
-	f.SpecFields.Insert(".chat_engine_config")
-	f.SpecFields.Insert(".search_engine_config")
-	f.SpecFields.Insert(".solution_type")
-	f.SpecFields.Insert(".data_store_ids")
-	f.SpecFields.Insert(".industry_vertical")
-	f.SpecFields.Insert(".disable_analytics")
-
-	// f.StatusFields.Insert(".create_time")
-	// f.StatusFields.Insert(".update_time")
-
+	f.KRMFields = engineKrmFields
 	return f
 }

--- a/pkg/controller/direct/iap/iapsettings_fuzzer.go
+++ b/pkg/controller/direct/iap/iapsettings_fuzzer.go
@@ -23,13 +23,12 @@ import (
 )
 
 func init() {
-	fuzztesting.RegisterKRMSpecFuzzer(iapsettingsFuzzer())
+	fuzztesting.RegisterFuzzer(iapsettingsSpecFuzzer().FuzzSpec)
 }
 
-func iapsettingsFuzzer() fuzztesting.KRMFuzzer {
-	f := fuzztesting.NewKRMTypedSpecFuzzer(&pb.IapSettings{},
+func iapsettingsSpecFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.IapSettings{},
 		IAPSettingsSpec_FromProto, IAPSettingsSpec_ToProto,
 	)
-
 	return f
 }

--- a/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/cluster_fuzzer.go
@@ -21,30 +21,40 @@ package managedkafka
 import (
 	pb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func init() {
-	fuzztesting.RegisterKRMFuzzer(managedKafkaClusterFuzzer())
+	fuzztesting.RegisterFuzzer(managedKafkaClusterSpecFuzzer().FuzzSpec)
+	fuzztesting.RegisterFuzzer(managedKafkaClusterObservedStateFuzzer().FuzzObservedState)
 }
 
-func managedKafkaClusterFuzzer() fuzztesting.KRMFuzzer {
+var managedKafkaClusterKrmFields = fuzztesting.KRMFields{
+	UnimplementedFields: sets.New(".name",
+		".satisfies_pzi",
+		".satisfies_pzs"),
+	SpecFields: sets.New(".labels",
+		".gcp_config",
+		".capacity_config",
+		".rebalance_config"),
+	ObservedStateFields: sets.New(".create_time",
+		".create_time",
+		".update_time",
+		".state"),
+}
+
+func managedKafkaClusterSpecFuzzer() fuzztesting.KRMFuzzer {
 	f := fuzztesting.NewKRMTypedFuzzer(&pb.Cluster{},
 		ManagedKafkaClusterSpec_FromProto, ManagedKafkaClusterSpec_ToProto,
+	)
+	f.KRMFields = managedKafkaClusterKrmFields
+	return f
+}
+
+func managedKafkaClusterObservedStateFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Cluster{},
 		ManagedKafkaClusterObservedState_FromProto, ManagedKafkaClusterObservedState_ToProto,
 	)
-
-	f.UnimplementedFields.Insert(".name")
-	f.UnimplementedFields.Insert(".satisfies_pzi")
-	f.UnimplementedFields.Insert(".satisfies_pzs")
-
-	f.SpecFields.Insert(".labels")
-	f.SpecFields.Insert(".gcp_config")
-	f.SpecFields.Insert(".capacity_config")
-	f.SpecFields.Insert(".rebalance_config")
-
-	f.StatusFields.Insert(".create_time")
-	f.StatusFields.Insert(".update_time")
-	f.StatusFields.Insert(".state")
-
+	f.KRMFields = managedKafkaClusterKrmFields
 	return f
 }

--- a/pkg/controller/direct/workstations/config_controller.go
+++ b/pkg/controller/direct/workstations/config_controller.go
@@ -40,39 +40,46 @@ import (
 
 func init() {
 	registry.RegisterModel(krm.WorkstationConfigGVK, NewWorkstationConfigModel)
-	fuzztesting.RegisterKRMFuzzer(workstationConfigFuzzer())
+
+	fuzztesting.RegisterFuzzer(workstationConfigSpecFuzzer().FuzzSpec)
+	fuzztesting.RegisterFuzzer(workstationConfigObservedStateFuzzer().FuzzObservedState)
 }
 
-func workstationConfigFuzzer() fuzztesting.KRMFuzzer {
+var workstationConfigKrmFields = fuzztesting.KRMFields{
+	UnimplementedFields: sets.New(".name", ".reconciling", ".conditions"),
+	SpecFields: sets.New(".display_name",
+		".annotations",
+		".labels",
+		".idle_timeout",
+		".running_timeout",
+		".host",
+		".persistent_directories",
+		".container",
+		".encryption_key",
+		".readiness_checks",
+		".replica_zones"),
+	ObservedStateFields: sets.New(".uid",
+		".create_time",
+		".update_time",
+		".delete_time",
+		".etag",
+		".host.gce_instance.pooled_instances",
+		".degraded"),
+}
+
+func workstationConfigSpecFuzzer() fuzztesting.KRMFuzzer {
 	f := fuzztesting.NewKRMTypedFuzzer(&pb.WorkstationConfig{},
 		WorkstationConfigSpec_FromProto, WorkstationConfigSpec_ToProto,
+	)
+	f.KRMFields = workstationConfigKrmFields
+	return f
+}
+
+func workstationConfigObservedStateFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.WorkstationConfig{},
 		WorkstationConfigObservedState_FromProto, WorkstationConfigObservedState_ToProto,
 	)
-
-	f.UnimplementedFields.Insert(".name")
-	f.UnimplementedFields.Insert(".reconciling")
-	f.UnimplementedFields.Insert(".conditions")
-
-	f.SpecFields.Insert(".display_name")
-	f.SpecFields.Insert(".annotations")
-	f.SpecFields.Insert(".labels")
-	f.SpecFields.Insert(".idle_timeout")
-	f.SpecFields.Insert(".running_timeout")
-	f.SpecFields.Insert(".host")
-	f.SpecFields.Insert(".persistent_directories")
-	f.SpecFields.Insert(".container")
-	f.SpecFields.Insert(".encryption_key")
-	f.SpecFields.Insert(".readiness_checks")
-	f.SpecFields.Insert(".replica_zones")
-
-	f.StatusFields.Insert(".uid")
-	f.StatusFields.Insert(".create_time")
-	f.StatusFields.Insert(".update_time")
-	f.StatusFields.Insert(".delete_time")
-	f.StatusFields.Insert(".etag")
-	f.StatusFields.Insert(".host.gce_instance.pooled_instances")
-	f.StatusFields.Insert(".degraded")
-
+	f.KRMFields = workstationConfigKrmFields
 	return f
 }
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Currently fuzzer test requires both Spec and ObservedState exist([code](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/7cd1b21e1d1e790d0c17108eb9b435a80332666a/pkg/fuzztesting/fuzzkrm.go#L72-L73)), and does not cover the Status fields.

This [function](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/7cd1b21e1d1e790d0c17108eb9b435a80332666a/pkg/fuzztesting/fuzzkrm.go#L105) is added for object that only has Spec fields, no Status or ObservedState fields.

For some resources(i.e. CloudIdentityGroup), it's possible that the object has Spec, Status and ObservedState fields, and some resources they only have Spec fields. Improve the fuzzer test to be able to test Spec, Status, and ObservedState Individually. 

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

Verified locally, test failed when I comment out certain fields in mapper.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
