### PR TITLE
mockgcp: fix for mockstorage normalization

### DIFF
--- a/mockgcp/mockstorage/normalize.go
+++ b/mockgcp/mockstorage/normalize.go
@@ -30,3 +30,6 @@ func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.
 	replacements.ReplacePath(".acl[].etag", "abcdef0123A")
 	replacements.ReplacePath(".defaultObjectAcl[].etag", "abcdef0123A=")
 }
+
+func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {
+}


### PR DESCRIPTION
Two PRs "crossed in the mail"
