### PR TITLE
tool: add `generate-fuzzer` to generate and qualify fuzzer

### DIFF
--- a/dev/tools/controllerbuilder/cmd/root.go
+++ b/dev/tools/controllerbuilder/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/exportcsv"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/generatecontroller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/generatedirectreconciler"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/generatefuzzer"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/generatemapper"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/generatetypes"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/commands/updatetypes"
@@ -48,6 +49,7 @@ func Execute() {
 	rootCmd.AddCommand(exportcsv.BuildPromptCommand(&generateOptions))
 	rootCmd.AddCommand(apply.BuildCommand(&generateOptions))
 	rootCmd.AddCommand(detectnewfields.BuildCommand(&generateOptions))
+	rootCmd.AddCommand(generatefuzzer.BuildCommand(&generateOptions))
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
@@ -1,0 +1,12 @@
+# Generate Fuzzer
+
+This command generates and qualifies a fuzzer for a given resource.
+
+## Usage
+
+```bash
+go run main.go generate-fuzzer \
+  --message "google.cloud.managedkafka.v1.Topic" \
+  --api-version "managedkafka.cnrm.cloud.google.com/v1alpha1" \
+  --max-attempts 3
+```

--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/generatefuzzercommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/generatefuzzercommand.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generatefuzzer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/options"
+	"github.com/spf13/cobra"
+)
+
+type generateFuzzerOptions struct {
+	*options.GenerateOptions
+	message     string
+	apiVersion  string
+	maxAttempts int
+}
+
+func (o *generateFuzzerOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.message, "message", o.message, "Proto message to generate fuzzer for")
+	cmd.Flags().StringVar(&o.apiVersion, "api-version", o.apiVersion, "API version to generate fuzzer for")
+	cmd.Flags().IntVar(&o.maxAttempts, "max-attempts", 5, "Maximum number of attempts to generate a valid fuzzer")
+}
+
+func BuildCommand(baseOptions *options.GenerateOptions) *cobra.Command {
+	opt := &generateFuzzerOptions{
+		GenerateOptions: baseOptions,
+	}
+	if err := opt.InitDefaults(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing defaults: %v\n", err)
+		os.Exit(1)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "generate-fuzzer",
+		Short: "Generate fuzzer tests for proto messages",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opt.message == "" {
+				// TODO: extract messages from generate.sh or api directory
+				return fmt.Errorf("--message flag is required")
+			}
+			if opt.apiVersion == "" {
+				return fmt.Errorf("--api-version flag is required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if err := RunGenerateFuzzer(ctx, opt); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	opt.BindFlags(cmd)
+	return cmd
+}
+
+func RunGenerateFuzzer(ctx context.Context, opt *generateFuzzerOptions) error {
+	root, err := options.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get repo root: %v", err)
+	}
+
+	goPackage := strings.Split(opt.apiVersion, ".")[0]                               // first token is Go package name which is also the subfolder name
+	resource := strings.ToLower(opt.message[strings.LastIndex(opt.message, ".")+1:]) // last token is the proto resource name
+
+	attempts := 0
+	for attempts < opt.maxAttempts {
+		attempts++
+
+		fmt.Printf("Generating fuzzer for %s.%s (attempt %d/%d)...\n", goPackage, resource, attempts, opt.maxAttempts)
+
+		// 1. Create output directory if it doesn't exist
+		outputPath := filepath.Join(root, "pkg/controller/direct", goPackage)
+		if err := os.MkdirAll(outputPath, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %v", err)
+		}
+
+		// 2. Generate fuzzer using the prompt command
+		cmd := exec.CommandContext(ctx, "go", "run", "main.go", "prompt")
+		cmd.Dir = filepath.Join(root, "dev/tools/controllerbuilder")
+		cmd.Env = append(os.Environ(), fmt.Sprintf("REPO_ROOT=%s", root))
+		// TODO: let user choose which LLM model to use via command flag, and pass it to the prompt command via env var
+
+		input := fmt.Sprintf("// +tool:fuzz-gen\n// proto.message: %s\n", opt.message)
+		cmd.Stdin = strings.NewReader(input)
+
+		outputFile := filepath.Join(root, "pkg/controller/direct", goPackage, fmt.Sprintf("%s_fuzzer.go", resource))
+		cmd.Stdout, err = os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %v", err)
+		}
+
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Fuzzer generation failed: %v\n%s\n", err, stderr.String())
+			continue // keep trying
+		}
+
+		// 3. Format the generated fuzzer
+		formatCmd := exec.CommandContext(ctx, "gofmt", "-w", outputFile)
+		var formatStderr bytes.Buffer
+		formatCmd.Stderr = &formatStderr
+
+		if err := formatCmd.Run(); err != nil {
+			fmt.Printf("gofmt failed: %v\nstderr: %s", err, formatStderr.String())
+			continue // gofmt failed, keep trying
+		}
+
+		// 4. Verify the generated fuzzer
+		fmt.Printf("Verifying fuzzer for %s.%s (attempt %d/%d)...\n", goPackage, resource, attempts, opt.maxAttempts)
+
+		testCmd := exec.CommandContext(ctx, "go", "test", "-v", filepath.Join(root, "pkg/fuzztesting/fuzztests"), "-fuzz=FuzzAllMappers", "-fuzztime", "60s")
+		var testStderr bytes.Buffer
+		testCmd.Stderr = &testStderr
+		if err := testCmd.Run(); err != nil {
+			fmt.Printf("Fuzzer verification failed: %v\nstderr: %s\n", err, testStderr.String())
+			continue // verification failed, keep trying
+		}
+
+		fmt.Printf("Fuzzer generated and verified for %s.%s\n", goPackage, resource)
+		break
+	}
+
+	return nil
+}

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -334,6 +334,12 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, input *Dat
 			lines = lines[:len(lines)-1]
 			continue
 		}
