### PR TITLE
codebot: improve fuzzer generation

### DIFF
--- a/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
@@ -26,6 +26,7 @@ var BigQueryDataTransferConfigGVK = GroupVersion.WithKind("BigQueryDataTransferC
 // +kcc:proto=google.cloud.bigquery.datatransfer.v1.EncryptionConfiguration
 type EncryptionConfiguration struct {
 	// The KMS key used for encrypting BigQuery data.
+	// +kcc:proto:field=google.cloud.bigquery.datatransfer.v1.EncryptionConfiguration.kms_key_name
 	KmsKeyRef *refv1beta1.KMSCryptoKeyRef `json:"kmsKeyRef,omitempty"`
 }
 
@@ -54,6 +55,7 @@ type Status struct {
 type EventDrivenSchedule struct {
 	// Pub/Sub subscription used to receive events.
 	//  Only Google Cloud Storage data source support this option.
+	// +kcc:proto:field=google.cloud.bigquery.datatransfer.v1.EventDrivenSchedule.pubsub_subscription
 	PubSubSubscriptionRef *refv1beta1.PubSubSubscriptionRef `json:"pubSubSubscriptionRef,omitempty"`
 }
 
@@ -80,6 +82,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	// The BigQuery target dataset id.
 	// +required
+	// +kcc:proto:field=google.cloud.bigquery.datatransfer.v1.TransferConfig.destination_dataset_id
 	DatasetRef *bigquery.DatasetRef `json:"datasetRef,omitempty"`
 
 	// Is this config disabled. When set to true, no runs will be scheduled for
@@ -106,6 +109,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	// Pub/Sub topic where notifications will be sent after transfer runs
 	//  associated with this transfer config finish.
+	// +kcc:proto:field=google.cloud.bigquery.datatransfer.v1.TransferConfig.notification_pubsub_topic
 	PubSubTopicRef *refv1beta1.PubSubTopicRef `json:"pubSubTopicRef,omitempty"`
 
 	// +required

--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -143,10 +143,15 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 
 	log.Info("built data point", "dataPoint", dataPoint)
 
-	out := &bytes.Buffer{}
-	if err := x.InferOutput_WithCompletion(ctx, dataPoint, out); err != nil {
-		return fmt.Errorf("running LLM inference: %w", err)
+	model := os.Getenv("LLM_MODEL")
+	if model == "" {
+		model = "gemini-2.0-pro-exp-02-05"
+	}
+	log.Info("using model", "model", model)
 
+	out := &bytes.Buffer{}
+	if err := x.InferOutput_WithCompletion(ctx, model, dataPoint, out); err != nil {
+		return fmt.Errorf("running LLM inference: %w", err)
 	}
 
 	if o.Output == "" {

--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -109,7 +109,12 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 	if err != nil {
 		return err
 	}
-	x, err := toolbot.NewCSVExporter(extractor, addProtoDefinition, addGoStruct)
+	mapperDir := o.SrcDir + "/pkg/controller/direct/" // direct controller directory contains all mapper functions
+	addMapperFunctions, err := toolbot.NewEnhanceWithMappers(mapperDir)
+	if err != nil {
+		return err
+	}
+	x, err := toolbot.NewCSVExporter(extractor, addProtoDefinition, addGoStruct, addMapperFunctions)
 	if err != nil {
 		return err
 	}

--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
@@ -2,11 +2,19 @@
 
 This command generates and qualifies a fuzzer for a given resource.
 
-## Usage
+## Example Usage
 
 ```bash
 go run main.go generate-fuzzer \
   --message "google.cloud.managedkafka.v1.Topic" \
   --api-version "managedkafka.cnrm.cloud.google.com/v1alpha1" \
+  --max-attempts 3
+```
+
+```bash
+go run main.go generate-fuzzer \
+  --message "google.cloud.bigquery.datatransfer.v1.TransferConfig" \
+  --api-version "bigquerydatatransfer.cnrm.cloud.google.com/v1beta1" \
+  --llm-model "gemini-2.0-flash-exp" \
   --max-attempts 3
 ```

--- a/dev/tools/controllerbuilder/pkg/llm/vertexai.go
+++ b/dev/tools/controllerbuilder/pkg/llm/vertexai.go
@@ -76,6 +76,11 @@ func (c *VertexAIClient) Close() error {
 	return c.client.Close()
 }
 
+func (c *VertexAIClient) WithModel(model string) *VertexAIClient {
+	c.model = model
+	return c
+}
+
 func (c *VertexAIClient) StartChat(systemPrompt string) Chat {
 	model := c.client.GenerativeModel(c.model)
 

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -198,6 +198,9 @@ func (x *CSVExporter) pickExamples(input *DataPoint) []*DataPoint {
 		if dataPoint.Type != input.Type {
 			continue
 		}
+		if dataPoint.Type == "fuzz-gen" && dataPoint.Input["api.group"] == "" { // Hack to only include data points with "api.group" marker
+			continue
+		}
 		examples = append(examples, dataPoint)
 	}
 	return examples

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -262,7 +262,7 @@ func (x *CSVExporter) InferOutput_WithChat(ctx context.Context, input *DataPoint
 }
 
 // InferOutput_WithCompletion tries to infer an output value, using the Completion LLM APIs.
-func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, input *DataPoint, out io.Writer) error {
+func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, model string, input *DataPoint, out io.Writer) error {
 	log := klog.FromContext(ctx)
 
 	client, err := llm.BuildVertexAIClient(ctx)
@@ -270,6 +270,10 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, input *Dat
 		return fmt.Errorf("building gemini client: %w", err)
 	}
 	defer client.Close()
+
+	if model != "" {
+		client.WithModel(model)
+	}
 
 	var prompt strings.Builder
 

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -282,7 +282,23 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, model stri
 		"mockgcp-support":
 		fmt.Fprintf(&prompt, "I'm implementing a mock for a proto API.  I need to implement go code that implements the proto service.  Here are some examples:\n")
 	case "fuzz-gen":
-		fmt.Fprintf(&prompt, "I'm implementing a fuzzer for a proto message.  I need to configure the fuzzer with the appropriate fields. Please only reference the exisitng mappers, do not create any new mapper.  Here are some examples:\n")
+		fmt.Fprintf(&prompt,
+			"Create a fuzzer function for testing KRM (Kubernetes Resource Model) type conversions.\n\n"+
+				"Function signature:\n"+
+				"func <resourceName>Fuzzer() fuzztesting.KRMFuzzer\n\n"+
+				"The function should:\n"+
+				"1. Create a new fuzzer with fuzztesting.NewKRMTypedFuzzer() using:\n"+
+				"   - Proto message type (&pb.YourType{})\n"+
+				"   - Top-level mapping functions (Spec_FromProto, Spec_ToProto, and if exists: ObservedState_FromProto, ObservedState_ToProto, or Status_FromProto, Status_ToProto)\n\n"+
+				"2. Configure field sets:\n"+
+				"   - UnimplementedFields: fields to exclude from fuzzing (e.g., NOTYET fields, a field that is not included in the mapping function of its parent message)\n"+
+				"   - SpecFields: fields in the resource spec\n"+
+				"   - StatusFields: fields in the resource status\n\n"+
+				"Context:\n"+
+				"- All mapper functions for the resource are provided for reference\n"+
+				"- Nested mapper functions can help identify which fields should be marked as unimplemented\n"+
+				"- Only top-level mapper functions are needed in the fuzzer initialization\n\n"+
+				"Examples:\n")
 	}
 
 	examples := x.pickExamples(input)

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -273,7 +273,13 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, input *Dat
 
 	var prompt strings.Builder
 
-	fmt.Fprintf(&prompt, "I'm implementing a mock for a proto API.  I need to implement go code that implements the proto service.  Here are some examples:\n")
+	switch input.Type {
+	case "mockgcp-service",
+		"mockgcp-support":
+		fmt.Fprintf(&prompt, "I'm implementing a mock for a proto API.  I need to implement go code that implements the proto service.  Here are some examples:\n")
+	case "fuzz-gen":
+		fmt.Fprintf(&prompt, "I'm implementing a fuzzer for a proto message.  I need to configure the fuzzer with the appropriate fields. Please only reference the exisitng mappers, do not create any new mapper.  Here are some examples:\n")
+	}
 
 	examples := x.pickExamples(input)
 

--- a/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+var _ Enhancer = &EnhanceWithMappers{}
+
+// EnhanceWithMappers is an enhancer that finds Go mapper functions in a directory
+type EnhanceWithMappers struct {
+	srcDirectory string
+}
+
+// NewEnhanceWithMappers creates a new EnhanceWithMappers
+func NewEnhanceWithMappers(srcDirectory string) (*EnhanceWithMappers, error) {
+	return &EnhanceWithMappers{
+		srcDirectory: srcDirectory,
+	}, nil
+}
+
+// EnhanceDataPoint enhances the data point by adding mapper function definitions
+func (x *EnhanceWithMappers) EnhanceDataPoint(ctx context.Context, p *DataPoint) error {
+	if p.Type != "fuzz-gen" { // Only enhance if this is a fuzz-gen tool
+		return nil
+	}
+
+	apiGroup := p.Input["api.group"]
+	if apiGroup == "" {
+		return nil
+	}
+
+	// Extract resource type from API group (e.g., "bigquerydatatransfer" from "bigquerydatatransfer.cnrm.cloud.google.com")
+	resourceType := strings.Split(apiGroup, ".")[0]
+
+	// Find mapper files in the resource-specific directory
+	mapperDir := filepath.Join(x.srcDirectory, resourceType)
+	files, err := os.ReadDir(mapperDir)
+	if err != nil {
+		return fmt.Errorf("reading mapper directory: %w", err)
+	}
+
+	var mappers []string
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".go") {
+			continue
+		}
+
+		// Look for mapper files. .e.g xx_mappings.go, xx_mapper.go, mapper.go, mappers.go, etc.
+		if !strings.Contains(file.Name(), "mapp") && !strings.Contains(file.Name(), "mapper.generated.go") {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(mapperDir, file.Name()))
+		if err != nil {
+			return fmt.Errorf("reading mapper file: %w", err)
+		}
+
+		// Skip license header, package declaration, and imports
+		lines := strings.Split(string(content), "\n")
+		start := 0
+		for i, line := range lines {
+			if strings.HasPrefix(strings.TrimSpace(line), "func ") {
+				start = i
+				break
+			}
+		}
+
+		mappers = append(mappers, strings.Join(lines[start:], "\n"))
+	}
+
+	if len(mappers) > 0 {
+		p.SetInput("go.mappers", strings.Join(mappers, "\n\n"))
+	} else {
+		klog.Infof("no mapper functions found for resource type %q", resourceType)
+	}
+
+	return nil
+}

--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -48,6 +48,7 @@ Note: For Beta resources, a fuzzer test is required for both the `Spec` and `Sta
 export REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd $REPO_ROOT/dev/tools/controllerbuilder
 
+LLM_MODEL="gemini-2.0-flash-exp" \
 go run main.go prompt \
   <<EOF > $REPO_ROOT/pkg/controller/direct/managedkafka/cluster_fuzzer.go
 // +tool:fuzz-gen

--- a/docs/develop-resources/deep-dives/3-add-mapper.md
+++ b/docs/develop-resources/deep-dives/3-add-mapper.md
@@ -50,9 +50,10 @@ cd $REPO_ROOT/dev/tools/controllerbuilder
 
 LLM_MODEL="gemini-2.0-flash-exp" \
 go run main.go prompt \
-  <<EOF > $REPO_ROOT/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+  <<EOF > $REPO_ROOT/pkg/controller/direct/bigquerydatatransfer/transferconfig_fuzzer.go
 // +tool:fuzz-gen
-// proto.message: google.cloud.managedkafka.v1.Cluster
+// proto.message: google.cloud.bigquery.datatransfer.v1.TransferConfig
+// api.group: bigquerydatatransfer.cnrm.cloud.google.com
 EOF
 ```
 

--- a/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransfer_mappings.go
+++ b/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransfer_mappings.go
@@ -156,6 +156,8 @@ func Status_ToProto(mapCtx *direct.MapContext, in *krm.Status) *statuspb.Status 
 	out := &statuspb.Status{}
 	out.Code = direct.ValueOf(in.Code)
 	out.Message = direct.ValueOf(in.Message)
+	// NOTYET
+	// out.Details
 	return out
 }
 func Status_FromProto(mapCtx *direct.MapContext, in *statuspb.Status) *krm.Status {
@@ -165,6 +167,8 @@ func Status_FromProto(mapCtx *direct.MapContext, in *statuspb.Status) *krm.Statu
 	out := &krm.Status{}
 	out.Code = direct.LazyPtr(in.GetCode())
 	out.Message = direct.LazyPtr(in.GetMessage())
+	// NOTYET
+	// out.Details
 	return out
 }
 func EventDrivenSchedule_FromProto(mapCtx *direct.MapContext, in *pb.EventDrivenSchedule) *krm.EventDrivenSchedule {

--- a/pkg/controller/direct/bigquerydatatransfer/transferconfig_fuzzer.go
+++ b/pkg/controller/direct/bigquerydatatransfer/transferconfig_fuzzer.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.bigquery.datatransfer.v1.TransferConfig
+// api.group: bigquerydatatransfer.cnrm.cloud.google.com
+
+package bigquerydatatransfer
+
+import (
+	pb "cloud.google.com/go/bigquery/datatransfer/apiv1/datatransferpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(bigQueryDataTransferConfigFuzzer())
+}
+
+func bigQueryDataTransferConfigFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.TransferConfig{},
+		BigQueryDataTransferConfigSpec_FromProto, BigQueryDataTransferConfigSpec_ToProto,
+		BigQueryDataTransferConfigObservedState_FromProto, BigQueryDataTransferConfigObservedState_ToProto,
+	)
+
+	f.SpecFields.Insert(".destination_dataset_id")
+	f.SpecFields.Insert(".display_name")
+	f.SpecFields.Insert(".data_source_id")
+	f.SpecFields.Insert(".params")
+	f.SpecFields.Insert(".schedule")
+	f.SpecFields.Insert(".schedule_options")
+	f.SpecFields.Insert(".data_refresh_window_days")
+	f.SpecFields.Insert(".disabled")
+	f.SpecFields.Insert(".notification_pubsub_topic")
+	f.SpecFields.Insert(".email_preferences")
+	f.SpecFields.Insert(".encryption_configuration")
+	f.SpecFields.Insert(".schedule_options_v2")
+
+	f.StatusFields.Insert(".name")
+	f.StatusFields.Insert(".update_time")
+	f.StatusFields.Insert(".next_run_time")
+	f.StatusFields.Insert(".state")
+	f.StatusFields.Insert(".dataset_region")
+	f.StatusFields.Insert(".owner_info")
+	f.StatusFields.Insert(".user_id")
+	f.StatusFields.Insert(".error")
+
+	f.UnimplementedFields.Insert(".error.details")
+
+	return f
+}

