### PR TITLE
chore: generate more fuzzers

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
@@ -18,3 +18,11 @@ go run main.go generate-fuzzer \
   --llm-model "gemini-2.0-flash-exp" \
   --max-attempts 3
 ```
+
+```bash
+go run main.go generate-fuzzer \
+  --message "google.cloud.redis.cluster.v1.Cluster" \
+  --api-version "redis.cnrm.cloud.google.com/v1beta1" \
+  --llm-model "gemini-2.0-flash-exp" \
+  --max-attempts 5
+```

--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
@@ -34,3 +34,11 @@ go run main.go generate-fuzzer \
   --llm-model "gemini-2.0-flash-exp" \
   --max-attempts 5
 ```
+
+```bash
+go run main.go generate-fuzzer \
+  --message "google.cloud.securesourcemanager.v1.Repository" \
+  --api-version "securesourcemanager.cnrm.cloud.google.com/v1alpha1" \
+  --llm-model "gemini-2.0-flash-exp" \
+  --max-attempts 5
+```

--- a/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
+++ b/dev/tools/controllerbuilder/pkg/commands/generatefuzzer/README.md
@@ -26,3 +26,11 @@ go run main.go generate-fuzzer \
   --llm-model "gemini-2.0-flash-exp" \
   --max-attempts 5
 ```
+
+```bash
+go run main.go generate-fuzzer \
+  --message "google.cloud.securesourcemanager.v1.Instance" \
+  --api-version "securesourcemanager.cnrm.cloud.google.com/v1alpha1" \
+  --llm-model "gemini-2.0-flash-exp" \
+  --max-attempts 5
+```

--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -290,17 +290,18 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, model stri
 				"Function signature:\n"+
 				"func <resourceName>Fuzzer() fuzztesting.KRMFuzzer\n\n"+
 				"The function should:\n"+
-				"1. Create a new fuzzer with fuzztesting.NewKRMTypedFuzzer() using:\n"+
+				"1. Create a new fuzzer using:\n"+
 				"   - Proto message type (&pb.YourType{})\n"+
 				"   - Top-level mapping functions (Spec_FromProto, Spec_ToProto, and if exists: ObservedState_FromProto, ObservedState_ToProto, or Status_FromProto, Status_ToProto)\n\n"+
 				"2. Configure field sets:\n"+
-				"   - UnimplementedFields: fields to exclude from fuzzing (e.g., NOTYET fields, a field that is not included in the mapping function of its parent message)\n"+
+				"   - UnimplementedFields: fields to exclude from fuzzing (e.g., NOTYET fields, or a field conversion that is missing in the mapping function of its parent message)\n"+
 				"   - SpecFields: fields in the resource spec\n"+
 				"   - StatusFields: fields in the resource status\n\n"+
 				"Context:\n"+
 				"- All mapper functions for the resource are provided for reference\n"+
 				"- Nested mapper functions can help identify which fields should be marked as unimplemented\n"+
-				"- Only top-level mapper functions are needed in the fuzzer initialization\n\n"+
+				"- Only top-level mapper functions are needed in the fuzzer initialization\n"+
+				"- Use the same protobuf import alias ('pb') as used in the mapper functions\n\n"+
 				"Examples:\n")
 	}
 
@@ -342,14 +343,19 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, model stri
 
 	lines := strings.Split(strings.TrimSpace(text), "\n")
 
-	// Remove some of the decoration
+	// First remove trailing empty lines
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Then remove decorative elements
 	for len(lines) > 1 {
 		if lines[0] == "```go" {
 			lines = lines[1:]
 			continue
 		}
 
