### PR TITLE
chore: add gcloud to RunTerminalCommand

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codebot/tool_run_cmd.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/tool_run_cmd.go
@@ -63,6 +63,8 @@ func (t *RunTerminalCommand) Run(ctx context.Context, c *Chat, args map[string]a
 		cmd = exec.CommandContext(ctx, "go", tokens[1:]...)
 	case "make":
 		cmd = exec.CommandContext(ctx, "make", tokens[1:]...)
+	case "gcloud":
+		cmd = exec.CommandContext(ctx, "gcloud", tokens[1:]...)
 	default:
 		cmd = exec.CommandContext(ctx, "bash", "-c", t.Command)
 	}


### PR DESCRIPTION
allows codebot to discover the gcloud-based mock