### PR TITLE
test: fix list fields detection in TestCRDFieldPresenceInUnstructured

### DIFF
--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -5,7 +5,6 @@
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].devicePolicy.osConstraints[].osType" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].devicePolicy.osConstraints[].requireVerifiedChromeOs" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].devicePolicy.requireAdminApproval" is not set in unstructured objects
-[missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].devicePolicy.requireCorpOwned" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].devicePolicy.requireScreenLock" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].ipSubnetworks[]" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.basic.conditions[].members[].serviceAccountRef" is not set; neither 'external' nor 'name' are set
@@ -20,36 +19,23 @@
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.custom.expr.location" is not set in unstructured objects
 [missing_field] crd=accesscontextmanageraccesslevels.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.custom.expr.title" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.accessLevels[].external" is not set in unstructured objects
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.accessLevels[].name" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.accessLevels[].namespace" is not set in unstructured objects
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressFrom.identities[].serviceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressFrom.identities[].user" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressFrom.identityType" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressTo.externalResources[]" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressTo.operations[].methodSelectors[].method" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressTo.operations[].methodSelectors[].permission" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressTo.operations[].serviceName" is not set in unstructured objects
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.egressPolicies[].egressTo.resources[].projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressFrom.identities[].serviceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressFrom.identities[].user" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressFrom.identityType" is not set in unstructured objects
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressFrom.sources[].accessLevelRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressFrom.sources[].projectRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressTo.operations[].methodSelectors[].method" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressTo.operations[].methodSelectors[].permission" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressTo.operations[].serviceName" is not set in unstructured objects
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.ingressPolicies[].ingressTo.resources[].projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.resources[].projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.restrictedServices[]" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.vpcAccessibleServices.allowedServices[]" is not set in unstructured objects
 [missing_field] crd=accesscontextmanagerserviceperimeters.accesscontextmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.vpcAccessibleServices.enableRestriction" is not set in unstructured objects
 [missing_field] crd=alloydbbackups.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.encryptionConfig.kmsKeyName" is not set in unstructured objects
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.quantityBasedRetention.count" is not set in unstructured objects
-[missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.weeklySchedule.daysOfWeek[]" is not set in unstructured objects
-[missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.weeklySchedule.startTimes[].hours" is not set in unstructured objects
-[missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.weeklySchedule.startTimes[].minutes" is not set in unstructured objects
-[missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.weeklySchedule.startTimes[].nanos" is not set in unstructured objects
-[missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.automatedBackupPolicy.weeklySchedule.startTimes[].seconds" is not set in unstructured objects
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.continuousBackupConfig.encryptionConfig.kmsKeyNameRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.continuousBackupConfig.recoveryWindowDays" is not set in unstructured objects
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.initialUser.password.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set
@@ -62,10 +48,6 @@
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.restoreContinuousBackupSource.clusterRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=alloydbclusters.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.restoreContinuousBackupSource.pointInTime" is not set in unstructured objects
 [missing_field] crd=alloydbinstances.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.gceZone" is not set in unstructured objects
-[missing_field] crd=alloydbinstances.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.networkConfig.authorizedExternalNetworks[].cidrRange" is not set in unstructured objects
-[missing_field] crd=alloydbusers.alloydb.cnrm.cloud.google.com version=v1beta1: field ".spec.databaseRoles[]" is not set in unstructured objects
-[missing_field] crd=apigeeenvgroups.apigee.cnrm.cloud.google.com version=v1beta1: field ".spec.hostnames[]" is not set in unstructured objects
-[missing_field] crd=apigeeinstances.apigee.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerAcceptList[]" is not set in unstructured objects
 [missing_field] crd=apigeeorganizations.apigee.cnrm.cloud.google.com version=v1beta1: field ".spec.runtimeDatabaseEncryptionKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.cleanupPolicies[].action" is not set in unstructured objects
 [missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.cleanupPolicies[].condition.newerThan" is not set in unstructured objects
@@ -86,10 +68,6 @@
 [missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.remoteRepositoryConfig.mavenRepository.publicRepository" is not set in unstructured objects
 [missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.remoteRepositoryConfig.npmRepository.publicRepository" is not set in unstructured objects
 [missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.remoteRepositoryConfig.pythonRepository.publicRepository" is not set in unstructured objects
-[missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.virtualRepositoryConfig.upstreamPolicies[].id" is not set in unstructured objects
-[missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.virtualRepositoryConfig.upstreamPolicies[].priority" is not set in unstructured objects
-[missing_field] crd=artifactregistryrepositories.artifactregistry.cnrm.cloud.google.com version=v1beta1: field ".spec.virtualRepositoryConfig.upstreamPolicies[].repositoryRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com version=v1beta1: field ".spec.categories[]" is not set in unstructured objects
 [missing_field] crd=bigqueryanalyticshublistings.bigqueryanalyticshub.cnrm.cloud.google.com version=v1beta1: field ".spec.source.bigQueryDatasetSource.selectedResources[].tableRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=bigqueryconnectionconnections.bigqueryconnection.cnrm.cloud.google.com version=v1beta1: field ".spec.cloudSpanner.useServerlessAnalytics" is not set in unstructured objects
 [missing_field] crd=bigqueryconnectionconnections.bigqueryconnection.cnrm.cloud.google.com version=v1beta1: field ".spec.spark.metastoreService.metastoreServiceRef" is not set; neither 'external' nor 'name' are set
@@ -97,15 +75,10 @@
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].dataset.dataset.datasetId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].dataset.dataset.projectId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].dataset.targetTypes[]" is not set in unstructured objects
-[missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].domain" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].groupByEmail" is not set in unstructured objects
-[missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].iamMember" is not set in unstructured objects
-[missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].role" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].routine.datasetId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].routine.projectId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].routine.routineId" is not set in unstructured objects
-[missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].specialGroup" is not set in unstructured objects
-[missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].userByEmail" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].view.datasetId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].view.projectId" is not set in unstructured objects
 [missing_field] crd=bigquerydatasets.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.access[].view.tableId" is not set in unstructured objects
@@ -163,14 +136,10 @@
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.maximumBillingTier" is not set in unstructured objects
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.maximumBytesBilled" is not set in unstructured objects
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.parameterMode" is not set in unstructured objects
-[missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.schemaUpdateOptions[]" is not set in unstructured objects
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.scriptOptions.statementByteBudget" is not set in unstructured objects
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.userDefinedFunctionResources[].inlineCode" is not set in unstructured objects
 [missing_field] crd=bigqueryjobs.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.query.userDefinedFunctionResources[].resourceUri" is not set in unstructured objects
-[missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.arguments[].argumentKind" is not set in unstructured objects
-[missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.arguments[].dataType" is not set in unstructured objects
 [missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.arguments[].mode" is not set in unstructured objects
-[missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.arguments[].name" is not set in unstructured objects
 [missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.importedLibraries[]" is not set in unstructured objects
 [missing_field] crd=bigqueryroutines.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.returnTableType" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.clustering[]" is not set in unstructured objects
@@ -201,7 +170,6 @@
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.externalDataConfiguration.parquetOptions.enumAsString" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.externalDataConfiguration.referenceFileSchemaUri" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.externalDataConfiguration.schema" is not set in unstructured objects
-[missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.externalDataConfiguration.sourceUris[]" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.materializedView.allowNonIncrementalDefinition" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.materializedView.query" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.materializedView.refreshIntervalMs" is not set in unstructured objects
@@ -222,52 +190,29 @@
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.timePartitioning.type" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.view.query" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.view.useLegacySql" is not set in unstructured objects
-[missing_field] crd=bigtableappprofiles.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.multiClusterRoutingClusterIds[]" is not set in unstructured objects
 [missing_field] crd=bigtablegcpolicies.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.maxAge[].days" is not set in unstructured objects
 [missing_field] crd=bigtablegcpolicies.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.maxAge[].duration" is not set in unstructured objects
 [missing_field] crd=bigtablegcpolicies.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.maxVersion[].number" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].autoscalingConfig.cpuTarget" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].autoscalingConfig.maxNodes" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].autoscalingConfig.minNodes" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].autoscalingConfig.storageTarget" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].clusterId" is not set in unstructured objects
 [missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].kmsKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].numNodes" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].storageType" is not set in unstructured objects
-[missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.cluster[].zone" is not set in unstructured objects
 [missing_field] crd=bigtableinstances.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.deletionProtection" is not set in unstructured objects
 [missing_field] crd=bigtabletables.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.changeStreamRetention" is not set in unstructured objects
-[missing_field] crd=bigtabletables.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.columnFamily[].family" is not set in unstructured objects
 [missing_field] crd=bigtabletables.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.deletionProtection" is not set in unstructured objects
-[missing_field] crd=bigtabletables.bigtable.cnrm.cloud.google.com version=v1beta1: field ".spec.splitKeys[]" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.allUpdatesRule.monitoringNotificationChannels[].external" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.allUpdatesRule.monitoringNotificationChannels[].name" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.allUpdatesRule.monitoringNotificationChannels[].namespace" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.creditTypes[]" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.projects[].external" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.projects[].name" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.projects[].namespace" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.services[]" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.subaccounts[].external" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.subaccounts[].name" is not set in unstructured objects
 [missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.budgetFilter.subaccounts[].namespace" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.thresholdRules[].spendBasis" is not set in unstructured objects
-[missing_field] crd=billingbudgetsbudgets.billingbudgets.cnrm.cloud.google.com version=v1beta1: field ".spec.thresholdRules[].thresholdPercent" is not set in unstructured objects
 [missing_field] crd=binaryauthorizationattestors.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.userOwnedDrydockNote.publicKeys[].asciiArmoredPgpPublicKey" is not set in unstructured objects
-[missing_field] crd=binaryauthorizationattestors.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.userOwnedDrydockNote.publicKeys[].comment" is not set in unstructured objects
 [missing_field] crd=binaryauthorizationattestors.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.userOwnedDrydockNote.publicKeys[].id" is not set in unstructured objects
-[missing_field] crd=binaryauthorizationattestors.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.userOwnedDrydockNote.publicKeys[].pkixPublicKey.publicKeyPem" is not set in unstructured objects
-[missing_field] crd=binaryauthorizationattestors.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.userOwnedDrydockNote.publicKeys[].pkixPublicKey.signatureAlgorithm" is not set in unstructured objects
-[missing_field] crd=binaryauthorizationpolicies.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.admissionWhitelistPatterns[].namePattern" is not set in unstructured objects
 [missing_field] crd=binaryauthorizationpolicies.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultAdmissionRule.requireAttestationsBy[].external" is not set in unstructured objects
-[missing_field] crd=binaryauthorizationpolicies.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultAdmissionRule.requireAttestationsBy[].name" is not set in unstructured objects
 [missing_field] crd=binaryauthorizationpolicies.binaryauthorization.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultAdmissionRule.requireAttestationsBy[].namespace" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificatemapentries.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.hostname" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.authorizationAttemptInfo[].details" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.authorizationAttemptInfo[].domain" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.authorizationAttemptInfo[].failureReason" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.authorizationAttemptInfo[].state" is not set in unstructured objects
-[missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.domains[]" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.issuanceConfigRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.provisioningIssue[].details" is not set in unstructured objects
 [missing_field] crd=certificatemanagercertificates.certificatemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.provisioningIssue[].reason" is not set in unstructured objects
@@ -292,9 +237,6 @@
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.artifacts.objects.paths[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.artifacts.objects.timing[].endTime" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.artifacts.objects.timing[].startTime" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.availableSecrets.secretManager[].env" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.availableSecrets.secretManager[].versionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.images[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.logsBucketRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.options.diskSizeGb" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.options.dynamicSubstitutions" is not set in unstructured objects
@@ -323,20 +265,12 @@
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.source.storageSource.object" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].allowExitCodes[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].allowFailure" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].args[]" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].dir" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].entrypoint" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].env[]" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].id" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].name" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].script" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].secretEnv[]" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].timeout" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].timing" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].volumes[].name" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].volumes[].path" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.step[].waitFor[]" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.build.tags[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.filename" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.gitFileSource.bitbucketServerConfigRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.gitFileSource.githubEnterpriseConfigRef" is not set; neither 'external' nor 'name' are set
@@ -354,9 +288,7 @@
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.github.push.branch" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.github.push.invertRegex" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.github.push.tag" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.ignoredFiles[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.includeBuildLogs" is not set in unstructured objects
-[missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.includedFiles[]" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfig.serviceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfig.state" is not set in unstructured objects
 [missing_field] crd=cloudbuildtriggers.cloudbuild.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfig.subscription" is not set in unstructured objects
@@ -383,10 +315,7 @@
 [missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.memberKey.id" is not set in unstructured objects
 [missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.memberKey.namespace" is not set in unstructured objects
 [missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.preferredMemberKey.namespace" is not set in unstructured objects
-[missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.roles[].expiryDetail.expireTime" is not set in unstructured objects
-[missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.roles[].name" is not set in unstructured objects
 [missing_field] crd=cloudidentitymemberships.cloudidentity.cnrm.cloud.google.com version=v1beta1: field ".spec.roles[].restrictionEvaluations.memberRestrictionEvaluation.state" is not set in unstructured objects
-[missing_field] crd=cloudidsendpoints.cloudids.cnrm.cloud.google.com version=v1beta1: field ".spec.threatExceptions[]" is not set in unstructured objects
 [missing_field] crd=cloudschedulerjobs.cloudscheduler.cnrm.cloud.google.com version=v1beta1: field ".spec.appEngineHttpTarget.appEngineRouting.instance" is not set in unstructured objects
 [missing_field] crd=cloudschedulerjobs.cloudscheduler.cnrm.cloud.google.com version=v1beta1: field ".spec.appEngineHttpTarget.appEngineRouting.service" is not set in unstructured objects
 [missing_field] crd=cloudschedulerjobs.cloudscheduler.cnrm.cloud.google.com version=v1beta1: field ".spec.appEngineHttpTarget.appEngineRouting.version" is not set in unstructured objects
@@ -429,7 +358,6 @@
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].capacityScaler" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].description" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].failover" is not set in unstructured objects
-[missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].group.instanceGroupRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].group.networkEndpointGroupRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].maxConnections" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.backend[].maxConnectionsPerEndpoint" is not set in unstructured objects
@@ -480,8 +408,6 @@
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.failoverPolicy.disableConnectionDrainOnFailover" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.failoverPolicy.dropTrafficIfUnhealthy" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.failoverPolicy.failoverRatio" is not set in unstructured objects
-[missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.healthChecks[].healthCheckRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.healthChecks[].httpHealthCheckRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.iap.oauth2ClientSecretSha256" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.localityLbPolicies[].customPolicy.data" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.localityLbPolicies[].customPolicy.name" is not set in unstructured objects
@@ -505,7 +431,6 @@
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.portName" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.securityPolicy" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.securityPolicyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.securitySettings.subjectAltNames[]" is not set in unstructured objects
 [missing_field] crd=computebackendservices.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.subsetting.policy" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.asyncPrimaryDisk.diskRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.diskEncryptionKey.kmsKeyRef" is not set; neither 'external' nor 'name' are set
@@ -523,7 +448,6 @@
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.physicalBlockSizeBytes" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.provisionedIops" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.provisionedThroughput" is not set in unstructured objects
-[missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaZones[]" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.resourcePolicies[].external" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.resourcePolicies[].name" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.resourcePolicies[].namespace" is not set in unstructured objects
@@ -536,28 +460,10 @@
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceSnapshotEncryptionKey.kmsKeyServiceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceSnapshotEncryptionKey.rawKey" is not set in unstructured objects
 [missing_field] crd=computedisks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceSnapshotEncryptionKey.sha256" is not set in unstructured objects
-[missing_field] crd=computeexternalvpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.interface[].id" is not set in unstructured objects
-[missing_field] crd=computeexternalvpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.interface[].ipAddress" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.destAddressGroups[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.destFqdns[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.destIPRanges[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.destRegionCodes[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.destThreatIntelligences[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.layer4Configs[].ipProtocol" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.layer4Configs[].ports[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.srcAddressGroups[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.srcFqdns[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.srcIPRanges[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.srcRegionCodes[]" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.match.srcThreatIntelligences[]" is not set in unstructured objects
 [missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetResources[].external" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetResources[].name" is not set in unstructured objects
 [missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetResources[].namespace" is not set in unstructured objects
 [missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].external" is not set in unstructured objects
-[missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].name" is not set in unstructured objects
 [missing_field] crd=computefirewallpolicyrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].namespace" is not set in unstructured objects
-[missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.allow[].ports[]" is not set in unstructured objects
-[missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.allow[].protocol" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.deny[].ports[]" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.deny[].protocol" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.destinationRanges[]" is not set in unstructured objects
@@ -568,14 +474,9 @@
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceServiceAccounts[].namespace" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceTags[]" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].external" is not set in unstructured objects
-[missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].name" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetServiceAccounts[].namespace" is not set in unstructured objects
 [missing_field] crd=computefirewalls.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.targetTags[]" is not set in unstructured objects
-[missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadataFilters[].filterLabels[].name" is not set in unstructured objects
-[missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadataFilters[].filterLabels[].value" is not set in unstructured objects
-[missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadataFilters[].filterMatchCriteria" is not set in unstructured objects
 [missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.noAutomateDnsZone" is not set in unstructured objects
-[missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.ports[]" is not set in unstructured objects
 [missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceDirectoryRegistrations[].namespace" is not set in unstructured objects
 [missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceDirectoryRegistrations[].service" is not set in unstructured objects
 [missing_field] crd=computeforwardingrules.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceIpRanges[]" is not set in unstructured objects
@@ -627,8 +528,6 @@
 [missing_field] crd=computeimages.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceImageRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeimages.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sourceSnapshotRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeimages.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.storageLocations[]" is not set in unstructured objects
-[missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.autoHealingPolicies[].healthCheckRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.autoHealingPolicies[].initialDelaySec" is not set in unstructured objects
 [missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.distributionPolicy.targetShape" is not set in unstructured objects
 [missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.distributionPolicy.zones[].zone" is not set in unstructured objects
 [missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.failoverAction" is not set in unstructured objects
@@ -649,10 +548,7 @@
 [missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.versions[].targetSize.fixed" is not set in unstructured objects
 [missing_field] crd=computeinstancegroupmanagers.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.versions[].targetSize.percent" is not set in unstructured objects
 [missing_field] crd=computeinstancegroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].external" is not set in unstructured objects
-[missing_field] crd=computeinstancegroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].name" is not set in unstructured objects
 [missing_field] crd=computeinstancegroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].namespace" is not set in unstructured objects
-[missing_field] crd=computeinstancegroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.namedPort[].name" is not set in unstructured objects
-[missing_field] crd=computeinstancegroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.namedPort[].port" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedMachineFeatures.enableNestedVirtualization" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedMachineFeatures.threadsPerCore" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedMachineFeatures.visibleCoreCount" is not set in unstructured objects
@@ -662,7 +558,6 @@
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.attachedDisk[].diskEncryptionKeySha256" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.attachedDisk[].kmsKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.attachedDisk[].mode" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.attachedDisk[].sourceDiskRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.bootDisk.deviceName" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.bootDisk.diskEncryptionKeyRaw.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.bootDisk.diskEncryptionKeySha256" is not set in unstructured objects
@@ -677,11 +572,7 @@
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.guestAccelerator[].count" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.guestAccelerator[].type" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.hostname" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadata[].key" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadata[].value" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.minCpuPlatform" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].natIpRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].networkTier" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].publicPtrDomainName" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].aliasIpRange[].ipCidrRange" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].aliasIpRange[].subnetworkRangeName" is not set in unstructured objects
@@ -694,14 +585,10 @@
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].ipv6AccessType" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].ipv6Address" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].name" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkIp" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkIpRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].nicType" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].queueCount" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].stackType" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].subnetworkProject" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].subnetworkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPerformanceConfig.totalEgressBandwidthTier" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.reservationAffinity.specificReservation.key" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.reservationAffinity.specificReservation.values[]" is not set in unstructured objects
@@ -719,7 +606,6 @@
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scheduling.provisioningModel" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scratchDisk[].interface" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scratchDisk[].size" is not set in unstructured objects
-[missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceAccount.scopes[]" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableIntegrityMonitoring" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableSecureBoot" is not set in unstructured objects
 [missing_field] crd=computeinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableVtpm" is not set in unstructured objects
@@ -728,8 +614,6 @@
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedMachineFeatures.threadsPerCore" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedMachineFeatures.visibleCoreCount" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.confidentialInstanceConfig.enableConfidentialCompute" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].autoDelete" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].boot" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].deviceName" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].diskEncryptionKey.kmsKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].diskName" is not set in unstructured objects
@@ -741,10 +625,8 @@
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].resourcePolicies[].external" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].resourcePolicies[].name" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].resourcePolicies[].namespace" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceDiskRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceImageEncryptionKey.kmsKeySelfLinkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceImageEncryptionKey.kmsKeyServiceAccountRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceImageRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceSnapshotEncryptionKey.kmsKeySelfLinkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceSnapshotEncryptionKey.kmsKeyServiceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.disk[].sourceSnapshotRef" is not set; neither 'external' nor 'name' are set
@@ -753,12 +635,8 @@
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.guestAccelerator[].count" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.guestAccelerator[].type" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instanceDescription" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadata[].key" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.metadata[].value" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.minCpuPlatform" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.namePrefix" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].natIpRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].networkTier" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].accessConfig[].publicPtrDomainName" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].aliasIpRange[].ipCidrRange" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].aliasIpRange[].subnetworkRangeName" is not set in unstructured objects
@@ -772,13 +650,10 @@
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].ipv6Address" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].name" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkAttachment" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkIp" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].nicType" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].queueCount" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].stackType" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].subnetworkProject" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkInterface[].subnetworkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPerformanceConfig.totalEgressBandwidthTier" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.reservationAffinity.specificReservation.key" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.reservationAffinity.specificReservation.values[]" is not set in unstructured objects
@@ -794,7 +669,6 @@
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scheduling.maxRunDuration.seconds" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scheduling.minNodeCpus" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.scheduling.provisioningModel" is not set in unstructured objects
-[missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceAccount.scopes[]" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableIntegrityMonitoring" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableSecureBoot" is not set in unstructured objects
 [missing_field] crd=computeinstancetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.shieldedInstanceConfig.enableVtpm" is not set in unstructured objects
@@ -806,7 +680,6 @@
 [missing_field] crd=computeinterconnectattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.ipsecInternalAddresses[].name" is not set in unstructured objects
 [missing_field] crd=computeinterconnectattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.ipsecInternalAddresses[].namespace" is not set in unstructured objects
 [missing_field] crd=computeinterconnectattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.vlanTag8021q" is not set in unstructured objects
-[missing_field] crd=computemanagedsslcertificates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.managed.domains[]" is not set in unstructured objects
 [missing_field] crd=computenetworkpeerings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.exportSubnetRoutesWithPublicIp" is not set in unstructured objects
 [missing_field] crd=computenetworkpeerings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.importSubnetRoutesWithPublicIp" is not set in unstructured objects
 [missing_field] crd=computenetworkpeerings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.stackType" is not set in unstructured objects
@@ -826,10 +699,7 @@
 [missing_field] crd=computenodetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeTypeFlexibility.localSsd" is not set in unstructured objects
 [missing_field] crd=computenodetemplates.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.serverBinding.type" is not set in unstructured objects
 [missing_field] crd=computepacketmirrorings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.mirroredResources.instances[].canonicalUrl" is not set in unstructured objects
-[missing_field] crd=computepacketmirrorings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.mirroredResources.instances[].urlRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computepacketmirrorings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.mirroredResources.subnetworks[].canonicalUrl" is not set in unstructured objects
-[missing_field] crd=computepacketmirrorings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.mirroredResources.subnetworks[].urlRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computepacketmirrorings.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.mirroredResources.tags[]" is not set in unstructured objects
 [missing_field] crd=computeregionnetworkendpointgroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.cloudFunction.urlMask" is not set in unstructured objects
 [missing_field] crd=computeregionnetworkendpointgroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.cloudRun.tag" is not set in unstructured objects
 [missing_field] crd=computeregionnetworkendpointgroups.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.cloudRun.urlMask" is not set in unstructured objects
@@ -854,7 +724,6 @@
 [missing_field] crd=computeresourcepolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.snapshotSchedulePolicy.schedule.weeklySchedule.dayOfWeeks[].day" is not set in unstructured objects
 [missing_field] crd=computeresourcepolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.snapshotSchedulePolicy.schedule.weeklySchedule.dayOfWeeks[].startTime" is not set in unstructured objects
 [missing_field] crd=computeresourcepolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.snapshotSchedulePolicy.snapshotProperties.chainName" is not set in unstructured objects
-[missing_field] crd=computeresourcepolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.snapshotSchedulePolicy.snapshotProperties.storageLocations[]" is not set in unstructured objects
 [missing_field] crd=computerouterinterfaces.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.interconnectAttachmentRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computerouterinterfaces.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.privateIpAddressRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computerouterinterfaces.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.redundantInterfaceRef" is not set; neither 'external' nor 'name' are set
@@ -869,14 +738,8 @@
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.maxPortsPerVm" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.minPortsPerVm" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natIps[].external" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natIps[].name" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natIps[].namespace" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].description" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].match" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].ruleNumber" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.subnetwork[].secondaryIpRangeNames[]" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.subnetwork[].sourceIpRangesToNat[]" is not set in unstructured objects
-[missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.subnetwork[].subnetworkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.tcpEstablishedIdleTimeoutSec" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.tcpTimeWaitTimeoutSec" is not set in unstructured objects
 [missing_field] crd=computerouternats.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.tcpTransitoryIdleTimeoutSec" is not set in unstructured objects
@@ -915,13 +778,10 @@
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedOptionsConfig.logLevel" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.advancedOptionsConfig.userIpRequestHeaders[]" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.recaptchaOptionsConfig.redirectSiteKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].action" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].description" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].headerAction.requestHeadersToAdds[].headerName" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].headerAction.requestHeadersToAdds[].headerValue" is not set in unstructured objects
-[missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].match.config.srcIpRanges[]" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].match.expr.expression" is not set in unstructured objects
-[missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].match.versionedExpr" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].requestCookie[].operator" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].requestCookie[].value" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].requestHeader[].operator" is not set in unstructured objects
@@ -932,8 +792,6 @@
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].requestUri[].value" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].targetRuleIds[]" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preconfiguredWafConfig.exclusion[].targetRuleSet" is not set in unstructured objects
-[missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].preview" is not set in unstructured objects
-[missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].priority" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].rateLimitOptions.banDurationSec" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].rateLimitOptions.banThreshold.count" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].rateLimitOptions.banThreshold.intervalSec" is not set in unstructured objects
@@ -949,13 +807,9 @@
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].rateLimitOptions.rateLimitThreshold.intervalSec" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].redirectOptions.target" is not set in unstructured objects
 [missing_field] crd=computesecuritypolicies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.rule[].redirectOptions.type" is not set in unstructured objects
-[missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerAcceptLists[].connectionLimit" is not set in unstructured objects
-[missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerAcceptLists[].projectRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerRejectLists[].external" is not set in unstructured objects
-[missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerRejectLists[].name" is not set in unstructured objects
 [missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.consumerRejectLists[].namespace" is not set in unstructured objects
 [missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natSubnets[].external" is not set in unstructured objects
-[missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natSubnets[].name" is not set in unstructured objects
 [missing_field] crd=computeserviceattachments.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natSubnets[].namespace" is not set in unstructured objects
 [missing_field] crd=computesnapshots.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.chainName" is not set in unstructured objects
 [missing_field] crd=computesnapshots.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.snapshotEncryptionKey.kmsKeyRef" is not set; neither 'external' nor 'name' are set
@@ -980,22 +834,17 @@
 [missing_field] crd=computesubnetworks.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.stackType" is not set in unstructured objects
 [missing_field] crd=computetargethttpproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.httpKeepAliveTimeoutSec" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.certificateManagerCertificates[].external" is not set in unstructured objects
-[missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.certificateManagerCertificates[].name" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.certificateManagerCertificates[].namespace" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.httpKeepAliveTimeoutSec" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].external" is not set in unstructured objects
-[missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].name" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].namespace" is not set in unstructured objects
 [missing_field] crd=computetargethttpsproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computetargetinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.natPolicy" is not set in unstructured objects
 [missing_field] crd=computetargetinstances.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.securityPolicyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computetargetpools.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.healthChecks[].httpHealthCheckRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computetargetpools.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].external" is not set in unstructured objects
-[missing_field] crd=computetargetpools.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].name" is not set in unstructured objects
 [missing_field] crd=computetargetpools.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.instances[].namespace" is not set in unstructured objects
 [missing_field] crd=computetargetpools.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.securityPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computetargetsslproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].external" is not set in unstructured objects
-[missing_field] crd=computetargetsslproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].name" is not set in unstructured objects
 [missing_field] crd=computetargetsslproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslCertificates[].namespace" is not set in unstructured objects
 [missing_field] crd=computetargetsslproxies.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.sslPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultRouteAction.corsPolicy.allowCredentials" is not set in unstructured objects
@@ -1046,8 +895,6 @@
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.headerAction.responseHeadersToAdd[].replace" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.headerAction.responseHeadersToRemove[]" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.hostRule[].description" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.hostRule[].hosts[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.hostRule[].pathMatcher" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.corsPolicy.allowCredentials" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.corsPolicy.allowHeaders[]" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.corsPolicy.allowMethods[]" is not set in unstructured objects
@@ -1080,8 +927,6 @@
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.weightedBackendServices[].headerAction.responseHeadersToAdd[].replace" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.weightedBackendServices[].headerAction.responseHeadersToRemove[]" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultRouteAction.weightedBackendServices[].weight" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultService.backendBucketRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultService.backendServiceRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultUrlRedirect.hostRedirect" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultUrlRedirect.httpsRedirect" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].defaultUrlRedirect.pathRedirect" is not set in unstructured objects
@@ -1097,40 +942,8 @@
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].headerAction.responseHeadersToAdd[].headerValue" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].headerAction.responseHeadersToAdd[].replace" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].headerAction.responseHeadersToRemove[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].name" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].paths[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.allowCredentials" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.allowHeaders[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.allowMethods[]" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.allowOriginRegexes[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.allowOrigins[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.disabled" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.exposeHeaders[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.corsPolicy.maxAge" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.faultInjectionPolicy.abort.httpStatus" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.faultInjectionPolicy.abort.percentage" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.faultInjectionPolicy.delay.fixedDelay.nanos" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.faultInjectionPolicy.delay.fixedDelay.seconds" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.faultInjectionPolicy.delay.percentage" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.requestMirrorPolicy.backendServiceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.retryPolicy.numRetries" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.retryPolicy.perTryTimeout.nanos" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.retryPolicy.perTryTimeout.seconds" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.retryPolicy.retryConditions[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.timeout.nanos" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.timeout.seconds" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.urlRewrite.hostRewrite" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.urlRewrite.pathPrefixRewrite" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].backendServiceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.requestHeadersToAdd[].headerName" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.requestHeadersToAdd[].headerValue" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.requestHeadersToAdd[].replace" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.requestHeadersToRemove[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.responseHeadersToAdd[].headerName" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.responseHeadersToAdd[].headerValue" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.responseHeadersToAdd[].replace" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].headerAction.responseHeadersToRemove[]" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].routeAction.weightedBackendServices[].weight" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].service.backendBucketRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].service.backendServiceRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].pathRule[].urlRedirect.hostRedirect" is not set in unstructured objects
@@ -1210,16 +1023,12 @@
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].routeRules[].urlRedirect.redirectResponseCode" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.pathMatcher[].routeRules[].urlRedirect.stripQuery" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.test[].description" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.test[].host" is not set in unstructured objects
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.test[].path" is not set in unstructured objects
 [missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.test[].service.backendBucketRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computeurlmaps.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.test[].service.backendServiceRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computevpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.stackType" is not set in unstructured objects
 [missing_field] crd=computevpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.vpnInterfaces[].id" is not set in unstructured objects
 [missing_field] crd=computevpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.vpnInterfaces[].interconnectAttachmentRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computevpngateways.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.vpnInterfaces[].ipAddress" is not set in unstructured objects
 [missing_field] crd=computevpntunnels.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.ikeVersion" is not set in unstructured objects
-[missing_field] crd=computevpntunnels.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.localTrafficSelector[]" is not set in unstructured objects
 [missing_field] crd=computevpntunnels.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.peerExternalGatewayInterface" is not set in unstructured objects
 [missing_field] crd=computevpntunnels.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.peerExternalGatewayRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computevpntunnels.compute.cnrm.cloud.google.com version=v1beta1: field ".spec.peerGCPGatewayRef" is not set; neither 'external' nor 'name' are set
@@ -1269,8 +1078,6 @@
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.relatedNoteNames[].external" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.relatedNoteNames[].name" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.relatedNoteNames[].namespace" is not set in unstructured objects
-[missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.relatedUrl[].label" is not set in unstructured objects
-[missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.relatedUrl[].url" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.cvssScore" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.cvssV3.attackComplexity" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.cvssV3.attackVector" is not set in unstructured objects
@@ -1314,9 +1121,7 @@
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.windowsDetails[].fixingKbs[].name" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.windowsDetails[].fixingKbs[].url" is not set in unstructured objects
 [missing_field] crd=containeranalysisnotes.containeranalysis.cnrm.cloud.google.com version=v1beta1: field ".spec.vulnerability.windowsDetails[].name" is not set in unstructured objects
-[missing_field] crd=containerattachedclusters.containerattached.cnrm.cloud.google.com version=v1beta1: field ".spec.authorization.adminUsers[]" is not set in unstructured objects
 [missing_field] crd=containerattachedclusters.containerattached.cnrm.cloud.google.com version=v1beta1: field ".spec.fleet.membership" is not set in unstructured objects
-[missing_field] crd=containerattachedclusters.containerattached.cnrm.cloud.google.com version=v1beta1: field ".spec.loggingConfig.componentConfig.enableComponents[]" is not set in unstructured objects
 [missing_field] crd=containerattachedclusters.containerattached.cnrm.cloud.google.com version=v1beta1: field ".spec.oidcConfig.jwks" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.allowNetAdmin" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.authenticatorGroupsConfig.securityGroup" is not set in unstructured objects
@@ -1339,9 +1144,6 @@
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.autoProvisioningDefaults.upgradeSettings.maxSurge" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.autoProvisioningDefaults.upgradeSettings.maxUnavailable" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.autoProvisioningDefaults.upgradeSettings.strategy" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.resourceLimits[].maximum" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.resourceLimits[].minimum" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterAutoscaling.resourceLimits[].resourceType" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterIpv4Cidr" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.clusterTelemetry.type" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.confidentialNodes.enabled" is not set in unstructured objects
@@ -1372,7 +1174,6 @@
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.ipAllocationPolicy.podCidrOverprovisionConfig.disabled" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.ipAllocationPolicy.servicesSecondaryRangeName" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.ipAllocationPolicy.stackType" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.loggingConfig.enableComponents[]" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.dailyMaintenanceWindow.duration" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.dailyMaintenanceWindow.startTime" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.maintenanceExclusion[].endTime" is not set in unstructured objects
@@ -1396,7 +1197,6 @@
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.minMasterVersion" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.monitoringConfig.advancedDatapathObservabilityConfig[].enableMetrics" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.monitoringConfig.advancedDatapathObservabilityConfig[].relayMode" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.monitoringConfig.enableComponents[]" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPolicy.enabled" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPolicy.provider" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkingMode" is not set in unstructured objects
@@ -1442,9 +1242,6 @@
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.soleTenantConfig.nodeAffinity[].values[]" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.spot" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.tags[]" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].effect" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].key" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].value" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.workloadMetadataConfig.mode" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.workloadMetadataConfig.nodeMetadata" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeLocations[]" is not set in unstructured objects
@@ -1533,9 +1330,6 @@
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.soleTenantConfig.nodeAffinity[].values[]" is not set in unstructured objects
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.spot" is not set in unstructured objects
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.tags[]" is not set in unstructured objects
-[missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].effect" is not set in unstructured objects
-[missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].key" is not set in unstructured objects
-[missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.taint[].value" is not set in unstructured objects
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.workloadMetadataConfig.mode" is not set in unstructured objects
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.workloadMetadataConfig.nodeMetadata" is not set in unstructured objects
 [missing_field] crd=containernodepools.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeLocations[]" is not set in unstructured objects
@@ -1557,8 +1351,6 @@
 [missing_field] crd=controllerresources.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.containers[].name" is not set in unstructured objects
 [missing_field] crd=controllerresources.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.replicas" is not set in unstructured objects
 [missing_field] crd=datacatalogpolicytags.datacatalog.cnrm.cloud.google.com version=v1beta1: field ".spec.parentPolicyTagRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=datacatalogtaxonomies.datacatalog.cnrm.cloud.google.com version=v1beta1: field ".spec.activatedPolicyTypes[]" is not set in unstructured objects
-[missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.additionalExperiments[]" is not set in unstructured objects
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.autoscalingAlgorithm" is not set in unstructured objects
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.kmsKeyNameRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.launcherMachineType" is not set in unstructured objects
@@ -1567,7 +1359,6 @@
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceAccountEmailRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.stagingLocation" is not set in unstructured objects
 [missing_field] crd=dataflowflextemplatejobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.tempLocation" is not set in unstructured objects
-[missing_field] crd=dataflowjobs.dataflow.cnrm.cloud.google.com version=v1beta1: field ".spec.additionalExperiments[]" is not set in unstructured objects
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.sshAuthenticationConfig.hostPublicKey" is not set in unstructured objects
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.gitRemoteSettings.sshAuthenticationConfig.userPrivateKeySecretVersionRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dataformrepositories.dataform.cnrm.cloud.google.com version=v1beta1: field ".spec.npmrcEnvironmentVariablesSecretVersionRef" is not set; neither 'external' nor 'name' are set
@@ -1615,11 +1406,9 @@
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].pigJob.jarFileUris[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].pigJob.queryFileUri" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].pigJob.queryList.queries[]" is not set in unstructured objects
-[missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prerequisiteStepIds[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prestoJob.clientTags[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prestoJob.continueOnFailure" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prestoJob.outputFormat" is not set in unstructured objects
-[missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prestoJob.queryFileUri" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].prestoJob.queryList.queries[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].pysparkJob.archiveUris[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].pysparkJob.args[]" is not set in unstructured objects
@@ -1633,7 +1422,6 @@
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkJob.args[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkJob.fileUris[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkJob.jarFileUris[]" is not set in unstructured objects
-[missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkJob.mainClass" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkJob.mainJarFileUri" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkRJob.archiveUris[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkRJob.args[]" is not set in unstructured objects
@@ -1642,7 +1430,6 @@
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkSqlJob.jarFileUris[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkSqlJob.queryFileUri" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].sparkSqlJob.queryList.queries[]" is not set in unstructured objects
-[missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.jobs[].stepId" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.parameters[].description" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.parameters[].fields[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.parameters[].name" is not set in unstructured objects
@@ -1664,7 +1451,6 @@
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.gceClusterConfig.shieldedInstanceConfig.enableSecureBoot" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.gceClusterConfig.shieldedInstanceConfig.enableVtpm" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.gceClusterConfig.subnetworkRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.gceClusterConfig.tags[]" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.gceClusterConfig.zone" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.initializationActions[].executableFile" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.initializationActions[].executionTimeout" is not set in unstructured objects
@@ -1711,14 +1497,12 @@
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.workerConfig.imageRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.workerConfig.minCpuPlatform" is not set in unstructured objects
 [missing_field] crd=dataprocworkflowtemplates.dataproc.cnrm.cloud.google.com version=v1beta1: field ".spec.placement.managedCluster.config.workerConfig.preemptibility" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].infoTypes[].name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.booleanValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.dateValue.day" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.dateValue.month" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.dateValue.year" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.integerValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.timeValue.minutes" is not set in unstructured objects
@@ -1731,7 +1515,6 @@
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.dateValue.year" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.integerValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].min.timeValue.minutes" is not set in unstructured objects
@@ -1744,52 +1527,28 @@
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.dateValue.year" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.integerValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.timeValue.minutes" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.timeValue.nanos" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.timeValue.seconds" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].replacementValue.timestampValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.characterMaskConfig.charactersToIgnore[].charactersToSkip" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.characterMaskConfig.charactersToIgnore[].commonCharactersToIgnore" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.characterMaskConfig.maskingCharacter" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.characterMaskConfig.numberToMask" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.characterMaskConfig.reverseOrder" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.context.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.cryptoKey.kmsWrapped.cryptoKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.cryptoKey.kmsWrapped.wrappedKey" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.cryptoKey.transient.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.cryptoKey.unwrapped.key" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoDeterministicConfig.surrogateInfoType.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoHashConfig.cryptoKey.kmsWrapped.cryptoKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoHashConfig.cryptoKey.kmsWrapped.wrappedKey" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoHashConfig.cryptoKey.transient.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoHashConfig.cryptoKey.unwrapped.key" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.commonAlphabet" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.context.name" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.cryptoKey.kmsWrapped.cryptoKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.cryptoKey.kmsWrapped.wrappedKey" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.cryptoKey.transient.name" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.cryptoKey.unwrapped.key" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.customAlphabet" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.radix" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.cryptoReplaceFfxFpeConfig.surrogateInfoType.name" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.context.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.cryptoKey.kmsWrapped.cryptoKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.cryptoKey.kmsWrapped.wrappedKey" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.cryptoKey.transient.name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.cryptoKey.unwrapped.key" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.lowerBoundDays" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.dateShiftConfig.upperBoundDays" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.bucketSize" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.booleanValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.dateValue.day" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.dateValue.month" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.dateValue.year" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.integerValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.lowerBound.timeValue.minutes" is not set in unstructured objects
@@ -1802,29 +1561,12 @@
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.dateValue.year" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.integerValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.timeValue.minutes" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.timeValue.nanos" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.timeValue.seconds" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.fixedSizeBucketingConfig.upperBound.timestampValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.booleanValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.dateValue.day" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.dateValue.month" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.dateValue.year" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.dayOfWeekValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.floatValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.integerValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.stringValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.timeValue.hours" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.timeValue.minutes" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.timeValue.nanos" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.timeValue.seconds" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.replaceConfig.newValue.timestampValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.infoTypeTransformations.transformations[].primitiveTransformation.timePartConfig.partToExtract" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].field.name" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].operator" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.booleanValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.dateValue.day" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.dateValue.month" is not set in unstructured objects
@@ -1832,14 +1574,11 @@
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.dayOfWeekValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.floatValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.integerValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.stringValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.timeValue.hours" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.timeValue.minutes" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.timeValue.nanos" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.timeValue.seconds" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.conditions.conditions[].value.timestampValue" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].condition.expressions.logicalOperator" is not set in unstructured objects
-[missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].fields[].name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].infoTypeTransformations.transformations[].infoTypes[].name" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.booleanValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.fieldTransformations[].infoTypeTransformations.transformations[].primitiveTransformation.bucketingConfig.buckets[].max.dateValue.day" is not set in unstructured objects
@@ -2079,84 +1818,9 @@
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.recordSuppressions[].condition.expressions.conditions.conditions[].value.timeValue.seconds" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.recordSuppressions[].condition.expressions.conditions.conditions[].value.timestampValue" is not set in unstructured objects
 [missing_field] crd=dlpdeidentifytemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.deidentifyConfig.recordTransformations.recordSuppressions[].condition.expressions.logicalOperator" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.contentOptions[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].dictionary.cloudStoragePath.path" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].dictionary.wordList.words[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].exclusionType" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].infoType.name" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].likelihood" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].regex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].regex.pattern" is not set in unstructured objects
 [missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].storedType.createTime" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.customInfoTypes[].storedType.nameRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.limits.maxFindingsPerInfoType[].infoType.name" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.limits.maxFindingsPerInfoType[].maxFindings" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.dictionary.cloudStoragePath.path" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.dictionary.wordList.words[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.excludeInfoTypes.infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.matchingType" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.regex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].exclusionRule.regex.pattern" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.hotwordRegex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.hotwordRegex.pattern" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.likelihoodAdjustment.fixedLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.likelihoodAdjustment.relativeLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.proximity.windowAfter" is not set in unstructured objects
-[missing_field] crd=dlpinspecttemplates.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectConfig.ruleSet[].rules[].hotwordRule.proximity.windowBefore" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.actions[].pubSub.topicRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.actions[].saveFindings.outputConfig.outputSchema" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.actions[].saveFindings.outputConfig.table.datasetRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.actions[].saveFindings.outputConfig.table.projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.actions[].saveFindings.outputConfig.table.tableRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.hotwordRegex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.hotwordRegex.pattern" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.likelihoodAdjustment.fixedLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.likelihoodAdjustment.relativeLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.proximity.windowAfter" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].detectionRules[].hotwordRule.proximity.windowBefore" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].dictionary.cloudStoragePath.path" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].dictionary.wordList.words[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].exclusionType" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].infoType.name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].infoType.version" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].likelihood" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].regex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].regex.pattern" is not set in unstructured objects
 [missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].storedType.createTime" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.customInfoTypes[].storedType.nameRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.limits.maxFindingsPerInfoType[].infoType.name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.limits.maxFindingsPerInfoType[].infoType.version" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.limits.maxFindingsPerInfoType[].maxFindings" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].infoTypes[].version" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.dictionary.cloudStoragePath.path" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.dictionary.wordList.words[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.excludeInfoTypes.infoTypes[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.excludeInfoTypes.infoTypes[].version" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.matchingType" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.regex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].exclusionRule.regex.pattern" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.hotwordRegex.groupIndexes[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.hotwordRegex.pattern" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.likelihoodAdjustment.fixedLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.likelihoodAdjustment.relativeLikelihood" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.proximity.windowAfter" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectConfig.ruleSet[].rules[].hotwordRule.proximity.windowBefore" is not set in unstructured objects
 [missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.inspectTemplateRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.bigQueryOptions.excludedFields[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.bigQueryOptions.identifyingFields[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.bigQueryOptions.includedFields[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.cloudStorageOptions.fileSet.regexFileSet.excludeRegex[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.cloudStorageOptions.fileSet.regexFileSet.includeRegex[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.cloudStorageOptions.fileTypes[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.hybridOptions.requiredFindingLabelKeys[]" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.inspectJob.storageConfig.hybridOptions.tableOptions.identifyingFields[].name" is not set in unstructured objects
-[missing_field] crd=dlpjobtriggers.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.triggers[].schedule.recurrencePeriodDuration" is not set in unstructured objects
-[missing_field] crd=dlpstoredinfotypes.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.dictionary.wordList.words[]" is not set in unstructured objects
-[missing_field] crd=dlpstoredinfotypes.dlp.cnrm.cloud.google.com version=v1beta1: field ".spec.regex.groupIndexes[]" is not set in unstructured objects
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.cloudLoggingConfig.enableLogging" is not set in unstructured objects
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.dnssecConfig.defaultKeySpecs[].algorithm" is not set in unstructured objects
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.dnssecConfig.defaultKeySpecs[].keyLength" is not set in unstructured objects
@@ -2169,22 +1833,11 @@
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.forwardingConfig.targetNameServers[].ipv4Address" is not set in unstructured objects
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.peeringConfig.targetNetwork.networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.privateVisibilityConfig.gkeClusters[].gkeClusterNameRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.privateVisibilityConfig.networks[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.reverseLookup" is not set in unstructured objects
 [missing_field] crd=dnsmanagedzones.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceDirectoryConfig.namespace.namespaceUrl" is not set in unstructured objects
 [missing_field] crd=dnspolicies.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.alternativeNameServerConfig.targetNameServers[].forwardingPath" is not set in unstructured objects
-[missing_field] crd=dnspolicies.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.alternativeNameServerConfig.targetNameServers[].ipv4Address" is not set in unstructured objects
 [missing_field] crd=dnspolicies.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.enableInboundForwarding" is not set in unstructured objects
-[missing_field] crd=dnspolicies.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.networks[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.enableGeoFencing" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].ipAddressRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].ipProtocol" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].loadBalancerType" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].networkRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].port" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].healthCheckedTargets.internalLoadBalancers[].regionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.geo[].location" is not set in unstructured objects
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].ipAddressRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].ipProtocol" is not set in unstructured objects
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].loadBalancerType" is not set in unstructured objects
@@ -2192,25 +1845,9 @@
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].port" is not set in unstructured objects
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].projectRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].healthCheckedTargets.internalLoadBalancers[].regionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.backupGeo[].location" is not set in unstructured objects
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.enableGeoFencingForBackups" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].ipAddressRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].ipProtocol" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].loadBalancerType" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].networkRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].port" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].projectRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.primary.internalLoadBalancers[].regionRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.primaryBackup.trickleRatio" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].ipAddressRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].ipProtocol" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].loadBalancerType" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].networkRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].port" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].projectRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].healthCheckedTargets.internalLoadBalancers[].regionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.routingPolicy.wrr[].weight" is not set in unstructured objects
-[missing_field] crd=dnsrecordsets.dns.cnrm.cloud.google.com version=v1beta1: field ".spec.rrdatas[]" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.controlPlane.local.machineFilter" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.controlPlane.local.nodeCount" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.controlPlane.local.nodeLocation" is not set in unstructured objects
@@ -2227,10 +1864,8 @@
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.window.recurringWindow.recurrence" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.window.recurringWindow.window.endTime" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.window.recurringWindow.window.startTime" is not set in unstructured objects
-[missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.networking.clusterIpv4CidrBlocks[]" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.networking.clusterIpv6CidrBlocks[]" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.networking.networkType" is not set in unstructured objects
-[missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.networking.servicesIpv4CidrBlocks[]" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.networking.servicesIpv6CidrBlocks[]" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.releaseChannel" is not set in unstructured objects
 [missing_field] crd=edgecontainerclusters.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.systemAddonsConfig.ingress.disabled" is not set in unstructured objects
@@ -2245,7 +1880,6 @@
 [missing_field] crd=edgecontainervpnconnections.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.router" is not set in unstructured objects
 [missing_field] crd=edgecontainervpnconnections.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.vpc" is not set in unstructured objects
 [missing_field] crd=edgecontainervpnconnections.edgecontainer.cnrm.cloud.google.com version=v1beta1: field ".spec.vpcProject.projectId" is not set in unstructured objects
-[missing_field] crd=edgenetworksubnets.edgenetwork.cnrm.cloud.google.com version=v1beta1: field ".spec.ipv4Cidr[]" is not set in unstructured objects
 [missing_field] crd=edgenetworksubnets.edgenetwork.cnrm.cloud.google.com version=v1beta1: field ".spec.ipv6Cidr[]" is not set in unstructured objects
 [missing_field] crd=edgenetworksubnets.edgenetwork.cnrm.cloud.google.com version=v1beta1: field ".spec.vlanId" is not set in unstructured objects
 [missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.channelRef" is not set; neither 'external' nor 'name' are set
@@ -2259,25 +1893,12 @@
 [missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.destination.networkConfig.networkAttachmentRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.destination.workflowRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.eventDataContentType" is not set in unstructured objects
-[missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.matchingCriteria[].attribute" is not set in unstructured objects
 [missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.matchingCriteria[].operator" is not set in unstructured objects
-[missing_field] crd=eventarctriggers.eventarc.cnrm.cloud.google.com version=v1beta1: field ".spec.matchingCriteria[].value" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].capacityGb" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].name" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].nfsExportOptions[].accessMode" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].nfsExportOptions[].anonGid" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].nfsExportOptions[].anonUid" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].nfsExportOptions[].ipRanges[]" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].nfsExportOptions[].squashMode" is not set in unstructured objects
 [missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fileShares[].sourceBackupRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.networks[].ipAddresses[]" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.networks[].modes[]" is not set in unstructured objects
-[missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.networks[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=filestoreinstances.filestore.cnrm.cloud.google.com version=v1beta1: field ".spec.networks[].reservedIPRange" is not set in unstructured objects
 [missing_field] crd=firestoreindexes.firestore.cnrm.cloud.google.com version=v1beta1: field ".spec.database" is not set in unstructured objects
 [missing_field] crd=firestoreindexes.firestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fields[].arrayConfig" is not set in unstructured objects
-[missing_field] crd=firestoreindexes.firestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fields[].fieldPath" is not set in unstructured objects
-[missing_field] crd=firestoreindexes.firestore.cnrm.cloud.google.com version=v1beta1: field ".spec.fields[].order" is not set in unstructured objects
 [missing_field] crd=firestoreindexes.firestore.cnrm.cloud.google.com version=v1beta1: field ".spec.queryScope" is not set in unstructured objects
 [missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.configmanagement.binauthz.enabled" is not set in unstructured objects
 [missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.configmanagement.configSync.metricsGcpServiceAccountRef" is not set; neither 'external' nor 'name' are set
@@ -2299,8 +1920,6 @@
 [missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.configmanagement.policyController.referentialRulesEnabled" is not set in unstructured objects
 [missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.configmanagement.policyController.templateLibraryInstalled" is not set in unstructured objects
 [missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.mesh.controlPlane" is not set in unstructured objects
-[missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.policycontroller.policyControllerHubConfig.exemptableNamespaces[]" is not set in unstructured objects
-[missing_field] crd=gkehubfeaturememberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.policycontroller.policyControllerHubConfig.monitoring.backends[]" is not set in unstructured objects
 [missing_field] crd=gkehubfeatures.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.fleetobservability.loggingConfig.defaultConfig.mode" is not set in unstructured objects
 [missing_field] crd=gkehubfeatures.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.spec.fleetobservability.loggingConfig.fleetScopeLogsConfig.mode" is not set in unstructured objects
 [missing_field] crd=gkehubmemberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.endpoint.kubernetesResource.membershipCrManifest" is not set in unstructured objects
@@ -2309,15 +1928,9 @@
 [missing_field] crd=gkehubmemberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.externalId" is not set in unstructured objects
 [missing_field] crd=gkehubmemberships.gkehub.cnrm.cloud.google.com version=v1beta1: field ".spec.infrastructureType" is not set in unstructured objects
 [missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availabilityCondition.description" is not set in unstructured objects
-[missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availabilityCondition.expression" is not set in unstructured objects
 [missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availabilityCondition.location" is not set in unstructured objects
-[missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availabilityCondition.title" is not set in unstructured objects
-[missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availablePermissions[]" is not set in unstructured objects
-[missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].accessBoundaryRule.availableResource" is not set in unstructured objects
-[missing_field] crd=iamaccessboundarypolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].description" is not set in unstructured objects
 [missing_field] crd=iamauditconfigs.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.auditLogConfigs[].exemptedMembers[]" is not set in unstructured objects
 [missing_field] crd=iamauditconfigs.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.auditLogConfigs[].logType" is not set in unstructured objects
-[missing_field] crd=iamcustomroles.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.permissions[]" is not set in unstructured objects
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.description" is not set in unstructured objects
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.expression" is not set in unstructured objects
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.title" is not set in unstructured objects
@@ -2327,21 +1940,14 @@
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].members[].memberFrom.serviceAccountRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].members[].memberFrom.serviceIdentityRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].members[].memberFrom.sqlInstanceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=iampartialpolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].role" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.auditConfigs[].auditLogConfigs[].exemptedMembers[]" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.auditConfigs[].auditLogConfigs[].logType" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.auditConfigs[].service" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.description" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.expression" is not set in unstructured objects
 [missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].condition.title" is not set in unstructured objects
-[missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].members[]" is not set in unstructured objects
-[missing_field] crd=iampolicies.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.bindings[].role" is not set in unstructured objects
 [missing_field] crd=iamserviceaccountkeys.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.publicKeyData" is not set in unstructured objects
 [missing_field] crd=iamworkforcepoolproviders.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.oidc.clientSecret.value.plainText.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=iamworkforcepoolproviders.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.oidc.webSsoConfig.additionalScopes[]" is not set in unstructured objects
-[missing_field] crd=iamworkloadidentitypoolproviders.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.aws.stsUri[]" is not set in unstructured objects
-[missing_field] crd=iamworkloadidentitypoolproviders.iam.cnrm.cloud.google.com version=v1beta1: field ".spec.oidc.allowedAudiences[]" is not set in unstructured objects
-[missing_field] crd=identityplatformconfigs.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.authorizedDomains[]" is not set in unstructured objects
 [missing_field] crd=identityplatformconfigs.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.notification.sendEmail.smtp.password.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=identityplatformoauthidpconfigs.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.responseType.code" is not set in unstructured objects
 [missing_field] crd=identityplatformoauthidpconfigs.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.responseType.idToken" is not set in unstructured objects
@@ -2352,7 +1958,6 @@
 [missing_field] crd=identityplatformtenants.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.disableAuth" is not set in unstructured objects
 [missing_field] crd=identityplatformtenants.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.enableAnonymousUser" is not set in unstructured objects
 [missing_field] crd=identityplatformtenants.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.enableEmailLinkSignin" is not set in unstructured objects
-[missing_field] crd=identityplatformtenants.identityplatform.cnrm.cloud.google.com version=v1beta1: field ".spec.mfaConfig.enabledProviders[]" is not set in unstructured objects
 [missing_field] crd=kmsautokeyconfigs.kms.cnrm.cloud.google.com version=v1beta1: field ".spec.keyProject.kind" is not set in unstructured objects
 [missing_field] crd=kmsautokeyconfigs.kms.cnrm.cloud.google.com version=v1beta1: field ".spec.keyProject.name" is not set in unstructured objects
 [missing_field] crd=kmsautokeyconfigs.kms.cnrm.cloud.google.com version=v1beta1: field ".spec.keyProject.namespace" is not set in unstructured objects
@@ -2360,10 +1965,6 @@
 [missing_field] crd=kmscryptokeys.kms.cnrm.cloud.google.com version=v1beta1: field ".spec.rotationPeriod" is not set in unstructured objects
 [missing_field] crd=kmscryptokeys.kms.cnrm.cloud.google.com version=v1beta1: field ".spec.skipInitialVersionCreation" is not set in unstructured objects
 [missing_field] crd=logginglogbuckets.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.enableAnalytics" is not set in unstructured objects
-[missing_field] crd=logginglogmetrics.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.bucketOptions.explicitBuckets.bounds[]" is not set in unstructured objects
-[missing_field] crd=logginglogmetrics.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.metricDescriptor.labels[].description" is not set in unstructured objects
-[missing_field] crd=logginglogmetrics.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.metricDescriptor.labels[].key" is not set in unstructured objects
-[missing_field] crd=logginglogmetrics.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.metricDescriptor.labels[].valueType" is not set in unstructured objects
 [missing_field] crd=logginglogsinks.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.bigqueryOptions.usePartitionedTables" is not set in unstructured objects
 [missing_field] crd=logginglogsinks.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.destination.loggingLogBucketRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=logginglogsinks.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.exclusions[].description" is not set in unstructured objects
@@ -2381,7 +1982,6 @@
 [missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.weeklyMaintenanceWindow[].startTime.seconds" is not set in unstructured objects
 [missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.memcacheParameters.id" is not set in unstructured objects
 [missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.memcacheVersion" is not set in unstructured objects
-[missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.zones[]" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.alertStrategy.autoClose" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.alertStrategy.notificationChannelStrategy[].notificationChannelNames[]" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.alertStrategy.notificationChannelStrategy[].renotifyInterval" is not set in unstructured objects
@@ -2405,57 +2005,30 @@
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionPrometheusQueryLanguage.evaluationInterval" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionPrometheusQueryLanguage.query" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionPrometheusQueryLanguage.ruleGroup" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.aggregations[].alignmentPeriod" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.aggregations[].crossSeriesReducer" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.aggregations[].groupByFields[]" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.aggregations[].perSeriesAligner" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.comparison" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.denominatorAggregations[].alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.denominatorAggregations[].crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.denominatorAggregations[].groupByFields[]" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.denominatorAggregations[].perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.denominatorFilter" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.duration" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.evaluationMissingData" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.filter" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.forecastOptions.forecastHorizon" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.thresholdValue" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.trigger.count" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].conditionThreshold.trigger.percent" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].displayName" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.conditions[].name" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationChannels[].external" is not set in unstructured objects
-[missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationChannels[].name" is not set in unstructured objects
 [missing_field] crd=monitoringalertpolicies.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationChannels[].namespace" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].weight" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].alertChart.alertPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].collapsibleGroup.collapsed" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].errorReportingPanel.services[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].errorReportingPanel.versions[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].id" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].incidentList.monitoredResources[].type" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].logsPanel.filter" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].logsPanel.resourceNames[].external" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].logsPanel.resourceNames[].kind" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].logsPanel.resourceNames[].name" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].logsPanel.resourceNames[].namespace" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.chartType" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].minAlignmentPeriod" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].sliceNameTemplate" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.outputFullDuration" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.prometheusQuery" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.groupByFields[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.perSeriesAligner" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.filter" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.direction" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.numTimeSeries" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.rankingMethod" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.secondaryAggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.secondaryAggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.secondaryAggregation.groupByFields[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilter.secondaryAggregation.perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.denominator.aggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.denominator.aggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.denominator.aggregation.groupByFields[]" is not set in unstructured objects
@@ -2475,7 +2048,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.secondaryAggregation.perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.timeSeriesQueryLanguage" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.dataSets[].timeSeriesQuery.unitOverride" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].pieChart.showLabels" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.gaugeView.lowerBound" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.gaugeView.upperBound" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.sparkChartView.minAlignmentPeriod" is not set in unstructured objects
@@ -2485,8 +2057,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.thresholds[].label" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.thresholds[].targetAxis" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.thresholds[].value" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.outputFullDuration" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.prometheusQuery" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.timeSeriesFilter.aggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.timeSeriesFilter.aggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.timeSeriesFilter.aggregation.groupByFields[]" is not set in unstructured objects
@@ -2520,27 +2090,13 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].scorecard.timeSeriesQuery.unitOverride" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].sectionHeader.dividerBelow" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].sectionHeader.subtitle" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.content" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.format" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.backgroundColor" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.fontSize" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.horizontalAlignment" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.padding" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.pointerLocation" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.textColor" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].text.style.verticalAlignment" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.columnSettings[].column" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.columnSettings[].visible" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].minAlignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].tableDisplayOptions.shownColumns[]" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].tableTemplate" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.outputFullDuration" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.prometheusQuery" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.groupByFields[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.perSeriesAligner" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.filter" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.direction" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.numTimeSeries" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.rankingMethod" is not set in unstructured objects
@@ -2567,20 +2123,14 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.secondaryAggregation.perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesQueryLanguage" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.dataSets[].timeSeriesQuery.unitOverride" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].timeSeriesTable.metricVisualization" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].title" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.chartOptions.mode" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].legendTemplate" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].minAlignmentPeriod" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].plotType" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].targetAxis" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.outputFullDuration" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.prometheusQuery" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.alignmentPeriod" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.crossSeriesReducer" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.groupByFields[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.aggregation.perSeriesAligner" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.filter" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.direction" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.numTimeSeries" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilter.pickTimeSeriesFilter.rankingMethod" is not set in unstructured objects
@@ -2606,23 +2156,10 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.secondaryAggregation.groupByFields[]" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesFilterRatio.secondaryAggregation.perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.timeSeriesQueryLanguage" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.dataSets[].timeSeriesQuery.unitOverride" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.thresholds[].color" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.thresholds[].direction" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.thresholds[].label" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.thresholds[].targetAxis" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.thresholds[].value" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.timeshiftDuration" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.xAxis.label" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.xAxis.scale" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.y2Axis.label" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.y2Axis.scale" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.yAxis.label" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.columnLayout.columns[].widgets[].xyChart.yAxis.scale" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.dashboardFilters[].filterType" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.dashboardFilters[].labelKey" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.dashboardFilters[].stringValue" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.dashboardFilters[].templateVariable" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.columns" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.widgets[].alertChart.alertPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.widgets[].collapsibleGroup.collapsed" is not set in unstructured objects
@@ -2815,12 +2352,9 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.widgets[].xyChart.y2Axis.scale" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.widgets[].xyChart.yAxis.label" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.gridLayout.widgets[].xyChart.yAxis.scale" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].height" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.alertChart.alertPolicyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.collapsibleGroup.collapsed" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.errorReportingPanel.services[]" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.errorReportingPanel.versions[]" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.id" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.incidentList.monitoredResources[].type" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.logsPanel.filter" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.logsPanel.resourceNames[].external" is not set in unstructured objects
@@ -2906,9 +2440,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.scorecard.timeSeriesQuery.timeSeriesFilterRatio.secondaryAggregation.perSeriesAligner" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.scorecard.timeSeriesQuery.timeSeriesQueryLanguage" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.scorecard.timeSeriesQuery.unitOverride" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.sectionHeader.dividerBelow" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.sectionHeader.subtitle" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.text.content" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.text.format" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.text.style.backgroundColor" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.text.style.fontSize" is not set in unstructured objects
@@ -2956,7 +2487,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.timeSeriesTable.dataSets[].timeSeriesQuery.timeSeriesQueryLanguage" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.timeSeriesTable.dataSets[].timeSeriesQuery.unitOverride" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.timeSeriesTable.metricVisualization" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.title" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.chartOptions.mode" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.dataSets[].legendTemplate" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.dataSets[].minAlignmentPeriod" is not set in unstructured objects
@@ -3007,9 +2537,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.y2Axis.scale" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.yAxis.label" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].widget.xyChart.yAxis.scale" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].width" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].xPos" is not set in unstructured objects
-[missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.mosaicLayout.tiles[].yPos" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.rowLayout.rows[].weight" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.rowLayout.rows[].widgets[].alertChart.alertPolicyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.rowLayout.rows[].widgets[].collapsibleGroup.collapsed" is not set in unstructured objects
@@ -3203,9 +2730,6 @@
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.rowLayout.rows[].widgets[].xyChart.yAxis.label" is not set in unstructured objects
 [missing_field] crd=monitoringdashboards.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.rowLayout.rows[].widgets[].xyChart.yAxis.scale" is not set in unstructured objects
 [missing_field] crd=monitoringgroups.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.isCluster" is not set in unstructured objects
-[missing_field] crd=monitoringmetricdescriptors.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].description" is not set in unstructured objects
-[missing_field] crd=monitoringmetricdescriptors.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].key" is not set in unstructured objects
-[missing_field] crd=monitoringmetricdescriptors.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].valueType" is not set in unstructured objects
 [missing_field] crd=monitoringnotificationchannels.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.sensitiveLabels.authToken.value" is not set in unstructured objects
 [missing_field] crd=monitoringnotificationchannels.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.sensitiveLabels.authToken.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=monitoringnotificationchannels.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.sensitiveLabels.password.value" is not set in unstructured objects
@@ -3225,10 +2749,7 @@
 [missing_field] crd=monitoringservicelevelobjectives.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceLevelIndicator.windowsBased.goodTotalRatioThreshold.basicSliPerformance.operationLatency.experience" is not set in unstructured objects
 [missing_field] crd=monitoringservicelevelobjectives.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceLevelIndicator.windowsBased.goodTotalRatioThreshold.basicSliPerformance.operationLatency.threshold" is not set in unstructured objects
 [missing_field] crd=monitoringservicelevelobjectives.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.serviceLevelIndicator.windowsBased.goodTotalRatioThreshold.basicSliPerformance.version[]" is not set in unstructured objects
-[missing_field] crd=monitoringuptimecheckconfigs.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.contentMatchers[].content" is not set in unstructured objects
-[missing_field] crd=monitoringuptimecheckconfigs.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.contentMatchers[].matcher" is not set in unstructured objects
 [missing_field] crd=monitoringuptimecheckconfigs.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.httpCheck.authInfo.password.value" is not set in unstructured objects
-[missing_field] crd=monitoringuptimecheckconfigs.monitoring.cnrm.cloud.google.com version=v1beta1: field ".spec.selectedRegions[]" is not set in unstructured objects
 [missing_field] crd=mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.webhooks[].name" is not set in unstructured objects
 [missing_field] crd=mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.webhooks[].timeoutSeconds" is not set in unstructured objects
 [missing_field] crd=namespacedcontrollerreconcilers.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.pprof.port" is not set in unstructured objects
@@ -3240,177 +2761,48 @@
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedInterconnectAttachments.uris[].external" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedInterconnectAttachments.uris[].name" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedInterconnectAttachments.uris[].namespace" is not set in unstructured objects
-[missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedRouterApplianceInstances.instances[].ipAddress" is not set in unstructured objects
-[missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedRouterApplianceInstances.instances[].virtualMachineRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVPCNetwork.excludeExportRanges[]" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVPCNetwork.uriRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVpnTunnels.siteToSiteDataTransfer" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVpnTunnels.uris[].external" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVpnTunnels.uris[].name" is not set in unstructured objects
 [missing_field] crd=networkconnectivityspokes.networkconnectivity.cnrm.cloud.google.com version=v1beta1: field ".spec.linkedVpnTunnels.uris[].namespace" is not set in unstructured objects
-[missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].destinations[].hosts[]" is not set in unstructured objects
 [missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].destinations[].httpHeaderMatch.headerName" is not set in unstructured objects
 [missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].destinations[].httpHeaderMatch.regexMatch" is not set in unstructured objects
-[missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].destinations[].methods[]" is not set in unstructured objects
-[missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].destinations[].ports[]" is not set in unstructured objects
-[missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].sources[].ipBlocks[]" is not set in unstructured objects
-[missing_field] crd=networksecurityauthorizationpolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].sources[].principals[]" is not set in unstructured objects
 [missing_field] crd=networksecurityclienttlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.clientCertificate.grpcEndpoint.targetUri" is not set in unstructured objects
-[missing_field] crd=networksecurityclienttlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.serverValidationCa[].certificateProviderInstance.pluginInstance" is not set in unstructured objects
 [missing_field] crd=networksecurityclienttlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.serverValidationCa[].grpcEndpoint.targetUri" is not set in unstructured objects
-[missing_field] crd=networksecurityservertlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.mtlsPolicy.clientValidationCa[].certificateProviderInstance.pluginInstance" is not set in unstructured objects
 [missing_field] crd=networksecurityservertlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.mtlsPolicy.clientValidationCa[].grpcEndpoint.targetUri" is not set in unstructured objects
 [missing_field] crd=networksecurityservertlspolicies.networksecurity.cnrm.cloud.google.com version=v1beta1: field ".spec.serverCertificate.grpcEndpoint.targetUri" is not set in unstructured objects
-[missing_field] crd=networkservicesendpointpolicies.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.endpointMatcher.metadataLabelMatcher.metadataLabels[].labelName" is not set in unstructured objects
-[missing_field] crd=networkservicesendpointpolicies.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.endpointMatcher.metadataLabelMatcher.metadataLabels[].labelValue" is not set in unstructured objects
-[missing_field] crd=networkservicesendpointpolicies.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.trafficPortSelector.ports[]" is not set in unstructured objects
 [missing_field] crd=networkservicesgateways.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.addresses[]" is not set in unstructured objects
-[missing_field] crd=networkservicesgateways.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.ports[]" is not set in unstructured objects
 [missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].external" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].name" is not set in unstructured objects
 [missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].namespace" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.hostnames[]" is not set in unstructured objects
 [missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].external" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].name" is not set in unstructured objects
 [missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].namespace" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].serviceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].weight" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.abort.httpStatus" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.abort.percentage" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.delay.fixedDelay" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.delay.percentage" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.retryPolicy.numRetries" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.retryPolicy.retryConditions[]" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.timeout" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].key" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].type" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].value" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].method.caseSensitive" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].method.grpcMethod" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].method.grpcService" is not set in unstructured objects
-[missing_field] crd=networkservicesgrpcroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].method.type" is not set in unstructured objects
 [missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].external" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].name" is not set in unstructured objects
 [missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].namespace" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.hostnames[]" is not set in unstructured objects
 [missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].external" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].name" is not set in unstructured objects
 [missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].namespace" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.allowCredentials" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.allowHeaders[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.allowMethods[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.allowOriginRegexes[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.allowOrigins[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.disabled" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.exposeHeaders[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.corsPolicy.maxAge" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].serviceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].weight" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.abort.httpStatus" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.abort.percentage" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.delay.fixedDelay" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.faultInjectionPolicy.delay.percentage" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.hostRedirect" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.httpsRedirect" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.pathRedirect" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.portRedirect" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.prefixRewrite" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.responseCode" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.redirect.stripQuery" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.requestHeaderModifier.remove[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.requestMirrorPolicy.destination.serviceRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.requestMirrorPolicy.destination.weight" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.responseHeaderModifier.remove[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.retryPolicy.numRetries" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.retryPolicy.perTryTimeout" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.retryPolicy.retryConditions[]" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.timeout" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.urlRewrite.hostRewrite" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.urlRewrite.pathPrefixRewrite" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].fullPathMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].exactMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].header" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].invertMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].prefixMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].presentMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].rangeMatch.end" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].rangeMatch.start" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].regexMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].headers[].suffixMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].ignoreCase" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].prefixMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].queryParameters[].exactMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].queryParameters[].presentMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].queryParameters[].queryParameter" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].queryParameters[].regexMatch" is not set in unstructured objects
-[missing_field] crd=networkserviceshttproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].regexMatch" is not set in unstructured objects
 [missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].external" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].name" is not set in unstructured objects
 [missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].namespace" is not set in unstructured objects
 [missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].external" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].name" is not set in unstructured objects
 [missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].namespace" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].serviceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].weight" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.originalDestination" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].address" is not set in unstructured objects
-[missing_field] crd=networkservicestcproutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].port" is not set in unstructured objects
 [missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].external" is not set in unstructured objects
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].name" is not set in unstructured objects
 [missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.gateways[].namespace" is not set in unstructured objects
 [missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].external" is not set in unstructured objects
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].name" is not set in unstructured objects
 [missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.meshes[].namespace" is not set in unstructured objects
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].serviceRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].action.destinations[].weight" is not set in unstructured objects
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].alpn[]" is not set in unstructured objects
-[missing_field] crd=networkservicestlsroutes.networkservices.cnrm.cloud.google.com version=v1beta1: field ".spec.rules[].matches[].sniHost[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.instanceNamePrefixes[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.instances[].external" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.instances[].name" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.instances[].namespace" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.osTypes[].osArchitecture" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.osTypes[].osShortName" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.osTypes[].osVersion" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.assignment.zones[]" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].apt.archiveType" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].apt.components[]" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].apt.distribution" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].apt.gpgKey" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].apt.uri" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].goo.name" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].goo.url" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].yum.baseUrl" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].yum.displayName" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].yum.gpgKeys[]" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].yum.id" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].zypper.baseUrl" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].zypper.displayName" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].zypper.gpgKeys[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packageRepositories[].zypper.id" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packages[].desiredState" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packages[].manager" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.packages[].name" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].gcs.bucketRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].id" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].remote.checksum" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].artifacts[].remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].desiredState" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].archiveExtraction.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].archiveExtraction.destination" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].archiveExtraction.type" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].dpkgInstallation.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileCopy.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileCopy.destination" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileCopy.overwrite" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileCopy.permissions" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileExec.allowedExitCodes[]" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileExec.args[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileExec.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].fileExec.localPath" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].msiInstallation.allowedExitCodes[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].msiInstallation.artifactId" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].msiInstallation.flags[]" is not set in unstructured objects
@@ -3418,19 +2810,12 @@
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].scriptRun.allowedExitCodes[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].scriptRun.interpreter" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].installSteps[].scriptRun.script" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].name" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].archiveExtraction.artifactId" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].archiveExtraction.destination" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].archiveExtraction.type" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].dpkgInstallation.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileCopy.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileCopy.destination" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileCopy.overwrite" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileCopy.permissions" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileExec.allowedExitCodes[]" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileExec.args[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileExec.artifactId" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].fileExec.localPath" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].msiInstallation.allowedExitCodes[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].msiInstallation.artifactId" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].msiInstallation.flags[]" is not set in unstructured objects
@@ -3438,124 +2823,12 @@
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].scriptRun.allowedExitCodes[]" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].scriptRun.interpreter" is not set in unstructured objects
 [missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].updateSteps[].scriptRun.script" is not set in unstructured objects
