### PR TITLE
chore: add a dedicated presubmit workflow to validate generated types

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -49,6 +49,20 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_HEAD: ${{ github.event.pull_request.head.sha }}
           COMMIT_CNT: ${{ github.event.pull_request.commits }}
+  validate-generated-types:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is to get all the commits in order to validate them
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Validate Generated Go Types"
+        run: |
+          dev/ci/presubmits/validate-generated-types.sh
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/dev/ci/presubmits/validate-generated-types.sh
+++ b/dev/ci/presubmits/validate-generated-types.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+### This check ensures that the generated Go types for direct resources are not manually modified by accident.
+### Ensures that the code generation tools can be safely re-run.
+### This check ignores copyright year changes.
+make generate-types
+diff_output=$(git diff --unified=0 | grep -v -E "^(diff --git|index |--- |\+\+\+ |@@ |[+-][[:space:]]*// Copyright.*Google LLC)") || true
+if echo "$diff_output" | grep -q "^[+-]"; then
+    echo "Full diff (excluding copyright changes):"
+    echo "$diff_output"
+    echo "ERROR: The generated types are outdated. Run 'make generate-types' to update them."
+    echo "If you need to modify any types, first move them out of the generated file."
+    echo "Then run 'make generate-types' again to ensure the generated file remains unchanged."
+    echo "Affected files:"
+    git diff --name-only
+    exit 1
+fi

--- a/scripts/validate-prereqs.sh
+++ b/scripts/validate-prereqs.sh
@@ -93,19 +93,3 @@ if [[ "${changed_file_count}" != "0" ]] || [[ "${added_reference_doc_file_count}
     git ls-files --others --exclude-standard scripts/generate-google3-docs/resource-reference/generated/
     exit 1
 fi
-
-### This check ensures that the generated Go types for direct resources are not manually modified by accident.
-### Ensures that the code generation tools can be safely re-run.
-### This check ignores copyright year changes.
-make generate-types
-diff_output=$(git diff --unified=0 | grep -v -E "^(diff --git|index |--- |\+\+\+ |@@ |[+-][[:space:]]*// Copyright.*Google LLC)") || true
-if echo "$diff_output" | grep -q "^[+-]"; then
-    echo "Full diff (excluding copyright changes):"
-    echo "$diff_output"
-    echo "ERROR: The generated types are outdated. Run 'make generate-types' to update them."
-    echo "If you need to modify any types, first move them out of the generated file."
-    echo "Then run 'make generate-types' again to ensure the generated file remains unchanged."
-    echo "Affected files:"
-    git diff --name-only
-    exit 1
-fi


### PR DESCRIPTION
#3396 introduced a step to validate the generated Go types for direct resources within `scripts/validate-prereqs.sh`. However, since this script is used by multiple systems, it may lead to unexpected errors. Let's separate the validation into its own script and presubmit workflow.