+
+		if strings.HasPrefix(lines[0], "out:") {
+			lines[0] = strings.TrimPrefix(lines[0], "out:")
+			continue
+		}
+
 		break
 	}
 

--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -52,7 +52,6 @@ go run main.go prompt \
   <<EOF > $REPO_ROOT/pkg/controller/direct/managedkafka/cluster_fuzzer.go
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Cluster
-// krm.kind: ManagedKafkaCluster
 EOF
 ```
 

--- a/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/cluster_fuzzer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Cluster
-// krm.kind: ManagedKafkaCluster
 
 package managedkafka
 
@@ -33,12 +32,12 @@ func managedKafkaClusterFuzzer() fuzztesting.KRMFuzzer {
 		ManagedKafkaClusterObservedState_FromProto, ManagedKafkaClusterObservedState_ToProto,
 	)
 
-	f.UnimplementedFields.Insert(".name")
-	f.UnimplementedFields.Insert(".satisfies_pzi")
-	f.UnimplementedFields.Insert(".satisfies_pzs")
+	f.UnimplementedFields.Insert(".name")          // special field
+	f.UnimplementedFields.Insert(".satisfies_pzi") // NOTYET
+	f.UnimplementedFields.Insert(".satisfies_pzs") // NOTYET
 
-	f.SpecFields.Insert(".labels")
 	f.SpecFields.Insert(".gcp_config")
+	f.SpecFields.Insert(".labels")
 	f.SpecFields.Insert(".capacity_config")
 	f.SpecFields.Insert(".rebalance_config")
 

--- a/pkg/controller/direct/managedkafka/topic_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/topic_fuzzer.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.managedkafka.v1.Topic
+
+package managedkafka
+
+import (
+	pb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMSpecFuzzer(managedKafkaTopicFuzzer())
+}
+
+func managedKafkaTopicFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedSpecFuzzer(&pb.Topic{},
+		ManagedKafkaTopicSpec_FromProto, ManagedKafkaTopicSpec_ToProto,
+	)
+
+	f.UnimplementedFields.Insert(".name")
+
+	f.SpecFields.Insert(".configs")
+	f.SpecFields.Insert(".partition_count")
+	f.SpecFields.Insert(".replication_factor")
+
+	return f
+}


### PR DESCRIPTION
Add a tool to automatically generate and validate the fuzzer for a direct resource.

```
$ go run main.go generate-fuzzer \
   --message "google.cloud.managedkafka.v1.Topic" \
   --api-version "managedkafka.cnrm.cloud.google.com/v1alpha1" \
   --max-attempts 3
Generating fuzzer for managedkafka.topic (attempt 1/3)...
Verifying fuzzer for managedkafka.topic (attempt 1/3)...
Fuzzer generated and verified for managedkafka.topic
```

```
$ go run main.go generate-fuzzer \
   --message "google.cloud.managedkafka.v1.Cluster" \
   --api-version "managedkafka.cnrm.cloud.google.com/v1alpha1" \
   --max-attempts 3
Generating fuzzer for managedkafka.cluster (attempt 1/3)...
Verifying fuzzer for managedkafka.cluster (attempt 1/3)...
Fuzzer generated and verified for managedkafka.cluster
```