-		if lines[len(lines)-1] == "```" {
+		if lines[len(lines)-1] == "```" || lines[len(lines)-1] == "``" {
 			lines = lines[:len(lines)-1]
 			continue
 		}

--- a/pkg/controller/direct/iap/iapsettings_fuzzer.go
+++ b/pkg/controller/direct/iap/iapsettings_fuzzer.go
@@ -14,7 +14,6 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.iap.v1.IapSettings
-// api.group: iap.cnrm.cloud.google.com
 
 package iap
 

--- a/pkg/controller/direct/managedkafka/topic_fuzzer.go
+++ b/pkg/controller/direct/managedkafka/topic_fuzzer.go
@@ -14,6 +14,7 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.managedkafka.v1.Topic
+// api.group: managedkafka.cnrm.cloud.google.com
 
 package managedkafka
 

--- a/pkg/controller/direct/redis/cluster/cluster_fuzzer.go
+++ b/pkg/controller/direct/redis/cluster/cluster_fuzzer.go
@@ -16,7 +16,7 @@
 // proto.message: google.cloud.redis.cluster.v1.Cluster
 // api.group: redis.cnrm.cloud.google.com
 
-package redis
+package cluster
 
 import (
 	pb "cloud.google.com/go/redis/cluster/apiv1/clusterpb"

--- a/pkg/controller/direct/redis/cluster_fuzzer.go
+++ b/pkg/controller/direct/redis/cluster_fuzzer.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.redis.cluster.v1.Cluster
+// api.group: redis.cnrm.cloud.google.com
+
+package redis
+
+import (
+	pb "cloud.google.com/go/redis/cluster/apiv1/clusterpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(redisClusterFuzzer())
+}
+
+func redisClusterFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Cluster{},
+		RedisClusterSpec_FromProto, RedisClusterSpec_ToProto,
+		RedisClusterObservedState_FromProto, RedisClusterObservedState_ToProto,
+	)
+
+	f.UnimplementedFields.Insert(".name") // Identifier
+
+	f.SpecFields.Insert(".authorization_mode")
+	f.SpecFields.Insert(".transit_encryption_mode")
+	f.SpecFields.Insert(".shard_count")
+	f.SpecFields.Insert(".psc_configs")
+	f.SpecFields.Insert(".node_type")
+	f.SpecFields.Insert(".persistence_config")
+	f.SpecFields.Insert(".redis_configs")
+	f.SpecFields.Insert(".replica_count")
+	f.SpecFields.Insert(".zone_distribution_config")
+	f.SpecFields.Insert(".deletion_protection_enabled")
+
+	f.StatusFields.Insert(".create_time")
+	f.StatusFields.Insert(".state")
+	f.StatusFields.Insert(".uid")
+	f.StatusFields.Insert(".size_gb")
+	f.StatusFields.Insert(".discovery_endpoints")
+	f.StatusFields.Insert(".psc_connections")
+	f.StatusFields.Insert(".state_info")
+	f.StatusFields.Insert(".precise_size_gb")
+
+	return f
+}

--- a/pkg/controller/direct/securesourcemanager/instance_fuzzer.go
+++ b/pkg/controller/direct/securesourcemanager/instance_fuzzer.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.securesourcemanager.v1.Instance
+// api.group: securesourcemanager.cnrm.cloud.google.com
+
+package securesourcemanager
+
+import (
+	pb "cloud.google.com/go/securesourcemanager/apiv1/securesourcemanagerpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(secureSourceManagerInstanceFuzzer())
+}
+
+func secureSourceManagerInstanceFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Instance{},
+		SecureSourceManagerInstanceSpec_FromProto, SecureSourceManagerInstanceSpec_ToProto,
+		SecureSourceManagerInstanceObservedState_FromProto, SecureSourceManagerInstanceObservedState_ToProto,
+	)
+
+	f.UnimplementedFields.Insert(".name")        // Identifier
+	f.UnimplementedFields.Insert(".create_time") // Output only
+	f.UnimplementedFields.Insert(".update_time") // Output only
+	f.UnimplementedFields.Insert(".labels")      // NOTYET
+
+	f.SpecFields.Insert(".private_config")
+	f.SpecFields.Insert(".kms_key")
+
+	f.StatusFields.Insert(".state")
+	f.StatusFields.Insert(".state_note")
+	f.StatusFields.Insert(".host_config")
+
+	return f
+}

--- a/pkg/controller/direct/securesourcemanager/repository_fuzzer.go
+++ b/pkg/controller/direct/securesourcemanager/repository_fuzzer.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:fuzz-gen
+// proto.message: google.cloud.securesourcemanager.v1.Repository
+// api.group: securesourcemanager.cnrm.cloud.google.com
+
+package securesourcemanager
+
+import (
+	pb "cloud.google.com/go/securesourcemanager/apiv1/securesourcemanagerpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/fuzztesting"
+)
+
+func init() {
+	fuzztesting.RegisterKRMFuzzer(secureSourceManagerRepositoryFuzzer())
+}
+
+func secureSourceManagerRepositoryFuzzer() fuzztesting.KRMFuzzer {
+	f := fuzztesting.NewKRMTypedFuzzer(&pb.Repository{},
+		SecureSourceManagerRepositorySpec_FromProto, SecureSourceManagerRepositorySpec_ToProto,
+		SecureSourceManagerRepositoryObservedState_FromProto, SecureSourceManagerRepositoryObservedState_ToProto,
+	)
+
+	f.UnimplementedFields.Insert(".name") // Identifier
+	f.UnimplementedFields.Insert(".description")
+	f.UnimplementedFields.Insert(".uid")
+	f.UnimplementedFields.Insert(".create_time")
+	f.UnimplementedFields.Insert(".update_time")
+	f.UnimplementedFields.Insert(".etag")
+	f.UnimplementedFields.Insert(".uris")
+
+	f.SpecFields.Insert(".instance")
+	f.SpecFields.Insert(".initial_config")
+
+	f.StatusFields.Insert(".uid")
+	f.StatusFields.Insert(".etag")
+	f.StatusFields.Insert(".uris")
+
+	return f
+}


### PR DESCRIPTION
Couple findings:
 - Many existing direct resources do not fully adhere to best practices, which means the fuzz gen tool won’t work well for them.
 - For some resources with the legacy "roundtrip_test.go" files. I noticed that some "roundtrip_test.go" files incorrectly mark fields—for example, in `XXXSpecFuzz`, unimplemented fields and status fields have the same effect, making them easy to mix up. The generated fuzzer does not have this issue.