--- a/pkg/controller/direct/iap/iapsettings_fuzzer.go
+++ b/pkg/controller/direct/iap/iapsettings_fuzzer.go
@@ -14,6 +14,7 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.iap.v1.IapSettings
+// api.group: iap.cnrm.cloud.google.com
 
 package iap
 

--- a/pkg/controller/direct/managedkafka/cluster_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/cluster_fuzzer.go
@@ -14,6 +14,7 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Cluster
+// api.group: managedkafka.cnrm.cloud.google.com
 
 package managedkafka
 

--- a/pkg/controller/direct/privilegedaccessmanager/fuzzers.go
+++ b/pkg/controller/direct/privilegedaccessmanager/fuzzers.go
@@ -14,6 +14,7 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.privilegedaccessmanager.v1.Entitlement
+// api.group: privilegedaccessmanager.cnrm.cloud.google.com
 
 package privilegedaccessmanager
 


### PR DESCRIPTION
Making some improvements to the fuzz-gen tool:  
- A configurable LLM model  
- An improved prompt  
- Enhanced data points with mapping functions (providing this info to the LLM since contributors also need it when manually writing a fuzzer)
- Generating a fuzzer for `BigQueryDataTransferConfig`, which is a fairly complex resource.

Example run:
```
go run main.go generate-fuzzer \
  --message "google.cloud.bigquery.datatransfer.v1.TransferConfig" \
  --api-version "bigquerydatatransfer.cnrm.cloud.google.com/v1beta1" \
  --llm-model "gemini-2.0-flash-exp" \
  --max-attempts 3
Generating fuzzer for bigquerydatatransfer.transferconfig (attempt 1/3)...
Verifying fuzzer for bigquerydatatransfer.transferconfig (attempt 1/3)...
Fuzzer verification failed: exit status 1
stderr: 
Generating fuzzer for bigquerydatatransfer.transferconfig (attempt 2/3)...
Verifying fuzzer for bigquerydatatransfer.transferconfig (attempt 2/3)...
Fuzzer generated and verified for bigquerydatatransfer.transferconfig
```