### PR TITLE
fix: wait for ref to be ready

### DIFF
--- a/apis/refs/v1beta1/computerefs.go
+++ b/apis/refs/v1beta1/computerefs.go
@@ -150,6 +150,13 @@ func (ref *ComputeNetworkRef) Normalize(ctx context.Context, reader client.Reade
 		}
 		return fmt.Errorf("error reading referenced ComputeNetwork %v: %w", key, err)
 	}
+	resource, err := k8s.NewResource(computeNetwork)
+	if err != nil {
+		return fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return k8s.NewReferenceNotReadyError(computeNetwork.GroupVersionKind(), key)
+	}
 
 	resourceID, err := GetResourceID(computeNetwork)
 	if err != nil {

--- a/apis/refs/v1beta1/dataprocclusterref.go
+++ b/apis/refs/v1beta1/dataprocclusterref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,6 +91,13 @@ func ResolveDataprocClusterRef(ctx context.Context, reader client.Reader, obj cl
 			return nil, fmt.Errorf("referenced DataprocCluster %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced DataprocCluster %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(cluster.GroupVersionKind(), key)
 	}
 
 	resourceID, _, err := unstructured.NestedString(cluster.Object, "spec", "resourceID")

--- a/apis/refs/v1beta1/kmsrefs.go
+++ b/apis/refs/v1beta1/kmsrefs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,6 +88,13 @@ func ResolveKMSCryptoKeyRef(ctx context.Context, reader client.Reader, src clien
 			return nil, fmt.Errorf("referenced KMSCryptoKey %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced KMSCryptoKey %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(kmsKey)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(kmsKey.GroupVersionKind(), key)
 	}
 
 	kmsKeyResourceID, err := GetResourceID(kmsKey)

--- a/apis/refs/v1beta1/privatecaref.go
+++ b/apis/refs/v1beta1/privatecaref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,6 +88,13 @@ func ResolvePrivateCACAPoolRef(ctx context.Context, reader client.Reader, src cl
 			return nil, fmt.Errorf("referenced PrivateCACAPool %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced PrivateCACAPool %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(caPool)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(caPool.GroupVersionKind(), key)
 	}
 
 	caPoolResourceID, err := GetResourceID(caPool)

--- a/apis/refs/v1beta1/pubsubref.go
+++ b/apis/refs/v1beta1/pubsubref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -85,6 +86,14 @@ func ResolvePubSubTopic(ctx context.Context, reader client.Reader, src client.Ob
 		}
 		return nil, fmt.Errorf("error reading referenced PubSubTopic %v: %w", nn, err)
 	}
+	resource, err := k8s.NewResource(pubSubTopic)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(pubSubTopic.GroupVersionKind(), nn)
+	}
+
 	projectID, err := ResolveProjectID(ctx, reader, pubSubTopic)
 	if err != nil {
 		return nil, err

--- a/apis/refs/v1beta1/secretmanagerrefs.go
+++ b/apis/refs/v1beta1/secretmanagerrefs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +87,13 @@ func ResolveSecretManagerSecretRef(ctx context.Context, reader client.Reader, sr
 			return nil, fmt.Errorf("referenced SecretManagerSecret %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced SecretManagerSecret %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(secret)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(secret.GroupVersionKind(), key)
 	}
 
 	secretResourceID, err := GetResourceID(secret)

--- a/apis/refs/v1beta1/spannerinstanceref.go
+++ b/apis/refs/v1beta1/spannerinstanceref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -88,6 +89,13 @@ func ResolveSpannerInstanceRef(ctx context.Context, reader client.Reader, obj cl
 			return nil, fmt.Errorf("referenced SpannerInstance %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced SpannerInstance %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(spannerinstance)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(spannerinstance.GroupVersionKind(), key)
 	}
 
 	resourceID, _, err := unstructured.NestedString(spannerinstance.Object, "spec", "resourceID")

--- a/apis/refs/v1beta1/sqlinstanceref.go
+++ b/apis/refs/v1beta1/sqlinstanceref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -93,6 +94,13 @@ func ResolveSQLInstanceRef(ctx context.Context, reader client.Reader, obj client
 			return nil, fmt.Errorf("referenced SQLInstance %v not found", key)
 		}
 		return nil, fmt.Errorf("error reading referenced SQLInstance %v: %w", key, err)
+	}
+	resource, err := k8s.NewResource(sqlinstance)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured to resource: %w", err)
+	}
+	if !k8s.IsResourceReady(resource) {
+		return nil, k8s.NewReferenceNotReadyError(sqlinstance.GroupVersionKind(), key)
 	}
 
 	resourceID, _, err := unstructured.NestedString(sqlinstance.Object, "spec", "resourceID")


### PR DESCRIPTION
Technically we want to wait for an object's reference to be ready before sending actual requests for the object to the cloud provider. The understanding is that those requests will fail bc the reference is not ready.

This PR adds fixes for the "old new" (intermediate) style refs.

(Will need rebasing on #3701)