### PR TITLE
mockgcp: support for resource-manager TagBindings

### DIFF
--- a/mockgcp/mockresourcemanager/tagbinding.go
+++ b/mockgcp/mockresourcemanager/tagbinding.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.resourcemanager.v3.TagBindings
+// proto.message: google.cloud.resourcemanager.v3.TagBinding
+
+package mockresourcemanager
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	lropb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/resourcemanager/v3"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+)
+
+func (s *TagBindingsServer) normalizeParent(ctx context.Context, parent string) (string, error) {
+	if suffix, ok := strings.CutPrefix(parent, "//cloudresourcemanager.googleapis.com/projects/"); ok {
+		project, err := s.Projects.GetProjectByIDOrNumber(suffix)
+		if err != nil {
+			return "", err
+		}
+		projectWithNumber := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%d", project.Number)
+		return projectWithNumber, nil
+	} else {
+		return "", status.Errorf(codes.InvalidArgument, "invalid parent")
+	}
+}
+
+func (s *TagBindingsServer) CreateTagBinding(ctx context.Context, req *pb.CreateTagBindingRequest) (*lropb.Operation, error) {
+	tagValue, err := s.tagValues.GetNamespacedTagValue(ctx, &pb.GetNamespacedTagValueRequest{
+		Name: req.GetTagBinding().GetTagValueNamespacedName(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	obj := &pb.TagBinding{}
+	obj.TagValue = tagValue.Name
+	obj.TagValueNamespacedName = tagValue.NamespacedName
+
+	normalizedParent, err := s.normalizeParent(ctx, req.GetTagBinding().GetParent())
+	if err != nil {
+		return nil, err
+	}
+	obj.Parent = normalizedParent
+	obj.Name = fmt.Sprintf("tagBindings/%s/tagValues/%s", url.PathEscape(normalizedParent), strings.TrimPrefix(tagValue.Name, "tagValues/"))
+
+	fqn := obj.Name
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return s.operations.DoneLRO(ctx, "", nil, obj)
+}
+
+func (s *TagBindingsServer) DeleteTagBinding(ctx context.Context, req *pb.DeleteTagBindingRequest) (*lropb.Operation, error) {
+	deleted := &pb.TagBinding{}
+
+	name := req.GetName()
+
+	tokens := strings.Split(name, "/")
+	if len(tokens) == 4 && tokens[0] == "tagBindings" && tokens[2] == "tagValues" {
+		// Normalize the parent
+		parent, err := url.PathUnescape(tokens[1])
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid name %q", name)
+		}
+		normalizedParent, err := s.normalizeParent(ctx, parent)
+		if err != nil {
+			return nil, err
+		}
+		tokens[1] = url.PathEscape(normalizedParent)
+	}
+	name = strings.Join(tokens, "/")
+
+	if err := s.storage.Delete(ctx, name, deleted); err != nil {
+		return nil, err
+	}
+
+	return s.operations.DoneLRO(ctx, "", nil, &emptypb.Empty{})
+}
+
+func (s *TagBindingsServer) ListTagBindings(ctx context.Context, req *pb.ListTagBindingsRequest) (*pb.ListTagBindingsResponse, error) {
+	findParent, err := s.normalizeParent(ctx, req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	var bindings []*pb.TagBinding
+
+	tagBindingKind := (&pb.TagBinding{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, tagBindingKind, storage.ListOptions{}, func(obj proto.Message) error {
+		tagBinding := obj.(*pb.TagBinding)
+		if tagBinding.Parent == findParent {
+			tagBinding.TagValueNamespacedName = "" // Not returned in list?
+
+			bindings = append(bindings, tagBinding)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &pb.ListTagBindingsResponse{
+		TagBindings: bindings,
+	}, nil
+}

--- a/mockgcp/mockresourcemanager/tagkeys.go
+++ b/mockgcp/mockresourcemanager/tagkeys.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:mockgcp-support
+// proto.service: google.cloud.resourcemanager.v3.TagKeys
+// proto.message: google.cloud.resourcemanager.v3.TagKey
+
 package mockresourcemanager
 
 import (

--- a/mockgcp/mockresourcemanager/tagvalues.go
+++ b/mockgcp/mockresourcemanager/tagvalues.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +tool:mockgcp-support
+// proto.service: google.cloud.resourcemanager.v3.TagValues
+// proto.message: google.cloud.resourcemanager.v3.TagValue
+
 package mockresourcemanager
 
 import (

--- a/mockgcp/mockresourcemanager/testdata/tagbinding/crud/_http.log
+++ b/mockgcp/mockresourcemanager/testdata/tagbinding/crud/_http.log
@@ -1,0 +1,511 @@
+POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 73
+Content-Type: application/json
+
+{
+  "parent": "projects/${projectId}",
+  "shortName": "test-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "${tagValueID}Name": "${projectId}/test-${uniqueId}",
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "parent": "projects/${projectNumber}",
+    "shortName": "test-${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "test-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagValueID}?alt=json&name=${projectId}%2Ftest-${uniqueId}
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "test-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 64
+Content-Type: application/json
+
+{
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "value1"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.CreateTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "${tagValueID}Name": "${projectId}/test-${uniqueId}/value1",
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "value1",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}/value1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "value1",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 144
+Content-Type: application/json
+
+{
+  "parent": "//cloudresourcemanager.googleapis.com/projects/${projectId}",
+  "tagValueNamespacedName": "${projectId}/test-${uniqueId}/value1"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagBinding",
+    "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+    "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
+    "tagValue": "tagValues/${tagValueID}",
+    "tagValueNamespacedName": "${projectId}/test-${uniqueId}/value1"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json&parent=%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectId}
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "tagBindings": [
+    {
+      "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F${projectNumber}/tagValues/${tagValueID}",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/${projectNumber}",
+      "tagValue": "tagValues/${tagValueID}"
+    }
+  ]
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json&name=${projectId}%2Ftest-${uniqueId}%2Fvalue1
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}/value1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "value1",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagBindings/%252F%252Fcloudresourcemanager.googleapis.com%252Fprojects%252F${projectId}/tagValues/${tagValueID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json&name=${projectId}%2Ftest-${uniqueId}%2Fvalue1
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}/value1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagValues/${tagValueID}",
+  "parent": "tagKeys/${tagKeyID}",
+  "shortName": "value1",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagValueMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "${tagValueID}Name": "${projectId}/test-${uniqueId}/value1",
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagValue",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "etag": "abcdef0123A=",
+    "name": "tagValues/${tagValueID}",
+    "parent": "tagKeys/${tagKeyID}",
+    "shortName": "value1",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagValueID}?alt=json&name=${projectId}%2Ftest-${uniqueId}
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "${tagValueID}Name": "${projectId}/test-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "tagKeys/${tagKeyID}",
+  "parent": "projects/${projectNumber}",
+  "shortName": "test-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Length: 0
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.DeleteTagKeyMetadata"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "${tagValueID}Name": "${projectId}/test-${uniqueId}",
+    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagKey",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "etag": "abcdef0123A=",
+    "name": "tagKeys/${tagKeyID}",
+    "parent": "projects/${projectNumber}",
+    "shortName": "test-${uniqueId}",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}

--- a/mockgcp/mockresourcemanager/testdata/tagbinding/crud/_http.log
+++ b/mockgcp/mockresourcemanager/testdata/tagbinding/crud/_http.log
@@ -2,7 +2,6 @@ POST https://cloudresourcemanager.googleapis.com/v3/tagKeys?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 73
 Content-Type: application/json
 
 {
@@ -33,7 +32,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -69,7 +67,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -97,7 +94,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagValueID}?alt=jso
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -125,7 +121,6 @@ POST https://cloudresourcemanager.googleapis.com/v3/tagValues?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 64
 Content-Type: application/json
 
 {
@@ -156,7 +151,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -192,7 +186,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=j
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -220,7 +213,6 @@ POST https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 144
 Content-Type: application/json
 
 {
@@ -256,7 +248,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagBindings?alt=json&parent=%
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -284,7 +275,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=j
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -312,7 +302,6 @@ DELETE https://cloudresourcemanager.googleapis.com/v3/tagBindings/%252F%252Fclou
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -338,7 +327,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?alt=j
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -366,7 +354,6 @@ DELETE https://cloudresourcemanager.googleapis.com/v3/tagValues/${tagValueID}?al
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -391,7 +378,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -427,7 +413,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagValueID}?alt=jso
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -455,7 +440,6 @@ DELETE https://cloudresourcemanager.googleapis.com/v3/tagKeys/${tagKeyID}?alt=js
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -480,7 +464,6 @@ GET https://cloudresourcemanager.googleapis.com/v3/operations/${operationID}?alt
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
-Content-Length: 0
 
 200 OK
 Content-Type: application/json; charset=UTF-8

--- a/mockgcp/mockresourcemanager/testdata/tagbinding/crud/script.yaml
+++ b/mockgcp/mockresourcemanager/testdata/tagbinding/crud/script.yaml
@@ -1,0 +1,9 @@
+- exec: gcloud resource-manager tags keys create test-${uniqueId} --parent=projects/${projectId}
+- exec: gcloud resource-manager tags values create value1 --parent=${projectId}/test-${uniqueId}
+
+- exec: gcloud resource-manager tags bindings create --parent=//cloudresourcemanager.googleapis.com/projects/${projectId} --tag-value=${projectId}/test-${uniqueId}/value1
+- exec: gcloud resource-manager tags bindings list --parent=//cloudresourcemanager.googleapis.com/projects/${projectId}
+- exec: gcloud resource-manager tags bindings delete --parent=//cloudresourcemanager.googleapis.com/projects/${projectId} --tag-value=${projectId}/test-${uniqueId}/value1  --quiet
+
+- exec: gcloud resource-manager tags values delete ${projectId}/test-${uniqueId}/value1 --quiet
+- exec: gcloud resource-manager tags keys delete ${projectId}/test-${uniqueId} --quiet


### PR DESCRIPTION
- **autogen: generate-script for gcloud resource-manager tags bindings**
- **autogen: Capture golden output for mockresourcemanager/testdata/tagbinding/crud**
- **mockgcp: support for resourcemanager tagbinding**
