### PR TITLE
fix: Remove deprecated SQLInstance failover configuration

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_generated_object_sqlinstance-replica-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_generated_object_sqlinstance-replica-direct.golden.yaml
@@ -18,8 +18,6 @@ spec:
   masterInstanceRef:
     name: sqlinstance-master-direct-${uniqueId}
   region: us-central1
-  replicaConfiguration:
-    failoverTarget: true
   settings:
     locationPreference:
       zone: us-central1-b

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/_http.log
@@ -400,10 +400,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
   "masterInstanceName": "${projectId}:sqlinstance-master-direct-${uniqueId}",
   "name": "sqlinstance-replica-direct-${uniqueId}",
   "region": "us-central1",
-  "replicaConfiguration": {
-    "failoverTarget": true,
-    "kind": "sql#replicaConfiguration"
-  },
   "settings": {
     "activationPolicy": "ALWAYS",
     "availabilityType": "ZONAL",
@@ -527,10 +523,6 @@ X-Xss-Protection: 0
   "name": "sqlinstance-replica-direct-${uniqueId}",
   "project": "${projectId}",
   "region": "us-central1",
-  "replicaConfiguration": {
-    "failoverTarget": true,
-    "kind": "sql#replicaConfiguration"
-  },
   "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-replica-direct-${uniqueId}",
   "serverCaCert": {
     "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
@@ -764,10 +756,6 @@ X-Xss-Protection: 0
   "name": "sqlinstance-replica-direct-${uniqueId}",
   "project": "${projectId}",
   "region": "us-central1",
-  "replicaConfiguration": {
-    "failoverTarget": true,
-    "kind": "sql#replicaConfiguration"
-  },
   "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/sqlinstance-replica-direct-${uniqueId}",
   "serverCaCert": {
     "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-replica-direct/create.yaml
@@ -24,8 +24,6 @@ spec:
   masterInstanceRef:
     name: sqlinstance-master-direct-${uniqueId}
   region: us-central1
-  replicaConfiguration:
-    failoverTarget: true
   settings:
     # Location preference is not actually a required field. However, setting it for tests
     # helps with with normalizing the GCP responses, because otherwise GCP chooses a zone

--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -3764,6 +3764,7 @@
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.clientKey" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.connectRetryInterval" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.dumpFilePath" is not set in unstructured objects
+[missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.failoverTarget" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.masterHeartbeatPeriod" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.password.value" is not set in unstructured objects
 [missing_field] crd=sqlinstances.sql.cnrm.cloud.google.com version=v1beta1: field ".spec.replicaConfiguration.password.valueFrom.secretKeyRef" is not set; neither 'external' nor 'name' are set


### PR DESCRIPTION
As of January 13, 2025, the SQLInstance API deprecated the previous method of failover configuration. This fixes the test case to no longer use the deprecated configuration method.

Ref: https://cloud.google.com/sql/docs/mysql/configure-legacy-ha