### PR TITLE
chore: move scenarios-tests github action to follow pattern

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -192,9 +192,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: "run tests-e2e-scenarios"
+      - name: "run scenarios-tests"
         run: |
-          ./scripts/github-actions/tests-e2e-scenarios.sh
+          ./dev/ci/scenarios-tests
   tests-e2e-fixtures-vcr:
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ powertool-tests:
 
 .PHONY: e2e-scenario-tests
 e2e-scenario-tests:
-	cd scripts/github-actions/ && ./tests-e2e-scenarios.sh
+	dev/ci/scenarios-tests
 
 # indicate which samples testcases will be run
 SAMPLE_TESTCASE ?= TestAllInSeries/samples

--- a/dev/ci/scenarios-tests
+++ b/dev/ci/scenarios-tests
@@ -18,11 +18,13 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
 export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+
+# Always write golden output
+export WRITE_GOLDEN_OUTPUT=1
 
 echo "Running scenarios tests..."
 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock RUN_E2E=1 \


### PR DESCRIPTION
* github actions should map to a script in dev/ci/
* scripts should be runnable directly
* tests that verify golden output should write the golden output
