### PR TITLE
Added conductor runner to generate mock service and resource go files.

### DIFF
--- a/experiments/conductor/branches.yaml
+++ b/experiments/conductor/branches.yaml
@@ -24,6 +24,8 @@ branches:
     package: google.cloud.accessapproval.v1
     proto: ApprovalRequest
     proto-path: google.cloud.accessapproval.v1.ApprovalRequest
+    proto-service: google.cloud.accessapproval.v1.AccessApproval
+    host-name: accessapproval.googleapis.com
     notes:
       - No gcloud command found
   - name: ai-customjobs
@@ -37,6 +39,8 @@ branches:
     package: ""
     proto: ""
     proto-path: ""
+    proto-svc: ""
+    host_name: ""
     notes:
   - name: compute-computebackendservice
     local: resource-compute-computebackendservice
@@ -47,6 +51,8 @@ branches:
     controller: terraform
     kind: ""
     package: ""
-    proto: ""
-    proto-path: ""
+    proto: BackendService
+    proto-path: google.cloud.compute.v1.BackendService
+    proto-service: google.cloud.compute.v1.BackendServices
+    host-name: compute.googleapis.com
     notes:

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -98,10 +98,12 @@ type Branch struct {
 	Resource   string `yaml:"resource"`   // model
 	Controller string `yaml:"controller"` // Unknown
 
-	Kind      string `yaml:"kind"`       // AIModel
-	Package   string `yaml:"package"`    // google.ai.generativelanguage.v1beta
-	Proto     string `yaml:"proto"`      // Model
-	ProtoPath string `yaml:"proto-path"` // google.ai.generativelanguage.v1beta.Model
+	Kind      string `yaml:"kind"`          // AIModel
+	Package   string `yaml:"package"`       // google.ai.generativelanguage.v1beta
+	Proto     string `yaml:"proto"`         // Model
+	ProtoPath string `yaml:"proto-path"`    // google.ai.generativelanguage.v1beta.Model
+	ProtoSvc  string `yaml:"proto-service"` // google.ai.generativelanguage.v1beta.ModelService
+	HostName  string `yaml:"host-name"`     // generativelanguage.googleapis.com
 
 	Notes []string `yaml:"notes"` // Observation goes here
 }
@@ -164,8 +166,13 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		}
 	case 5:
 		for idx, branch := range branches.Branches {
-			log.Printf("Catpure HTTP Log: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			log.Printf("Capture HTTP Log: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			captureHttpLog(opts, branch)
+		}
+	case 6:
+		for idx, branch := range branches.Branches {
+			log.Printf("Generate mock Service and Resource go files: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			generateMockGo(opts, branch)
 		}
 	default:
 		log.Fatalf("unrecognixed command: %d", opts.command)

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -91,6 +91,17 @@ func cdRepoBranchDirBash(opts *RunnerOptions, subdir string, stdin io.WriteClose
 	return msg
 }
 
+func checkoutBranch(branch Branch, workDir string, out strings.Builder) {
+	log.Printf("COMMAND: git checkout %s\r\n", branch.Local)
+	checkout := exec.Command("git", "checkout", branch.Local)
+	checkout.Dir = workDir
+	checkout.Stdout = &out
+	if err := checkout.Run(); err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("BRANCH CHECKOUT: %q\n", out.String())
+}
+
 type closer func()
 
 func setLoggingWriter(opts *RunnerOptions, branch Branch) closer {
@@ -139,7 +150,6 @@ func setLoggingWriter(opts *RunnerOptions, branch Branch) closer {
 	return func() {
 		// Initially force out to stdout in case we hit an error we don't
 		// want to pollute a different runs logs with our logs.
-		// TODO: Return a log object so we can run in parrellel.
 		log.SetOutput(os.Stdout)
 		if err := out.Close(); err != nil {
 			log.Printf("Failed to clode logging file %s, :%v", logFile, err)
@@ -148,5 +158,4 @@ func setLoggingWriter(opts *RunnerOptions, branch Branch) closer {
 }
 
 func noOp() {
-	return
 }


### PR DESCRIPTION
### Change description

Added conductor runner to generate mock service and resource go files.

### Tests you have done

./bin/conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/cheftako/k8s-config-connector_branches --branch-conf=branches.yaml --logging-dir=./logs --command=6

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
