### PR TITLE
fix: update groupversion_info.go

### DIFF
--- a/apis/apigee/v1beta1/groupversion_info.go
+++ b/apis/apigee/v1beta1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "apigee.cnrm.cloud.google.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "apigee.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}


### PR DESCRIPTION
This should probably be `v1beta1`. Yet another thing we can write a linter for 😝