-[missing_field] crd=osconfigguestpolicies.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.recipes[].version" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].allowNoResourceGroupMatch" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].description" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].id" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].mode" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].inventoryFilters[].osShortName" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].inventoryFilters[].osVersion" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.args[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.file.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.interpreter" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.outputFilePath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.enforce.script" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.args[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.file.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.interpreter" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.outputFilePath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].exec.validate.script" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.content" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.file.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.path" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.permissions" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].file.state" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].id" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.apt.name" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.pullDeps" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.deb.source.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.desiredState" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.googet.name" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.properties[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.msi.source.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.pullDeps" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.allowInsecure" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.gcs.bucket" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.gcs.generation" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.gcs.object" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.localPath" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.remote.sha256Checksum" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.rpm.source.remote.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.yum.name" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].pkg.zypper.name" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.apt.archiveType" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.apt.components[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.apt.distribution" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.apt.gpgKey" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.apt.uri" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.goo.name" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.goo.url" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.yum.baseUrl" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.yum.displayName" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.yum.gpgKeys[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.yum.id" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.zypper.baseUrl" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.zypper.displayName" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.zypper.gpgKeys[]" is not set in unstructured objects
-[missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.osPolicies[].resourceGroups[].resources[].repository.zypper.id" is not set in unstructured objects
 [missing_field] crd=osconfigospolicyassignments.osconfig.cnrm.cloud.google.com version=v1beta1: field ".spec.skipAwaitRollout" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.allowedKeyTypes[].ellipticCurve.signatureAlgorithm" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.allowedKeyTypes[].rsa.maxModulusSize" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.allowedKeyTypes[].rsa.minModulusSize" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.additionalExtensions[].critical" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.additionalExtensions[].objectId.objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.additionalExtensions[].value" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.aiaOcspServers[]" is not set in unstructured objects
 [missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.caOptions.zeroMaxIssuerPathLength" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.keyUsage.unknownExtendedKeyUsages[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.baselineValues.policyIds[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.passthroughExtensions.additionalExtensions[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacapools.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.issuancePolicy.passthroughExtensions.knownExtensions[]" is not set in unstructured objects
 [missing_field] crd=privatecacertificateauthorities.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.gcsBucketRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=privatecacertificateauthorities.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.keySpec.cloudKmsKeyVersionRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=privatecacertificates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.certificateTemplateRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=privatecacertificates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.pemCsr" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.passthroughExtensions.additionalExtensions[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.passthroughExtensions.knownExtensions[]" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.additionalExtensions[].critical" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.additionalExtensions[].objectId.objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.additionalExtensions[].value" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.aiaOcspServers[]" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.keyUsage.unknownExtendedKeyUsages[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privatecacertificatetemplates.privateca.cnrm.cloud.google.com version=v1beta1: field ".spec.predefinedValues.policyIds[].objectIdPath[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.additionalNotificationTargets.adminEmailRecipients[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.additionalNotificationTargets.requesterEmailRecipients[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.approvalWorkflow.manualApprovals.steps[].approvalsNeeded" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.approvalWorkflow.manualApprovals.steps[].approverEmailRecipients[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.approvalWorkflow.manualApprovals.steps[].approvers[].principals[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.eligibleUsers[].principals[]" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.privilegedAccess.gcpIAMAccess.roleBindings[].conditionExpression" is not set in unstructured objects
-[missing_field] crd=privilegedaccessmanagerentitlements.privilegedaccessmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.privilegedAccess.gcpIAMAccess.roleBindings[].role" is not set in unstructured objects
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.bigqueryConfig.dropUnknownFields" is not set in unstructured objects
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.bigqueryConfig.useTopicSchema" is not set in unstructured objects
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.bigqueryConfig.writeMetadata" is not set in unstructured objects
@@ -3577,12 +2850,8 @@
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.retryPolicy.maximumBackoff" is not set in unstructured objects
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.retryPolicy.minimumBackoff" is not set in unstructured objects
 [missing_field] crd=pubsubtopics.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.messageStoragePolicy.allowedPersistenceRegions[]" is not set in unstructured objects
-[missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.androidSettings.allowedPackageNames[]" is not set in unstructured objects
-[missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.iosSettings.allowedBundleIds[]" is not set in unstructured objects
 [missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.wafSettings.wafFeature" is not set in unstructured objects
 [missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.wafSettings.wafService" is not set in unstructured objects
-[missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.webSettings.allowedDomains[]" is not set in unstructured objects
-[missing_field] crd=redisclusters.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.pscConfigs[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.alternativeLocationId" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.authEnabled" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.authString" is not set in unstructured objects
@@ -3598,9 +2867,6 @@
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.weeklyMaintenanceWindow[].startTime.minutes" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.weeklyMaintenanceWindow[].startTime.nanos" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.weeklyMaintenanceWindow[].startTime.seconds" is not set in unstructured objects
-[missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenanceSchedule[].endTime" is not set in unstructured objects
-[missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenanceSchedule[].scheduleDeadlineTime" is not set in unstructured objects
-[missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenanceSchedule[].startTime" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.persistenceConfig.persistenceMode" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.persistenceConfig.rdbNextSnapshotTime" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.persistenceConfig.rdbSnapshotPeriod" is not set in unstructured objects
@@ -3609,10 +2875,8 @@
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.redisVersion" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.reservedIpRange" is not set in unstructured objects
 [missing_field] crd=redisinstances.redis.cnrm.cloud.google.com version=v1beta1: field ".spec.secondaryIpRange" is not set in unstructured objects
-[missing_field] crd=resourcemanagerliens.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.restrictions[]" is not set in unstructured objects
 [missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.booleanPolicy.enforced" is not set in unstructured objects
 [missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.listPolicy.allow.all" is not set in unstructured objects
-[missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.listPolicy.allow.values[]" is not set in unstructured objects
 [missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.listPolicy.deny.values[]" is not set in unstructured objects
 [missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.listPolicy.inheritFromParent" is not set in unstructured objects
 [missing_field] crd=resourcemanagerpolicies.resourcemanager.cnrm.cloud.google.com version=v1beta1: field ".spec.listPolicy.suggestedValue" is not set in unstructured objects
@@ -3626,12 +2890,7 @@
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.taskCount" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].args[]" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].command[]" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].env[].name" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].env[].value" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].env[].valueSource.secretKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].env[].valueSource.secretKeyRef.secretRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].env[].valueSource.secretKeyRef.versionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].image" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.failureThreshold" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.httpGet.httpHeaders[].name" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.httpGet.httpHeaders[].value" is not set in unstructured objects
@@ -3640,7 +2899,6 @@
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.periodSeconds" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.tcpSocket.port" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].livenessProbe.timeoutSeconds" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].name" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].ports[].containerPort" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].ports[].name" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].startupProbe.failureThreshold" is not set in unstructured objects
@@ -3651,15 +2909,12 @@
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].startupProbe.periodSeconds" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].startupProbe.tcpSocket.port" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].startupProbe.timeoutSeconds" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].volumeMounts[].mountPath" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].volumeMounts[].name" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.containers[].workingDir" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.executionEnvironment" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.maxRetries" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.timeout" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].emptyDir.medium" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].emptyDir.sizeLimit" is not set in unstructured objects
-[missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].name" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].secret.defaultMode" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].secret.items[].mode" is not set in unstructured objects
 [missing_field] crd=runjobs.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.template.volumes[].secret.items[].path" is not set in unstructured objects
@@ -3676,40 +2931,27 @@
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].args[]" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].command[]" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].dependsOn[]" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].env[].name" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].env[].value" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].env[].valueSource.secretKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].env[].valueSource.secretKeyRef.secretRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].env[].valueSource.secretKeyRef.versionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].image" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.failureThreshold" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.grpc.port" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.grpc.service" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.httpGet.httpHeaders[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.httpGet.httpHeaders[].value" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.httpGet.path" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.httpGet.port" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.initialDelaySeconds" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.periodSeconds" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].livenessProbe.timeoutSeconds" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].name" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].ports[].containerPort" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].ports[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].resources.cpuIdle" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].resources.startupCpuBoost" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.failureThreshold" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.grpc.port" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.grpc.service" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.httpGet.httpHeaders[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.httpGet.httpHeaders[].value" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.httpGet.path" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.httpGet.port" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.initialDelaySeconds" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.periodSeconds" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.tcpSocket.port" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].startupProbe.timeoutSeconds" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].volumeMounts[].mountPath" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].volumeMounts[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.containers[].workingDir" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.executionEnvironment" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.maxInstanceRequestConcurrency" is not set in unstructured objects
@@ -3718,36 +2960,21 @@
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.sessionAffinity" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.timeout" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].cloudSqlInstance.instances[].external" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].cloudSqlInstance.instances[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].cloudSqlInstance.instances[].namespace" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].emptyDir.medium" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].emptyDir.sizeLimit" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].name" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].secret.defaultMode" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].secret.items[].mode" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].secret.items[].path" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].secret.items[].versionRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.volumes[].secret.secretRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.vpcAccess.networkInterfaces[].networkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.vpcAccess.networkInterfaces[].subnetworkRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.template.vpcAccess.networkInterfaces[].tags[]" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.traffic[].percent" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.traffic[].revision" is not set in unstructured objects
 [missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.traffic[].tag" is not set in unstructured objects
-[missing_field] crd=runservices.run.cnrm.cloud.google.com version=v1beta1: field ".spec.traffic[].type" is not set in unstructured objects
-[missing_field] crd=secretmanagersecrets.secretmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.replication.userManaged.replicas[].customerManagedEncryption.kmsKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=secretmanagersecrets.secretmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.replication.userManaged.replicas[].location" is not set in unstructured objects
-[missing_field] crd=secretmanagersecrets.secretmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.topics[].topicRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=secretmanagersecretversions.secretmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.isSecretDataBase64" is not set in unstructured objects
 [missing_field] crd=secretmanagersecretversions.secretmanager.cnrm.cloud.google.com version=v1beta1: field ".spec.secretData.value" is not set in unstructured objects
 [missing_field] crd=servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com version=v1beta1: field ".spec.reservedPeeringRanges[].external" is not set in unstructured objects
-[missing_field] crd=servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com version=v1beta1: field ".spec.reservedPeeringRanges[].name" is not set in unstructured objects
 [missing_field] crd=servicenetworkingconnections.servicenetworking.cnrm.cloud.google.com version=v1beta1: field ".spec.reservedPeeringRanges[].namespace" is not set in unstructured objects
-[missing_field] crd=sourcereporepositories.sourcerepo.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfigs[].messageFormat" is not set in unstructured objects
-[missing_field] crd=sourcereporepositories.sourcerepo.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfigs[].serviceAccountRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=sourcereporepositories.sourcerepo.cnrm.cloud.google.com version=v1beta1: field ".spec.pubsubConfigs[].topicRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=spannerdatabases.spanner.cnrm.cloud.google.com version=v1beta1: field ".spec.databaseDialect" is not set in unstructured objects
-[missing_field] crd=spannerdatabases.spanner.cnrm.cloud.google.com version=v1beta1: field ".spec.ddl[]" is not set in unstructured objects
 [missing_field] crd=spannerdatabases.spanner.cnrm.cloud.google.com version=v1beta1: field ".spec.enableDropProtection" is not set in unstructured objects
 [missing_field] crd=spannerdatabases.spanner.cnrm.cloud.google.com version=v1beta1: field ".spec.encryptionConfig.kmsKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=spannerdatabases.spanner.cnrm.cloud.google.com version=v1beta1: field ".spec.versionRetentionPeriod" is not set in unstructured objects
@@ -3774,11 +3001,6 @@
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.activeDirectoryConfig.domain" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.authorizedGaeApplications[]" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.crashSafeReplication" is not set in unstructured objects
-[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.databaseFlags[].name" is not set in unstructured objects
-[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.databaseFlags[].value" is not set in unstructured objects
-[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.ipConfiguration.authorizedNetworks[].expirationTime" is not set in unstructured objects
-[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.ipConfiguration.authorizedNetworks[].name" is not set in unstructured objects
-[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.ipConfiguration.authorizedNetworks[].value" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.ipConfiguration.pscConfig[].allowedConsumerProjects[]" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.ipConfiguration.pscConfig[].pscEnabled" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.settings.locationPreference.followGaeApplication" is not set in unstructured objects
@@ -3800,8 +3022,6 @@
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.defaultEventBasedHold" is not set in unstructured objects
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.encryption.kmsKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].action.storageClass" is not set in unstructured objects
-[missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].action.type" is not set in unstructured objects
-[missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].condition.age" is not set in unstructured objects
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].condition.createdBefore" is not set in unstructured objects
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].condition.customTimeBefore" is not set in unstructured objects
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.lifecycleRule[].condition.daysSinceCustomTime" is not set in unstructured objects
@@ -3823,7 +3043,6 @@
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.website.mainPageSuffix" is not set in unstructured objects
 [missing_field] crd=storagebuckets.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.website.notFoundPage" is not set in unstructured objects
 [missing_field] crd=storagedefaultobjectaccesscontrols.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.object" is not set in unstructured objects
-[missing_field] crd=storagenotifications.storage.cnrm.cloud.google.com version=v1beta1: field ".spec.eventTypes[]" is not set in unstructured objects
 [missing_field] crd=storagetransferjobs.storagetransfer.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationConfig.eventTypes[]" is not set in unstructured objects
 [missing_field] crd=storagetransferjobs.storagetransfer.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationConfig.payloadFormat" is not set in unstructured objects
 [missing_field] crd=storagetransferjobs.storagetransfer.cnrm.cloud.google.com version=v1beta1: field ".spec.notificationConfig.topicRef" is not set; neither 'external' nor 'name' are set
@@ -3858,34 +3077,13 @@
 [missing_field] crd=storagetransferjobs.storagetransfer.cnrm.cloud.google.com version=v1beta1: field ".spec.transferSpec.transferOptions.overwriteWhen" is not set in unstructured objects
 [missing_field] crd=validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.webhooks[].name" is not set in unstructured objects
 [missing_field] crd=validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com version=v1beta1: field ".spec.webhooks[].timeoutSeconds" is not set in unstructured objects
-[missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].key" is not set in unstructured objects
-[missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].value" is not set in unstructured objects
-[missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].key" is not set in unstructured objects
-[missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].value" is not set in unstructured objects
-[missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.privateClusterConfig.allowedProjects[].external" is not set in unstructured objects
 [missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.privateClusterConfig.allowedProjects[].kind" is not set in unstructured objects
 [missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.privateClusterConfig.allowedProjects[].name" is not set in unstructured objects
 [missing_field] crd=workstationclusters.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.privateClusterConfig.allowedProjects[].namespace" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].key" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].value" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.args[]" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.command[]" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.env[].name" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.env[].value" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.runAsUser" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.container.workingDir" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].key" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].value" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].gcePD.diskType" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].gcePD.fsType" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].gcePD.reclaimPolicy" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].gcePD.sizeGB" is not set in unstructured objects
 [missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].gcePD.sourceSnapshot" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.persistentDirectories[].mountPath" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.readinessChecks[].path" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.readinessChecks[].port" is not set in unstructured objects
-[missing_field] crd=workstationconfigs.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaZones[]" is not set in unstructured objects
-[missing_field] crd=workstations.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].key" is not set in unstructured objects
-[missing_field] crd=workstations.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.annotations[].value" is not set in unstructured objects
-[missing_field] crd=workstations.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].key" is not set in unstructured objects
-[missing_field] crd=workstations.workstations.cnrm.cloud.google.com version=v1beta1: field ".spec.labels[].value" is not set in unstructured objects


### PR DESCRIPTION
Unblocks #3632

Fixed the incorrect detection of list fields in `TestCRDFieldPresenceInUnstructured`.

e.g.
```
=== FAIL: tests/apichecks TestCRDFieldPresenceInUnstructured (6.00s)
    utils.go:149: FAIL: unexpected diff in testdata/exceptions/missingfields.txt:   (
          	"""
          	... // 2370 identical lines
          	[missing_field] crd=logginglogsinks.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.exclusions[].filter" is not set in unstructured objects
          	[missing_field] crd=logginglogsinks.logging.cnrm.cloud.google.com version=v1beta1: field ".spec.exclusions[].name" is not set in unstructured objects
        + 	[missing_field] crd=managedkafkaclusters.managedkafka.cnrm.cloud.google.com version=v1beta1: field ".spec.gcpConfig.accessConfig.networkConfigs[].subnetworkRef" is not set; neither 'external' nor 'name' are set
          	[missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.createTime" is not set in unstructured objects
exit status 1
          	[missing_field] crd=memcacheinstances.memcache.cnrm.cloud.google.com version=v1beta1: field ".spec.maintenancePolicy.description" is not set in unstructured objects
          	... // 1517 identical lines
          	"""
          )
```