### PR TITLE
fix: apigee: wait for ref to be ready

### DIFF
--- a/apis/apigee/v1beta1/organization_reference.go
+++ b/apis/apigee/v1beta1/organization_reference.go
@@ -85,6 +85,15 @@ func (r *OrganizationRef) NormalizedExternal(ctx context.Context, reader client.
 
 	// TODO: Use status.externalRef once direct controller is implemented.
 	// For now, we can use status.projectID.
+	// BUT only construct the reference if the resource is ready
+	resource, err := k8s.NewResource(u)
+	if err != nil {
+		return "", fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return "", k8s.NewReferenceNotReadyError(u.GroupVersionKind(), key)
+	}
+
 	projectID, _, err := unstructured.NestedString(u.Object, "status", "projectId")
 	if err != nil {
 		return "", fmt.Errorf("reading status.externalRef: %w", err)


### PR DESCRIPTION
Technically we want to wait for an object's reference to be ready before sending actual requests for the object to the cloud provider. The understanding is that those requests will fail bc the reference is not ready.

(probably need to rebase on #3701 once merged)