### PR TITLE
test: fix computenetworkautocreatesubnets test

### DIFF
--- a/config/samples/resources/computenetwork/compute_v1beta1_computenetwork.yaml
+++ b/config/samples/resources/computenetwork/compute_v1beta1_computenetwork.yaml
@@ -21,3 +21,5 @@ metadata:
 spec:
   routingMode: REGIONAL
   autoCreateSubnetworks: true
+  # ULA internal ipv6 is not supported for auto mode network
+  enableUlaInternalIpv6: false

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_generated_object_computenetworkautocreatesubnets.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_generated_object_computenetworkautocreatesubnets.golden.yaml
@@ -11,12 +11,12 @@ metadata:
   generation: 3
   labels:
     cnrm-test: "true"
-    label-one: value-one
+    label-one: value-two
   name: computenetwork-${uniqueId}
   namespace: ${uniqueId}
 spec:
   autoCreateSubnetworks: true
-  enableUlaInternalIpv6: true
+  enableUlaInternalIpv6: false
   resourceID: computenetwork-${uniqueId}
   routingMode: GLOBAL
 status:

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/create.yaml
@@ -23,4 +23,5 @@ metadata:
 spec:
   routingMode: REGIONAL
   autoCreateSubnetworks: true
+  # ULA internal ipv6 is not supported for auto mode network
   enableUlaInternalIpv6: false

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/update.yaml
@@ -18,9 +18,10 @@ metadata:
   annotations:
     cnrm.cloud.google.com/project-id: "${projectId}"
   labels:
-    label-one: "value-one"
+    label-one: "value-two"
   name: computenetwork-${uniqueId}
 spec:
   routingMode: GLOBAL
   autoCreateSubnetworks: true
-  enableUlaInternalIpv6: true
+  # ULA internal ipv6 is not supported for auto mode network
+  enableUlaInternalIpv6: false

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenetwork.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computenetwork.md
@@ -332,6 +332,8 @@ metadata:
 spec:
   routingMode: REGIONAL
   autoCreateSubnetworks: true
+  # ULA internal ipv6 is not supported for auto mode network
+  enableUlaInternalIpv6: false
 ```
 
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
error message: `ULA internal ipv6 is not supported for auto mode network`

This was introduced in #1506. `enable_ula_internal_ipv6` should remain `false` when `autoCreateSubnetworks` is set to true. The update of this field was covered in computenetworkbasic test.
Also updated the samples yaml with a comment.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->
--- PASS: TestCreateNoChangeUpdateDelete (0.17s)
    --- PASS: TestCreateNoChangeUpdateDelete/compute (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/compute/basic-computenetworkautocreatesubnets (316.60s)
PASS

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
