### PR TITLE
Add serviceToRoundTip and protoToMakefile commands.

### DIFF
--- a/experiments/conductor/branches-all.yaml
+++ b/experiments/conductor/branches-all.yaml
@@ -23,7 +23,7 @@ branches:
       kind: AICachedContent
       package: google.ai.generativelanguage.v1beta
       proto: CachedContent
-      proto-path: google.ai.generativelanguage.v1beta.CachedContent
+      proto-msg: google.ai.generativelanguage.v1beta.CachedContent
       notes:
         - No gcloud command found
     - name: ai-file
@@ -36,7 +36,7 @@ branches:
       kind: AIFile
       package: google.ai.generativelanguage.v1beta
       proto: File
-      proto-path: google.ai.generativelanguage.v1beta.File
+      proto-msg: google.ai.generativelanguage.v1beta.File
       notes:
         - No gcloud command found
     - name: ai-corpus
@@ -49,7 +49,7 @@ branches:
       kind: AICorpus
       package: google.ai.generativelanguage.v1beta
       proto: Corpus
-      proto-path: google.ai.generativelanguage.v1beta.Corpus
+      proto-msg: google.ai.generativelanguage.v1beta.Corpus
       notes:
         - No gcloud command found
     - name: ai-document
@@ -62,7 +62,7 @@ branches:
       kind: AIDocument
       package: google.ai.generativelanguage.v1beta
       proto: Document
-      proto-path: google.ai.generativelanguage.v1beta.Document
+      proto-msg: google.ai.generativelanguage.v1beta.Document
       notes:
         - No gcloud command found
     - name: ai-chunk
@@ -75,7 +75,7 @@ branches:
       kind: AIChunk
       package: google.ai.generativelanguage.v1beta
       proto: Chunk
-      proto-path: google.ai.generativelanguage.v1beta.Chunk
+      proto-msg: google.ai.generativelanguage.v1beta.Chunk
       notes:
         - No gcloud command found
     - name: ai-model
@@ -88,7 +88,7 @@ branches:
       kind: AIModel
       package: google.ai.generativelanguage.v1beta3
       proto: Model
-      proto-path: google.ai.generativelanguage.v1beta3.Model
+      proto-msg: google.ai.generativelanguage.v1beta3.Model
       notes: []
     - name: ai-permission
       local: resource-ai-permission
@@ -100,7 +100,7 @@ branches:
       kind: AIPermission
       package: google.ai.generativelanguage.v1beta3
       proto: Permission
-      proto-path: google.ai.generativelanguage.v1beta3.Permission
+      proto-msg: google.ai.generativelanguage.v1beta3.Permission
       notes:
         - No gcloud command found
     - name: ai-tunedmodel
@@ -113,7 +113,7 @@ branches:
       kind: AITunedModel
       package: google.ai.generativelanguage.v1beta3
       proto: TunedModel
-      proto-path: google.ai.generativelanguage.v1beta3.TunedModel
+      proto-msg: google.ai.generativelanguage.v1beta3.TunedModel
       notes:
     - name: analytics-account
       local: resource-analytics-account
@@ -125,7 +125,7 @@ branches:
       kind: AnalyticsAccount
       package: google.analytics.admin.v1beta
       proto: Account
-      proto-path: google.analytics.admin.v1beta.Account
+      proto-msg: google.analytics.admin.v1beta.Account
       notes:
         - No gcloud command found
     - name: analytics-property
@@ -138,7 +138,7 @@ branches:
       kind: AnalyticsProperty
       package: google.analytics.admin.v1beta
       proto: Property
-      proto-path: google.analytics.admin.v1beta.Property
+      proto-msg: google.analytics.admin.v1beta.Property
       notes:
         - No gcloud command found
     - name: analytics-datastream
@@ -151,7 +151,7 @@ branches:
       kind: AnalyticsDataStream
       package: google.analytics.admin.v1beta
       proto: DataStream
-      proto-path: google.analytics.admin.v1beta.DataStream
+      proto-msg: google.analytics.admin.v1beta.DataStream
       notes:
         - No gcloud command found
     - name: analytics-firebaselink
@@ -164,7 +164,7 @@ branches:
       kind: AnalyticsFirebaseLink
       package: google.analytics.admin.v1beta
       proto: FirebaseLink
-      proto-path: google.analytics.admin.v1beta.FirebaseLink
+      proto-msg: google.analytics.admin.v1beta.FirebaseLink
       notes:
         - No gcloud command found
     - name: analytics-googleadslink
@@ -177,7 +177,7 @@ branches:
       kind: AnalyticsGoogleAdsLink
       package: google.analytics.admin.v1beta
       proto: GoogleAdsLink
-      proto-path: google.analytics.admin.v1beta.GoogleAdsLink
+      proto-msg: google.analytics.admin.v1beta.GoogleAdsLink
       notes:
         - No gcloud command found
     - name: analytics-datasharingsettings
@@ -190,7 +190,7 @@ branches:
       kind: AnalyticsDataSharingSettings
       package: google.analytics.admin.v1beta
       proto: DataSharingSettings
-      proto-path: google.analytics.admin.v1beta.DataSharingSettings
+      proto-msg: google.analytics.admin.v1beta.DataSharingSettings
       notes:
         - No gcloud command found
     - name: analytics-accountsummary
@@ -203,7 +203,7 @@ branches:
       kind: AnalyticsAccountSummary
       package: google.analytics.admin.v1beta
       proto: AccountSummary
-      proto-path: google.analytics.admin.v1beta.AccountSummary
+      proto-msg: google.analytics.admin.v1beta.AccountSummary
       notes:
         - No gcloud command found
     - name: analytics-measurementprotocolsecret
@@ -216,7 +216,7 @@ branches:
       kind: AnalyticsMeasurementProtocolSecret
       package: google.analytics.admin.v1beta
       proto: MeasurementProtocolSecret
-      proto-path: google.analytics.admin.v1beta.MeasurementProtocolSecret
+      proto-msg: google.analytics.admin.v1beta.MeasurementProtocolSecret
       notes:
         - No gcloud command found
     - name: analytics-conversionevent
@@ -229,7 +229,7 @@ branches:
       kind: AnalyticsConversionEvent
       package: google.analytics.admin.v1beta
       proto: ConversionEvent
-      proto-path: google.analytics.admin.v1beta.ConversionEvent
+      proto-msg: google.analytics.admin.v1beta.ConversionEvent
       notes:
         - No gcloud command found
     - name: analytics-keyevent
@@ -242,7 +242,7 @@ branches:
       kind: AnalyticsKeyEvent
       package: google.analytics.admin.v1beta
       proto: KeyEvent
-      proto-path: google.analytics.admin.v1beta.KeyEvent
+      proto-msg: google.analytics.admin.v1beta.KeyEvent
       notes:
         - No gcloud command found
     - name: analytics-customdimension
@@ -255,7 +255,7 @@ branches:
       kind: AnalyticsCustomDimension
       package: google.analytics.admin.v1beta
       proto: CustomDimension
-      proto-path: google.analytics.admin.v1beta.CustomDimension
+      proto-msg: google.analytics.admin.v1beta.CustomDimension
       notes:
         - No gcloud command found
     - name: analytics-custommetric
@@ -268,7 +268,7 @@ branches:
       kind: AnalyticsCustomMetric
       package: google.analytics.admin.v1beta
       proto: CustomMetric
-      proto-path: google.analytics.admin.v1beta.CustomMetric
+      proto-msg: google.analytics.admin.v1beta.CustomMetric
       notes:
         - No gcloud command found
     - name: analytics-dataretentionsettings
@@ -281,7 +281,7 @@ branches:
       kind: AnalyticsDataRetentionSettings
       package: google.analytics.admin.v1beta
       proto: DataRetentionSettings
-      proto-path: google.analytics.admin.v1beta.DataRetentionSettings
+      proto-msg: google.analytics.admin.v1beta.DataRetentionSettings
       notes:
         - No gcloud command found
     - name: analytics-metadata
@@ -294,7 +294,7 @@ branches:
       kind: AnalyticsMetadata
       package: google.analytics.data.v1beta
       proto: Metadata
-      proto-path: google.analytics.data.v1beta.Metadata
+      proto-msg: google.analytics.data.v1beta.Metadata
       notes:
         - No gcloud command found
     - name: analytics-audienceexport
@@ -307,7 +307,7 @@ branches:
       kind: AnalyticsAudienceExport
       package: google.analytics.data.v1beta
       proto: AudienceExport
-      proto-path: google.analytics.data.v1beta.AudienceExport
+      proto-msg: google.analytics.data.v1beta.AudienceExport
       notes:
         - No gcloud command found
     - name: api-key
@@ -320,7 +320,7 @@ branches:
       kind: APIKey
       package: google.api.apikeys.v2
       proto: Key
-      proto-path: google.api.apikeys.v2.Key
+      proto-msg: google.api.apikeys.v2.Key
       notes:
         - No matching generated proto
     - name: api-quotainfo
@@ -333,7 +333,7 @@ branches:
       kind: APIQuotaInfo
       package: google.api.cloudquotas.v1
       proto: QuotaInfo
-      proto-path: google.api.cloudquotas.v1.QuotaInfo
+      proto-msg: google.api.cloudquotas.v1.QuotaInfo
       notes: []
     - name: api-quotapreference
       local: resource-api-quotapreference
@@ -345,7 +345,7 @@ branches:
       kind: APIQuotaPreference
       package: google.api.cloudquotas.v1
       proto: QuotaPreference
-      proto-path: google.api.cloudquotas.v1.QuotaPreference
+      proto-msg: google.api.cloudquotas.v1.QuotaPreference
       notes: []
     - name: api-quotaadjustersettings
       local: resource-api-quotaadjustersettings
@@ -357,7 +357,7 @@ branches:
       kind: APIQuotaAdjusterSettings
       package: google.api.cloudquotas.v1beta
       proto: QuotaAdjusterSettings
-      proto-path: google.api.cloudquotas.v1beta.QuotaAdjusterSettings
+      proto-msg: google.api.cloudquotas.v1beta.QuotaAdjusterSettings
       notes: []
     - name: api-service
       local: resource-api-service
@@ -369,7 +369,7 @@ branches:
       kind: APIService
       package: google.api.serviceusage.v1
       proto: Service
-      proto-path: google.api.serviceusage.v1.Service
+      proto-msg: google.api.serviceusage.v1.Service
       notes:
         - No gcloud command found
     - name: appengine-instance
@@ -382,7 +382,7 @@ branches:
       kind: AppEngineInstance
       package: google.appengine.v1
       proto: Instance
-      proto-path: google.appengine.v1.Instance
+      proto-msg: google.appengine.v1.Instance
       notes: []
     - name: bigtable-instance
       local: resource-bigtable-instance
@@ -394,7 +394,7 @@ branches:
       kind: BigtableInstance
       package: google.bigtable.admin.v2
       proto: Instance
-      proto-path: google.bigtable.admin.v2.Instance
+      proto-msg: google.bigtable.admin.v2.Instance
       notes: []
     - name: bigtable-cluster
       local: resource-bigtable-cluster
@@ -406,7 +406,7 @@ branches:
       kind: BigtableCluster
       package: google.bigtable.admin.v2
       proto: Cluster
-      proto-path: google.bigtable.admin.v2.Cluster
+      proto-msg: google.bigtable.admin.v2.Cluster
       notes: []
     - name: bigtable-appprofile
       local: resource-bigtable-appprofile
@@ -418,7 +418,7 @@ branches:
       kind: BigtableAppProfile
       package: google.bigtable.admin.v2
       proto: AppProfile
-      proto-path: google.bigtable.admin.v2.AppProfile
+      proto-msg: google.bigtable.admin.v2.AppProfile
       notes: []
     - name: bigtable-hottablet
       local: resource-bigtable-hottablet
@@ -430,7 +430,7 @@ branches:
       kind: BigtableHotTablet
       package: google.bigtable.admin.v2
       proto: HotTablet
-      proto-path: google.bigtable.admin.v2.HotTablet
+      proto-msg: google.bigtable.admin.v2.HotTablet
       notes: []
     - name: bigtable-table
       local: resource-bigtable-table
@@ -442,7 +442,7 @@ branches:
       kind: BigtableTable
       package: google.bigtable.admin.v2
       proto: Table
-      proto-path: google.bigtable.admin.v2.Table
+      proto-msg: google.bigtable.admin.v2.Table
       notes: []
     - name: bigtable-authorizedview
       local: resource-bigtable-authorizedview
@@ -454,7 +454,7 @@ branches:
       kind: BigtableAuthorizedView
       package: google.bigtable.admin.v2
       proto: AuthorizedView
-      proto-path: google.bigtable.admin.v2.AuthorizedView
+      proto-msg: google.bigtable.admin.v2.AuthorizedView
       notes: []
     - name: bigtable-snapshot
       local: resource-bigtable-snapshot
@@ -466,7 +466,7 @@ branches:
       kind: BigtableSnapshot
       package: google.bigtable.admin.v2
       proto: Snapshot
-      proto-path: google.bigtable.admin.v2.Snapshot
+      proto-msg: google.bigtable.admin.v2.Snapshot
       notes:
         - No gcloud command found
     - name: bigtable-backup
@@ -479,7 +479,7 @@ branches:
       kind: BigtableBackup
       package: google.bigtable.admin.v2
       proto: Backup
-      proto-path: google.bigtable.admin.v2.Backup
+      proto-msg: google.bigtable.admin.v2.Backup
       notes: []
     - name: accessapproval-approvalrequest
       local: resource-accessapproval-approvalrequest
@@ -491,7 +491,7 @@ branches:
       kind: AccessApprovalApprovalRequest
       package: google.cloud.accessapproval.v1
       proto: ApprovalRequest
-      proto-path: google.cloud.accessapproval.v1.ApprovalRequest
+      proto-msg: google.cloud.accessapproval.v1.ApprovalRequest
       notes:
         - No gcloud command found
     - name: accessapproval-accessapprovalsettings
@@ -504,7 +504,7 @@ branches:
       kind: AccessApprovalAccessApprovalSettings
       package: google.cloud.accessapproval.v1
       proto: AccessApprovalSettings
-      proto-path: google.cloud.accessapproval.v1.AccessApprovalSettings
+      proto-msg: google.cloud.accessapproval.v1.AccessApprovalSettings
       notes:
         - No gcloud command found
     - name: accessapproval-accessapprovalserviceaccount
@@ -517,7 +517,7 @@ branches:
       kind: AccessApprovalAccessApprovalServiceAccount
       package: google.cloud.accessapproval.v1
       proto: AccessApprovalServiceAccount
-      proto-path: google.cloud.accessapproval.v1.AccessApprovalServiceAccount
+      proto-msg: google.cloud.accessapproval.v1.AccessApprovalServiceAccount
       notes:
         - No gcloud command found
     - name: advisorynotifications-notification
@@ -530,7 +530,7 @@ branches:
       kind: AdvisoryNotificationsNotification
       package: google.cloud.advisorynotifications.v1
       proto: Notification
-      proto-path: google.cloud.advisorynotifications.v1.Notification
+      proto-msg: google.cloud.advisorynotifications.v1.Notification
       notes:
         - No gcloud command found
     - name: advisorynotifications-settings
@@ -543,7 +543,7 @@ branches:
       kind: AdvisoryNotificationsSettings
       package: google.cloud.advisorynotifications.v1
       proto: Settings
-      proto-path: google.cloud.advisorynotifications.v1.Settings
+      proto-msg: google.cloud.advisorynotifications.v1.Settings
       notes:
         - No gcloud command found
     - name: aiplatform-annotation
@@ -556,7 +556,7 @@ branches:
       kind: AIPlatformAnnotation
       package: google.cloud.aiplatform.v1
       proto: Annotation
-      proto-path: google.cloud.aiplatform.v1.Annotation
+      proto-msg: google.cloud.aiplatform.v1.Annotation
       notes:
         - No gcloud command found
     - name: aiplatform-annotationspec
@@ -569,7 +569,7 @@ branches:
       kind: AIPlatformAnnotationSpec
       package: google.cloud.aiplatform.v1
       proto: AnnotationSpec
-      proto-path: google.cloud.aiplatform.v1.AnnotationSpec
+      proto-msg: google.cloud.aiplatform.v1.AnnotationSpec
       notes:
         - No gcloud command found
     - name: aiplatform-artifact
@@ -582,7 +582,7 @@ branches:
       kind: AIPlatformArtifact
       package: google.cloud.aiplatform.v1
       proto: Artifact
-      proto-path: google.cloud.aiplatform.v1.Artifact
+      proto-msg: google.cloud.aiplatform.v1.Artifact
       notes:
         - No gcloud command found
     - name: aiplatform-batchpredictionjob
@@ -595,7 +595,7 @@ branches:
       kind: AIPlatformBatchPredictionJob
       package: google.cloud.aiplatform.v1
       proto: BatchPredictionJob
-      proto-path: google.cloud.aiplatform.v1.BatchPredictionJob
+      proto-msg: google.cloud.aiplatform.v1.BatchPredictionJob
       notes:
         - No gcloud command found
     - name: aiplatform-cachedcontent
@@ -608,7 +608,7 @@ branches:
       kind: AIPlatformCachedContent
       package: google.cloud.aiplatform.v1
       proto: CachedContent
-      proto-path: google.cloud.aiplatform.v1.CachedContent
+      proto-msg: google.cloud.aiplatform.v1.CachedContent
       notes:
         - No gcloud command found
     - name: aiplatform-context
@@ -621,7 +621,7 @@ branches:
       kind: AIPlatformContext
       package: google.cloud.aiplatform.v1
       proto: Context
-      proto-path: google.cloud.aiplatform.v1.Context
+      proto-msg: google.cloud.aiplatform.v1.Context
       notes:
         - No gcloud command found
     - name: aiplatform-customjob
@@ -634,7 +634,7 @@ branches:
       kind: AIPlatformCustomJob
       package: google.cloud.aiplatform.v1
       proto: CustomJob
-      proto-path: google.cloud.aiplatform.v1.CustomJob
+      proto-msg: google.cloud.aiplatform.v1.CustomJob
       notes:
         - No gcloud command found
     - name: aiplatform-dataitem
@@ -647,7 +647,7 @@ branches:
       kind: AIPlatformDataItem
       package: google.cloud.aiplatform.v1
       proto: DataItem
-      proto-path: google.cloud.aiplatform.v1.DataItem
+      proto-msg: google.cloud.aiplatform.v1.DataItem
       notes:
         - No gcloud command found
     - name: aiplatform-datalabelingjob
@@ -660,7 +660,7 @@ branches:
       kind: AIPlatformDataLabelingJob
       package: google.cloud.aiplatform.v1
       proto: DataLabelingJob
-      proto-path: google.cloud.aiplatform.v1.DataLabelingJob
+      proto-msg: google.cloud.aiplatform.v1.DataLabelingJob
       notes:
         - No gcloud command found
     - name: aiplatform-dataset
@@ -673,7 +673,7 @@ branches:
       kind: AIPlatformDataset
       package: google.cloud.aiplatform.v1
       proto: Dataset
-      proto-path: google.cloud.aiplatform.v1.Dataset
+      proto-msg: google.cloud.aiplatform.v1.Dataset
       notes:
         - No gcloud command found
     - name: aiplatform-datasetversion
@@ -686,7 +686,7 @@ branches:
       kind: AIPlatformDatasetVersion
       package: google.cloud.aiplatform.v1
       proto: DatasetVersion
-      proto-path: google.cloud.aiplatform.v1.DatasetVersion
+      proto-msg: google.cloud.aiplatform.v1.DatasetVersion
       notes:
         - No gcloud command found
     - name: aiplatform-deploymentresourcepool
@@ -699,7 +699,7 @@ branches:
       kind: AIPlatformDeploymentResourcePool
       package: google.cloud.aiplatform.v1
       proto: DeploymentResourcePool
-      proto-path: google.cloud.aiplatform.v1.DeploymentResourcePool
+      proto-msg: google.cloud.aiplatform.v1.DeploymentResourcePool
       notes:
         - No gcloud command found
     - name: aiplatform-endpoint
@@ -712,7 +712,7 @@ branches:
       kind: AIPlatformEndpoint
       package: google.cloud.aiplatform.v1
       proto: Endpoint
-      proto-path: google.cloud.aiplatform.v1.Endpoint
+      proto-msg: google.cloud.aiplatform.v1.Endpoint
       notes:
         - No gcloud command found
     - name: aiplatform-entitytype
@@ -725,7 +725,7 @@ branches:
       kind: AIPlatformEntityType
       package: google.cloud.aiplatform.v1
       proto: EntityType
-      proto-path: google.cloud.aiplatform.v1.EntityType
+      proto-msg: google.cloud.aiplatform.v1.EntityType
       notes:
         - No gcloud command found
     - name: aiplatform-execution
@@ -738,7 +738,7 @@ branches:
       kind: AIPlatformExecution
       package: google.cloud.aiplatform.v1
       proto: Execution
-      proto-path: google.cloud.aiplatform.v1.Execution
+      proto-msg: google.cloud.aiplatform.v1.Execution
       notes:
         - No gcloud command found
     - name: aiplatform-feature
@@ -751,7 +751,7 @@ branches:
       kind: AIPlatformFeature
       package: google.cloud.aiplatform.v1
       proto: Feature
-      proto-path: google.cloud.aiplatform.v1.Feature
+      proto-msg: google.cloud.aiplatform.v1.Feature
       notes:
         - No gcloud command found
     - name: aiplatform-featuregroup
@@ -764,7 +764,7 @@ branches:
       kind: AIPlatformFeatureGroup
       package: google.cloud.aiplatform.v1
       proto: FeatureGroup
-      proto-path: google.cloud.aiplatform.v1.FeatureGroup
+      proto-msg: google.cloud.aiplatform.v1.FeatureGroup
       notes:
         - No gcloud command found
     - name: aiplatform-featureonlinestore
@@ -777,7 +777,7 @@ branches:
       kind: AIPlatformFeatureOnlineStore
       package: google.cloud.aiplatform.v1
       proto: FeatureOnlineStore
-      proto-path: google.cloud.aiplatform.v1.FeatureOnlineStore
+      proto-msg: google.cloud.aiplatform.v1.FeatureOnlineStore
       notes:
         - No gcloud command found
     - name: aiplatform-featureview
@@ -790,7 +790,7 @@ branches:
       kind: AIPlatformFeatureView
       package: google.cloud.aiplatform.v1
       proto: FeatureView
-      proto-path: google.cloud.aiplatform.v1.FeatureView
+      proto-msg: google.cloud.aiplatform.v1.FeatureView
       notes:
         - No gcloud command found
     - name: aiplatform-featureviewsync
@@ -803,7 +803,7 @@ branches:
       kind: AIPlatformFeatureViewSync
       package: google.cloud.aiplatform.v1
       proto: FeatureViewSync
-      proto-path: google.cloud.aiplatform.v1.FeatureViewSync
+      proto-msg: google.cloud.aiplatform.v1.FeatureViewSync
       notes:
         - No gcloud command found
     - name: aiplatform-featurestore
@@ -816,7 +816,7 @@ branches:
       kind: AIPlatformFeaturestore
       package: google.cloud.aiplatform.v1
       proto: Featurestore
-      proto-path: google.cloud.aiplatform.v1.Featurestore
+      proto-msg: google.cloud.aiplatform.v1.Featurestore
       notes:
         - No gcloud command found
     - name: aiplatform-hyperparametertuningjob
@@ -829,7 +829,7 @@ branches:
       kind: AIPlatformHyperparameterTuningJob
       package: google.cloud.aiplatform.v1
       proto: HyperparameterTuningJob
-      proto-path: google.cloud.aiplatform.v1.HyperparameterTuningJob
+      proto-msg: google.cloud.aiplatform.v1.HyperparameterTuningJob
       notes:
         - No gcloud command found
     - name: aiplatform-index
@@ -842,7 +842,7 @@ branches:
       kind: AIPlatformIndex
       package: google.cloud.aiplatform.v1
       proto: Index
-      proto-path: google.cloud.aiplatform.v1.Index
+      proto-msg: google.cloud.aiplatform.v1.Index
       notes:
         - No gcloud command found
     - name: aiplatform-indexendpoint
@@ -855,7 +855,7 @@ branches:
       kind: AIPlatformIndexEndpoint
       package: google.cloud.aiplatform.v1
       proto: IndexEndpoint
-      proto-path: google.cloud.aiplatform.v1.IndexEndpoint
+      proto-msg: google.cloud.aiplatform.v1.IndexEndpoint
       notes:
         - No gcloud command found
     - name: aiplatform-metadataschema
@@ -868,7 +868,7 @@ branches:
       kind: AIPlatformMetadataSchema
       package: google.cloud.aiplatform.v1
       proto: MetadataSchema
-      proto-path: google.cloud.aiplatform.v1.MetadataSchema
+      proto-msg: google.cloud.aiplatform.v1.MetadataSchema
       notes:
         - No gcloud command found
     - name: aiplatform-metadatastore
@@ -881,7 +881,7 @@ branches:
       kind: AIPlatformMetadataStore
       package: google.cloud.aiplatform.v1
       proto: MetadataStore
-      proto-path: google.cloud.aiplatform.v1.MetadataStore
+      proto-msg: google.cloud.aiplatform.v1.MetadataStore
       notes:
         - No gcloud command found
     - name: aiplatform-model
@@ -894,7 +894,7 @@ branches:
       kind: AIPlatformModel
       package: google.cloud.aiplatform.v1
       proto: Model
-      proto-path: google.cloud.aiplatform.v1.Model
+      proto-msg: google.cloud.aiplatform.v1.Model
       notes: []
     - name: aiplatform-modeldeploymentmonitoringjob
       local: resource-aiplatform-modeldeploymentmonitoringjob
@@ -906,7 +906,7 @@ branches:
       kind: AIPlatformModelDeploymentMonitoringJob
       package: google.cloud.aiplatform.v1
       proto: ModelDeploymentMonitoringJob
-      proto-path: google.cloud.aiplatform.v1.ModelDeploymentMonitoringJob
+      proto-msg: google.cloud.aiplatform.v1.ModelDeploymentMonitoringJob
       notes:
         - No gcloud command found
     - name: aiplatform-modelevaluation
@@ -919,7 +919,7 @@ branches:
       kind: AIPlatformModelEvaluation
       package: google.cloud.aiplatform.v1
       proto: ModelEvaluation
-      proto-path: google.cloud.aiplatform.v1.ModelEvaluation
+      proto-msg: google.cloud.aiplatform.v1.ModelEvaluation
       notes:
         - No gcloud command found
     - name: aiplatform-modelevaluationslice
@@ -932,7 +932,7 @@ branches:
       kind: AIPlatformModelEvaluationSlice
       package: google.cloud.aiplatform.v1
       proto: ModelEvaluationSlice
-      proto-path: google.cloud.aiplatform.v1.ModelEvaluationSlice
+      proto-msg: google.cloud.aiplatform.v1.ModelEvaluationSlice
       notes:
         - No gcloud command found
     - name: aiplatform-nasjob
@@ -945,7 +945,7 @@ branches:
       kind: AIPlatformNasJob
       package: google.cloud.aiplatform.v1
       proto: NasJob
-      proto-path: google.cloud.aiplatform.v1.NasJob
+      proto-msg: google.cloud.aiplatform.v1.NasJob
       notes:
         - No gcloud command found
     - name: aiplatform-nastrialdetail
@@ -958,7 +958,7 @@ branches:
       kind: AIPlatformNasTrialDetail
       package: google.cloud.aiplatform.v1
       proto: NasTrialDetail
-      proto-path: google.cloud.aiplatform.v1.NasTrialDetail
+      proto-msg: google.cloud.aiplatform.v1.NasTrialDetail
       notes:
         - No gcloud command found
     - name: aiplatform-notebookexecutionjob
@@ -971,7 +971,7 @@ branches:
       kind: AIPlatformNotebookExecutionJob
       package: google.cloud.aiplatform.v1
       proto: NotebookExecutionJob
-      proto-path: google.cloud.aiplatform.v1.NotebookExecutionJob
+      proto-msg: google.cloud.aiplatform.v1.NotebookExecutionJob
       notes:
         - No gcloud command found
     - name: aiplatform-notebookruntimetemplate
@@ -984,7 +984,7 @@ branches:
       kind: AIPlatformNotebookRuntimeTemplate
       package: google.cloud.aiplatform.v1
       proto: NotebookRuntimeTemplate
-      proto-path: google.cloud.aiplatform.v1.NotebookRuntimeTemplate
+      proto-msg: google.cloud.aiplatform.v1.NotebookRuntimeTemplate
       notes:
         - No gcloud command found
     - name: aiplatform-notebookruntime
@@ -997,7 +997,7 @@ branches:
       kind: AIPlatformNotebookRuntime
       package: google.cloud.aiplatform.v1
       proto: NotebookRuntime
-      proto-path: google.cloud.aiplatform.v1.NotebookRuntime
+      proto-msg: google.cloud.aiplatform.v1.NotebookRuntime
       notes:
         - No gcloud command found
     - name: aiplatform-persistentresource
@@ -1010,7 +1010,7 @@ branches:
       kind: AIPlatformPersistentResource
       package: google.cloud.aiplatform.v1
       proto: PersistentResource
-      proto-path: google.cloud.aiplatform.v1.PersistentResource
+      proto-msg: google.cloud.aiplatform.v1.PersistentResource
       notes:
         - No gcloud command found
     - name: aiplatform-pipelinejob
@@ -1023,7 +1023,7 @@ branches:
       kind: AIPlatformPipelineJob
       package: google.cloud.aiplatform.v1
       proto: PipelineJob
-      proto-path: google.cloud.aiplatform.v1.PipelineJob
+      proto-msg: google.cloud.aiplatform.v1.PipelineJob
       notes:
         - No gcloud command found
     - name: aiplatform-publishermodel
@@ -1036,7 +1036,7 @@ branches:
       kind: AIPlatformPublisherModel
       package: google.cloud.aiplatform.v1
       proto: PublisherModel
-      proto-path: google.cloud.aiplatform.v1.PublisherModel
+      proto-msg: google.cloud.aiplatform.v1.PublisherModel
       notes:
         - No gcloud command found
     - name: aiplatform-reasoningengine
@@ -1049,7 +1049,7 @@ branches:
       kind: AIPlatformReasoningEngine
       package: google.cloud.aiplatform.v1
       proto: ReasoningEngine
-      proto-path: google.cloud.aiplatform.v1.ReasoningEngine
+      proto-msg: google.cloud.aiplatform.v1.ReasoningEngine
       notes:
         - No gcloud command found
     - name: aiplatform-savedquery
@@ -1062,7 +1062,7 @@ branches:
       kind: AIPlatformSavedQuery
       package: google.cloud.aiplatform.v1
       proto: SavedQuery
-      proto-path: google.cloud.aiplatform.v1.SavedQuery
+      proto-msg: google.cloud.aiplatform.v1.SavedQuery
       notes:
         - No gcloud command found
     - name: aiplatform-schedule
@@ -1075,7 +1075,7 @@ branches:
       kind: AIPlatformSchedule
       package: google.cloud.aiplatform.v1
       proto: Schedule
-      proto-path: google.cloud.aiplatform.v1.Schedule
+      proto-msg: google.cloud.aiplatform.v1.Schedule
       notes:
         - No gcloud command found
     - name: aiplatform-specialistpool
@@ -1088,7 +1088,7 @@ branches:
       kind: AIPlatformSpecialistPool
       package: google.cloud.aiplatform.v1
       proto: SpecialistPool
-      proto-path: google.cloud.aiplatform.v1.SpecialistPool
+      proto-msg: google.cloud.aiplatform.v1.SpecialistPool
       notes:
         - No gcloud command found
     - name: aiplatform-study
@@ -1101,7 +1101,7 @@ branches:
       kind: AIPlatformStudy
       package: google.cloud.aiplatform.v1
       proto: Study
-      proto-path: google.cloud.aiplatform.v1.Study
+      proto-msg: google.cloud.aiplatform.v1.Study
       notes:
         - No gcloud command found
     - name: aiplatform-trial
@@ -1114,7 +1114,7 @@ branches:
       kind: AIPlatformTrial
       package: google.cloud.aiplatform.v1
       proto: Trial
-      proto-path: google.cloud.aiplatform.v1.Trial
+      proto-msg: google.cloud.aiplatform.v1.Trial
       notes:
         - No gcloud command found
     - name: aiplatform-tensorboard
@@ -1127,7 +1127,7 @@ branches:
       kind: AIPlatformTensorboard
       package: google.cloud.aiplatform.v1
       proto: Tensorboard
-      proto-path: google.cloud.aiplatform.v1.Tensorboard
+      proto-msg: google.cloud.aiplatform.v1.Tensorboard
       notes:
         - No gcloud command found
     - name: aiplatform-tensorboardexperiment
@@ -1140,7 +1140,7 @@ branches:
       kind: AIPlatformTensorboardExperiment
       package: google.cloud.aiplatform.v1
       proto: TensorboardExperiment
-      proto-path: google.cloud.aiplatform.v1.TensorboardExperiment
+      proto-msg: google.cloud.aiplatform.v1.TensorboardExperiment
       notes:
         - No gcloud command found
     - name: aiplatform-tensorboardrun
@@ -1153,7 +1153,7 @@ branches:
       kind: AIPlatformTensorboardRun
       package: google.cloud.aiplatform.v1
       proto: TensorboardRun
-      proto-path: google.cloud.aiplatform.v1.TensorboardRun
+      proto-msg: google.cloud.aiplatform.v1.TensorboardRun
       notes:
         - No gcloud command found
     - name: aiplatform-tensorboardtimeseries
@@ -1166,7 +1166,7 @@ branches:
       kind: AIPlatformTensorboardTimeSeries
       package: google.cloud.aiplatform.v1
       proto: TensorboardTimeSeries
-      proto-path: google.cloud.aiplatform.v1.TensorboardTimeSeries
+      proto-msg: google.cloud.aiplatform.v1.TensorboardTimeSeries
       notes:
         - No gcloud command found
     - name: aiplatform-trainingpipeline
@@ -1179,7 +1179,7 @@ branches:
       kind: AIPlatformTrainingPipeline
       package: google.cloud.aiplatform.v1
       proto: TrainingPipeline
-      proto-path: google.cloud.aiplatform.v1.TrainingPipeline
+      proto-msg: google.cloud.aiplatform.v1.TrainingPipeline
       notes:
         - No gcloud command found
     - name: aiplatform-tuningjob
@@ -1192,7 +1192,7 @@ branches:
       kind: AIPlatformTuningJob
       package: google.cloud.aiplatform.v1
       proto: TuningJob
-      proto-path: google.cloud.aiplatform.v1.TuningJob
+      proto-msg: google.cloud.aiplatform.v1.TuningJob
       notes:
         - No gcloud command found
     - name: aiplatform-ragcorpus
@@ -1205,7 +1205,7 @@ branches:
       kind: AIPlatformRagCorpus
       package: google.cloud.aiplatform.v1
       proto: RagCorpus
-      proto-path: google.cloud.aiplatform.v1.RagCorpus
+      proto-msg: google.cloud.aiplatform.v1.RagCorpus
       notes:
         - No gcloud command found
     - name: aiplatform-ragfile
@@ -1218,7 +1218,7 @@ branches:
       kind: AIPlatformRagFile
       package: google.cloud.aiplatform.v1
       proto: RagFile
-      proto-path: google.cloud.aiplatform.v1.RagFile
+      proto-msg: google.cloud.aiplatform.v1.RagFile
       notes:
         - No gcloud command found
     - name: aiplatform-extension
@@ -1231,7 +1231,7 @@ branches:
       kind: AIPlatformExtension
       package: google.cloud.aiplatform.v1beta1
       proto: Extension
-      proto-path: google.cloud.aiplatform.v1beta1.Extension
+      proto-msg: google.cloud.aiplatform.v1beta1.Extension
       notes:
         - No gcloud command found
     - name: aiplatform-featuremonitor
@@ -1244,7 +1244,7 @@ branches:
       kind: AIPlatformFeatureMonitor
       package: google.cloud.aiplatform.v1beta1
       proto: FeatureMonitor
-      proto-path: google.cloud.aiplatform.v1beta1.FeatureMonitor
+      proto-msg: google.cloud.aiplatform.v1beta1.FeatureMonitor
       notes:
         - No gcloud command found
     - name: aiplatform-featuremonitorjob
@@ -1257,7 +1257,7 @@ branches:
       kind: AIPlatformFeatureMonitorJob
       package: google.cloud.aiplatform.v1beta1
       proto: FeatureMonitorJob
-      proto-path: google.cloud.aiplatform.v1beta1.FeatureMonitorJob
+      proto-msg: google.cloud.aiplatform.v1beta1.FeatureMonitorJob
       notes:
         - No gcloud command found
     - name: aiplatform-modelmonitor
@@ -1270,7 +1270,7 @@ branches:
       kind: AIPlatformModelMonitor
       package: google.cloud.aiplatform.v1beta1
       proto: ModelMonitor
-      proto-path: google.cloud.aiplatform.v1beta1.ModelMonitor
+      proto-msg: google.cloud.aiplatform.v1beta1.ModelMonitor
       notes:
         - No gcloud command found
     - name: aiplatform-modelmonitoringjob
@@ -1283,7 +1283,7 @@ branches:
       kind: AIPlatformModelMonitoringJob
       package: google.cloud.aiplatform.v1beta1
       proto: ModelMonitoringJob
-      proto-path: google.cloud.aiplatform.v1beta1.ModelMonitoringJob
+      proto-msg: google.cloud.aiplatform.v1beta1.ModelMonitoringJob
       notes:
         - No gcloud command found
     - name: alloydb-cluster
@@ -1296,7 +1296,7 @@ branches:
       kind: AlloydbCluster
       package: google.cloud.alloydb.v1
       proto: Cluster
-      proto-path: google.cloud.alloydb.v1.Cluster
+      proto-msg: google.cloud.alloydb.v1.Cluster
       notes: []
     - name: alloydb-instance
       local: resource-alloydb-instance
@@ -1308,7 +1308,7 @@ branches:
       kind: AlloydbInstance
       package: google.cloud.alloydb.v1
       proto: Instance
-      proto-path: google.cloud.alloydb.v1.Instance
+      proto-msg: google.cloud.alloydb.v1.Instance
       notes: []
     - name: alloydb-connectioninfo
       local: resource-alloydb-connectioninfo
@@ -1320,7 +1320,7 @@ branches:
       kind: AlloydbConnectionInfo
       package: google.cloud.alloydb.v1
       proto: ConnectionInfo
-      proto-path: google.cloud.alloydb.v1.ConnectionInfo
+      proto-msg: google.cloud.alloydb.v1.ConnectionInfo
       notes:
         - No gcloud command found
     - name: alloydb-backup
@@ -1333,7 +1333,7 @@ branches:
       kind: AlloydbBackup
       package: google.cloud.alloydb.v1
       proto: Backup
-      proto-path: google.cloud.alloydb.v1.Backup
+      proto-msg: google.cloud.alloydb.v1.Backup
       notes: []
     - name: alloydb-supporteddatabaseflag
       local: resource-alloydb-supporteddatabaseflag
@@ -1345,7 +1345,7 @@ branches:
       kind: AlloydbSupportedDatabaseFlag
       package: google.cloud.alloydb.v1
       proto: SupportedDatabaseFlag
-      proto-path: google.cloud.alloydb.v1.SupportedDatabaseFlag
+      proto-msg: google.cloud.alloydb.v1.SupportedDatabaseFlag
       notes:
         - No gcloud command found
     - name: alloydb-user
@@ -1358,7 +1358,7 @@ branches:
       kind: AlloydbUser
       package: google.cloud.alloydb.v1
       proto: User
-      proto-path: google.cloud.alloydb.v1.User
+      proto-msg: google.cloud.alloydb.v1.User
       notes: []
     - name: alloydb-database
       local: resource-alloydb-database
@@ -1370,7 +1370,7 @@ branches:
       kind: AlloydbDatabase
       package: google.cloud.alloydb.v1
       proto: Database
-      proto-path: google.cloud.alloydb.v1.Database
+      proto-msg: google.cloud.alloydb.v1.Database
       notes:
         - No gcloud command found
     - name: apigateway-api
@@ -1383,7 +1383,7 @@ branches:
       kind: APIGatewayAPI
       package: google.cloud.apigateway.v1
       proto: Api
-      proto-path: google.cloud.apigateway.v1.Api
+      proto-msg: google.cloud.apigateway.v1.Api
       notes: []
     - name: apigateway-apiconfig
       local: resource-apigateway-apiconfig
@@ -1395,7 +1395,7 @@ branches:
       kind: APIGatewayAPIConfig
       package: google.cloud.apigateway.v1
       proto: ApiConfig
-      proto-path: google.cloud.apigateway.v1.ApiConfig
+      proto-msg: google.cloud.apigateway.v1.ApiConfig
       notes: []
     - name: apigateway-gateway
       local: resource-apigateway-gateway
@@ -1407,7 +1407,7 @@ branches:
       kind: APIGatewayGateway
       package: google.cloud.apigateway.v1
       proto: Gateway
-      proto-path: google.cloud.apigateway.v1.Gateway
+      proto-msg: google.cloud.apigateway.v1.Gateway
       notes: []
     - name: apigeeregistry-instance
       local: resource-apigeeregistry-instance
@@ -1419,7 +1419,7 @@ branches:
       kind: APIgeeRegistryInstance
       package: google.cloud.apigeeregistry.v1
       proto: Instance
-      proto-path: google.cloud.apigeeregistry.v1.Instance
+      proto-msg: google.cloud.apigeeregistry.v1.Instance
       notes:
         - No gcloud command found
     - name: apigeeregistry-api
@@ -1432,7 +1432,7 @@ branches:
       kind: APIgeeRegistryApi
       package: google.cloud.apigeeregistry.v1
       proto: Api
-      proto-path: google.cloud.apigeeregistry.v1.Api
+      proto-msg: google.cloud.apigeeregistry.v1.Api
       notes: []
     - name: apigeeregistry-apiversion
       local: resource-apigeeregistry-apiversion
@@ -1444,7 +1444,7 @@ branches:
       kind: APIgeeRegistryApiVersion
       package: google.cloud.apigeeregistry.v1
       proto: ApiVersion
-      proto-path: google.cloud.apigeeregistry.v1.ApiVersion
+      proto-msg: google.cloud.apigeeregistry.v1.ApiVersion
       notes:
         - No gcloud command found
     - name: apigeeregistry-apispec
@@ -1457,7 +1457,7 @@ branches:
       kind: APIgeeRegistryApiSpec
       package: google.cloud.apigeeregistry.v1
       proto: ApiSpec
-      proto-path: google.cloud.apigeeregistry.v1.ApiSpec
+      proto-msg: google.cloud.apigeeregistry.v1.ApiSpec
       notes:
         - No gcloud command found
     - name: apigeeregistry-apideployment
@@ -1470,7 +1470,7 @@ branches:
       kind: APIgeeRegistryApiDeployment
       package: google.cloud.apigeeregistry.v1
       proto: ApiDeployment
-      proto-path: google.cloud.apigeeregistry.v1.ApiDeployment
+      proto-msg: google.cloud.apigeeregistry.v1.ApiDeployment
       notes: []
     - name: apigeeregistry-artifact
       local: resource-apigeeregistry-artifact
@@ -1482,7 +1482,7 @@ branches:
       kind: APIgeeRegistryArtifact
       package: google.cloud.apigeeregistry.v1
       proto: Artifact
-      proto-path: google.cloud.apigeeregistry.v1.Artifact
+      proto-msg: google.cloud.apigeeregistry.v1.Artifact
       notes:
         - No gcloud command found
     - name: apihub-api
@@ -1495,7 +1495,7 @@ branches:
       kind: APIHubApi
       package: google.cloud.apihub.v1
       proto: Api
-      proto-path: google.cloud.apihub.v1.Api
+      proto-msg: google.cloud.apihub.v1.Api
       notes:
         - No gcloud command found
     - name: apihub-version
@@ -1508,7 +1508,7 @@ branches:
       kind: APIHubVersion
       package: google.cloud.apihub.v1
       proto: Version
-      proto-path: google.cloud.apihub.v1.Version
+      proto-msg: google.cloud.apihub.v1.Version
       notes:
         - No gcloud command found
     - name: apihub-spec
@@ -1521,7 +1521,7 @@ branches:
       kind: APIHubSpec
       package: google.cloud.apihub.v1
       proto: Spec
-      proto-path: google.cloud.apihub.v1.Spec
+      proto-msg: google.cloud.apihub.v1.Spec
       notes:
         - No gcloud command found
     - name: apihub-deployment
@@ -1534,7 +1534,7 @@ branches:
       kind: APIHubDeployment
       package: google.cloud.apihub.v1
       proto: Deployment
-      proto-path: google.cloud.apihub.v1.Deployment
+      proto-msg: google.cloud.apihub.v1.Deployment
       notes:
         - No gcloud command found
     - name: apihub-apioperation
@@ -1547,7 +1547,7 @@ branches:
       kind: APIHubAPIOperation
       package: google.cloud.apihub.v1
       proto: ApiOperation
-      proto-path: google.cloud.apihub.v1.ApiOperation
+      proto-msg: google.cloud.apihub.v1.ApiOperation
       notes:
         - No gcloud command found
     - name: apihub-definition
@@ -1560,7 +1560,7 @@ branches:
       kind: APIHubDefinition
       package: google.cloud.apihub.v1
       proto: Definition
-      proto-path: google.cloud.apihub.v1.Definition
+      proto-msg: google.cloud.apihub.v1.Definition
       notes:
         - No gcloud command found
     - name: apihub-attribute
@@ -1573,7 +1573,7 @@ branches:
       kind: APIHubAttribute
       package: google.cloud.apihub.v1
       proto: Attribute
-      proto-path: google.cloud.apihub.v1.Attribute
+      proto-msg: google.cloud.apihub.v1.Attribute
       notes:
         - No gcloud command found
     - name: apihub-dependency
@@ -1586,7 +1586,7 @@ branches:
       kind: APIHubDependency
       package: google.cloud.apihub.v1
       proto: Dependency
-      proto-path: google.cloud.apihub.v1.Dependency
+      proto-msg: google.cloud.apihub.v1.Dependency
       notes:
         - No gcloud command found
     - name: apihub-apihubinstance
@@ -1599,7 +1599,7 @@ branches:
       kind: APIHubAPIHubInstance
       package: google.cloud.apihub.v1
       proto: ApiHubInstance
-      proto-path: google.cloud.apihub.v1.ApiHubInstance
+      proto-msg: google.cloud.apihub.v1.ApiHubInstance
       notes:
         - No gcloud command found
     - name: apihub-externalapi
@@ -1612,7 +1612,7 @@ branches:
       kind: APIHubExternalAPI
       package: google.cloud.apihub.v1
       proto: ExternalApi
-      proto-path: google.cloud.apihub.v1.ExternalApi
+      proto-msg: google.cloud.apihub.v1.ExternalApi
       notes:
         - No gcloud command found
     - name: apihub-hostprojectregistration
@@ -1625,7 +1625,7 @@ branches:
       kind: APIHubHostProjectRegistration
       package: google.cloud.apihub.v1
       proto: HostProjectRegistration
-      proto-path: google.cloud.apihub.v1.HostProjectRegistration
+      proto-msg: google.cloud.apihub.v1.HostProjectRegistration
       notes:
         - No gcloud command found
     - name: apihub-styleguide
@@ -1638,7 +1638,7 @@ branches:
       kind: APIHubStyleGuide
       package: google.cloud.apihub.v1
       proto: StyleGuide
-      proto-path: google.cloud.apihub.v1.StyleGuide
+      proto-msg: google.cloud.apihub.v1.StyleGuide
       notes:
         - No gcloud command found
     - name: apihub-plugin
@@ -1651,7 +1651,7 @@ branches:
       kind: APIHubPlugin
       package: google.cloud.apihub.v1
       proto: Plugin
-      proto-path: google.cloud.apihub.v1.Plugin
+      proto-msg: google.cloud.apihub.v1.Plugin
       notes:
         - No gcloud command found
     - name: apihub-runtimeprojectattachment
@@ -1664,7 +1664,7 @@ branches:
       kind: APIHubRuntimeProjectAttachment
       package: google.cloud.apihub.v1
       proto: RuntimeProjectAttachment
-      proto-path: google.cloud.apihub.v1.RuntimeProjectAttachment
+      proto-msg: google.cloud.apihub.v1.RuntimeProjectAttachment
       notes:
         - No gcloud command found
     - name: apphub-applications
@@ -1677,7 +1677,7 @@ branches:
       kind: AppHubApplication
       package: google.cloud.apphub.v1
       proto: Application
-      proto-path: google.cloud.apphub.v1.Application
+      proto-msg: google.cloud.apphub.v1.Application
       notes: []
     - name: apphub-service
       local: resource-apphub-service
@@ -1689,7 +1689,7 @@ branches:
       kind: AppHubService
       package: google.cloud.apphub.v1
       proto: Service
-      proto-path: google.cloud.apphub.v1.Service
+      proto-msg: google.cloud.apphub.v1.Service
       notes:
         - No gcloud command found
     - name: apphub-discoveredservice
@@ -1702,7 +1702,7 @@ branches:
       kind: AppHubDiscoveredService
       package: google.cloud.apphub.v1
       proto: DiscoveredService
-      proto-path: google.cloud.apphub.v1.DiscoveredService
+      proto-msg: google.cloud.apphub.v1.DiscoveredService
       notes: []
     - name: apphub-serviceprojectattachment
       local: resource-apphub-serviceprojectattachment
@@ -1714,7 +1714,7 @@ branches:
       kind: AppHubServiceProjectAttachment
       package: google.cloud.apphub.v1
       proto: ServiceProjectAttachment
-      proto-path: google.cloud.apphub.v1.ServiceProjectAttachment
+      proto-msg: google.cloud.apphub.v1.ServiceProjectAttachment
       notes:
         - No gcloud command found
     - name: apphub-workload
@@ -1727,7 +1727,7 @@ branches:
       kind: AppHubWorkload
       package: google.cloud.apphub.v1
       proto: Workload
-      proto-path: google.cloud.apphub.v1.Workload
+      proto-msg: google.cloud.apphub.v1.Workload
       notes:
         - No gcloud command found
     - name: apphub-discoveredworkload
@@ -1740,7 +1740,7 @@ branches:
       kind: AppHubDiscoveredWorkload
       package: google.cloud.apphub.v1
       proto: DiscoveredWorkload
-      proto-path: google.cloud.apphub.v1.DiscoveredWorkload
+      proto-msg: google.cloud.apphub.v1.DiscoveredWorkload
       notes: []
     - name: asset-feed
       local: resource-asset-feed
@@ -1752,7 +1752,7 @@ branches:
       kind: AssetFeed
       package: google.cloud.asset.v1
       proto: Feed
-      proto-path: google.cloud.asset.v1.Feed
+      proto-msg: google.cloud.asset.v1.Feed
       notes: []
     - name: asset-savedquery
       local: resource-asset-savedquery
@@ -1764,7 +1764,7 @@ branches:
       kind: AssetSavedQuery
       package: google.cloud.asset.v1
       proto: SavedQuery
-      proto-path: google.cloud.asset.v1.SavedQuery
+      proto-msg: google.cloud.asset.v1.SavedQuery
       notes: []
     - name: asset-asset
       local: resource-asset-asset
@@ -1776,7 +1776,7 @@ branches:
       kind: AssetAsset
       package: google.cloud.asset.v1
       proto: Asset
-      proto-path: google.cloud.asset.v1.Asset
+      proto-msg: google.cloud.asset.v1.Asset
       notes:
         - No gcloud command found
     - name: assuredworkloads-workload
@@ -1789,7 +1789,7 @@ branches:
       kind: AssuredWorkloadsWorkload
       package: google.cloud.assuredworkloads.v1
       proto: Workload
-      proto-path: google.cloud.assuredworkloads.v1.Workload
+      proto-msg: google.cloud.assuredworkloads.v1.Workload
       notes: []
     - name: assuredworkloads-violation
       local: resource-assuredworkloads-violation
@@ -1801,7 +1801,7 @@ branches:
       kind: AssuredWorkloadsViolation
       package: google.cloud.assuredworkloads.v1
       proto: Violation
-      proto-path: google.cloud.assuredworkloads.v1.Violation
+      proto-msg: google.cloud.assuredworkloads.v1.Violation
       notes:
         - No gcloud command found
     - name: automl-annotationspec
@@ -1814,7 +1814,7 @@ branches:
       kind: AutoMLAnnotationSpec
       package: google.cloud.automl.v1
       proto: AnnotationSpec
-      proto-path: google.cloud.automl.v1.AnnotationSpec
+      proto-msg: google.cloud.automl.v1.AnnotationSpec
       notes:
         - No gcloud command found
     - name: automl-dataset
@@ -1827,7 +1827,7 @@ branches:
       kind: AutoMLDataset
       package: google.cloud.automl.v1
       proto: Dataset
-      proto-path: google.cloud.automl.v1.Dataset
+      proto-msg: google.cloud.automl.v1.Dataset
       notes:
         - No gcloud command found
     - name: automl-model
@@ -1840,7 +1840,7 @@ branches:
       kind: AutoMLModel
       package: google.cloud.automl.v1
       proto: Model
-      proto-path: google.cloud.automl.v1.Model
+      proto-msg: google.cloud.automl.v1.Model
       notes:
         - No gcloud command found
     - name: automl-modelevaluation
@@ -1853,7 +1853,7 @@ branches:
       kind: AutoMLModelEvaluation
       package: google.cloud.automl.v1
       proto: ModelEvaluation
-      proto-path: google.cloud.automl.v1.ModelEvaluation
+      proto-msg: google.cloud.automl.v1.ModelEvaluation
       notes:
         - No gcloud command found
     - name: automl-columnspec
@@ -1866,7 +1866,7 @@ branches:
       kind: AutoMLColumnSpec
       package: google.cloud.automl.v1beta1
       proto: ColumnSpec
-      proto-path: google.cloud.automl.v1beta1.ColumnSpec
+      proto-msg: google.cloud.automl.v1beta1.ColumnSpec
       notes:
         - No gcloud command found
     - name: automl-tablespec
@@ -1879,7 +1879,7 @@ branches:
       kind: AutoMLTableSpec
       package: google.cloud.automl.v1beta1
       proto: TableSpec
-      proto-path: google.cloud.automl.v1beta1.TableSpec
+      proto-msg: google.cloud.automl.v1beta1.TableSpec
       notes:
         - No gcloud command found
     - name: backupdr-managementserver
@@ -1892,7 +1892,7 @@ branches:
       kind: BackupDRManagementServer
       package: google.cloud.backupdr.v1
       proto: ManagementServer
-      proto-path: google.cloud.backupdr.v1.ManagementServer
+      proto-msg: google.cloud.backupdr.v1.ManagementServer
       notes: []
     - name: backupdr-backupplan
       local: resource-backupdr-backupplan
@@ -1904,7 +1904,7 @@ branches:
       kind: BackupDRBackupPlan
       package: google.cloud.backupdr.v1
       proto: BackupPlan
-      proto-path: google.cloud.backupdr.v1.BackupPlan
+      proto-msg: google.cloud.backupdr.v1.BackupPlan
       notes: []
     - name: backupdr-backupplanassociation
       local: resource-backupdr-backupplanassociation
@@ -1916,7 +1916,7 @@ branches:
       kind: BackupDRBackupPlanAssociation
       package: google.cloud.backupdr.v1
       proto: BackupPlanAssociation
-      proto-path: google.cloud.backupdr.v1.BackupPlanAssociation
+      proto-msg: google.cloud.backupdr.v1.BackupPlanAssociation
       notes: []
     - name: backupdr-backupvault
       local: resource-backupdr-backupvault
@@ -1928,7 +1928,7 @@ branches:
       kind: BackupDRBackupVault
       package: google.cloud.backupdr.v1
       proto: BackupVault
-      proto-path: google.cloud.backupdr.v1.BackupVault
+      proto-msg: google.cloud.backupdr.v1.BackupVault
       notes: []
     - name: backupdr-datasource
       local: resource-backupdr-datasource
@@ -1940,7 +1940,7 @@ branches:
       kind: BackupDRDataSource
       package: google.cloud.backupdr.v1
       proto: DataSource
-      proto-path: google.cloud.backupdr.v1.DataSource
+      proto-msg: google.cloud.backupdr.v1.DataSource
       notes: []
     - name: backupdr-backup
       local: resource-backupdr-backup
@@ -1952,7 +1952,7 @@ branches:
       kind: BackupDRBackup
       package: google.cloud.backupdr.v1
       proto: Backup
-      proto-path: google.cloud.backupdr.v1.Backup
+      proto-msg: google.cloud.backupdr.v1.Backup
       notes: []
     - name: baremetalsolution-instance
       local: resource-baremetalsolution-instance
@@ -1964,7 +1964,7 @@ branches:
       kind: BareMetalSolutionInstance
       package: google.cloud.baremetalsolution.v2
       proto: Instance
-      proto-path: google.cloud.baremetalsolution.v2.Instance
+      proto-msg: google.cloud.baremetalsolution.v2.Instance
       notes: []
     - name: baremetalsolution-servernetworktemplate
       local: resource-baremetalsolution-servernetworktemplate
@@ -1976,7 +1976,7 @@ branches:
       kind: BareMetalSolutionServerNetworkTemplate
       package: google.cloud.baremetalsolution.v2
       proto: ServerNetworkTemplate
-      proto-path: google.cloud.baremetalsolution.v2.ServerNetworkTemplate
+      proto-msg: google.cloud.baremetalsolution.v2.ServerNetworkTemplate
       notes:
         - No gcloud command found
     - name: baremetalsolution-lun
@@ -1989,7 +1989,7 @@ branches:
       kind: BareMetalSolutionLun
       package: google.cloud.baremetalsolution.v2
       proto: Lun
-      proto-path: google.cloud.baremetalsolution.v2.Lun
+      proto-msg: google.cloud.baremetalsolution.v2.Lun
       notes:
         - No gcloud command found
     - name: baremetalsolution-network
@@ -2002,7 +2002,7 @@ branches:
       kind: BareMetalSolutionNetwork
       package: google.cloud.baremetalsolution.v2
       proto: Network
-      proto-path: google.cloud.baremetalsolution.v2.Network
+      proto-msg: google.cloud.baremetalsolution.v2.Network
       notes: []
     - name: baremetalsolution-nfsshare
       local: resource-baremetalsolution-nfsshare
@@ -2014,7 +2014,7 @@ branches:
       kind: BareMetalSolutionNfsShare
       package: google.cloud.baremetalsolution.v2
       proto: NfsShare
-      proto-path: google.cloud.baremetalsolution.v2.NfsShare
+      proto-msg: google.cloud.baremetalsolution.v2.NfsShare
       notes: []
     - name: baremetalsolution-osimage
       local: resource-baremetalsolution-osimage
@@ -2026,7 +2026,7 @@ branches:
       kind: BareMetalSolutionOSImage
       package: google.cloud.baremetalsolution.v2
       proto: OSImage
-      proto-path: google.cloud.baremetalsolution.v2.OSImage
+      proto-msg: google.cloud.baremetalsolution.v2.OSImage
       notes: []
     - name: baremetalsolution-provisioningconfig
       local: resource-baremetalsolution-provisioningconfig
@@ -2038,7 +2038,7 @@ branches:
       kind: BareMetalSolutionProvisioningConfig
       package: google.cloud.baremetalsolution.v2
       proto: ProvisioningConfig
-      proto-path: google.cloud.baremetalsolution.v2.ProvisioningConfig
+      proto-msg: google.cloud.baremetalsolution.v2.ProvisioningConfig
       notes:
         - No gcloud command found
     - name: baremetalsolution-provisioningquota
@@ -2051,7 +2051,7 @@ branches:
       kind: BareMetalSolutionProvisioningQuota
       package: google.cloud.baremetalsolution.v2
       proto: ProvisioningQuota
-      proto-path: google.cloud.baremetalsolution.v2.ProvisioningQuota
+      proto-msg: google.cloud.baremetalsolution.v2.ProvisioningQuota
       notes:
         - No gcloud command found
     - name: baremetalsolution-instanceconfig
@@ -2064,7 +2064,7 @@ branches:
       kind: BareMetalSolutionInstanceConfig
       package: google.cloud.baremetalsolution.v2
       proto: InstanceConfig
-      proto-path: google.cloud.baremetalsolution.v2.InstanceConfig
+      proto-msg: google.cloud.baremetalsolution.v2.InstanceConfig
       notes:
         - No gcloud command found
     - name: baremetalsolution-volumeconfig
@@ -2077,7 +2077,7 @@ branches:
       kind: BareMetalSolutionVolumeConfig
       package: google.cloud.baremetalsolution.v2
       proto: VolumeConfig
-      proto-path: google.cloud.baremetalsolution.v2.VolumeConfig
+      proto-msg: google.cloud.baremetalsolution.v2.VolumeConfig
       notes:
         - No gcloud command found
     - name: baremetalsolution-networkconfig
@@ -2090,7 +2090,7 @@ branches:
       kind: BareMetalSolutionNetworkConfig
       package: google.cloud.baremetalsolution.v2
       proto: NetworkConfig
-      proto-path: google.cloud.baremetalsolution.v2.NetworkConfig
+      proto-msg: google.cloud.baremetalsolution.v2.NetworkConfig
       notes:
         - No gcloud command found
     - name: baremetalsolution-instancequota
@@ -2103,7 +2103,7 @@ branches:
       kind: BareMetalSolutionInstanceQuota
       package: google.cloud.baremetalsolution.v2
       proto: InstanceQuota
-      proto-path: google.cloud.baremetalsolution.v2.InstanceQuota
+      proto-msg: google.cloud.baremetalsolution.v2.InstanceQuota
       notes:
         - No gcloud command found
     - name: baremetalsolution-sshkey
@@ -2116,7 +2116,7 @@ branches:
       kind: BareMetalSolutionSSHKey
       package: google.cloud.baremetalsolution.v2
       proto: SSHKey
-      proto-path: google.cloud.baremetalsolution.v2.SSHKey
+      proto-msg: google.cloud.baremetalsolution.v2.SSHKey
       notes: []
     - name: baremetalsolution-volume
       local: resource-baremetalsolution-volume
@@ -2128,7 +2128,7 @@ branches:
       kind: BareMetalSolutionVolume
       package: google.cloud.baremetalsolution.v2
       proto: Volume
-      proto-path: google.cloud.baremetalsolution.v2.Volume
+      proto-msg: google.cloud.baremetalsolution.v2.Volume
       notes: []
     - name: baremetalsolution-volumesnapshot
       local: resource-baremetalsolution-volumesnapshot
@@ -2140,7 +2140,7 @@ branches:
       kind: BareMetalSolutionVolumeSnapshot
       package: google.cloud.baremetalsolution.v2
       proto: VolumeSnapshot
-      proto-path: google.cloud.baremetalsolution.v2.VolumeSnapshot
+      proto-msg: google.cloud.baremetalsolution.v2.VolumeSnapshot
       notes:
         - No gcloud command found
     - name: batch-job
@@ -2153,7 +2153,7 @@ branches:
       kind: BatchJob
       package: google.cloud.batch.v1
       proto: Job
-      proto-path: google.cloud.batch.v1.Job
+      proto-msg: google.cloud.batch.v1.Job
       notes: []
     - name: batch-taskgroup
       local: resource-batch-taskgroup
@@ -2165,7 +2165,7 @@ branches:
       kind: BatchTaskGroup
       package: google.cloud.batch.v1
       proto: TaskGroup
-      proto-path: google.cloud.batch.v1.TaskGroup
+      proto-msg: google.cloud.batch.v1.TaskGroup
       notes:
         - No gcloud command found
     - name: batch-task
@@ -2178,7 +2178,7 @@ branches:
       kind: BatchTask
       package: google.cloud.batch.v1
       proto: Task
-      proto-path: google.cloud.batch.v1.Task
+      proto-msg: google.cloud.batch.v1.Task
       notes: []
     - name: beyondcorp-appconnection
       local: resource-beyondcorp-appconnection
@@ -2190,7 +2190,7 @@ branches:
       kind: BeyondCorpAppConnection
       package: google.cloud.beyondcorp.appconnections.v1
       proto: AppConnection
-      proto-path: google.cloud.beyondcorp.appconnections.v1.AppConnection
+      proto-msg: google.cloud.beyondcorp.appconnections.v1.AppConnection
       notes:
         - No gcloud command found
     - name: beyondcorp-appconnector
@@ -2203,7 +2203,7 @@ branches:
       kind: BeyondCorpAppConnector
       package: google.cloud.beyondcorp.appconnectors.v1
       proto: AppConnector
-      proto-path: google.cloud.beyondcorp.appconnectors.v1.AppConnector
+      proto-msg: google.cloud.beyondcorp.appconnectors.v1.AppConnector
       notes:
         - No gcloud command found
     - name: beyondcorp-appgateway
@@ -2216,7 +2216,7 @@ branches:
       kind: BeyondCorpAppGateway
       package: google.cloud.beyondcorp.appgateways.v1
       proto: AppGateway
-      proto-path: google.cloud.beyondcorp.appgateways.v1.AppGateway
+      proto-msg: google.cloud.beyondcorp.appgateways.v1.AppGateway
       notes:
         - No gcloud command found
     - name: beyondcorp-clientconnectorservice
@@ -2229,7 +2229,7 @@ branches:
       kind: BeyondCorpClientConnectorService
       package: google.cloud.beyondcorp.clientconnectorservices.v1
       proto: ClientConnectorService
-      proto-path: google.cloud.beyondcorp.clientconnectorservices.v1.ClientConnectorService
+      proto-msg: google.cloud.beyondcorp.clientconnectorservices.v1.ClientConnectorService
       notes: []
     - name: beyondcorp-clientgateway
       local: resource-beyondcorp-clientgateway
@@ -2241,7 +2241,7 @@ branches:
       kind: BeyondCorpClientGateway
       package: google.cloud.beyondcorp.clientgateways.v1
       proto: ClientGateway
-      proto-path: google.cloud.beyondcorp.clientgateways.v1.ClientGateway
+      proto-msg: google.cloud.beyondcorp.clientgateways.v1.ClientGateway
       notes:
         - No gcloud command found
     - name: bigquery-dataexchange
@@ -2254,7 +2254,7 @@ branches:
       kind: BigqueryDataExchange
       package: google.cloud.bigquery.analyticshub.v1
       proto: DataExchange
-      proto-path: google.cloud.bigquery.analyticshub.v1.DataExchange
+      proto-msg: google.cloud.bigquery.analyticshub.v1.DataExchange
       notes:
         - No gcloud command found
     - name: bigquery-listing
@@ -2267,7 +2267,7 @@ branches:
       kind: BigqueryListing
       package: google.cloud.bigquery.analyticshub.v1
       proto: Listing
-      proto-path: google.cloud.bigquery.analyticshub.v1.Listing
+      proto-msg: google.cloud.bigquery.analyticshub.v1.Listing
       notes:
         - No gcloud command found
     - name: bigquery-subscription
@@ -2280,7 +2280,7 @@ branches:
       kind: BigquerySubscription
       package: google.cloud.bigquery.analyticshub.v1
       proto: Subscription
-      proto-path: google.cloud.bigquery.analyticshub.v1.Subscription
+      proto-msg: google.cloud.bigquery.analyticshub.v1.Subscription
       notes:
         - No gcloud command found
     - name: bigquery-catalog
@@ -2293,7 +2293,7 @@ branches:
       kind: BigqueryCatalog
       package: google.cloud.bigquery.biglake.v1
       proto: Catalog
-      proto-path: google.cloud.bigquery.biglake.v1.Catalog
+      proto-msg: google.cloud.bigquery.biglake.v1.Catalog
       notes:
         - No gcloud command found
     - name: bigquery-database
@@ -2306,7 +2306,7 @@ branches:
       kind: BigqueryDatabase
       package: google.cloud.bigquery.biglake.v1
       proto: Database
-      proto-path: google.cloud.bigquery.biglake.v1.Database
+      proto-msg: google.cloud.bigquery.biglake.v1.Database
       notes:
         - No gcloud command found
     - name: bigquery-table
@@ -2319,7 +2319,7 @@ branches:
       kind: BigqueryTable
       package: google.cloud.bigquery.biglake.v1
       proto: Table
-      proto-path: google.cloud.bigquery.biglake.v1.Table
+      proto-msg: google.cloud.bigquery.biglake.v1.Table
       notes:
         - No gcloud command found
     - name: bigquery-connection
@@ -2332,7 +2332,7 @@ branches:
       kind: BigqueryConnection
       package: google.cloud.bigquery.connection.v1
       proto: Connection
-      proto-path: google.cloud.bigquery.connection.v1.Connection
+      proto-msg: google.cloud.bigquery.connection.v1.Connection
       notes:
         - No gcloud command found
     - name: bigquery-datapolicy
@@ -2345,7 +2345,7 @@ branches:
       kind: BigqueryDataPolicy
       package: google.cloud.bigquery.datapolicies.v1
       proto: DataPolicy
-      proto-path: google.cloud.bigquery.datapolicies.v1.DataPolicy
+      proto-msg: google.cloud.bigquery.datapolicies.v1.DataPolicy
       notes:
         - No gcloud command found
     - name: bigquery-datasource
@@ -2358,7 +2358,7 @@ branches:
       kind: BigqueryDataSource
       package: google.cloud.bigquery.datatransfer.v1
       proto: DataSource
-      proto-path: google.cloud.bigquery.datatransfer.v1.DataSource
+      proto-msg: google.cloud.bigquery.datatransfer.v1.DataSource
       notes:
         - No gcloud command found
     - name: bigquery-transferconfig
@@ -2371,7 +2371,7 @@ branches:
       kind: BigqueryTransferConfig
       package: google.cloud.bigquery.datatransfer.v1
       proto: TransferConfig
-      proto-path: google.cloud.bigquery.datatransfer.v1.TransferConfig
+      proto-msg: google.cloud.bigquery.datatransfer.v1.TransferConfig
       notes:
         - No gcloud command found
     - name: bigquery-transferrun
@@ -2384,7 +2384,7 @@ branches:
       kind: BigqueryTransferRun
       package: google.cloud.bigquery.datatransfer.v1
       proto: TransferRun
-      proto-path: google.cloud.bigquery.datatransfer.v1.TransferRun
+      proto-msg: google.cloud.bigquery.datatransfer.v1.TransferRun
       notes:
         - No gcloud command found
     - name: bigquery-migrationworkflow
@@ -2397,7 +2397,7 @@ branches:
       kind: BigqueryMigrationWorkflow
       package: google.cloud.bigquery.migration.v2
       proto: MigrationWorkflow
-      proto-path: google.cloud.bigquery.migration.v2.MigrationWorkflow
+      proto-msg: google.cloud.bigquery.migration.v2.MigrationWorkflow
       notes:
         - No gcloud command found
     - name: bigquery-migrationsubtask
@@ -2410,7 +2410,7 @@ branches:
       kind: BigqueryMigrationSubtask
       package: google.cloud.bigquery.migration.v2
       proto: MigrationSubtask
-      proto-path: google.cloud.bigquery.migration.v2.MigrationSubtask
+      proto-msg: google.cloud.bigquery.migration.v2.MigrationSubtask
       notes:
         - No gcloud command found
     - name: bigquery-reservation
@@ -2423,7 +2423,7 @@ branches:
       kind: BigqueryReservation
       package: google.cloud.bigquery.reservation.v1
       proto: Reservation
-      proto-path: google.cloud.bigquery.reservation.v1.Reservation
+      proto-msg: google.cloud.bigquery.reservation.v1.Reservation
       notes:
         - No gcloud command found
     - name: bigquery-capacitycommitment
@@ -2436,7 +2436,7 @@ branches:
       kind: BigqueryCapacityCommitment
       package: google.cloud.bigquery.reservation.v1
       proto: CapacityCommitment
-      proto-path: google.cloud.bigquery.reservation.v1.CapacityCommitment
+      proto-msg: google.cloud.bigquery.reservation.v1.CapacityCommitment
       notes:
         - No gcloud command found
     - name: bigquery-assignment
@@ -2449,7 +2449,7 @@ branches:
       kind: BigqueryAssignment
       package: google.cloud.bigquery.reservation.v1
       proto: Assignment
-      proto-path: google.cloud.bigquery.reservation.v1.Assignment
+      proto-msg: google.cloud.bigquery.reservation.v1.Assignment
       notes:
         - No gcloud command found
     - name: bigquery-bireservation
@@ -2462,7 +2462,7 @@ branches:
       kind: BigqueryBiReservation
       package: google.cloud.bigquery.reservation.v1
       proto: BiReservation
-      proto-path: google.cloud.bigquery.reservation.v1.BiReservation
+      proto-msg: google.cloud.bigquery.reservation.v1.BiReservation
       notes:
         - No gcloud command found
     - name: bigquery-readsession
@@ -2475,7 +2475,7 @@ branches:
       kind: BigqueryReadSession
       package: google.cloud.bigquery.storage.v1
       proto: ReadSession
-      proto-path: google.cloud.bigquery.storage.v1.ReadSession
+      proto-msg: google.cloud.bigquery.storage.v1.ReadSession
       notes:
         - No gcloud command found
     - name: bigquery-readstream
@@ -2488,7 +2488,7 @@ branches:
       kind: BigqueryReadStream
       package: google.cloud.bigquery.storage.v1
       proto: ReadStream
-      proto-path: google.cloud.bigquery.storage.v1.ReadStream
+      proto-msg: google.cloud.bigquery.storage.v1.ReadStream
       notes:
         - No gcloud command found
     - name: bigquery-writestream
@@ -2501,7 +2501,7 @@ branches:
       kind: BigqueryWriteStream
       package: google.cloud.bigquery.storage.v1
       proto: WriteStream
-      proto-path: google.cloud.bigquery.storage.v1.WriteStream
+      proto-msg: google.cloud.bigquery.storage.v1.WriteStream
       notes:
         - No gcloud command found
     - name: bigquery-stream
@@ -2514,7 +2514,7 @@ branches:
       kind: BigqueryStream
       package: google.cloud.bigquery.storage.v1beta1
       proto: Stream
-      proto-path: google.cloud.bigquery.storage.v1beta1.Stream
+      proto-msg: google.cloud.bigquery.storage.v1beta1.Stream
       notes:
         - No gcloud command found
     - name: billing-budget
@@ -2527,7 +2527,7 @@ branches:
       kind: BillingBudget
       package: google.cloud.billing.budgets.v1
       proto: Budget
-      proto-path: google.cloud.billing.budgets.v1.Budget
+      proto-msg: google.cloud.billing.budgets.v1.Budget
       notes: []
     - name: billing-billingaccount
       local: resource-billing-billingaccount
@@ -2539,7 +2539,7 @@ branches:
       kind: BillingBillingAccount
       package: google.cloud.billing.v1
       proto: BillingAccount
-      proto-path: google.cloud.billing.v1.BillingAccount
+      proto-msg: google.cloud.billing.v1.BillingAccount
       notes: []
     - name: billing-projectbillinginfo
       local: resource-billing-projectbillinginfo
@@ -2551,7 +2551,7 @@ branches:
       kind: BillingProjectBillingInfo
       package: google.cloud.billing.v1
       proto: ProjectBillingInfo
-      proto-path: google.cloud.billing.v1.ProjectBillingInfo
+      proto-msg: google.cloud.billing.v1.ProjectBillingInfo
       notes:
         - No gcloud command found
     - name: billing-service
@@ -2564,7 +2564,7 @@ branches:
       kind: BillingService
       package: google.cloud.billing.v1
       proto: Service
-      proto-path: google.cloud.billing.v1.Service
+      proto-msg: google.cloud.billing.v1.Service
       notes:
         - No gcloud command found
     - name: billing-sku
@@ -2577,7 +2577,7 @@ branches:
       kind: BillingSKU
       package: google.cloud.billing.v1
       proto: Sku
-      proto-path: google.cloud.billing.v1.Sku
+      proto-msg: google.cloud.billing.v1.Sku
       notes:
         - No gcloud command found
     - name: binaryauthorization-policy
@@ -2590,7 +2590,7 @@ branches:
       kind: BinaryAuthorizationPolicy
       package: google.cloud.binaryauthorization.v1
       proto: Policy
-      proto-path: google.cloud.binaryauthorization.v1.Policy
+      proto-msg: google.cloud.binaryauthorization.v1.Policy
       notes:
         - No gcloud command found
     - name: binaryauthorization-attestor
@@ -2603,7 +2603,7 @@ branches:
       kind: BinaryAuthorizationAttestor
       package: google.cloud.binaryauthorization.v1
       proto: Attestor
-      proto-path: google.cloud.binaryauthorization.v1.Attestor
+      proto-msg: google.cloud.binaryauthorization.v1.Attestor
       notes:
         - No gcloud command found
     - name: blockchainnodeengine-blockchainnode
@@ -2616,7 +2616,7 @@ branches:
       kind: BlockchainNodeEngineBlockchainNode
       package: google.cloud.blockchainnodeengine.v1
       proto: BlockchainNode
-      proto-path: google.cloud.blockchainnodeengine.v1.BlockchainNode
+      proto-msg: google.cloud.blockchainnodeengine.v1.BlockchainNode
       notes:
         - No gcloud command found
     - name: certificatemanager-certificateissuanceconfig
@@ -2629,7 +2629,7 @@ branches:
       kind: CertificateManagerCertificateIssuanceConfig
       package: google.cloud.certificatemanager.v1
       proto: CertificateIssuanceConfig
-      proto-path: google.cloud.certificatemanager.v1.CertificateIssuanceConfig
+      proto-msg: google.cloud.certificatemanager.v1.CertificateIssuanceConfig
       notes: []
     - name: certificatemanager-certificate
       local: resource-certificatemanager-certificate
@@ -2641,7 +2641,7 @@ branches:
       kind: CertificateManagerCertificate
       package: google.cloud.certificatemanager.v1
       proto: Certificate
-      proto-path: google.cloud.certificatemanager.v1.Certificate
+      proto-msg: google.cloud.certificatemanager.v1.Certificate
       notes: []
     - name: certificatemanager-certificatemap
       local: resource-certificatemanager-certificatemap
@@ -2653,7 +2653,7 @@ branches:
       kind: CertificateManagerCertificateMap
       package: google.cloud.certificatemanager.v1
       proto: CertificateMap
-      proto-path: google.cloud.certificatemanager.v1.CertificateMap
+      proto-msg: google.cloud.certificatemanager.v1.CertificateMap
       notes:
         - No gcloud command found
     - name: certificatemanager-certificatemapentry
@@ -2666,7 +2666,7 @@ branches:
       kind: CertificateManagerCertificateMapEntry
       package: google.cloud.certificatemanager.v1
       proto: CertificateMapEntry
-      proto-path: google.cloud.certificatemanager.v1.CertificateMapEntry
+      proto-msg: google.cloud.certificatemanager.v1.CertificateMapEntry
       notes:
         - No gcloud command found
     - name: certificatemanager-dnsauthorization
@@ -2679,7 +2679,7 @@ branches:
       kind: CertificateManagerDnsAuthorization
       package: google.cloud.certificatemanager.v1
       proto: DnsAuthorization
-      proto-path: google.cloud.certificatemanager.v1.DnsAuthorization
+      proto-msg: google.cloud.certificatemanager.v1.DnsAuthorization
       notes: []
     - name: certificatemanager-trustconfig
       local: resource-certificatemanager-trustconfig
@@ -2691,7 +2691,7 @@ branches:
       kind: CertificateManagerTrustConfig
       package: google.cloud.certificatemanager.v1
       proto: TrustConfig
-      proto-path: google.cloud.certificatemanager.v1.TrustConfig
+      proto-msg: google.cloud.certificatemanager.v1.TrustConfig
       notes: []
     - name: channel-billingaccount
       local: resource-channel-billingaccount
@@ -2703,7 +2703,7 @@ branches:
       kind: ChannelBillingAccount
       package: google.cloud.channel.v1
       proto: BillingAccount
-      proto-path: google.cloud.channel.v1.BillingAccount
+      proto-msg: google.cloud.channel.v1.BillingAccount
       notes:
         - No gcloud command found
     - name: channel-channelpartnerlink
@@ -2716,7 +2716,7 @@ branches:
       kind: ChannelChannelPartnerLink
       package: google.cloud.channel.v1
       proto: ChannelPartnerLink
-      proto-path: google.cloud.channel.v1.ChannelPartnerLink
+      proto-msg: google.cloud.channel.v1.ChannelPartnerLink
       notes:
         - No gcloud command found
     - name: channel-customer
@@ -2729,7 +2729,7 @@ branches:
       kind: ChannelCustomer
       package: google.cloud.channel.v1
       proto: Customer
-      proto-path: google.cloud.channel.v1.Customer
+      proto-msg: google.cloud.channel.v1.Customer
       notes:
         - No gcloud command found
     - name: channel-entitlement
@@ -2742,7 +2742,7 @@ branches:
       kind: ChannelEntitlement
       package: google.cloud.channel.v1
       proto: Entitlement
-      proto-path: google.cloud.channel.v1.Entitlement
+      proto-msg: google.cloud.channel.v1.Entitlement
       notes:
         - No gcloud command found
     - name: channel-offer
@@ -2755,7 +2755,7 @@ branches:
       kind: ChannelOffer
       package: google.cloud.channel.v1
       proto: Offer
-      proto-path: google.cloud.channel.v1.Offer
+      proto-msg: google.cloud.channel.v1.Offer
       notes:
         - No gcloud command found
     - name: channel-product
@@ -2768,7 +2768,7 @@ branches:
       kind: ChannelProduct
       package: google.cloud.channel.v1
       proto: Product
-      proto-path: google.cloud.channel.v1.Product
+      proto-msg: google.cloud.channel.v1.Product
       notes:
         - No gcloud command found
     - name: channel-sku
@@ -2781,7 +2781,7 @@ branches:
       kind: ChannelSku
       package: google.cloud.channel.v1
       proto: Sku
-      proto-path: google.cloud.channel.v1.Sku
+      proto-msg: google.cloud.channel.v1.Sku
       notes:
         - No gcloud command found
     - name: channel-reportjob
@@ -2794,7 +2794,7 @@ branches:
       kind: ChannelReportJob
       package: google.cloud.channel.v1
       proto: ReportJob
-      proto-path: google.cloud.channel.v1.ReportJob
+      proto-msg: google.cloud.channel.v1.ReportJob
       notes:
         - No gcloud command found
     - name: channel-report
@@ -2807,7 +2807,7 @@ branches:
       kind: ChannelReport
       package: google.cloud.channel.v1
       proto: Report
-      proto-path: google.cloud.channel.v1.Report
+      proto-msg: google.cloud.channel.v1.Report
       notes:
         - No gcloud command found
     - name: channel-customerrepricingconfig
@@ -2820,7 +2820,7 @@ branches:
       kind: ChannelCustomerRepricingConfig
       package: google.cloud.channel.v1
       proto: CustomerRepricingConfig
-      proto-path: google.cloud.channel.v1.CustomerRepricingConfig
+      proto-msg: google.cloud.channel.v1.CustomerRepricingConfig
       notes:
         - No gcloud command found
     - name: channel-channelpartnerrepricingconfig
@@ -2833,7 +2833,7 @@ branches:
       kind: ChannelChannelPartnerRepricingConfig
       package: google.cloud.channel.v1
       proto: ChannelPartnerRepricingConfig
-      proto-path: google.cloud.channel.v1.ChannelPartnerRepricingConfig
+      proto-msg: google.cloud.channel.v1.ChannelPartnerRepricingConfig
       notes:
         - No gcloud command found
     - name: channel-skugroup
@@ -2846,7 +2846,7 @@ branches:
       kind: ChannelSkuGroup
       package: google.cloud.channel.v1
       proto: SkuGroup
-      proto-path: google.cloud.channel.v1.SkuGroup
+      proto-msg: google.cloud.channel.v1.SkuGroup
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-accessapprovalrequest
@@ -2859,7 +2859,7 @@ branches:
       kind: CloudControlsPartnerAccessApprovalRequest
       package: google.cloud.cloudcontrolspartner.v1
       proto: AccessApprovalRequest
-      proto-path: google.cloud.cloudcontrolspartner.v1.AccessApprovalRequest
+      proto-msg: google.cloud.cloudcontrolspartner.v1.AccessApprovalRequest
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-workload
@@ -2872,7 +2872,7 @@ branches:
       kind: CloudControlsPartnerWorkload
       package: google.cloud.cloudcontrolspartner.v1
       proto: Workload
-      proto-path: google.cloud.cloudcontrolspartner.v1.Workload
+      proto-msg: google.cloud.cloudcontrolspartner.v1.Workload
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-customer
@@ -2885,7 +2885,7 @@ branches:
       kind: CloudControlsPartnerCustomer
       package: google.cloud.cloudcontrolspartner.v1
       proto: Customer
-      proto-path: google.cloud.cloudcontrolspartner.v1.Customer
+      proto-msg: google.cloud.cloudcontrolspartner.v1.Customer
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-ekmconnection
@@ -2898,7 +2898,7 @@ branches:
       kind: CloudControlsPartnerEkmConnection
       package: google.cloud.cloudcontrolspartner.v1
       proto: EkmConnections
-      proto-path: google.cloud.cloudcontrolspartner.v1.EkmConnections
+      proto-msg: google.cloud.cloudcontrolspartner.v1.EkmConnections
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-partnerpermission
@@ -2911,7 +2911,7 @@ branches:
       kind: CloudControlsPartnerPartnerPermission
       package: google.cloud.cloudcontrolspartner.v1
       proto: PartnerPermissions
-      proto-path: google.cloud.cloudcontrolspartner.v1.PartnerPermissions
+      proto-msg: google.cloud.cloudcontrolspartner.v1.PartnerPermissions
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-partner
@@ -2924,7 +2924,7 @@ branches:
       kind: CloudControlsPartnerPartner
       package: google.cloud.cloudcontrolspartner.v1
       proto: Partner
-      proto-path: google.cloud.cloudcontrolspartner.v1.Partner
+      proto-msg: google.cloud.cloudcontrolspartner.v1.Partner
       notes:
         - No gcloud command found
     - name: cloudcontrolspartner-violation
@@ -2937,7 +2937,7 @@ branches:
       kind: CloudControlsPartnerViolation
       package: google.cloud.cloudcontrolspartner.v1
       proto: Violation
-      proto-path: google.cloud.cloudcontrolspartner.v1.Violation
+      proto-msg: google.cloud.cloudcontrolspartner.v1.Violation
       notes:
         - No gcloud command found
     - name: clouddms-migrationjob
@@ -2950,7 +2950,7 @@ branches:
       kind: CloudDMSMigrationJob
       package: google.cloud.clouddms.v1
       proto: MigrationJob
-      proto-path: google.cloud.clouddms.v1.MigrationJob
+      proto-msg: google.cloud.clouddms.v1.MigrationJob
       notes: []
     - name: clouddms-connectionprofile
       local: resource-clouddms-connectionprofile
@@ -2962,7 +2962,7 @@ branches:
       kind: CloudDMSConnectionProfile
       package: google.cloud.clouddms.v1
       proto: ConnectionProfile
-      proto-path: google.cloud.clouddms.v1.ConnectionProfile
+      proto-msg: google.cloud.clouddms.v1.ConnectionProfile
       notes: []
     - name: clouddms-privateconnection
       local: resource-clouddms-privateconnection
@@ -2974,7 +2974,7 @@ branches:
       kind: CloudDMSPrivateConnection
       package: google.cloud.clouddms.v1
       proto: PrivateConnection
-      proto-path: google.cloud.clouddms.v1.PrivateConnection
+      proto-msg: google.cloud.clouddms.v1.PrivateConnection
       notes: []
     - name: clouddms-conversionworkspace
       local: resource-clouddms-conversionworkspace
@@ -2986,7 +2986,7 @@ branches:
       kind: CloudDMSConversionWorkspace
       package: google.cloud.clouddms.v1
       proto: ConversionWorkspace
-      proto-path: google.cloud.clouddms.v1.ConversionWorkspace
+      proto-msg: google.cloud.clouddms.v1.ConversionWorkspace
       notes: []
     - name: clouddms-mappingrule
       local: resource-clouddms-mappingrule
@@ -2998,7 +2998,7 @@ branches:
       kind: CloudDMSMappingRule
       package: google.cloud.clouddms.v1
       proto: MappingRule
-      proto-path: google.cloud.clouddms.v1.MappingRule
+      proto-msg: google.cloud.clouddms.v1.MappingRule
       notes:
         - No gcloud command found
     - name: commerce-licensepool
@@ -3011,7 +3011,7 @@ branches:
       kind: CommerceLicensePool
       package: google.cloud.commerce.consumer.procurement.v1
       proto: LicensePool
-      proto-path: google.cloud.commerce.consumer.procurement.v1.LicensePool
+      proto-msg: google.cloud.commerce.consumer.procurement.v1.LicensePool
       notes:
         - No gcloud command found
     - name: commerce-order
@@ -3024,7 +3024,7 @@ branches:
       kind: CommerceOrder
       package: google.cloud.commerce.consumer.procurement.v1
       proto: Order
-      proto-path: google.cloud.commerce.consumer.procurement.v1.Order
+      proto-msg: google.cloud.commerce.consumer.procurement.v1.Order
       notes:
         - No gcloud command found
     - name: confidentialcomputing-challenge
@@ -3037,7 +3037,7 @@ branches:
       kind: ConfidentialComputingChallenge
       package: google.cloud.confidentialcomputing.v1
       proto: Challenge
-      proto-path: google.cloud.confidentialcomputing.v1.Challenge
+      proto-msg: google.cloud.confidentialcomputing.v1.Challenge
       notes:
         - No gcloud command found
     - name: config-deployment
@@ -3050,7 +3050,7 @@ branches:
       kind: ConfigDeployment
       package: google.cloud.config.v1
       proto: Deployment
-      proto-path: google.cloud.config.v1.Deployment
+      proto-msg: google.cloud.config.v1.Deployment
       notes:
         - No gcloud command found
     - name: config-revision
@@ -3063,7 +3063,7 @@ branches:
       kind: ConfigRevision
       package: google.cloud.config.v1
       proto: Revision
-      proto-path: google.cloud.config.v1.Revision
+      proto-msg: google.cloud.config.v1.Revision
       notes:
         - No gcloud command found
     - name: config-resource
@@ -3076,7 +3076,7 @@ branches:
       kind: ConfigResource
       package: google.cloud.config.v1
       proto: Resource
-      proto-path: google.cloud.config.v1.Resource
+      proto-msg: google.cloud.config.v1.Resource
       notes:
         - No gcloud command found
     - name: config-preview
@@ -3089,7 +3089,7 @@ branches:
       kind: ConfigPreview
       package: google.cloud.config.v1
       proto: Preview
-      proto-path: google.cloud.config.v1.Preview
+      proto-msg: google.cloud.config.v1.Preview
       notes:
         - No gcloud command found
     - name: config-terraformversion
@@ -3102,7 +3102,7 @@ branches:
       kind: ConfigTerraformVersion
       package: google.cloud.config.v1
       proto: TerraformVersion
-      proto-path: google.cloud.config.v1.TerraformVersion
+      proto-msg: google.cloud.config.v1.TerraformVersion
       notes:
         - No gcloud command found
     - name: connectors-connection
@@ -3115,7 +3115,7 @@ branches:
       kind: ConnectorsConnection
       package: google.cloud.connectors.v1
       proto: Connection
-      proto-path: google.cloud.connectors.v1.Connection
+      proto-msg: google.cloud.connectors.v1.Connection
       notes:
         - No gcloud command found
     - name: connectors-connectionschemametadata
@@ -3128,7 +3128,7 @@ branches:
       kind: ConnectorsConnectionSchemaMetadata
       package: google.cloud.connectors.v1
       proto: ConnectionSchemaMetadata
-      proto-path: google.cloud.connectors.v1.ConnectionSchemaMetadata
+      proto-msg: google.cloud.connectors.v1.ConnectionSchemaMetadata
       notes:
         - No gcloud command found
     - name: connectors-connector
@@ -3141,7 +3141,7 @@ branches:
       kind: ConnectorsConnector
       package: google.cloud.connectors.v1
       proto: Connector
-      proto-path: google.cloud.connectors.v1.Connector
+      proto-msg: google.cloud.connectors.v1.Connector
       notes:
         - No gcloud command found
     - name: connectors-connectorversion
@@ -3154,7 +3154,7 @@ branches:
       kind: ConnectorsConnectorVersion
       package: google.cloud.connectors.v1
       proto: ConnectorVersion
-      proto-path: google.cloud.connectors.v1.ConnectorVersion
+      proto-msg: google.cloud.connectors.v1.ConnectorVersion
       notes:
         - No gcloud command found
     - name: connectors-provider
@@ -3167,7 +3167,7 @@ branches:
       kind: ConnectorsProvider
       package: google.cloud.connectors.v1
       proto: Provider
-      proto-path: google.cloud.connectors.v1.Provider
+      proto-msg: google.cloud.connectors.v1.Provider
       notes:
         - No gcloud command found
     - name: connectors-runtimeconfig
@@ -3180,7 +3180,7 @@ branches:
       kind: ConnectorsRuntimeConfig
       package: google.cloud.connectors.v1
       proto: RuntimeConfig
-      proto-path: google.cloud.connectors.v1.RuntimeConfig
+      proto-msg: google.cloud.connectors.v1.RuntimeConfig
       notes:
         - No gcloud command found
     - name: connectors-settings
@@ -3193,7 +3193,7 @@ branches:
       kind: ConnectorsSettings
       package: google.cloud.connectors.v1
       proto: Settings
-      proto-path: google.cloud.connectors.v1.Settings
+      proto-msg: google.cloud.connectors.v1.Settings
       notes:
         - No gcloud command found
     - name: contactcenterinsights-conversation
@@ -3206,7 +3206,7 @@ branches:
       kind: ContactCenterInsightsConversation
       package: google.cloud.contactcenterinsights.v1
       proto: Conversation
-      proto-path: google.cloud.contactcenterinsights.v1.Conversation
+      proto-msg: google.cloud.contactcenterinsights.v1.Conversation
       notes:
         - No gcloud command found
     - name: contactcenterinsights-analysis
@@ -3219,7 +3219,7 @@ branches:
       kind: ContactCenterInsightsAnalysis
       package: google.cloud.contactcenterinsights.v1
       proto: Analysis
-      proto-path: google.cloud.contactcenterinsights.v1.Analysis
+      proto-msg: google.cloud.contactcenterinsights.v1.Analysis
       notes:
         - No gcloud command found
     - name: contactcenterinsights-feedbacklabel
@@ -3232,7 +3232,7 @@ branches:
       kind: ContactCenterInsightsFeedbackLabel
       package: google.cloud.contactcenterinsights.v1
       proto: FeedbackLabel
-      proto-path: google.cloud.contactcenterinsights.v1.FeedbackLabel
+      proto-msg: google.cloud.contactcenterinsights.v1.FeedbackLabel
       notes:
         - No gcloud command found
     - name: contactcenterinsights-issuemodel
@@ -3245,7 +3245,7 @@ branches:
       kind: ContactCenterInsightsIssueModel
       package: google.cloud.contactcenterinsights.v1
       proto: IssueModel
-      proto-path: google.cloud.contactcenterinsights.v1.IssueModel
+      proto-msg: google.cloud.contactcenterinsights.v1.IssueModel
       notes:
         - No gcloud command found
     - name: contactcenterinsights-issue
@@ -3258,7 +3258,7 @@ branches:
       kind: ContactCenterInsightsIssue
       package: google.cloud.contactcenterinsights.v1
       proto: Issue
-      proto-path: google.cloud.contactcenterinsights.v1.Issue
+      proto-msg: google.cloud.contactcenterinsights.v1.Issue
       notes:
         - No gcloud command found
     - name: contactcenterinsights-phrasematcher
@@ -3271,7 +3271,7 @@ branches:
       kind: ContactCenterInsightsPhraseMatcher
       package: google.cloud.contactcenterinsights.v1
       proto: PhraseMatcher
-      proto-path: google.cloud.contactcenterinsights.v1.PhraseMatcher
+      proto-msg: google.cloud.contactcenterinsights.v1.PhraseMatcher
       notes:
         - No gcloud command found
     - name: contactcenterinsights-settings
@@ -3284,7 +3284,7 @@ branches:
       kind: ContactCenterInsightsSettings
       package: google.cloud.contactcenterinsights.v1
       proto: Settings
-      proto-path: google.cloud.contactcenterinsights.v1.Settings
+      proto-msg: google.cloud.contactcenterinsights.v1.Settings
       notes:
         - No gcloud command found
     - name: contactcenterinsights-analysisrule
@@ -3297,7 +3297,7 @@ branches:
       kind: ContactCenterInsightsAnalysisRule
       package: google.cloud.contactcenterinsights.v1
       proto: AnalysisRule
-      proto-path: google.cloud.contactcenterinsights.v1.AnalysisRule
+      proto-msg: google.cloud.contactcenterinsights.v1.AnalysisRule
       notes:
         - No gcloud command found
     - name: contactcenterinsights-encryptionspec
@@ -3310,7 +3310,7 @@ branches:
       kind: ContactCenterInsightsEncryptionSpec
       package: google.cloud.contactcenterinsights.v1
       proto: EncryptionSpec
-      proto-path: google.cloud.contactcenterinsights.v1.EncryptionSpec
+      proto-msg: google.cloud.contactcenterinsights.v1.EncryptionSpec
       notes:
         - No gcloud command found
     - name: contactcenterinsights-view
@@ -3323,7 +3323,7 @@ branches:
       kind: ContactCenterInsightsView
       package: google.cloud.contactcenterinsights.v1
       proto: View
-      proto-path: google.cloud.contactcenterinsights.v1.View
+      proto-msg: google.cloud.contactcenterinsights.v1.View
       notes:
         - No gcloud command found
     - name: contactcenterinsights-qaquestion
@@ -3336,7 +3336,7 @@ branches:
       kind: ContactCenterInsightsQaQuestion
       package: google.cloud.contactcenterinsights.v1
       proto: QaQuestion
-      proto-path: google.cloud.contactcenterinsights.v1.QaQuestion
+      proto-msg: google.cloud.contactcenterinsights.v1.QaQuestion
       notes:
         - No gcloud command found
     - name: contactcenterinsights-qascorecard
@@ -3349,7 +3349,7 @@ branches:
       kind: ContactCenterInsightsQaScorecard
       package: google.cloud.contactcenterinsights.v1
       proto: QaScorecard
-      proto-path: google.cloud.contactcenterinsights.v1.QaScorecard
+      proto-msg: google.cloud.contactcenterinsights.v1.QaScorecard
       notes:
         - No gcloud command found
     - name: contactcenterinsights-qascorecardrevision
@@ -3362,7 +3362,7 @@ branches:
       kind: ContactCenterInsightsQaScorecardRevision
       package: google.cloud.contactcenterinsights.v1
       proto: QaScorecardRevision
-      proto-path: google.cloud.contactcenterinsights.v1.QaScorecardRevision
+      proto-msg: google.cloud.contactcenterinsights.v1.QaScorecardRevision
       notes:
         - No gcloud command found
     - name: ""
@@ -3375,7 +3375,7 @@ branches:
       kind: ContactCenterInsightsQaScorecardResult
       package: google.cloud.contactcenterinsights.v1
       proto: QaScorecardResult
-      proto-path: google.cloud.contactcenterinsights.v1.QaScorecardResult
+      proto-msg: google.cloud.contactcenterinsights.v1.QaScorecardResult
       notes:
         - No gcloud command found
     - name: contentwarehouse-document
@@ -3388,7 +3388,7 @@ branches:
       kind: ContentWarehouseDocument
       package: google.cloud.contentwarehouse.v1
       proto: Document
-      proto-path: google.cloud.contentwarehouse.v1.Document
+      proto-msg: google.cloud.contentwarehouse.v1.Document
       notes:
         - No gcloud command found
     - name: contentwarehouse-documentlink
@@ -3401,7 +3401,7 @@ branches:
       kind: ContentWarehouseDocumentLink
       package: google.cloud.contentwarehouse.v1
       proto: DocumentLink
-      proto-path: google.cloud.contentwarehouse.v1.DocumentLink
+      proto-msg: google.cloud.contentwarehouse.v1.DocumentLink
       notes:
         - No gcloud command found
     - name: contentwarehouse-documentschema
@@ -3414,7 +3414,7 @@ branches:
       kind: ContentWarehouseDocumentSchema
       package: google.cloud.contentwarehouse.v1
       proto: DocumentSchema
-      proto-path: google.cloud.contentwarehouse.v1.DocumentSchema
+      proto-msg: google.cloud.contentwarehouse.v1.DocumentSchema
       notes:
         - No gcloud command found
     - name: contentwarehouse-ruleset
@@ -3427,7 +3427,7 @@ branches:
       kind: ContentWarehouseRuleSet
       package: google.cloud.contentwarehouse.v1
       proto: RuleSet
-      proto-path: google.cloud.contentwarehouse.v1.RuleSet
+      proto-msg: google.cloud.contentwarehouse.v1.RuleSet
       notes:
         - No gcloud command found
     - name: contentwarehouse-synonymset
@@ -3440,7 +3440,7 @@ branches:
       kind: ContentWarehouseSynonymSet
       package: google.cloud.contentwarehouse.v1
       proto: SynonymSet
-      proto-path: google.cloud.contentwarehouse.v1.SynonymSet
+      proto-msg: google.cloud.contentwarehouse.v1.SynonymSet
       notes:
         - No gcloud command found
     - name: datacatalog-process
@@ -3453,7 +3453,7 @@ branches:
       kind: DataCatalogProcess
       package: google.cloud.datacatalog.lineage.v1
       proto: Process
-      proto-path: google.cloud.datacatalog.lineage.v1.Process
+      proto-msg: google.cloud.datacatalog.lineage.v1.Process
       notes:
         - No gcloud command found
     - name: datacatalog-run
@@ -3466,7 +3466,7 @@ branches:
       kind: DataCatalogRun
       package: google.cloud.datacatalog.lineage.v1
       proto: Run
-      proto-path: google.cloud.datacatalog.lineage.v1.Run
+      proto-msg: google.cloud.datacatalog.lineage.v1.Run
       notes:
         - No gcloud command found
     - name: datacatalog-lineageevent
@@ -3479,7 +3479,7 @@ branches:
       kind: DataCatalogLineageEvent
       package: google.cloud.datacatalog.lineage.v1
       proto: LineageEvent
-      proto-path: google.cloud.datacatalog.lineage.v1.LineageEvent
+      proto-msg: google.cloud.datacatalog.lineage.v1.LineageEvent
       notes:
         - No gcloud command found
     - name: datacatalog-entry
@@ -3492,7 +3492,7 @@ branches:
       kind: DataCatalogEntry
       package: google.cloud.datacatalog.v1
       proto: Entry
-      proto-path: google.cloud.datacatalog.v1.Entry
+      proto-msg: google.cloud.datacatalog.v1.Entry
       notes: []
     - name: datacatalog-entrygroup
       local: resource-datacatalog-entrygroup
@@ -3504,7 +3504,7 @@ branches:
       kind: DataCatalogEntryGroup
       package: google.cloud.datacatalog.v1
       proto: EntryGroup
-      proto-path: google.cloud.datacatalog.v1.EntryGroup
+      proto-msg: google.cloud.datacatalog.v1.EntryGroup
       notes: []
     - name: datacatalog-taxonomy
       local: resource-datacatalog-taxonomy
@@ -3516,7 +3516,7 @@ branches:
       kind: DataCatalogTaxonomy
       package: google.cloud.datacatalog.v1
       proto: Taxonomy
-      proto-path: google.cloud.datacatalog.v1.Taxonomy
+      proto-msg: google.cloud.datacatalog.v1.Taxonomy
       notes: []
     - name: datacatalog-policytag
       local: resource-datacatalog-policytag
@@ -3528,7 +3528,7 @@ branches:
       kind: DataCatalogPolicyTag
       package: google.cloud.datacatalog.v1
       proto: PolicyTag
-      proto-path: google.cloud.datacatalog.v1.PolicyTag
+      proto-msg: google.cloud.datacatalog.v1.PolicyTag
       notes:
         - No gcloud command found
     - name: datacatalog-tag
@@ -3541,7 +3541,7 @@ branches:
       kind: DataCatalogTag
       package: google.cloud.datacatalog.v1
       proto: Tag
-      proto-path: google.cloud.datacatalog.v1.Tag
+      proto-msg: google.cloud.datacatalog.v1.Tag
       notes: []
     - name: datacatalog-tagtemplate
       local: resource-datacatalog-tagtemplate
@@ -3553,7 +3553,7 @@ branches:
       kind: DataCatalogTagTemplate
       package: google.cloud.datacatalog.v1
       proto: TagTemplate
-      proto-path: google.cloud.datacatalog.v1.TagTemplate
+      proto-msg: google.cloud.datacatalog.v1.TagTemplate
       notes: []
     - name: datacatalog-tagtemplatefield
       local: resource-datacatalog-tagtemplatefield
@@ -3565,7 +3565,7 @@ branches:
       kind: DataCatalogTagTemplateField
       package: google.cloud.datacatalog.v1
       proto: TagTemplateField
-      proto-path: google.cloud.datacatalog.v1.TagTemplateField
+      proto-msg: google.cloud.datacatalog.v1.TagTemplateField
       notes:
         - No gcloud command found
     - name: dataform-repository
@@ -3578,7 +3578,7 @@ branches:
       kind: DataformRepository
       package: google.cloud.dataform.v1beta1
       proto: Repository
-      proto-path: google.cloud.dataform.v1beta1.Repository
+      proto-msg: google.cloud.dataform.v1beta1.Repository
       notes: []
     - name: dataform-workspace
       local: resource-dataform-workspace
@@ -3590,7 +3590,7 @@ branches:
       kind: DataformWorkspace
       package: google.cloud.dataform.v1beta1
       proto: Workspace
-      proto-path: google.cloud.dataform.v1beta1.Workspace
+      proto-msg: google.cloud.dataform.v1beta1.Workspace
       notes:
         - No gcloud command found
     - name: dataform-releaseconfig
@@ -3603,7 +3603,7 @@ branches:
       kind: DataformReleaseConfig
       package: google.cloud.dataform.v1beta1
       proto: ReleaseConfig
-      proto-path: google.cloud.dataform.v1beta1.ReleaseConfig
+      proto-msg: google.cloud.dataform.v1beta1.ReleaseConfig
       notes:
         - No gcloud command found
     - name: dataform-compilationresult
@@ -3616,7 +3616,7 @@ branches:
       kind: DataformCompilationResult
       package: google.cloud.dataform.v1beta1
       proto: CompilationResult
-      proto-path: google.cloud.dataform.v1beta1.CompilationResult
+      proto-msg: google.cloud.dataform.v1beta1.CompilationResult
       notes:
         - No gcloud command found
     - name: dataform-workflowconfig
@@ -3629,7 +3629,7 @@ branches:
       kind: DataformWorkflowConfig
       package: google.cloud.dataform.v1beta1
       proto: WorkflowConfig
-      proto-path: google.cloud.dataform.v1beta1.WorkflowConfig
+      proto-msg: google.cloud.dataform.v1beta1.WorkflowConfig
       notes:
         - No gcloud command found
     - name: dataform-workflowinvocation
@@ -3642,7 +3642,7 @@ branches:
       kind: DataformWorkflowInvocation
       package: google.cloud.dataform.v1beta1
       proto: WorkflowInvocation
-      proto-path: google.cloud.dataform.v1beta1.WorkflowInvocation
+      proto-msg: google.cloud.dataform.v1beta1.WorkflowInvocation
       notes:
         - No gcloud command found
     - name: datafusion-instance
@@ -3655,7 +3655,7 @@ branches:
       kind: DataFusionInstance
       package: google.cloud.datafusion.v1
       proto: Instance
-      proto-path: google.cloud.datafusion.v1.Instance
+      proto-msg: google.cloud.datafusion.v1.Instance
       notes:
         - No gcloud command found
     - name: datafusion-namespace
@@ -3668,7 +3668,7 @@ branches:
       kind: DataFusionNamespace
       package: google.cloud.datafusion.v1beta1
       proto: Namespace
-      proto-path: google.cloud.datafusion.v1beta1.Namespace
+      proto-msg: google.cloud.datafusion.v1beta1.Namespace
       notes:
         - No gcloud command found
     - name: datalabeling-annotationspecset
@@ -3681,7 +3681,7 @@ branches:
       kind: DataLabelingAnnotationSpecSet
       package: google.cloud.datalabeling.v1beta1
       proto: AnnotationSpecSet
-      proto-path: google.cloud.datalabeling.v1beta1.AnnotationSpecSet
+      proto-msg: google.cloud.datalabeling.v1beta1.AnnotationSpecSet
       notes:
         - No gcloud command found
     - name: datalabeling-dataset
@@ -3694,7 +3694,7 @@ branches:
       kind: DataLabelingDataset
       package: google.cloud.datalabeling.v1beta1
       proto: Dataset
-      proto-path: google.cloud.datalabeling.v1beta1.Dataset
+      proto-msg: google.cloud.datalabeling.v1beta1.Dataset
       notes:
         - No gcloud command found
     - name: datalabeling-dataitem
@@ -3707,7 +3707,7 @@ branches:
       kind: DataLabelingDataItem
       package: google.cloud.datalabeling.v1beta1
       proto: DataItem
-      proto-path: google.cloud.datalabeling.v1beta1.DataItem
+      proto-msg: google.cloud.datalabeling.v1beta1.DataItem
       notes:
         - No gcloud command found
     - name: datalabeling-annotateddataset
@@ -3720,7 +3720,7 @@ branches:
       kind: DataLabelingAnnotatedDataset
       package: google.cloud.datalabeling.v1beta1
       proto: AnnotatedDataset
-      proto-path: google.cloud.datalabeling.v1beta1.AnnotatedDataset
+      proto-msg: google.cloud.datalabeling.v1beta1.AnnotatedDataset
       notes:
         - No gcloud command found
     - name: datalabeling-example
@@ -3733,7 +3733,7 @@ branches:
       kind: DataLabelingExample
       package: google.cloud.datalabeling.v1beta1
       proto: Example
-      proto-path: google.cloud.datalabeling.v1beta1.Example
+      proto-msg: google.cloud.datalabeling.v1beta1.Example
       notes:
         - No gcloud command found
     - name: datalabeling-evaluation
@@ -3746,7 +3746,7 @@ branches:
       kind: DataLabelingEvaluation
       package: google.cloud.datalabeling.v1beta1
       proto: Evaluation
-      proto-path: google.cloud.datalabeling.v1beta1.Evaluation
+      proto-msg: google.cloud.datalabeling.v1beta1.Evaluation
       notes:
         - No gcloud command found
     - name: datalabeling-evaluationjob
@@ -3759,7 +3759,7 @@ branches:
       kind: DataLabelingEvaluationJob
       package: google.cloud.datalabeling.v1beta1
       proto: EvaluationJob
-      proto-path: google.cloud.datalabeling.v1beta1.EvaluationJob
+      proto-msg: google.cloud.datalabeling.v1beta1.EvaluationJob
       notes:
         - No gcloud command found
     - name: datalabeling-instruction
@@ -3772,7 +3772,7 @@ branches:
       kind: DataLabelingInstruction
       package: google.cloud.datalabeling.v1beta1
       proto: Instruction
-      proto-path: google.cloud.datalabeling.v1beta1.Instruction
+      proto-msg: google.cloud.datalabeling.v1beta1.Instruction
       notes:
         - No gcloud command found
     - name: dataplex-environment
@@ -3785,7 +3785,7 @@ branches:
       kind: DataplexEnvironment
       package: google.cloud.dataplex.v1
       proto: Environment
-      proto-path: google.cloud.dataplex.v1.Environment
+      proto-msg: google.cloud.dataplex.v1.Environment
       notes: []
     - name: dataplex-content
       local: resource-dataplex-content
@@ -3797,7 +3797,7 @@ branches:
       kind: DataplexContent
       package: google.cloud.dataplex.v1
       proto: Content
-      proto-path: google.cloud.dataplex.v1.Content
+      proto-msg: google.cloud.dataplex.v1.Content
       notes: []
     - name: dataplex-session
       local: resource-dataplex-session
@@ -3809,7 +3809,7 @@ branches:
       kind: DataplexSession
       package: google.cloud.dataplex.v1
       proto: Session
-      proto-path: google.cloud.dataplex.v1.Session
+      proto-msg: google.cloud.dataplex.v1.Session
       notes:
         - No gcloud command found
     - name: dataplex-aspecttype
@@ -3822,7 +3822,7 @@ branches:
       kind: DataplexAspectType
       package: google.cloud.dataplex.v1
       proto: AspectType
-      proto-path: google.cloud.dataplex.v1.AspectType
+      proto-msg: google.cloud.dataplex.v1.AspectType
       notes: []
     - name: dataplex-entrygroup
       local: resource-dataplex-entrygroup
@@ -3834,7 +3834,7 @@ branches:
       kind: DataplexEntryGroup
       package: google.cloud.dataplex.v1
       proto: EntryGroup
-      proto-path: google.cloud.dataplex.v1.EntryGroup
+      proto-msg: google.cloud.dataplex.v1.EntryGroup
       notes: []
     - name: dataplex-entrytype
       local: resource-dataplex-entrytype
@@ -3846,7 +3846,7 @@ branches:
       kind: DataplexEntryType
       package: google.cloud.dataplex.v1
       proto: EntryType
-      proto-path: google.cloud.dataplex.v1.EntryType
+      proto-msg: google.cloud.dataplex.v1.EntryType
       notes: []
     - name: dataplex-entry
       local: resource-dataplex-entry
@@ -3858,7 +3858,7 @@ branches:
       kind: DataplexEntry
       package: google.cloud.dataplex.v1
       proto: Entry
-      proto-path: google.cloud.dataplex.v1.Entry
+      proto-msg: google.cloud.dataplex.v1.Entry
       notes: []
     - name: dataplex-metadatajob
       local: resource-dataplex-metadatajob
@@ -3870,7 +3870,7 @@ branches:
       kind: DataplexMetadataJob
       package: google.cloud.dataplex.v1
       proto: MetadataJob
-      proto-path: google.cloud.dataplex.v1.MetadataJob
+      proto-msg: google.cloud.dataplex.v1.MetadataJob
       notes:
         - No gcloud command found
     - name: dataplex-datataxonomy
@@ -3883,7 +3883,7 @@ branches:
       kind: DataplexDataTaxonomy
       package: google.cloud.dataplex.v1
       proto: DataTaxonomy
-      proto-path: google.cloud.dataplex.v1.DataTaxonomy
+      proto-msg: google.cloud.dataplex.v1.DataTaxonomy
       notes:
         - No gcloud command found
     - name: dataplex-dataattribute
@@ -3896,7 +3896,7 @@ branches:
       kind: DataplexDataAttribute
       package: google.cloud.dataplex.v1
       proto: DataAttribute
-      proto-path: google.cloud.dataplex.v1.DataAttribute
+      proto-msg: google.cloud.dataplex.v1.DataAttribute
       notes:
         - No gcloud command found
     - name: dataplex-dataattributebinding
@@ -3909,7 +3909,7 @@ branches:
       kind: DataplexDataAttributeBinding
       package: google.cloud.dataplex.v1
       proto: DataAttributeBinding
-      proto-path: google.cloud.dataplex.v1.DataAttributeBinding
+      proto-msg: google.cloud.dataplex.v1.DataAttributeBinding
       notes:
         - No gcloud command found
     - name: dataplex-datascan
@@ -3922,7 +3922,7 @@ branches:
       kind: DataplexDataScan
       package: google.cloud.dataplex.v1
       proto: DataScan
-      proto-path: google.cloud.dataplex.v1.DataScan
+      proto-msg: google.cloud.dataplex.v1.DataScan
       notes: []
     - name: dataplex-datascanjob
       local: resource-dataplex-datascanjob
@@ -3934,7 +3934,7 @@ branches:
       kind: DataplexDataScanJob
       package: google.cloud.dataplex.v1
       proto: DataScanJob
-      proto-path: google.cloud.dataplex.v1.DataScanJob
+      proto-msg: google.cloud.dataplex.v1.DataScanJob
       notes:
         - No gcloud command found
     - name: dataplex-entity
@@ -3947,7 +3947,7 @@ branches:
       kind: DataplexEntity
       package: google.cloud.dataplex.v1
       proto: Entity
-      proto-path: google.cloud.dataplex.v1.Entity
+      proto-msg: google.cloud.dataplex.v1.Entity
       notes:
         - No gcloud command found
     - name: dataplex-partition
@@ -3960,7 +3960,7 @@ branches:
       kind: DataplexPartition
       package: google.cloud.dataplex.v1
       proto: Partition
-      proto-path: google.cloud.dataplex.v1.Partition
+      proto-msg: google.cloud.dataplex.v1.Partition
       notes:
         - No gcloud command found
     - name: dataplex-lake
@@ -3973,7 +3973,7 @@ branches:
       kind: DataplexLake
       package: google.cloud.dataplex.v1
       proto: Lake
-      proto-path: google.cloud.dataplex.v1.Lake
+      proto-msg: google.cloud.dataplex.v1.Lake
       notes: []
     - name: dataplex-zone
       local: resource-dataplex-zone
@@ -3985,7 +3985,7 @@ branches:
       kind: DataplexZone
       package: google.cloud.dataplex.v1
       proto: Zone
-      proto-path: google.cloud.dataplex.v1.Zone
+      proto-msg: google.cloud.dataplex.v1.Zone
       notes: []
     - name: dataplex-action
       local: resource-dataplex-action
@@ -3997,7 +3997,7 @@ branches:
       kind: DataplexAction
       package: google.cloud.dataplex.v1
       proto: Action
-      proto-path: google.cloud.dataplex.v1.Action
+      proto-msg: google.cloud.dataplex.v1.Action
       notes:
         - No gcloud command found
     - name: dataplex-asset
@@ -4010,7 +4010,7 @@ branches:
       kind: DataplexAsset
       package: google.cloud.dataplex.v1
       proto: Asset
-      proto-path: google.cloud.dataplex.v1.Asset
+      proto-msg: google.cloud.dataplex.v1.Asset
       notes: []
     - name: dataplex-task
       local: resource-dataplex-task
@@ -4022,7 +4022,7 @@ branches:
       kind: DataplexTask
       package: google.cloud.dataplex.v1
       proto: Task
-      proto-path: google.cloud.dataplex.v1.Task
+      proto-msg: google.cloud.dataplex.v1.Task
       notes: []
     - name: dataplex-job
       local: resource-dataplex-job
@@ -4034,7 +4034,7 @@ branches:
       kind: DataplexJob
       package: google.cloud.dataplex.v1
       proto: Job
-      proto-path: google.cloud.dataplex.v1.Job
+      proto-msg: google.cloud.dataplex.v1.Job
       notes:
         - No gcloud command found
     - name: dataproc-autoscalingpolicy
@@ -4047,7 +4047,7 @@ branches:
       kind: DataprocAutoscalingPolicy
       package: google.cloud.dataproc.v1
       proto: AutoscalingPolicy
-      proto-path: google.cloud.dataproc.v1.AutoscalingPolicy
+      proto-msg: google.cloud.dataproc.v1.AutoscalingPolicy
       notes: []
     - name: dataproc-batch
       local: resource-dataproc-batch
@@ -4059,7 +4059,7 @@ branches:
       kind: DataprocBatch
       package: google.cloud.dataproc.v1
       proto: Batch
-      proto-path: google.cloud.dataproc.v1.Batch
+      proto-msg: google.cloud.dataproc.v1.Batch
       notes: []
     - name: dataproc-nodegroup
       local: resource-dataproc-nodegroup
@@ -4071,7 +4071,7 @@ branches:
       kind: DataprocNodeGroup
       package: google.cloud.dataproc.v1
       proto: NodeGroup
-      proto-path: google.cloud.dataproc.v1.NodeGroup
+      proto-msg: google.cloud.dataproc.v1.NodeGroup
       notes: []
     - name: dataproc-sessiontemplate
       local: resource-dataproc-sessiontemplate
@@ -4083,7 +4083,7 @@ branches:
       kind: DataprocSessionTemplate
       package: google.cloud.dataproc.v1
       proto: SessionTemplate
-      proto-path: google.cloud.dataproc.v1.SessionTemplate
+      proto-msg: google.cloud.dataproc.v1.SessionTemplate
       notes:
         - No gcloud command found
     - name: dataproc-session
@@ -4096,7 +4096,7 @@ branches:
       kind: DataprocSession
       package: google.cloud.dataproc.v1
       proto: Session
-      proto-path: google.cloud.dataproc.v1.Session
+      proto-msg: google.cloud.dataproc.v1.Session
       notes:
         - No gcloud command found
     - name: dataproc-workflowtemplate
@@ -4109,7 +4109,7 @@ branches:
       kind: DataprocWorkflowTemplate
       package: google.cloud.dataproc.v1
       proto: WorkflowTemplate
-      proto-path: google.cloud.dataproc.v1.WorkflowTemplate
+      proto-msg: google.cloud.dataproc.v1.WorkflowTemplate
       notes: []
     - name: datastream-privateconnection
       local: resource-datastream-privateconnection
@@ -4121,7 +4121,7 @@ branches:
       kind: DatastreamPrivateConnection
       package: google.cloud.datastream.v1
       proto: PrivateConnection
-      proto-path: google.cloud.datastream.v1.PrivateConnection
+      proto-msg: google.cloud.datastream.v1.PrivateConnection
       notes: []
     - name: datastream-route
       local: resource-datastream-route
@@ -4133,7 +4133,7 @@ branches:
       kind: DatastreamRoute
       package: google.cloud.datastream.v1
       proto: Route
-      proto-path: google.cloud.datastream.v1.Route
+      proto-msg: google.cloud.datastream.v1.Route
       notes: []
     - name: datastream-connectionprofile
       local: resource-datastream-connectionprofile
@@ -4145,7 +4145,7 @@ branches:
       kind: DatastreamConnectionProfile
       package: google.cloud.datastream.v1
       proto: ConnectionProfile
-      proto-path: google.cloud.datastream.v1.ConnectionProfile
+      proto-msg: google.cloud.datastream.v1.ConnectionProfile
       notes: []
     - name: datastream-stream
       local: resource-datastream-stream
@@ -4157,7 +4157,7 @@ branches:
       kind: DatastreamStream
       package: google.cloud.datastream.v1
       proto: Stream
-      proto-path: google.cloud.datastream.v1.Stream
+      proto-msg: google.cloud.datastream.v1.Stream
       notes: []
     - name: datastream-streamobject
       local: resource-datastream-streamobject
@@ -4169,7 +4169,7 @@ branches:
       kind: DatastreamStreamObject
       package: google.cloud.datastream.v1
       proto: StreamObject
-      proto-path: google.cloud.datastream.v1.StreamObject
+      proto-msg: google.cloud.datastream.v1.StreamObject
       notes:
         - No gcloud command found
     - name: deploy-deliverypipeline
@@ -4182,7 +4182,7 @@ branches:
       kind: DeployDeliveryPipeline
       package: google.cloud.deploy.v1
       proto: DeliveryPipeline
-      proto-path: google.cloud.deploy.v1.DeliveryPipeline
+      proto-msg: google.cloud.deploy.v1.DeliveryPipeline
       notes: []
     - name: deploy-target
       local: resource-deploy-target
@@ -4194,7 +4194,7 @@ branches:
       kind: DeployTarget
       package: google.cloud.deploy.v1
       proto: Target
-      proto-path: google.cloud.deploy.v1.Target
+      proto-msg: google.cloud.deploy.v1.Target
       notes: []
     - name: deploy-customtargettype
       local: resource-deploy-customtargettype
@@ -4206,7 +4206,7 @@ branches:
       kind: DeployCustomTargetType
       package: google.cloud.deploy.v1
       proto: CustomTargetType
-      proto-path: google.cloud.deploy.v1.CustomTargetType
+      proto-msg: google.cloud.deploy.v1.CustomTargetType
       notes: []
     - name: deploy-deploypolicy
       local: resource-deploy-deploypolicy
@@ -4218,7 +4218,7 @@ branches:
       kind: DeployDeployPolicy
       package: google.cloud.deploy.v1
       proto: DeployPolicy
-      proto-path: google.cloud.deploy.v1.DeployPolicy
+      proto-msg: google.cloud.deploy.v1.DeployPolicy
       notes: []
     - name: deploy-release
       local: resource-deploy-release
@@ -4230,7 +4230,7 @@ branches:
       kind: DeployRelease
       package: google.cloud.deploy.v1
       proto: Release
-      proto-path: google.cloud.deploy.v1.Release
+      proto-msg: google.cloud.deploy.v1.Release
       notes: []
     - name: deploy-rollout
       local: resource-deploy-rollout
@@ -4242,7 +4242,7 @@ branches:
       kind: DeployRollout
       package: google.cloud.deploy.v1
       proto: Rollout
-      proto-path: google.cloud.deploy.v1.Rollout
+      proto-msg: google.cloud.deploy.v1.Rollout
       notes: []
     - name: deploy-jobrun
       local: resource-deploy-jobrun
@@ -4254,7 +4254,7 @@ branches:
       kind: DeployJobRun
       package: google.cloud.deploy.v1
       proto: JobRun
-      proto-path: google.cloud.deploy.v1.JobRun
+      proto-msg: google.cloud.deploy.v1.JobRun
       notes: []
     - name: deploy-config
       local: resource-deploy-config
@@ -4266,7 +4266,7 @@ branches:
       kind: DeployConfig
       package: google.cloud.deploy.v1
       proto: Config
-      proto-path: google.cloud.deploy.v1.Config
+      proto-msg: google.cloud.deploy.v1.Config
       notes:
         - No gcloud command found
     - name: deploy-automation
@@ -4279,7 +4279,7 @@ branches:
       kind: DeployAutomation
       package: google.cloud.deploy.v1
       proto: Automation
-      proto-path: google.cloud.deploy.v1.Automation
+      proto-msg: google.cloud.deploy.v1.Automation
       notes: []
     - name: deploy-automationrun
       local: resource-deploy-automationrun
@@ -4291,7 +4291,7 @@ branches:
       kind: DeployAutomationRun
       package: google.cloud.deploy.v1
       proto: AutomationRun
-      proto-path: google.cloud.deploy.v1.AutomationRun
+      proto-msg: google.cloud.deploy.v1.AutomationRun
       notes: []
     - name: developerconnect-connection
       local: resource-developerconnect-connection
@@ -4303,7 +4303,7 @@ branches:
       kind: DeveloperConnectConnection
       package: google.cloud.developerconnect.v1
       proto: Connection
-      proto-path: google.cloud.developerconnect.v1.Connection
+      proto-msg: google.cloud.developerconnect.v1.Connection
       notes: []
     - name: developerconnect-gitrepositorylink
       local: resource-developerconnect-gitrepositorylink
@@ -4315,7 +4315,7 @@ branches:
       kind: DeveloperConnectGitRepositoryLink
       package: google.cloud.developerconnect.v1
       proto: GitRepositoryLink
-      proto-path: google.cloud.developerconnect.v1.GitRepositoryLink
+      proto-msg: google.cloud.developerconnect.v1.GitRepositoryLink
       notes:
         - No gcloud command found
     - name: dialogflow-agentvalidationresult
@@ -4328,7 +4328,7 @@ branches:
       kind: DialogflowAgentValidationResult
       package: google.cloud.dialogflow.cx.v3
       proto: AgentValidationResult
-      proto-path: google.cloud.dialogflow.cx.v3.AgentValidationResult
+      proto-msg: google.cloud.dialogflow.cx.v3.AgentValidationResult
       notes:
         - No gcloud command found
     - name: dialogflow-changelog
@@ -4341,7 +4341,7 @@ branches:
       kind: DialogflowChangelog
       package: google.cloud.dialogflow.cx.v3
       proto: Changelog
-      proto-path: google.cloud.dialogflow.cx.v3.Changelog
+      proto-msg: google.cloud.dialogflow.cx.v3.Changelog
       notes:
         - No gcloud command found
     - name: dialogflow-deployment
@@ -4354,7 +4354,7 @@ branches:
       kind: DialogflowDeployment
       package: google.cloud.dialogflow.cx.v3
       proto: Deployment
-      proto-path: google.cloud.dialogflow.cx.v3.Deployment
+      proto-msg: google.cloud.dialogflow.cx.v3.Deployment
       notes:
         - No gcloud command found
     - name: dialogflow-entitytype
@@ -4367,7 +4367,7 @@ branches:
       kind: DialogflowEntityType
       package: google.cloud.dialogflow.cx.v3
       proto: EntityType
-      proto-path: google.cloud.dialogflow.cx.v3.EntityType
+      proto-msg: google.cloud.dialogflow.cx.v3.EntityType
       notes: []
     - name: dialogflow-environment
       local: resource-dialogflow-environment
@@ -4379,7 +4379,7 @@ branches:
       kind: DialogflowEnvironment
       package: google.cloud.dialogflow.cx.v3
       proto: Environment
-      proto-path: google.cloud.dialogflow.cx.v3.Environment
+      proto-msg: google.cloud.dialogflow.cx.v3.Environment
       notes:
         - No gcloud command found
     - name: dialogflow-continuoustestresult
@@ -4392,7 +4392,7 @@ branches:
       kind: DialogflowContinuousTestResult
       package: google.cloud.dialogflow.cx.v3
       proto: ContinuousTestResult
-      proto-path: google.cloud.dialogflow.cx.v3.ContinuousTestResult
+      proto-msg: google.cloud.dialogflow.cx.v3.ContinuousTestResult
       notes:
         - No gcloud command found
     - name: dialogflow-experiment
@@ -4405,7 +4405,7 @@ branches:
       kind: DialogflowExperiment
       package: google.cloud.dialogflow.cx.v3
       proto: Experiment
-      proto-path: google.cloud.dialogflow.cx.v3.Experiment
+      proto-msg: google.cloud.dialogflow.cx.v3.Experiment
       notes:
         - No gcloud command found
     - name: dialogflow-flow
@@ -4418,7 +4418,7 @@ branches:
       kind: DialogflowFlow
       package: google.cloud.dialogflow.cx.v3
       proto: Flow
-      proto-path: google.cloud.dialogflow.cx.v3.Flow
+      proto-msg: google.cloud.dialogflow.cx.v3.Flow
       notes:
         - No gcloud command found
     - name: dialogflow-flowvalidationresult
@@ -4431,7 +4431,7 @@ branches:
       kind: DialogflowFlowValidationResult
       package: google.cloud.dialogflow.cx.v3
       proto: FlowValidationResult
-      proto-path: google.cloud.dialogflow.cx.v3.FlowValidationResult
+      proto-msg: google.cloud.dialogflow.cx.v3.FlowValidationResult
       notes:
         - No gcloud command found
     - name: dialogflow-generativesettings
@@ -4444,7 +4444,7 @@ branches:
       kind: DialogflowGenerativeSettings
       package: google.cloud.dialogflow.cx.v3
       proto: GenerativeSettings
-      proto-path: google.cloud.dialogflow.cx.v3.GenerativeSettings
+      proto-msg: google.cloud.dialogflow.cx.v3.GenerativeSettings
       notes:
         - No gcloud command found
     - name: dialogflow-generator
@@ -4457,7 +4457,7 @@ branches:
       kind: DialogflowGenerator
       package: google.cloud.dialogflow.cx.v3
       proto: Generator
-      proto-path: google.cloud.dialogflow.cx.v3.Generator
+      proto-msg: google.cloud.dialogflow.cx.v3.Generator
       notes:
         - No gcloud command found
     - name: dialogflow-intent
@@ -4470,7 +4470,7 @@ branches:
       kind: DialogflowIntent
       package: google.cloud.dialogflow.cx.v3
       proto: Intent
-      proto-path: google.cloud.dialogflow.cx.v3.Intent
+      proto-msg: google.cloud.dialogflow.cx.v3.Intent
       notes: []
     - name: dialogflow-page
       local: resource-dialogflow-page
@@ -4482,7 +4482,7 @@ branches:
       kind: DialogflowPage
       package: google.cloud.dialogflow.cx.v3
       proto: Page
-      proto-path: google.cloud.dialogflow.cx.v3.Page
+      proto-msg: google.cloud.dialogflow.cx.v3.Page
       notes:
         - No gcloud command found
     - name: dialogflow-securitysettings
@@ -4495,7 +4495,7 @@ branches:
       kind: DialogflowSecuritySettings
       package: google.cloud.dialogflow.cx.v3
       proto: SecuritySettings
-      proto-path: google.cloud.dialogflow.cx.v3.SecuritySettings
+      proto-msg: google.cloud.dialogflow.cx.v3.SecuritySettings
       notes:
         - No gcloud command found
     - name: dialogflow-sessionentitytype
@@ -4508,7 +4508,7 @@ branches:
       kind: DialogflowSessionEntityType
       package: google.cloud.dialogflow.cx.v3
       proto: SessionEntityType
-      proto-path: google.cloud.dialogflow.cx.v3.SessionEntityType
+      proto-msg: google.cloud.dialogflow.cx.v3.SessionEntityType
       notes:
         - No gcloud command found
     - name: dialogflow-testcase
@@ -4521,7 +4521,7 @@ branches:
       kind: DialogflowTestCase
       package: google.cloud.dialogflow.cx.v3
       proto: TestCase
-      proto-path: google.cloud.dialogflow.cx.v3.TestCase
+      proto-msg: google.cloud.dialogflow.cx.v3.TestCase
       notes:
         - No gcloud command found
     - name: dialogflow-testcaseresult
@@ -4534,7 +4534,7 @@ branches:
       kind: DialogflowTestCaseResult
       package: google.cloud.dialogflow.cx.v3
       proto: TestCaseResult
-      proto-path: google.cloud.dialogflow.cx.v3.TestCaseResult
+      proto-msg: google.cloud.dialogflow.cx.v3.TestCaseResult
       notes:
         - No gcloud command found
     - name: dialogflow-transitionroutegroup
@@ -4547,7 +4547,7 @@ branches:
       kind: DialogflowTransitionRouteGroup
       package: google.cloud.dialogflow.cx.v3
       proto: TransitionRouteGroup
-      proto-path: google.cloud.dialogflow.cx.v3.TransitionRouteGroup
+      proto-msg: google.cloud.dialogflow.cx.v3.TransitionRouteGroup
       notes:
         - No gcloud command found
     - name: dialogflow-version
@@ -4560,7 +4560,7 @@ branches:
       kind: DialogflowVersion
       package: google.cloud.dialogflow.cx.v3
       proto: Version
-      proto-path: google.cloud.dialogflow.cx.v3.Version
+      proto-msg: google.cloud.dialogflow.cx.v3.Version
       notes:
         - No gcloud command found
     - name: dialogflow-webhook
@@ -4573,7 +4573,7 @@ branches:
       kind: DialogflowWebhook
       package: google.cloud.dialogflow.cx.v3
       proto: Webhook
-      proto-path: google.cloud.dialogflow.cx.v3.Webhook
+      proto-msg: google.cloud.dialogflow.cx.v3.Webhook
       notes:
         - No gcloud command found
     - name: dialogflow-example
@@ -4586,7 +4586,7 @@ branches:
       kind: DialogflowExample
       package: google.cloud.dialogflow.cx.v3beta1
       proto: Example
-      proto-path: google.cloud.dialogflow.cx.v3beta1.Example
+      proto-msg: google.cloud.dialogflow.cx.v3beta1.Example
       notes:
         - No gcloud command found
     - name: dialogflow-playbook
@@ -4599,7 +4599,7 @@ branches:
       kind: DialogflowPlaybook
       package: google.cloud.dialogflow.cx.v3beta1
       proto: Playbook
-      proto-path: google.cloud.dialogflow.cx.v3beta1.Playbook
+      proto-msg: google.cloud.dialogflow.cx.v3beta1.Playbook
       notes:
         - No gcloud command found
     - name: dialogflow-playbookversion
@@ -4612,7 +4612,7 @@ branches:
       kind: DialogflowPlaybookVersion
       package: google.cloud.dialogflow.cx.v3beta1
       proto: PlaybookVersion
-      proto-path: google.cloud.dialogflow.cx.v3beta1.PlaybookVersion
+      proto-msg: google.cloud.dialogflow.cx.v3beta1.PlaybookVersion
       notes:
         - No gcloud command found
     - name: dialogflow-tool
@@ -4625,7 +4625,7 @@ branches:
       kind: DialogflowTool
       package: google.cloud.dialogflow.cx.v3beta1
       proto: Tool
-      proto-path: google.cloud.dialogflow.cx.v3beta1.Tool
+      proto-msg: google.cloud.dialogflow.cx.v3beta1.Tool
       notes:
         - No gcloud command found
     - name: dialogflow-agent
@@ -4638,7 +4638,7 @@ branches:
       kind: DialogflowAgent
       package: google.cloud.dialogflow.v2
       proto: Agent
-      proto-path: google.cloud.dialogflow.v2.Agent
+      proto-msg: google.cloud.dialogflow.v2.Agent
       notes: []
     - name: dialogflow-answerrecord
       local: resource-dialogflow-answerrecord
@@ -4650,7 +4650,7 @@ branches:
       kind: DialogflowAnswerRecord
       package: google.cloud.dialogflow.v2
       proto: AnswerRecord
-      proto-path: google.cloud.dialogflow.v2.AnswerRecord
+      proto-msg: google.cloud.dialogflow.v2.AnswerRecord
       notes:
         - No gcloud command found
     - name: dialogflow-context
@@ -4663,7 +4663,7 @@ branches:
       kind: DialogflowContext
       package: google.cloud.dialogflow.v2
       proto: Context
-      proto-path: google.cloud.dialogflow.v2.Context
+      proto-msg: google.cloud.dialogflow.v2.Context
       notes:
         - No gcloud command found
     - name: dialogflow-conversation
@@ -4676,7 +4676,7 @@ branches:
       kind: DialogflowConversation
       package: google.cloud.dialogflow.v2
       proto: Conversation
-      proto-path: google.cloud.dialogflow.v2.Conversation
+      proto-msg: google.cloud.dialogflow.v2.Conversation
       notes:
         - No gcloud command found
     - name: dialogflow-conversationdataset
@@ -4689,7 +4689,7 @@ branches:
       kind: DialogflowConversationDataset
       package: google.cloud.dialogflow.v2
       proto: ConversationDataset
-      proto-path: google.cloud.dialogflow.v2.ConversationDataset
+      proto-msg: google.cloud.dialogflow.v2.ConversationDataset
       notes:
         - No gcloud command found
     - name: dialogflow-conversationmodel
@@ -4702,7 +4702,7 @@ branches:
       kind: DialogflowConversationModel
       package: google.cloud.dialogflow.v2
       proto: ConversationModel
-      proto-path: google.cloud.dialogflow.v2.ConversationModel
+      proto-msg: google.cloud.dialogflow.v2.ConversationModel
       notes:
         - No gcloud command found
     - name: dialogflow-conversationmodelevaluation
@@ -4715,7 +4715,7 @@ branches:
       kind: DialogflowConversationModelEvaluation
       package: google.cloud.dialogflow.v2
       proto: ConversationModelEvaluation
-      proto-path: google.cloud.dialogflow.v2.ConversationModelEvaluation
+      proto-msg: google.cloud.dialogflow.v2.ConversationModelEvaluation
       notes:
         - No gcloud command found
     - name: dialogflow-conversationprofile
@@ -4728,7 +4728,7 @@ branches:
       kind: DialogflowConversationProfile
       package: google.cloud.dialogflow.v2
       proto: ConversationProfile
-      proto-path: google.cloud.dialogflow.v2.ConversationProfile
+      proto-msg: google.cloud.dialogflow.v2.ConversationProfile
       notes:
         - No gcloud command found
     - name: dialogflow-document
@@ -4741,7 +4741,7 @@ branches:
       kind: DialogflowDocument
       package: google.cloud.dialogflow.v2
       proto: Document
-      proto-path: google.cloud.dialogflow.v2.Document
+      proto-msg: google.cloud.dialogflow.v2.Document
       notes:
         - No gcloud command found
     - name: dialogflow-encryptionspec
@@ -4754,7 +4754,7 @@ branches:
       kind: DialogflowEncryptionSpec
       package: google.cloud.dialogflow.v2
       proto: EncryptionSpec
-      proto-path: google.cloud.dialogflow.v2.EncryptionSpec
+      proto-msg: google.cloud.dialogflow.v2.EncryptionSpec
       notes:
         - No gcloud command found
     - name: dialogflow-fulfillment
@@ -4767,7 +4767,7 @@ branches:
       kind: DialogflowFulfillment
       package: google.cloud.dialogflow.v2
       proto: Fulfillment
-      proto-path: google.cloud.dialogflow.v2.Fulfillment
+      proto-msg: google.cloud.dialogflow.v2.Fulfillment
       notes:
         - No gcloud command found
     - name: dialogflow-knowledgebase
@@ -4780,7 +4780,7 @@ branches:
       kind: DialogflowKnowledgeBase
       package: google.cloud.dialogflow.v2
       proto: KnowledgeBase
-      proto-path: google.cloud.dialogflow.v2.KnowledgeBase
+      proto-msg: google.cloud.dialogflow.v2.KnowledgeBase
       notes:
         - No gcloud command found
     - name: dialogflow-participant
@@ -4793,7 +4793,7 @@ branches:
       kind: DialogflowParticipant
       package: google.cloud.dialogflow.v2
       proto: Participant
-      proto-path: google.cloud.dialogflow.v2.Participant
+      proto-msg: google.cloud.dialogflow.v2.Participant
       notes:
         - No gcloud command found
     - name: dialogflow-message
@@ -4806,7 +4806,7 @@ branches:
       kind: DialogflowMessage
       package: google.cloud.dialogflow.v2
       proto: Message
-      proto-path: google.cloud.dialogflow.v2.Message
+      proto-msg: google.cloud.dialogflow.v2.Message
       notes:
         - No gcloud command found
     - name: dialogflow-siptrunk
@@ -4819,7 +4819,7 @@ branches:
       kind: DialogflowSipTrunk
       package: google.cloud.dialogflow.v2beta1
       proto: SipTrunk
-      proto-path: google.cloud.dialogflow.v2beta1.SipTrunk
+      proto-msg: google.cloud.dialogflow.v2beta1.SipTrunk
       notes:
         - No gcloud command found
     - name: discoveryengine-answer
@@ -4832,7 +4832,7 @@ branches:
       kind: DiscoveryEngineAnswer
       package: google.cloud.discoveryengine.v1
       proto: Answer
-      proto-path: google.cloud.discoveryengine.v1.Answer
+      proto-msg: google.cloud.discoveryengine.v1.Answer
       notes:
         - No gcloud command found
     - name: discoveryengine-chunk
@@ -4845,7 +4845,7 @@ branches:
       kind: DiscoveryEngineChunk
       package: google.cloud.discoveryengine.v1
       proto: Chunk
-      proto-path: google.cloud.discoveryengine.v1.Chunk
+      proto-msg: google.cloud.discoveryengine.v1.Chunk
       notes:
         - No gcloud command found
     - name: discoveryengine-control
@@ -4858,7 +4858,7 @@ branches:
       kind: DiscoveryEngineControl
       package: google.cloud.discoveryengine.v1
       proto: Control
-      proto-path: google.cloud.discoveryengine.v1.Control
+      proto-msg: google.cloud.discoveryengine.v1.Control
       notes:
         - No gcloud command found
     - name: discoveryengine-conversation
@@ -4871,7 +4871,7 @@ branches:
       kind: DiscoveryEngineConversation
       package: google.cloud.discoveryengine.v1
       proto: Conversation
-      proto-path: google.cloud.discoveryengine.v1.Conversation
+      proto-msg: google.cloud.discoveryengine.v1.Conversation
       notes:
         - No gcloud command found
     - name: discoveryengine-customtuningmodel
@@ -4884,7 +4884,7 @@ branches:
       kind: DiscoveryEngineCustomTuningModel
       package: google.cloud.discoveryengine.v1
       proto: CustomTuningModel
-      proto-path: google.cloud.discoveryengine.v1.CustomTuningModel
+      proto-msg: google.cloud.discoveryengine.v1.CustomTuningModel
       notes:
         - No gcloud command found
     - name: discoveryengine-datastore
@@ -4897,7 +4897,7 @@ branches:
       kind: DiscoveryEngineDataStore
       package: google.cloud.discoveryengine.v1
       proto: DataStore
-      proto-path: google.cloud.discoveryengine.v1.DataStore
+      proto-msg: google.cloud.discoveryengine.v1.DataStore
       notes:
         - No gcloud command found
     - name: discoveryengine-document
@@ -4910,7 +4910,7 @@ branches:
       kind: DiscoveryEngineDocument
       package: google.cloud.discoveryengine.v1
       proto: Document
-      proto-path: google.cloud.discoveryengine.v1.Document
+      proto-msg: google.cloud.discoveryengine.v1.Document
       notes:
         - No gcloud command found
     - name: discoveryengine-documentprocessingconfig
@@ -4923,7 +4923,7 @@ branches:
       kind: DiscoveryEngineDocumentProcessingConfig
       package: google.cloud.discoveryengine.v1
       proto: DocumentProcessingConfig
-      proto-path: google.cloud.discoveryengine.v1.DocumentProcessingConfig
+      proto-msg: google.cloud.discoveryengine.v1.DocumentProcessingConfig
       notes:
         - No gcloud command found
     - name: discoveryengine-engine
@@ -4936,7 +4936,7 @@ branches:
       kind: DiscoveryEngineEngine
       package: google.cloud.discoveryengine.v1
       proto: Engine
-      proto-path: google.cloud.discoveryengine.v1.Engine
+      proto-msg: google.cloud.discoveryengine.v1.Engine
       notes:
         - No gcloud command found
     - name: discoveryengine-project
@@ -4949,7 +4949,7 @@ branches:
       kind: DiscoveryEngineProject
       package: google.cloud.discoveryengine.v1
       proto: Project
-      proto-path: google.cloud.discoveryengine.v1.Project
+      proto-msg: google.cloud.discoveryengine.v1.Project
       notes:
         - No gcloud command found
     - name: discoveryengine-schema
@@ -4962,7 +4962,7 @@ branches:
       kind: DiscoveryEngineSchema
       package: google.cloud.discoveryengine.v1
       proto: Schema
-      proto-path: google.cloud.discoveryengine.v1.Schema
+      proto-msg: google.cloud.discoveryengine.v1.Schema
       notes:
         - No gcloud command found
     - name: discoveryengine-session
@@ -4975,7 +4975,7 @@ branches:
       kind: DiscoveryEngineSession
       package: google.cloud.discoveryengine.v1
       proto: Session
-      proto-path: google.cloud.discoveryengine.v1.Session
+      proto-msg: google.cloud.discoveryengine.v1.Session
       notes:
         - No gcloud command found
     - name: discoveryengine-sitesearchengine
@@ -4988,7 +4988,7 @@ branches:
       kind: DiscoveryEngineSiteSearchEngine
       package: google.cloud.discoveryengine.v1
       proto: SiteSearchEngine
-      proto-path: google.cloud.discoveryengine.v1.SiteSearchEngine
+      proto-msg: google.cloud.discoveryengine.v1.SiteSearchEngine
       notes:
         - No gcloud command found
     - name: discoveryengine-targetsite
@@ -5001,7 +5001,7 @@ branches:
       kind: DiscoveryEngineTargetSite
       package: google.cloud.discoveryengine.v1
       proto: TargetSite
-      proto-path: google.cloud.discoveryengine.v1.TargetSite
+      proto-msg: google.cloud.discoveryengine.v1.TargetSite
       notes:
         - No gcloud command found
     - name: discoveryengine-evaluation
@@ -5014,7 +5014,7 @@ branches:
       kind: DiscoveryEngineEvaluation
       package: google.cloud.discoveryengine.v1beta
       proto: Evaluation
-      proto-path: google.cloud.discoveryengine.v1beta.Evaluation
+      proto-msg: google.cloud.discoveryengine.v1beta.Evaluation
       notes:
         - No gcloud command found
     - name: discoveryengine-groundingconfig
@@ -5027,7 +5027,7 @@ branches:
       kind: DiscoveryEngineGroundingConfig
       package: google.cloud.discoveryengine.v1beta
       proto: GroundingConfig
-      proto-path: google.cloud.discoveryengine.v1beta.GroundingConfig
+      proto-msg: google.cloud.discoveryengine.v1beta.GroundingConfig
       notes:
         - No gcloud command found
     - name: discoveryengine-samplequery
@@ -5040,7 +5040,7 @@ branches:
       kind: DiscoveryEngineSampleQuery
       package: google.cloud.discoveryengine.v1beta
       proto: SampleQuery
-      proto-path: google.cloud.discoveryengine.v1beta.SampleQuery
+      proto-msg: google.cloud.discoveryengine.v1beta.SampleQuery
       notes:
         - No gcloud command found
     - name: discoveryengine-samplequeryset
@@ -5053,7 +5053,7 @@ branches:
       kind: DiscoveryEngineSampleQuerySet
       package: google.cloud.discoveryengine.v1beta
       proto: SampleQuerySet
-      proto-path: google.cloud.discoveryengine.v1beta.SampleQuerySet
+      proto-msg: google.cloud.discoveryengine.v1beta.SampleQuerySet
       notes:
         - No gcloud command found
     - name: discoveryengine-servingconfig
@@ -5066,7 +5066,7 @@ branches:
       kind: DiscoveryEngineServingConfig
       package: google.cloud.discoveryengine.v1beta
       proto: ServingConfig
-      proto-path: google.cloud.discoveryengine.v1beta.ServingConfig
+      proto-msg: google.cloud.discoveryengine.v1beta.ServingConfig
       notes:
         - No gcloud command found
     - name: discoveryengine-sitemap
@@ -5079,7 +5079,7 @@ branches:
       kind: DiscoveryEngineSitemap
       package: google.cloud.discoveryengine.v1beta
       proto: Sitemap
-      proto-path: google.cloud.discoveryengine.v1beta.Sitemap
+      proto-msg: google.cloud.discoveryengine.v1beta.Sitemap
       notes:
         - No gcloud command found
     - name: documentai-evaluation
@@ -5092,7 +5092,7 @@ branches:
       kind: DocumentAIEvaluation
       package: google.cloud.documentai.v1
       proto: Evaluation
-      proto-path: google.cloud.documentai.v1.Evaluation
+      proto-msg: google.cloud.documentai.v1.Evaluation
       notes:
         - No gcloud command found
     - name: documentai-processorversion
@@ -5105,7 +5105,7 @@ branches:
       kind: DocumentAIProcessorVersion
       package: google.cloud.documentai.v1
       proto: ProcessorVersion
-      proto-path: google.cloud.documentai.v1.ProcessorVersion
+      proto-msg: google.cloud.documentai.v1.ProcessorVersion
       notes:
         - No gcloud command found
     - name: documentai-processor
@@ -5118,7 +5118,7 @@ branches:
       kind: DocumentAIProcessor
       package: google.cloud.documentai.v1
       proto: Processor
-      proto-path: google.cloud.documentai.v1.Processor
+      proto-msg: google.cloud.documentai.v1.Processor
       notes:
         - No gcloud command found
     - name: documentai-processortype
@@ -5131,7 +5131,7 @@ branches:
       kind: DocumentAIProcessorType
       package: google.cloud.documentai.v1
       proto: ProcessorType
-      proto-path: google.cloud.documentai.v1.ProcessorType
+      proto-msg: google.cloud.documentai.v1.ProcessorType
       notes:
         - No gcloud command found
     - name: documentai-dataset
@@ -5144,7 +5144,7 @@ branches:
       kind: DocumentAIDataset
       package: google.cloud.documentai.v1beta3
       proto: Dataset
-      proto-path: google.cloud.documentai.v1beta3.Dataset
+      proto-msg: google.cloud.documentai.v1beta3.Dataset
       notes:
         - No gcloud command found
     - name: documentai-datasetschema
@@ -5157,7 +5157,7 @@ branches:
       kind: DocumentAIDatasetSchema
       package: google.cloud.documentai.v1beta3
       proto: DatasetSchema
-      proto-path: google.cloud.documentai.v1beta3.DatasetSchema
+      proto-msg: google.cloud.documentai.v1beta3.DatasetSchema
       notes:
         - No gcloud command found
     - name: domains-registration
@@ -5170,7 +5170,7 @@ branches:
       kind: DomainsRegistration
       package: google.cloud.domains.v1
       proto: Registration
-      proto-path: google.cloud.domains.v1.Registration
+      proto-msg: google.cloud.domains.v1.Registration
       notes: []
     - name: edgecontainer-cluster
       local: resource-edgecontainer-cluster
@@ -5182,7 +5182,7 @@ branches:
       kind: EdgeContainerCluster
       package: google.cloud.edgecontainer.v1
       proto: Cluster
-      proto-path: google.cloud.edgecontainer.v1.Cluster
+      proto-msg: google.cloud.edgecontainer.v1.Cluster
       notes: []
     - name: edgecontainer-nodepool
       local: resource-edgecontainer-nodepool
@@ -5194,7 +5194,7 @@ branches:
       kind: EdgeContainerNodePool
       package: google.cloud.edgecontainer.v1
       proto: NodePool
-      proto-path: google.cloud.edgecontainer.v1.NodePool
+      proto-msg: google.cloud.edgecontainer.v1.NodePool
       notes:
         - No gcloud command found
     - name: edgecontainer-machine
@@ -5207,7 +5207,7 @@ branches:
       kind: EdgeContainerMachine
       package: google.cloud.edgecontainer.v1
       proto: Machine
-      proto-path: google.cloud.edgecontainer.v1.Machine
+      proto-msg: google.cloud.edgecontainer.v1.Machine
       notes: []
     - name: edgecontainer-vpnconnection
       local: resource-edgecontainer-vpnconnection
@@ -5219,7 +5219,7 @@ branches:
       kind: EdgeContainerVpnConnection
       package: google.cloud.edgecontainer.v1
       proto: VpnConnection
-      proto-path: google.cloud.edgecontainer.v1.VpnConnection
+      proto-msg: google.cloud.edgecontainer.v1.VpnConnection
       notes: []
     - name: edgenetwork-zone
       local: resource-edgenetwork-zone
@@ -5231,7 +5231,7 @@ branches:
       kind: EdgeNetworkZone
       package: google.cloud.edgenetwork.v1
       proto: Zone
-      proto-path: google.cloud.edgenetwork.v1.Zone
+      proto-msg: google.cloud.edgenetwork.v1.Zone
       notes: []
     - name: edgenetwork-network
       local: resource-edgenetwork-network
@@ -5243,7 +5243,7 @@ branches:
       kind: EdgeNetworkNetwork
       package: google.cloud.edgenetwork.v1
       proto: Network
-      proto-path: google.cloud.edgenetwork.v1.Network
+      proto-msg: google.cloud.edgenetwork.v1.Network
       notes: []
     - name: edgenetwork-subnet
       local: resource-edgenetwork-subnet
@@ -5255,7 +5255,7 @@ branches:
       kind: EdgeNetworkSubnet
       package: google.cloud.edgenetwork.v1
       proto: Subnet
-      proto-path: google.cloud.edgenetwork.v1.Subnet
+      proto-msg: google.cloud.edgenetwork.v1.Subnet
       notes: []
     - name: edgenetwork-interconnect
       local: resource-edgenetwork-interconnect
@@ -5267,7 +5267,7 @@ branches:
       kind: EdgeNetworkInterconnect
       package: google.cloud.edgenetwork.v1
       proto: Interconnect
-      proto-path: google.cloud.edgenetwork.v1.Interconnect
+      proto-msg: google.cloud.edgenetwork.v1.Interconnect
       notes: []
     - name: edgenetwork-interconnectattachment
       local: resource-edgenetwork-interconnectattachment
@@ -5279,7 +5279,7 @@ branches:
       kind: EdgeNetworkInterconnectAttachment
       package: google.cloud.edgenetwork.v1
       proto: InterconnectAttachment
-      proto-path: google.cloud.edgenetwork.v1.InterconnectAttachment
+      proto-msg: google.cloud.edgenetwork.v1.InterconnectAttachment
       notes:
         - No gcloud command found
     - name: edgenetwork-router
@@ -5292,7 +5292,7 @@ branches:
       kind: EdgeNetworkRouter
       package: google.cloud.edgenetwork.v1
       proto: Router
-      proto-path: google.cloud.edgenetwork.v1.Router
+      proto-msg: google.cloud.edgenetwork.v1.Router
       notes: []
     - name: enterpriseknowledgegraph-entityreconciliationjob
       local: resource-enterpriseknowledgegraph-entityreconciliationjob
@@ -5304,7 +5304,7 @@ branches:
       kind: EnterpriseKnowledgeGraphEntityReconciliationJob
       package: google.cloud.enterpriseknowledgegraph.v1
       proto: EntityReconciliationJob
-      proto-path: google.cloud.enterpriseknowledgegraph.v1.EntityReconciliationJob
+      proto-msg: google.cloud.enterpriseknowledgegraph.v1.EntityReconciliationJob
       notes:
         - No gcloud command found
     - name: essentialcontacts-contact
@@ -5317,7 +5317,7 @@ branches:
       kind: EssentialContactsContact
       package: google.cloud.essentialcontacts.v1
       proto: Contact
-      proto-path: google.cloud.essentialcontacts.v1.Contact
+      proto-msg: google.cloud.essentialcontacts.v1.Contact
       notes: []
     - name: eventarc-channel
       local: resource-eventarc-channel
@@ -5329,7 +5329,7 @@ branches:
       kind: EventarcChannel
       package: google.cloud.eventarc.v1
       proto: Channel
-      proto-path: google.cloud.eventarc.v1.Channel
+      proto-msg: google.cloud.eventarc.v1.Channel
       notes: []
     - name: eventarc-channelconnection
       local: resource-eventarc-channelconnection
@@ -5341,7 +5341,7 @@ branches:
       kind: EventarcChannelConnection
       package: google.cloud.eventarc.v1
       proto: ChannelConnection
-      proto-path: google.cloud.eventarc.v1.ChannelConnection
+      proto-msg: google.cloud.eventarc.v1.ChannelConnection
       notes: []
     - name: eventarc-provider
       local: resource-eventarc-provider
@@ -5353,7 +5353,7 @@ branches:
       kind: EventarcProvider
       package: google.cloud.eventarc.v1
       proto: Provider
-      proto-path: google.cloud.eventarc.v1.Provider
+      proto-msg: google.cloud.eventarc.v1.Provider
       notes: []
     - name: eventarc-enrollment
       local: resource-eventarc-enrollment
@@ -5365,7 +5365,7 @@ branches:
       kind: EventarcEnrollment
       package: google.cloud.eventarc.v1
       proto: Enrollment
-      proto-path: google.cloud.eventarc.v1.Enrollment
+      proto-msg: google.cloud.eventarc.v1.Enrollment
       notes:
         - No gcloud command found
     - name: eventarc-googleapisource
@@ -5378,7 +5378,7 @@ branches:
       kind: EventarcGoogleApiSource
       package: google.cloud.eventarc.v1
       proto: GoogleApiSource
-      proto-path: google.cloud.eventarc.v1.GoogleApiSource
+      proto-msg: google.cloud.eventarc.v1.GoogleApiSource
       notes:
         - No gcloud command found
     - name: eventarc-googlechannelconfig
@@ -5391,7 +5391,7 @@ branches:
       kind: EventarcGoogleChannelConfig
       package: google.cloud.eventarc.v1
       proto: GoogleChannelConfig
-      proto-path: google.cloud.eventarc.v1.GoogleChannelConfig
+      proto-msg: google.cloud.eventarc.v1.GoogleChannelConfig
       notes: []
     - name: eventarc-messagebus
       local: resource-eventarc-messagebus
@@ -5403,7 +5403,7 @@ branches:
       kind: EventarcMessageBus
       package: google.cloud.eventarc.v1
       proto: MessageBus
-      proto-path: google.cloud.eventarc.v1.MessageBus
+      proto-msg: google.cloud.eventarc.v1.MessageBus
       notes:
         - No gcloud command found
     - name: eventarc-pipeline
@@ -5416,7 +5416,7 @@ branches:
       kind: EventarcPipeline
       package: google.cloud.eventarc.v1
       proto: Pipeline
-      proto-path: google.cloud.eventarc.v1.Pipeline
+      proto-msg: google.cloud.eventarc.v1.Pipeline
       notes:
         - No gcloud command found
     - name: eventarc-trigger
@@ -5429,7 +5429,7 @@ branches:
       kind: EventarcTrigger
       package: google.cloud.eventarc.v1
       proto: Trigger
-      proto-path: google.cloud.eventarc.v1.Trigger
+      proto-msg: google.cloud.eventarc.v1.Trigger
       notes: []
     - name: filestore-instance
       local: resource-filestore-instance
@@ -5441,7 +5441,7 @@ branches:
       kind: FilestoreInstance
       package: google.cloud.filestore.v1
       proto: Instance
-      proto-path: google.cloud.filestore.v1.Instance
+      proto-msg: google.cloud.filestore.v1.Instance
       notes: []
     - name: filestore-snapshot
       local: resource-filestore-snapshot
@@ -5453,7 +5453,7 @@ branches:
       kind: FilestoreSnapshot
       package: google.cloud.filestore.v1
       proto: Snapshot
-      proto-path: google.cloud.filestore.v1.Snapshot
+      proto-msg: google.cloud.filestore.v1.Snapshot
       notes:
         - No gcloud command found
     - name: filestore-backup
@@ -5466,7 +5466,7 @@ branches:
       kind: FilestoreBackup
       package: google.cloud.filestore.v1
       proto: Backup
-      proto-path: google.cloud.filestore.v1.Backup
+      proto-msg: google.cloud.filestore.v1.Backup
       notes: []
     - name: filestore-share
       local: resource-filestore-share
@@ -5478,7 +5478,7 @@ branches:
       kind: FilestoreShare
       package: google.cloud.filestore.v1beta1
       proto: Share
-      proto-path: google.cloud.filestore.v1beta1.Share
+      proto-msg: google.cloud.filestore.v1beta1.Share
       notes:
         - No gcloud command found
     - name: functions-cloudfunction
@@ -5491,7 +5491,7 @@ branches:
       kind: FunctionsCloudFunction
       package: google.cloud.functions.v1
       proto: CloudFunction
-      proto-path: google.cloud.functions.v1.CloudFunction
+      proto-msg: google.cloud.functions.v1.CloudFunction
       notes:
         - No gcloud command found
     - name: functions-function
@@ -5504,7 +5504,7 @@ branches:
       kind: FunctionsFunction
       package: google.cloud.functions.v2
       proto: Function
-      proto-path: google.cloud.functions.v2.Function
+      proto-msg: google.cloud.functions.v2.Function
       notes:
         - No gcloud command found
     - name: gkebackup-backup
@@ -5517,7 +5517,7 @@ branches:
       kind: GKEBackupBackup
       package: google.cloud.gkebackup.v1
       proto: Backup
-      proto-path: google.cloud.gkebackup.v1.Backup
+      proto-msg: google.cloud.gkebackup.v1.Backup
       notes: []
     - name: gkebackup-backupplan
       local: resource-gkebackup-backupplan
@@ -5529,7 +5529,7 @@ branches:
       kind: GKEBackupBackupPlan
       package: google.cloud.gkebackup.v1
       proto: BackupPlan
-      proto-path: google.cloud.gkebackup.v1.BackupPlan
+      proto-msg: google.cloud.gkebackup.v1.BackupPlan
       notes: []
     - name: gkebackup-restore
       local: resource-gkebackup-restore
@@ -5541,7 +5541,7 @@ branches:
       kind: GKEBackupRestore
       package: google.cloud.gkebackup.v1
       proto: Restore
-      proto-path: google.cloud.gkebackup.v1.Restore
+      proto-msg: google.cloud.gkebackup.v1.Restore
       notes: []
     - name: gkebackup-restoreplan
       local: resource-gkebackup-restoreplan
@@ -5553,7 +5553,7 @@ branches:
       kind: GKEBackupRestorePlan
       package: google.cloud.gkebackup.v1
       proto: RestorePlan
-      proto-path: google.cloud.gkebackup.v1.RestorePlan
+      proto-msg: google.cloud.gkebackup.v1.RestorePlan
       notes: []
     - name: gkebackup-volumebackup
       local: resource-gkebackup-volumebackup
@@ -5565,7 +5565,7 @@ branches:
       kind: GKEBackupVolumeBackup
       package: google.cloud.gkebackup.v1
       proto: VolumeBackup
-      proto-path: google.cloud.gkebackup.v1.VolumeBackup
+      proto-msg: google.cloud.gkebackup.v1.VolumeBackup
       notes: []
     - name: gkebackup-volumerestore
       local: resource-gkebackup-volumerestore
@@ -5577,7 +5577,7 @@ branches:
       kind: GKEBackupVolumeRestore
       package: google.cloud.gkebackup.v1
       proto: VolumeRestore
-      proto-path: google.cloud.gkebackup.v1.VolumeRestore
+      proto-msg: google.cloud.gkebackup.v1.VolumeRestore
       notes: []
     - name: gkehub-feature
       local: resource-gkehub-feature
@@ -5589,7 +5589,7 @@ branches:
       kind: GKEHubFeature
       package: google.cloud.gkehub.v1
       proto: Feature
-      proto-path: google.cloud.gkehub.v1.Feature
+      proto-msg: google.cloud.gkehub.v1.Feature
       notes:
         - No gcloud command found
     - name: gkehub-membership
@@ -5602,7 +5602,7 @@ branches:
       kind: GKEHubMembership
       package: google.cloud.gkehub.v1
       proto: Membership
-      proto-path: google.cloud.gkehub.v1.Membership
+      proto-msg: google.cloud.gkehub.v1.Membership
       notes:
         - No gcloud command found
     - name: gkemulticloud-attachedcluster
@@ -5615,7 +5615,7 @@ branches:
       kind: GkeMultiCloudAttachedCluster
       package: google.cloud.gkemulticloud.v1
       proto: AttachedCluster
-      proto-path: google.cloud.gkemulticloud.v1.AttachedCluster
+      proto-msg: google.cloud.gkemulticloud.v1.AttachedCluster
       notes: []
     - name: gkemulticloud-attachedserverconfig
       local: resource-gkemulticloud-attachedserverconfig
@@ -5627,7 +5627,7 @@ branches:
       kind: GkeMultiCloudAttachedServerConfig
       package: google.cloud.gkemulticloud.v1
       proto: AttachedServerConfig
-      proto-path: google.cloud.gkemulticloud.v1.AttachedServerConfig
+      proto-msg: google.cloud.gkemulticloud.v1.AttachedServerConfig
       notes: []
     - name: gkemulticloud-awscluster
       local: resource-gkemulticloud-awscluster
@@ -5639,7 +5639,7 @@ branches:
       kind: GkeMultiCloudAwsCluster
       package: google.cloud.gkemulticloud.v1
       proto: AwsCluster
-      proto-path: google.cloud.gkemulticloud.v1.AwsCluster
+      proto-msg: google.cloud.gkemulticloud.v1.AwsCluster
       notes:
         - No gcloud command found
     - name: gkemulticloud-awsnodepool
@@ -5652,7 +5652,7 @@ branches:
       kind: GkeMultiCloudAwsNodePool
       package: google.cloud.gkemulticloud.v1
       proto: AwsNodePool
-      proto-path: google.cloud.gkemulticloud.v1.AwsNodePool
+      proto-msg: google.cloud.gkemulticloud.v1.AwsNodePool
       notes:
         - No gcloud command found
     - name: gkemulticloud-awsserverconfig
@@ -5665,7 +5665,7 @@ branches:
       kind: GkeMultiCloudAwsServerConfig
       package: google.cloud.gkemulticloud.v1
       proto: AwsServerConfig
-      proto-path: google.cloud.gkemulticloud.v1.AwsServerConfig
+      proto-msg: google.cloud.gkemulticloud.v1.AwsServerConfig
       notes:
         - No gcloud command found
     - name: gkemulticloud-azurecluster
@@ -5678,7 +5678,7 @@ branches:
       kind: GkeMultiCloudAzureCluster
       package: google.cloud.gkemulticloud.v1
       proto: AzureCluster
-      proto-path: google.cloud.gkemulticloud.v1.AzureCluster
+      proto-msg: google.cloud.gkemulticloud.v1.AzureCluster
       notes:
         - No gcloud command found
     - name: gkemulticloud-azureclient
@@ -5691,7 +5691,7 @@ branches:
       kind: GkeMultiCloudAzureClient
       package: google.cloud.gkemulticloud.v1
       proto: AzureClient
-      proto-path: google.cloud.gkemulticloud.v1.AzureClient
+      proto-msg: google.cloud.gkemulticloud.v1.AzureClient
       notes:
         - No gcloud command found
     - name: gkemulticloud-azurenodepool
@@ -5704,7 +5704,7 @@ branches:
       kind: GkeMultiCloudAzureNodePool
       package: google.cloud.gkemulticloud.v1
       proto: AzureNodePool
-      proto-path: google.cloud.gkemulticloud.v1.AzureNodePool
+      proto-msg: google.cloud.gkemulticloud.v1.AzureNodePool
       notes:
         - No gcloud command found
     - name: gkemulticloud-azureserverconfig
@@ -5717,7 +5717,7 @@ branches:
       kind: GkeMultiCloudAzureServerConfig
       package: google.cloud.gkemulticloud.v1
       proto: AzureServerConfig
-      proto-path: google.cloud.gkemulticloud.v1.AzureServerConfig
+      proto-msg: google.cloud.gkemulticloud.v1.AzureServerConfig
       notes:
         - No gcloud command found
     - name: gsuiteaddons-authorization
@@ -5730,7 +5730,7 @@ branches:
       kind: GSuiteAddonsAuthorization
       package: google.cloud.gsuiteaddons.v1
       proto: Authorization
-      proto-path: google.cloud.gsuiteaddons.v1.Authorization
+      proto-msg: google.cloud.gsuiteaddons.v1.Authorization
       notes:
         - No gcloud command found
     - name: gsuiteaddons-installstatus
@@ -5743,7 +5743,7 @@ branches:
       kind: GSuiteAddonsInstallStatus
       package: google.cloud.gsuiteaddons.v1
       proto: InstallStatus
-      proto-path: google.cloud.gsuiteaddons.v1.InstallStatus
+      proto-msg: google.cloud.gsuiteaddons.v1.InstallStatus
       notes:
         - No gcloud command found
     - name: gsuiteaddons-deployment
@@ -5756,7 +5756,7 @@ branches:
       kind: GSuiteAddonsDeployment
       package: google.cloud.gsuiteaddons.v1
       proto: Deployment
-      proto-path: google.cloud.gsuiteaddons.v1.Deployment
+      proto-msg: google.cloud.gsuiteaddons.v1.Deployment
       notes:
         - No gcloud command found
     - name: iap-tunneldestgroup
@@ -5769,7 +5769,7 @@ branches:
       kind: IAPTunnelDestGroup
       package: google.cloud.iap.v1
       proto: TunnelDestGroup
-      proto-path: google.cloud.iap.v1.TunnelDestGroup
+      proto-msg: google.cloud.iap.v1.TunnelDestGroup
       notes:
         - No gcloud command found
     - name: ids-endpoint
@@ -5782,7 +5782,7 @@ branches:
       kind: IDsEndpoint
       package: google.cloud.ids.v1
       proto: Endpoint
-      proto-path: google.cloud.ids.v1.Endpoint
+      proto-msg: google.cloud.ids.v1.Endpoint
       notes: []
     - name: iot-device
       local: resource-iot-device
@@ -5794,7 +5794,7 @@ branches:
       kind: IoTDevice
       package: google.cloud.iot.v1
       proto: Device
-      proto-path: google.cloud.iot.v1.Device
+      proto-msg: google.cloud.iot.v1.Device
       notes:
         - No gcloud command found
     - name: iot-deviceregistry
@@ -5807,7 +5807,7 @@ branches:
       kind: IoTDeviceRegistry
       package: google.cloud.iot.v1
       proto: DeviceRegistry
-      proto-path: google.cloud.iot.v1.DeviceRegistry
+      proto-msg: google.cloud.iot.v1.DeviceRegistry
       notes:
         - No gcloud command found
     - name: kms-protectedresourcessummary
@@ -5820,7 +5820,7 @@ branches:
       kind: KMSProtectedResourcesSummary
       package: google.cloud.kms.inventory.v1
       proto: ProtectedResourcesSummary
-      proto-path: google.cloud.kms.inventory.v1.ProtectedResourcesSummary
+      proto-msg: google.cloud.kms.inventory.v1.ProtectedResourcesSummary
       notes:
         - No gcloud command found
     - name: kms-protectedresource
@@ -5833,7 +5833,7 @@ branches:
       kind: KMSProtectedResource
       package: google.cloud.kms.inventory.v1
       proto: ProtectedResource
-      proto-path: google.cloud.kms.inventory.v1.ProtectedResource
+      proto-msg: google.cloud.kms.inventory.v1.ProtectedResource
       notes:
         - No gcloud command found
     - name: kms-keyhandle
@@ -5846,7 +5846,7 @@ branches:
       kind: KMSKeyHandle
       package: google.cloud.kms.v1
       proto: KeyHandle
-      proto-path: google.cloud.kms.v1.KeyHandle
+      proto-msg: google.cloud.kms.v1.KeyHandle
       notes: []
     - name: kms-autokeyconfig
       local: resource-kms-autokeyconfig
@@ -5858,7 +5858,7 @@ branches:
       kind: KMSAutokeyConfig
       package: google.cloud.kms.v1
       proto: AutokeyConfig
-      proto-path: google.cloud.kms.v1.AutokeyConfig
+      proto-msg: google.cloud.kms.v1.AutokeyConfig
       notes: []
     - name: kms-ekmconnection
       local: resource-kms-ekmconnection
@@ -5870,7 +5870,7 @@ branches:
       kind: KMSEkmConnection
       package: google.cloud.kms.v1
       proto: EkmConnection
-      proto-path: google.cloud.kms.v1.EkmConnection
+      proto-msg: google.cloud.kms.v1.EkmConnection
       notes: []
     - name: kms-ekmconfig
       local: resource-kms-ekmconfig
@@ -5882,7 +5882,7 @@ branches:
       kind: KMSEkmConfig
       package: google.cloud.kms.v1
       proto: EkmConfig
-      proto-path: google.cloud.kms.v1.EkmConfig
+      proto-msg: google.cloud.kms.v1.EkmConfig
       notes: []
     - name: kms-keyring
       local: resource-kms-keyring
@@ -5894,7 +5894,7 @@ branches:
       kind: KMSKeyRing
       package: google.cloud.kms.v1
       proto: KeyRing
-      proto-path: google.cloud.kms.v1.KeyRing
+      proto-msg: google.cloud.kms.v1.KeyRing
       notes: []
     - name: kms-cryptokey
       local: resource-kms-cryptokey
@@ -5906,7 +5906,7 @@ branches:
       kind: KMSCryptoKey
       package: google.cloud.kms.v1
       proto: CryptoKey
-      proto-path: google.cloud.kms.v1.CryptoKey
+      proto-msg: google.cloud.kms.v1.CryptoKey
       notes: []
     - name: kms-cryptokeyversion
       local: resource-kms-cryptokeyversion
@@ -5918,7 +5918,7 @@ branches:
       kind: KMSCryptoKeyVersion
       package: google.cloud.kms.v1
       proto: CryptoKeyVersion
-      proto-path: google.cloud.kms.v1.CryptoKeyVersion
+      proto-msg: google.cloud.kms.v1.CryptoKeyVersion
       notes: []
     - name: kms-publickey
       local: resource-kms-publickey
@@ -5930,7 +5930,7 @@ branches:
       kind: KMSPublicKey
       package: google.cloud.kms.v1
       proto: PublicKey
-      proto-path: google.cloud.kms.v1.PublicKey
+      proto-msg: google.cloud.kms.v1.PublicKey
       notes:
         - No gcloud command found
     - name: kms-importjob
@@ -5943,7 +5943,7 @@ branches:
       kind: KMSImportJob
       package: google.cloud.kms.v1
       proto: ImportJob
-      proto-path: google.cloud.kms.v1.ImportJob
+      proto-msg: google.cloud.kms.v1.ImportJob
       notes: []
     - name: managedidentities-domain
       local: resource-managedidentities-domain
@@ -5955,7 +5955,7 @@ branches:
       kind: ManagedIdentitiesDomain
       package: google.cloud.managedidentities.v1
       proto: Domain
-      proto-path: google.cloud.managedidentities.v1.Domain
+      proto-msg: google.cloud.managedidentities.v1.Domain
       notes:
         - No gcloud command found
     - name: managedkafka-cluster
@@ -5968,7 +5968,7 @@ branches:
       kind: ManagedKafkaCluster
       package: google.cloud.managedkafka.v1
       proto: Cluster
-      proto-path: google.cloud.managedkafka.v1.Cluster
+      proto-msg: google.cloud.managedkafka.v1.Cluster
       notes: []
     - name: managedkafka-topic
       local: resource-managedkafka-topic
@@ -5980,7 +5980,7 @@ branches:
       kind: ManagedKafkaTopic
       package: google.cloud.managedkafka.v1
       proto: Topic
-      proto-path: google.cloud.managedkafka.v1.Topic
+      proto-msg: google.cloud.managedkafka.v1.Topic
       notes: []
     - name: managedkafka-consumergroup
       local: resource-managedkafka-consumergroup
@@ -5992,7 +5992,7 @@ branches:
       kind: ManagedKafkaConsumerGroup
       package: google.cloud.managedkafka.v1
       proto: ConsumerGroup
-      proto-path: google.cloud.managedkafka.v1.ConsumerGroup
+      proto-msg: google.cloud.managedkafka.v1.ConsumerGroup
       notes: []
     - name: memcache-instance
       local: resource-memcache-instance
@@ -6004,7 +6004,7 @@ branches:
       kind: MemcacheInstance
       package: google.cloud.memcache.v1
       proto: Instance
-      proto-path: google.cloud.memcache.v1.Instance
+      proto-msg: google.cloud.memcache.v1.Instance
       notes: []
     - name: memorystore-instance
       local: resource-memorystore-instance
@@ -6016,7 +6016,7 @@ branches:
       kind: MemorystoreInstance
       package: google.cloud.memorystore.v1
       proto: Instance
-      proto-path: google.cloud.memorystore.v1.Instance
+      proto-msg: google.cloud.memorystore.v1.Instance
       notes: []
     - name: memorystore-certificateauthority
       local: resource-memorystore-certificateauthority
@@ -6028,7 +6028,7 @@ branches:
       kind: MemorystoreCertificateAuthority
       package: google.cloud.memorystore.v1
       proto: CertificateAuthority
-      proto-path: google.cloud.memorystore.v1.CertificateAuthority
+      proto-msg: google.cloud.memorystore.v1.CertificateAuthority
       notes:
         - No gcloud command found
     - name: metastore-service
@@ -6041,7 +6041,7 @@ branches:
       kind: MetastoreService
       package: google.cloud.metastore.v1
       proto: Service
-      proto-path: google.cloud.metastore.v1.Service
+      proto-msg: google.cloud.metastore.v1.Service
       notes: []
     - name: metastore-metadataimport
       local: resource-metastore-metadataimport
@@ -6053,7 +6053,7 @@ branches:
       kind: MetastoreMetadataImport
       package: google.cloud.metastore.v1
       proto: MetadataImport
-      proto-path: google.cloud.metastore.v1.MetadataImport
+      proto-msg: google.cloud.metastore.v1.MetadataImport
       notes:
         - No gcloud command found
     - name: metastore-backup
@@ -6066,7 +6066,7 @@ branches:
       kind: MetastoreBackup
       package: google.cloud.metastore.v1
       proto: Backup
-      proto-path: google.cloud.metastore.v1.Backup
+      proto-msg: google.cloud.metastore.v1.Backup
       notes: []
     - name: metastore-federation
       local: resource-metastore-federation
@@ -6078,7 +6078,7 @@ branches:
       kind: MetastoreFederation
       package: google.cloud.metastore.v1
       proto: Federation
-      proto-path: google.cloud.metastore.v1.Federation
+      proto-msg: google.cloud.metastore.v1.Federation
       notes: []
     - name: migrationcenter-asset
       local: resource-migrationcenter-asset
@@ -6090,7 +6090,7 @@ branches:
       kind: MigrationCenterAsset
       package: google.cloud.migrationcenter.v1
       proto: Asset
-      proto-path: google.cloud.migrationcenter.v1.Asset
+      proto-msg: google.cloud.migrationcenter.v1.Asset
       notes:
         - No gcloud command found
     - name: migrationcenter-preferenceset
@@ -6103,7 +6103,7 @@ branches:
       kind: MigrationCenterPreferenceSet
       package: google.cloud.migrationcenter.v1
       proto: PreferenceSet
-      proto-path: google.cloud.migrationcenter.v1.PreferenceSet
+      proto-msg: google.cloud.migrationcenter.v1.PreferenceSet
       notes:
         - No gcloud command found
     - name: migrationcenter-importjob
@@ -6116,7 +6116,7 @@ branches:
       kind: MigrationCenterImportJob
       package: google.cloud.migrationcenter.v1
       proto: ImportJob
-      proto-path: google.cloud.migrationcenter.v1.ImportJob
+      proto-msg: google.cloud.migrationcenter.v1.ImportJob
       notes:
         - No gcloud command found
     - name: migrationcenter-importdatafile
@@ -6129,7 +6129,7 @@ branches:
       kind: MigrationCenterImportDataFile
       package: google.cloud.migrationcenter.v1
       proto: ImportDataFile
-      proto-path: google.cloud.migrationcenter.v1.ImportDataFile
+      proto-msg: google.cloud.migrationcenter.v1.ImportDataFile
       notes:
         - No gcloud command found
     - name: migrationcenter-group
@@ -6142,7 +6142,7 @@ branches:
       kind: MigrationCenterGroup
       package: google.cloud.migrationcenter.v1
       proto: Group
-      proto-path: google.cloud.migrationcenter.v1.Group
+      proto-msg: google.cloud.migrationcenter.v1.Group
       notes:
         - No gcloud command found
     - name: migrationcenter-errorframe
@@ -6155,7 +6155,7 @@ branches:
       kind: MigrationCenterErrorFrame
       package: google.cloud.migrationcenter.v1
       proto: ErrorFrame
-      proto-path: google.cloud.migrationcenter.v1.ErrorFrame
+      proto-msg: google.cloud.migrationcenter.v1.ErrorFrame
       notes:
         - No gcloud command found
     - name: migrationcenter-source
@@ -6168,7 +6168,7 @@ branches:
       kind: MigrationCenterSource
       package: google.cloud.migrationcenter.v1
       proto: Source
-      proto-path: google.cloud.migrationcenter.v1.Source
+      proto-msg: google.cloud.migrationcenter.v1.Source
       notes:
         - No gcloud command found
     - name: migrationcenter-reportconfig
@@ -6181,7 +6181,7 @@ branches:
       kind: MigrationCenterReportConfig
       package: google.cloud.migrationcenter.v1
       proto: ReportConfig
-      proto-path: google.cloud.migrationcenter.v1.ReportConfig
+      proto-msg: google.cloud.migrationcenter.v1.ReportConfig
       notes:
         - No gcloud command found
     - name: migrationcenter-report
@@ -6194,7 +6194,7 @@ branches:
       kind: MigrationCenterReport
       package: google.cloud.migrationcenter.v1
       proto: Report
-      proto-path: google.cloud.migrationcenter.v1.Report
+      proto-msg: google.cloud.migrationcenter.v1.Report
       notes:
         - No gcloud command found
     - name: migrationcenter-settings
@@ -6207,7 +6207,7 @@ branches:
       kind: MigrationCenterSettings
       package: google.cloud.migrationcenter.v1
       proto: Settings
-      proto-path: google.cloud.migrationcenter.v1.Settings
+      proto-msg: google.cloud.migrationcenter.v1.Settings
       notes:
         - No gcloud command found
     - name: modelarmor-template
@@ -6220,7 +6220,7 @@ branches:
       kind: ModelArmorTemplate
       package: google.cloud.modelarmor.v1
       proto: Template
-      proto-path: google.cloud.modelarmor.v1.Template
+      proto-msg: google.cloud.modelarmor.v1.Template
       notes: []
     - name: modelarmor-floorsetting
       local: resource-modelarmor-floorsetting
@@ -6232,7 +6232,7 @@ branches:
       kind: ModelArmorFloorSetting
       package: google.cloud.modelarmor.v1
       proto: FloorSetting
-      proto-path: google.cloud.modelarmor.v1.FloorSetting
+      proto-msg: google.cloud.modelarmor.v1.FloorSetting
       notes: []
     - name: netapp-activedirectory
       local: resource-netapp-activedirectory
@@ -6244,7 +6244,7 @@ branches:
       kind: NetAppActiveDirectory
       package: google.cloud.netapp.v1
       proto: ActiveDirectory
-      proto-path: google.cloud.netapp.v1.ActiveDirectory
+      proto-msg: google.cloud.netapp.v1.ActiveDirectory
       notes: []
     - name: netapp-backup
       local: resource-netapp-backup
@@ -6256,7 +6256,7 @@ branches:
       kind: NetAppBackup
       package: google.cloud.netapp.v1
       proto: Backup
-      proto-path: google.cloud.netapp.v1.Backup
+      proto-msg: google.cloud.netapp.v1.Backup
       notes:
         - No gcloud command found
     - name: netapp-backuppolicy
@@ -6269,7 +6269,7 @@ branches:
       kind: NetAppBackupPolicy
       package: google.cloud.netapp.v1
       proto: BackupPolicy
-      proto-path: google.cloud.netapp.v1.BackupPolicy
+      proto-msg: google.cloud.netapp.v1.BackupPolicy
       notes: []
     - name: netapp-backupvault
       local: resource-netapp-backupvault
@@ -6281,7 +6281,7 @@ branches:
       kind: NetAppBackupVault
       package: google.cloud.netapp.v1
       proto: BackupVault
-      proto-path: google.cloud.netapp.v1.BackupVault
+      proto-msg: google.cloud.netapp.v1.BackupVault
       notes: []
     - name: netapp-kmsconfig
       local: resource-netapp-kmsconfig
@@ -6293,7 +6293,7 @@ branches:
       kind: NetAppKmsConfig
       package: google.cloud.netapp.v1
       proto: KmsConfig
-      proto-path: google.cloud.netapp.v1.KmsConfig
+      proto-msg: google.cloud.netapp.v1.KmsConfig
       notes: []
     - name: netapp-quotarule
       local: resource-netapp-quotarule
@@ -6305,7 +6305,7 @@ branches:
       kind: NetAppQuotaRule
       package: google.cloud.netapp.v1
       proto: QuotaRule
-      proto-path: google.cloud.netapp.v1.QuotaRule
+      proto-msg: google.cloud.netapp.v1.QuotaRule
       notes:
         - No gcloud command found
     - name: netapp-replication
@@ -6318,7 +6318,7 @@ branches:
       kind: NetAppReplication
       package: google.cloud.netapp.v1
       proto: Replication
-      proto-path: google.cloud.netapp.v1.Replication
+      proto-msg: google.cloud.netapp.v1.Replication
       notes:
         - No gcloud command found
     - name: netapp-snapshot
@@ -6331,7 +6331,7 @@ branches:
       kind: NetAppSnapshot
       package: google.cloud.netapp.v1
       proto: Snapshot
-      proto-path: google.cloud.netapp.v1.Snapshot
+      proto-msg: google.cloud.netapp.v1.Snapshot
       notes:
         - No gcloud command found
     - name: netapp-storagepool
@@ -6344,7 +6344,7 @@ branches:
       kind: NetAppStoragePool
       package: google.cloud.netapp.v1
       proto: StoragePool
-      proto-path: google.cloud.netapp.v1.StoragePool
+      proto-msg: google.cloud.netapp.v1.StoragePool
       notes: []
     - name: netapp-volume
       local: resource-netapp-volume
@@ -6356,7 +6356,7 @@ branches:
       kind: NetAppVolume
       package: google.cloud.netapp.v1
       proto: Volume
-      proto-path: google.cloud.netapp.v1.Volume
+      proto-msg: google.cloud.netapp.v1.Volume
       notes: []
     - name: networkconnectivity-hub
       local: resource-networkconnectivity-hub
@@ -6368,7 +6368,7 @@ branches:
       kind: NetworkConnectivityHub
       package: google.cloud.networkconnectivity.v1
       proto: Hub
-      proto-path: google.cloud.networkconnectivity.v1.Hub
+      proto-msg: google.cloud.networkconnectivity.v1.Hub
       notes: []
     - name: networkconnectivity-spoke
       local: resource-networkconnectivity-spoke
@@ -6380,7 +6380,7 @@ branches:
       kind: NetworkConnectivitySpoke
       package: google.cloud.networkconnectivity.v1
       proto: Spoke
-      proto-path: google.cloud.networkconnectivity.v1.Spoke
+      proto-msg: google.cloud.networkconnectivity.v1.Spoke
       notes: []
     - name: networkconnectivity-routetable
       local: resource-networkconnectivity-routetable
@@ -6392,7 +6392,7 @@ branches:
       kind: NetworkConnectivityRouteTable
       package: google.cloud.networkconnectivity.v1
       proto: RouteTable
-      proto-path: google.cloud.networkconnectivity.v1.RouteTable
+      proto-msg: google.cloud.networkconnectivity.v1.RouteTable
       notes:
         - No gcloud command found
     - name: networkconnectivity-route
@@ -6405,7 +6405,7 @@ branches:
       kind: NetworkConnectivityRoute
       package: google.cloud.networkconnectivity.v1
       proto: Route
-      proto-path: google.cloud.networkconnectivity.v1.Route
+      proto-msg: google.cloud.networkconnectivity.v1.Route
       notes:
         - No gcloud command found
     - name: networkconnectivity-group
@@ -6418,7 +6418,7 @@ branches:
       kind: NetworkConnectivityGroup
       package: google.cloud.networkconnectivity.v1
       proto: Group
-      proto-path: google.cloud.networkconnectivity.v1.Group
+      proto-msg: google.cloud.networkconnectivity.v1.Group
       notes:
         - No gcloud command found
     - name: networkconnectivity-policybasedroute
@@ -6431,7 +6431,7 @@ branches:
       kind: NetworkConnectivityPolicyBasedRoute
       package: google.cloud.networkconnectivity.v1
       proto: PolicyBasedRoute
-      proto-path: google.cloud.networkconnectivity.v1.PolicyBasedRoute
+      proto-msg: google.cloud.networkconnectivity.v1.PolicyBasedRoute
       notes: []
     - name: networkmanagement-connectivitytest
       local: resource-networkmanagement-connectivitytest
@@ -6443,7 +6443,7 @@ branches:
       kind: NetworkManagementConnectivityTest
       package: google.cloud.networkmanagement.v1
       proto: ConnectivityTest
-      proto-path: google.cloud.networkmanagement.v1.ConnectivityTest
+      proto-msg: google.cloud.networkmanagement.v1.ConnectivityTest
       notes: []
     - name: networkmanagement-vpcflowlogsconfig
       local: resource-networkmanagement-vpcflowlogsconfig
@@ -6455,7 +6455,7 @@ branches:
       kind: NetworkManagementVpcFlowLogsConfig
       package: google.cloud.networkmanagement.v1
       proto: VpcFlowLogsConfig
-      proto-path: google.cloud.networkmanagement.v1.VpcFlowLogsConfig
+      proto-msg: google.cloud.networkmanagement.v1.VpcFlowLogsConfig
       notes: []
     - name: networksecurity-authorizationpolicy
       local: resource-networksecurity-authorizationpolicy
@@ -6467,7 +6467,7 @@ branches:
       kind: NetworkSecurityAuthorizationPolicy
       package: google.cloud.networksecurity.v1
       proto: AuthorizationPolicy
-      proto-path: google.cloud.networksecurity.v1.AuthorizationPolicy
+      proto-msg: google.cloud.networksecurity.v1.AuthorizationPolicy
       notes: []
     - name: networksecurity-clienttlspolicy
       local: resource-networksecurity-clienttlspolicy
@@ -6479,7 +6479,7 @@ branches:
       kind: NetworkSecurityClientTlsPolicy
       package: google.cloud.networksecurity.v1
       proto: ClientTlsPolicy
-      proto-path: google.cloud.networksecurity.v1.ClientTlsPolicy
+      proto-msg: google.cloud.networksecurity.v1.ClientTlsPolicy
       notes: []
     - name: networksecurity-servertlspolicy
       local: resource-networksecurity-servertlspolicy
@@ -6491,7 +6491,7 @@ branches:
       kind: NetworkSecurityServerTlsPolicy
       package: google.cloud.networksecurity.v1
       proto: ServerTlsPolicy
-      proto-path: google.cloud.networksecurity.v1.ServerTlsPolicy
+      proto-msg: google.cloud.networksecurity.v1.ServerTlsPolicy
       notes: []
     - name: networkservices-lbtrafficextension
       local: resource-networkservices-lbtrafficextension
@@ -6503,7 +6503,7 @@ branches:
       kind: NetworkServicesLbTrafficExtension
       package: google.cloud.networkservices.v1
       proto: LbTrafficExtension
-      proto-path: google.cloud.networkservices.v1.LbTrafficExtension
+      proto-msg: google.cloud.networkservices.v1.LbTrafficExtension
       notes:
         - No gcloud command found
     - name: networkservices-lbrouteextension
@@ -6516,7 +6516,7 @@ branches:
       kind: NetworkServicesLbRouteExtension
       package: google.cloud.networkservices.v1
       proto: LbRouteExtension
-      proto-path: google.cloud.networkservices.v1.LbRouteExtension
+      proto-msg: google.cloud.networkservices.v1.LbRouteExtension
       notes:
         - No gcloud command found
     - name: networkservices-endpointpolicy
@@ -6529,7 +6529,7 @@ branches:
       kind: NetworkServicesEndpointPolicy
       package: google.cloud.networkservices.v1
       proto: EndpointPolicy
-      proto-path: google.cloud.networkservices.v1.EndpointPolicy
+      proto-msg: google.cloud.networkservices.v1.EndpointPolicy
       notes: []
     - name: networkservices-gateway
       local: resource-networkservices-gateway
@@ -6541,7 +6541,7 @@ branches:
       kind: NetworkServicesGateway
       package: google.cloud.networkservices.v1
       proto: Gateway
-      proto-path: google.cloud.networkservices.v1.Gateway
+      proto-msg: google.cloud.networkservices.v1.Gateway
       notes: []
     - name: networkservices-grpcroute
       local: resource-networkservices-grpcroute
@@ -6553,7 +6553,7 @@ branches:
       kind: NetworkServicesGrpcRoute
       package: google.cloud.networkservices.v1
       proto: GrpcRoute
-      proto-path: google.cloud.networkservices.v1.GrpcRoute
+      proto-msg: google.cloud.networkservices.v1.GrpcRoute
       notes: []
     - name: networkservices-httproute
       local: resource-networkservices-httproute
@@ -6565,7 +6565,7 @@ branches:
       kind: NetworkServicesHttpRoute
       package: google.cloud.networkservices.v1
       proto: HttpRoute
-      proto-path: google.cloud.networkservices.v1.HttpRoute
+      proto-msg: google.cloud.networkservices.v1.HttpRoute
       notes: []
     - name: networkservices-mesh
       local: resource-networkservices-mesh
@@ -6577,7 +6577,7 @@ branches:
       kind: NetworkServicesMesh
       package: google.cloud.networkservices.v1
       proto: Mesh
-      proto-path: google.cloud.networkservices.v1.Mesh
+      proto-msg: google.cloud.networkservices.v1.Mesh
       notes: []
     - name: networkservices-servicebinding
       local: resource-networkservices-servicebinding
@@ -6589,7 +6589,7 @@ branches:
       kind: NetworkServicesServiceBinding
       package: google.cloud.networkservices.v1
       proto: ServiceBinding
-      proto-path: google.cloud.networkservices.v1.ServiceBinding
+      proto-msg: google.cloud.networkservices.v1.ServiceBinding
       notes: []
     - name: networkservices-tcproute
       local: resource-networkservices-tcproute
@@ -6601,7 +6601,7 @@ branches:
       kind: NetworkServicesTcpRoute
       package: google.cloud.networkservices.v1
       proto: TcpRoute
-      proto-path: google.cloud.networkservices.v1.TcpRoute
+      proto-msg: google.cloud.networkservices.v1.TcpRoute
       notes: []
     - name: networkservices-tlsroute
       local: resource-networkservices-tlsroute
@@ -6613,7 +6613,7 @@ branches:
       kind: NetworkServicesTlsRoute
       package: google.cloud.networkservices.v1
       proto: TlsRoute
-      proto-path: google.cloud.networkservices.v1.TlsRoute
+      proto-msg: google.cloud.networkservices.v1.TlsRoute
       notes: []
     - name: notebooks-environment
       local: resource-notebooks-environment
@@ -6625,7 +6625,7 @@ branches:
       kind: NotebooksEnvironment
       package: google.cloud.notebooks.v1
       proto: Environment
-      proto-path: google.cloud.notebooks.v1.Environment
+      proto-msg: google.cloud.notebooks.v1.Environment
       notes: []
     - name: notebooks-execution
       local: resource-notebooks-execution
@@ -6637,7 +6637,7 @@ branches:
       kind: NotebooksExecution
       package: google.cloud.notebooks.v1
       proto: Execution
-      proto-path: google.cloud.notebooks.v1.Execution
+      proto-msg: google.cloud.notebooks.v1.Execution
       notes:
         - No gcloud command found
     - name: notebooks-runtime
@@ -6650,7 +6650,7 @@ branches:
       kind: NotebooksRuntime
       package: google.cloud.notebooks.v1
       proto: Runtime
-      proto-path: google.cloud.notebooks.v1.Runtime
+      proto-msg: google.cloud.notebooks.v1.Runtime
       notes: []
     - name: notebooks-schedule
       local: resource-notebooks-schedule
@@ -6662,7 +6662,7 @@ branches:
       kind: NotebooksSchedule
       package: google.cloud.notebooks.v1
       proto: Schedule
-      proto-path: google.cloud.notebooks.v1.Schedule
+      proto-msg: google.cloud.notebooks.v1.Schedule
       notes:
         - No gcloud command found
     - name: notebooks-instance
@@ -6675,7 +6675,7 @@ branches:
       kind: NotebooksInstance
       package: google.cloud.notebooks.v2
       proto: Instance
-      proto-path: google.cloud.notebooks.v2.Instance
+      proto-msg: google.cloud.notebooks.v2.Instance
       notes: []
     - name: oracledatabase-autonomousdatabase
       local: resource-oracledatabase-autonomousdatabase
@@ -6687,7 +6687,7 @@ branches:
       kind: OracleDatabaseAutonomousDatabase
       package: google.cloud.oracledatabase.v1
       proto: AutonomousDatabase
-      proto-path: google.cloud.oracledatabase.v1.AutonomousDatabase
+      proto-msg: google.cloud.oracledatabase.v1.AutonomousDatabase
       notes: []
     - name: oracledatabase-autonomousdatabasecharacterset
       local: resource-oracledatabase-autonomousdatabasecharacterset
@@ -6699,7 +6699,7 @@ branches:
       kind: OracleDatabaseAutonomousDatabaseCharacterSet
       package: google.cloud.oracledatabase.v1
       proto: AutonomousDatabaseCharacterSet
-      proto-path: google.cloud.oracledatabase.v1.AutonomousDatabaseCharacterSet
+      proto-msg: google.cloud.oracledatabase.v1.AutonomousDatabaseCharacterSet
       notes: []
     - name: oracledatabase-autonomousdatabasebackup
       local: resource-oracledatabase-autonomousdatabasebackup
@@ -6711,7 +6711,7 @@ branches:
       kind: OracleDatabaseAutonomousDatabaseBackup
       package: google.cloud.oracledatabase.v1
       proto: AutonomousDatabaseBackup
-      proto-path: google.cloud.oracledatabase.v1.AutonomousDatabaseBackup
+      proto-msg: google.cloud.oracledatabase.v1.AutonomousDatabaseBackup
       notes: []
     - name: oracledatabase-autonomousdbversion
       local: resource-oracledatabase-autonomousdbversion
@@ -6723,7 +6723,7 @@ branches:
       kind: OracleDatabaseAutonomousDbVersion
       package: google.cloud.oracledatabase.v1
       proto: AutonomousDbVersion
-      proto-path: google.cloud.oracledatabase.v1.AutonomousDbVersion
+      proto-msg: google.cloud.oracledatabase.v1.AutonomousDbVersion
       notes: []
     - name: oracledatabase-dbnode
       local: resource-oracledatabase-dbnode
@@ -6735,7 +6735,7 @@ branches:
       kind: OracleDatabaseDbNode
       package: google.cloud.oracledatabase.v1
       proto: DbNode
-      proto-path: google.cloud.oracledatabase.v1.DbNode
+      proto-msg: google.cloud.oracledatabase.v1.DbNode
       notes:
         - No gcloud command found
     - name: oracledatabase-dbserver
@@ -6748,7 +6748,7 @@ branches:
       kind: OracleDatabaseDbServer
       package: google.cloud.oracledatabase.v1
       proto: DbServer
-      proto-path: google.cloud.oracledatabase.v1.DbServer
+      proto-msg: google.cloud.oracledatabase.v1.DbServer
       notes:
         - No gcloud command found
     - name: oracledatabase-dbsystemshape
@@ -6761,7 +6761,7 @@ branches:
       kind: OracleDatabaseDbSystemShape
       package: google.cloud.oracledatabase.v1
       proto: DbSystemShape
-      proto-path: google.cloud.oracledatabase.v1.DbSystemShape
+      proto-msg: google.cloud.oracledatabase.v1.DbSystemShape
       notes: []
     - name: oracledatabase-entitlement
       local: resource-oracledatabase-entitlement
@@ -6773,7 +6773,7 @@ branches:
       kind: OracleDatabaseEntitlement
       package: google.cloud.oracledatabase.v1
       proto: Entitlement
-      proto-path: google.cloud.oracledatabase.v1.Entitlement
+      proto-msg: google.cloud.oracledatabase.v1.Entitlement
       notes: []
     - name: oracledatabase-cloudexadatainfrastructure
       local: resource-oracledatabase-cloudexadatainfrastructure
@@ -6785,7 +6785,7 @@ branches:
       kind: OracleDatabaseCloudExadataInfrastructure
       package: google.cloud.oracledatabase.v1
       proto: CloudExadataInfrastructure
-      proto-path: google.cloud.oracledatabase.v1.CloudExadataInfrastructure
+      proto-msg: google.cloud.oracledatabase.v1.CloudExadataInfrastructure
       notes: []
     - name: oracledatabase-giversion
       local: resource-oracledatabase-giversion
@@ -6797,7 +6797,7 @@ branches:
       kind: OracleDatabaseGiVersion
       package: google.cloud.oracledatabase.v1
       proto: GiVersion
-      proto-path: google.cloud.oracledatabase.v1.GiVersion
+      proto-msg: google.cloud.oracledatabase.v1.GiVersion
       notes: []
     - name: oracledatabase-cloudvmcluster
       local: resource-oracledatabase-cloudvmcluster
@@ -6809,7 +6809,7 @@ branches:
       kind: OracleDatabaseCloudVmCluster
       package: google.cloud.oracledatabase.v1
       proto: CloudVmCluster
-      proto-path: google.cloud.oracledatabase.v1.CloudVmCluster
+      proto-msg: google.cloud.oracledatabase.v1.CloudVmCluster
       notes: []
     - name: orchestration-userworkloadssecret
       local: resource-orchestration-userworkloadssecret
@@ -6821,7 +6821,7 @@ branches:
       kind: OrchestrationUserWorkloadsSecret
       package: google.cloud.orchestration.airflow.service.v1
       proto: UserWorkloadsSecret
-      proto-path: google.cloud.orchestration.airflow.service.v1.UserWorkloadsSecret
+      proto-msg: google.cloud.orchestration.airflow.service.v1.UserWorkloadsSecret
       notes:
         - No gcloud command found
     - name: orchestration-userworkloadsconfigmap
@@ -6834,7 +6834,7 @@ branches:
       kind: OrchestrationUserWorkloadsConfigMap
       package: google.cloud.orchestration.airflow.service.v1
       proto: UserWorkloadsConfigMap
-      proto-path: google.cloud.orchestration.airflow.service.v1.UserWorkloadsConfigMap
+      proto-msg: google.cloud.orchestration.airflow.service.v1.UserWorkloadsConfigMap
       notes:
         - No gcloud command found
     - name: orchestration-environment
@@ -6847,7 +6847,7 @@ branches:
       kind: OrchestrationEnvironment
       package: google.cloud.orchestration.airflow.service.v1
       proto: Environment
-      proto-path: google.cloud.orchestration.airflow.service.v1.Environment
+      proto-msg: google.cloud.orchestration.airflow.service.v1.Environment
       notes:
         - No gcloud command found
     - name: orgpolicy-constraint
@@ -6860,7 +6860,7 @@ branches:
       kind: OrgPolicyConstraint
       package: google.cloud.orgpolicy.v2
       proto: Constraint
-      proto-path: google.cloud.orgpolicy.v2.Constraint
+      proto-msg: google.cloud.orgpolicy.v2.Constraint
       notes:
         - No gcloud command found
     - name: orgpolicy-customconstraint
@@ -6873,7 +6873,7 @@ branches:
       kind: OrgPolicyCustomConstraint
       package: google.cloud.orgpolicy.v2
       proto: CustomConstraint
-      proto-path: google.cloud.orgpolicy.v2.CustomConstraint
+      proto-msg: google.cloud.orgpolicy.v2.CustomConstraint
       notes:
         - No gcloud command found
     - name: orgpolicy-policy
@@ -6886,7 +6886,7 @@ branches:
       kind: OrgPolicyPolicy
       package: google.cloud.orgpolicy.v2
       proto: Policy
-      proto-path: google.cloud.orgpolicy.v2.Policy
+      proto-msg: google.cloud.orgpolicy.v2.Policy
       notes: []
     - name: osconfig-inventory
       local: resource-osconfig-inventory
@@ -6898,7 +6898,7 @@ branches:
       kind: OSConfigInventory
       package: google.cloud.osconfig.v1
       proto: Inventory
-      proto-path: google.cloud.osconfig.v1.Inventory
+      proto-msg: google.cloud.osconfig.v1.Inventory
       notes: []
     - name: osconfig-ospolicyassignmentreport
       local: resource-osconfig-ospolicyassignmentreport
@@ -6910,7 +6910,7 @@ branches:
       kind: OSConfigOSPolicyAssignmentReport
       package: google.cloud.osconfig.v1
       proto: OSPolicyAssignmentReport
-      proto-path: google.cloud.osconfig.v1.OSPolicyAssignmentReport
+      proto-msg: google.cloud.osconfig.v1.OSPolicyAssignmentReport
       notes: []
     - name: osconfig-ospolicyassignment
       local: resource-osconfig-ospolicyassignment
@@ -6922,7 +6922,7 @@ branches:
       kind: OSConfigOSPolicyAssignment
       package: google.cloud.osconfig.v1
       proto: OSPolicyAssignment
-      proto-path: google.cloud.osconfig.v1.OSPolicyAssignment
+      proto-msg: google.cloud.osconfig.v1.OSPolicyAssignment
       notes: []
     - name: osconfig-patchdeployment
       local: resource-osconfig-patchdeployment
@@ -6934,7 +6934,7 @@ branches:
       kind: OSConfigPatchDeployment
       package: google.cloud.osconfig.v1
       proto: PatchDeployment
-      proto-path: google.cloud.osconfig.v1.PatchDeployment
+      proto-msg: google.cloud.osconfig.v1.PatchDeployment
       notes: []
     - name: osconfig-patchjob
       local: resource-osconfig-patchjob
@@ -6946,7 +6946,7 @@ branches:
       kind: OSConfigPatchJob
       package: google.cloud.osconfig.v1
       proto: PatchJob
-      proto-path: google.cloud.osconfig.v1.PatchJob
+      proto-msg: google.cloud.osconfig.v1.PatchJob
       notes: []
     - name: osconfig-vulnerabilityreport
       local: resource-osconfig-vulnerabilityreport
@@ -6958,7 +6958,7 @@ branches:
       kind: OSConfigVulnerabilityReport
       package: google.cloud.osconfig.v1
       proto: VulnerabilityReport
-      proto-path: google.cloud.osconfig.v1.VulnerabilityReport
+      proto-msg: google.cloud.osconfig.v1.VulnerabilityReport
       notes: []
     - name: osconfig-guestpolicy
       local: resource-osconfig-guestpolicy
@@ -6970,7 +6970,7 @@ branches:
       kind: OSConfigGuestPolicy
       package: google.cloud.osconfig.v1beta
       proto: GuestPolicy
-      proto-path: google.cloud.osconfig.v1beta.GuestPolicy
+      proto-msg: google.cloud.osconfig.v1beta.GuestPolicy
       notes:
         - No gcloud command found
     - name: oslogin-posixaccount
@@ -6983,7 +6983,7 @@ branches:
       kind: OSLoginPosixAccount
       package: google.cloud.oslogin.common
       proto: PosixAccount
-      proto-path: google.cloud.oslogin.common.PosixAccount
+      proto-msg: google.cloud.oslogin.common.PosixAccount
       notes:
         - No gcloud command found
     - name: oslogin-sshpublickey
@@ -6996,7 +6996,7 @@ branches:
       kind: OSLoginSshPublicKey
       package: google.cloud.oslogin.common
       proto: SshPublicKey
-      proto-path: google.cloud.oslogin.common.SshPublicKey
+      proto-msg: google.cloud.oslogin.common.SshPublicKey
       notes: []
     - name: parallelstore-instance
       local: resource-parallelstore-instance
@@ -7008,7 +7008,7 @@ branches:
       kind: ParallelstoreInstance
       package: google.cloud.parallelstore.v1
       proto: Instance
-      proto-path: google.cloud.parallelstore.v1.Instance
+      proto-msg: google.cloud.parallelstore.v1.Instance
       notes: []
     - name: parametermanager-parameter
       local: resource-parametermanager-parameter
@@ -7020,7 +7020,7 @@ branches:
       kind: ParameterManagerParameter
       package: google.cloud.parametermanager.v1
       proto: Parameter
-      proto-path: google.cloud.parametermanager.v1.Parameter
+      proto-msg: google.cloud.parametermanager.v1.Parameter
       notes:
         - No gcloud command found
     - name: parametermanager-parameterversion
@@ -7033,7 +7033,7 @@ branches:
       kind: ParameterManagerParameterVersion
       package: google.cloud.parametermanager.v1
       proto: ParameterVersion
-      proto-path: google.cloud.parametermanager.v1.ParameterVersion
+      proto-msg: google.cloud.parametermanager.v1.ParameterVersion
       notes:
         - No gcloud command found
     - name: paymentgateway-accountmanagertransaction
@@ -7046,7 +7046,7 @@ branches:
       kind: PaymentGatewayAccountManagerTransaction
       package: google.cloud.paymentgateway.issuerswitch.accountmanager.v1
       proto: AccountManagerTransaction
-      proto-path: google.cloud.paymentgateway.issuerswitch.accountmanager.v1.AccountManagerTransaction
+      proto-msg: google.cloud.paymentgateway.issuerswitch.accountmanager.v1.AccountManagerTransaction
       notes:
         - No gcloud command found
     - name: paymentgateway-managedaccount
@@ -7059,7 +7059,7 @@ branches:
       kind: PaymentGatewayManagedAccount
       package: google.cloud.paymentgateway.issuerswitch.accountmanager.v1
       proto: ManagedAccount
-      proto-path: google.cloud.paymentgateway.issuerswitch.accountmanager.v1.ManagedAccount
+      proto-msg: google.cloud.paymentgateway.issuerswitch.accountmanager.v1.ManagedAccount
       notes:
         - No gcloud command found
     - name: paymentgateway-complaint
@@ -7072,7 +7072,7 @@ branches:
       kind: PaymentGatewayComplaint
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: Complaint
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.Complaint
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.Complaint
       notes:
         - No gcloud command found
     - name: paymentgateway-dispute
@@ -7085,7 +7085,7 @@ branches:
       kind: PaymentGatewayDispute
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: Dispute
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.Dispute
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.Dispute
       notes:
         - No gcloud command found
     - name: paymentgateway-rule
@@ -7098,7 +7098,7 @@ branches:
       kind: PaymentGatewayRule
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: Rule
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.Rule
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.Rule
       notes:
         - No gcloud command found
     - name: paymentgateway-rulemetadata
@@ -7111,7 +7111,7 @@ branches:
       kind: PaymentGatewayRuleMetadata
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: RuleMetadata
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.RuleMetadata
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.RuleMetadata
       notes:
         - No gcloud command found
     - name: paymentgateway-rulemetadatavalue
@@ -7124,7 +7124,7 @@ branches:
       kind: PaymentGatewayRuleMetadataValue
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: RuleMetadataValue
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.RuleMetadataValue
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.RuleMetadataValue
       notes:
         - No gcloud command found
     - name: paymentgateway-metadatatransaction
@@ -7137,7 +7137,7 @@ branches:
       kind: PaymentGatewayMetadataTransaction
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: MetadataTransaction
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.MetadataTransaction
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.MetadataTransaction
       notes:
         - No gcloud command found
     - name: paymentgateway-financialtransaction
@@ -7150,7 +7150,7 @@ branches:
       kind: PaymentGatewayFinancialTransaction
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: FinancialTransaction
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.FinancialTransaction
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.FinancialTransaction
       notes:
         - No gcloud command found
     - name: paymentgateway-mandatetransaction
@@ -7163,7 +7163,7 @@ branches:
       kind: PaymentGatewayMandateTransaction
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: MandateTransaction
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.MandateTransaction
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.MandateTransaction
       notes:
         - No gcloud command found
     - name: paymentgateway-complainttransaction
@@ -7176,7 +7176,7 @@ branches:
       kind: PaymentGatewayComplaintTransaction
       package: google.cloud.paymentgateway.issuerswitch.v1
       proto: ComplaintTransaction
-      proto-path: google.cloud.paymentgateway.issuerswitch.v1.ComplaintTransaction
+      proto-msg: google.cloud.paymentgateway.issuerswitch.v1.ComplaintTransaction
       notes:
         - No gcloud command found
     - name: policysimulator-replay
@@ -7189,7 +7189,7 @@ branches:
       kind: PolicySimulatorReplay
       package: google.cloud.policysimulator.v1
       proto: Replay
-      proto-path: google.cloud.policysimulator.v1.Replay
+      proto-msg: google.cloud.policysimulator.v1.Replay
       notes:
         - No gcloud command found
     - name: policysimulator-replayresult
@@ -7202,7 +7202,7 @@ branches:
       kind: PolicySimulatorReplayResult
       package: google.cloud.policysimulator.v1
       proto: ReplayResult
-      proto-path: google.cloud.policysimulator.v1.ReplayResult
+      proto-msg: google.cloud.policysimulator.v1.ReplayResult
       notes:
         - No gcloud command found
     - name: privatecatalog-catalog
@@ -7215,7 +7215,7 @@ branches:
       kind: PrivateCatalogCatalog
       package: google.cloud.privatecatalog.v1beta1
       proto: Catalog
-      proto-path: google.cloud.privatecatalog.v1beta1.Catalog
+      proto-msg: google.cloud.privatecatalog.v1beta1.Catalog
       notes:
         - No gcloud command found
     - name: privatecatalog-product
@@ -7228,7 +7228,7 @@ branches:
       kind: PrivateCatalogProduct
       package: google.cloud.privatecatalog.v1beta1
       proto: Product
-      proto-path: google.cloud.privatecatalog.v1beta1.Product
+      proto-msg: google.cloud.privatecatalog.v1beta1.Product
       notes:
         - No gcloud command found
     - name: privatecatalog-version
@@ -7241,7 +7241,7 @@ branches:
       kind: PrivateCatalogVersion
       package: google.cloud.privatecatalog.v1beta1
       proto: Version
-      proto-path: google.cloud.privatecatalog.v1beta1.Version
+      proto-msg: google.cloud.privatecatalog.v1beta1.Version
       notes:
         - No gcloud command found
     - name: privilegedaccessmanager-entitlement
@@ -7254,7 +7254,7 @@ branches:
       kind: PrivilegedAccessManagerEntitlement
       package: google.cloud.privilegedaccessmanager.v1
       proto: Entitlement
-      proto-path: google.cloud.privilegedaccessmanager.v1.Entitlement
+      proto-msg: google.cloud.privilegedaccessmanager.v1.Entitlement
       notes: []
     - name: privilegedaccessmanager-grant
       local: resource-privilegedaccessmanager-grant
@@ -7266,7 +7266,7 @@ branches:
       kind: PrivilegedAccessManagerGrant
       package: google.cloud.privilegedaccessmanager.v1
       proto: Grant
-      proto-path: google.cloud.privilegedaccessmanager.v1.Grant
+      proto-msg: google.cloud.privilegedaccessmanager.v1.Grant
       notes: []
     - name: pubsublite-reservation
       local: resource-pubsublite-reservation
@@ -7278,7 +7278,7 @@ branches:
       kind: PubSubliteReservation
       package: google.cloud.pubsublite.v1
       proto: Reservation
-      proto-path: google.cloud.pubsublite.v1.Reservation
+      proto-msg: google.cloud.pubsublite.v1.Reservation
       notes: []
     - name: pubsublite-topic
       local: resource-pubsublite-topic
@@ -7290,7 +7290,7 @@ branches:
       kind: PubSubliteTopic
       package: google.cloud.pubsublite.v1
       proto: Topic
-      proto-path: google.cloud.pubsublite.v1.Topic
+      proto-msg: google.cloud.pubsublite.v1.Topic
       notes: []
     - name: pubsublite-subscription
       local: resource-pubsublite-subscription
@@ -7302,7 +7302,7 @@ branches:
       kind: PubSubliteSubscription
       package: google.cloud.pubsublite.v1
       proto: Subscription
-      proto-path: google.cloud.pubsublite.v1.Subscription
+      proto-msg: google.cloud.pubsublite.v1.Subscription
       notes: []
     - name: rapidmigrationassessment-collector
       local: resource-rapidmigrationassessment-collector
@@ -7314,7 +7314,7 @@ branches:
       kind: RapidMigrationAssessmentCollector
       package: google.cloud.rapidmigrationassessment.v1
       proto: Collector
-      proto-path: google.cloud.rapidmigrationassessment.v1.Collector
+      proto-msg: google.cloud.rapidmigrationassessment.v1.Collector
       notes:
         - No gcloud command found
     - name: rapidmigrationassessment-annotation
@@ -7327,7 +7327,7 @@ branches:
       kind: RapidMigrationAssessmentAnnotation
       package: google.cloud.rapidmigrationassessment.v1
       proto: Annotation
-      proto-path: google.cloud.rapidmigrationassessment.v1.Annotation
+      proto-msg: google.cloud.rapidmigrationassessment.v1.Annotation
       notes:
         - No gcloud command found
     - name: recaptchaenterprise-assessment
@@ -7340,7 +7340,7 @@ branches:
       kind: ReCAPTCHAEnterpriseAssessment
       package: google.cloud.recaptchaenterprise.v1
       proto: Assessment
-      proto-path: google.cloud.recaptchaenterprise.v1.Assessment
+      proto-msg: google.cloud.recaptchaenterprise.v1.Assessment
       notes:
         - No gcloud command found
     - name: recaptchaenterprise-metrics
@@ -7353,7 +7353,7 @@ branches:
       kind: ReCAPTCHAEnterpriseMetrics
       package: google.cloud.recaptchaenterprise.v1
       proto: Metrics
-      proto-path: google.cloud.recaptchaenterprise.v1.Metrics
+      proto-msg: google.cloud.recaptchaenterprise.v1.Metrics
       notes:
         - No gcloud command found
     - name: recaptchaenterprise-key
@@ -7366,7 +7366,7 @@ branches:
       kind: ReCAPTCHAEnterpriseKey
       package: google.cloud.recaptchaenterprise.v1
       proto: Key
-      proto-path: google.cloud.recaptchaenterprise.v1.Key
+      proto-msg: google.cloud.recaptchaenterprise.v1.Key
       notes: []
     - name: recaptchaenterprise-firewallpolicy
       local: resource-recaptchaenterprise-firewallpolicy
@@ -7378,7 +7378,7 @@ branches:
       kind: ReCAPTCHAEnterpriseFirewallPolicy
       package: google.cloud.recaptchaenterprise.v1
       proto: FirewallPolicy
-      proto-path: google.cloud.recaptchaenterprise.v1.FirewallPolicy
+      proto-msg: google.cloud.recaptchaenterprise.v1.FirewallPolicy
       notes: []
     - name: recaptchaenterprise-relatedaccountgroupmembership
       local: resource-recaptchaenterprise-relatedaccountgroupmembership
@@ -7390,7 +7390,7 @@ branches:
       kind: ReCAPTCHAEnterpriseRelatedAccountGroupMembership
       package: google.cloud.recaptchaenterprise.v1
       proto: RelatedAccountGroupMembership
-      proto-path: google.cloud.recaptchaenterprise.v1.RelatedAccountGroupMembership
+      proto-msg: google.cloud.recaptchaenterprise.v1.RelatedAccountGroupMembership
       notes:
         - No gcloud command found
     - name: recaptchaenterprise-relatedaccountgroup
@@ -7403,7 +7403,7 @@ branches:
       kind: ReCAPTCHAEnterpriseRelatedAccountGroup
       package: google.cloud.recaptchaenterprise.v1
       proto: RelatedAccountGroup
-      proto-path: google.cloud.recaptchaenterprise.v1.RelatedAccountGroup
+      proto-msg: google.cloud.recaptchaenterprise.v1.RelatedAccountGroup
       notes:
         - No gcloud command found
     - name: recommender-insight
@@ -7416,7 +7416,7 @@ branches:
       kind: RecommenderInsight
       package: google.cloud.recommender.v1
       proto: Insight
-      proto-path: google.cloud.recommender.v1.Insight
+      proto-msg: google.cloud.recommender.v1.Insight
       notes: []
     - name: recommender-insighttypeconfig
       local: resource-recommender-insighttypeconfig
@@ -7428,7 +7428,7 @@ branches:
       kind: RecommenderInsightTypeConfig
       package: google.cloud.recommender.v1
       proto: InsightTypeConfig
-      proto-path: google.cloud.recommender.v1.InsightTypeConfig
+      proto-msg: google.cloud.recommender.v1.InsightTypeConfig
       notes: []
     - name: recommender-recommendation
       local: resource-recommender-recommendation
@@ -7440,7 +7440,7 @@ branches:
       kind: RecommenderRecommendation
       package: google.cloud.recommender.v1
       proto: Recommendation
-      proto-path: google.cloud.recommender.v1.Recommendation
+      proto-msg: google.cloud.recommender.v1.Recommendation
       notes: []
     - name: recommender-recommenderconfig
       local: resource-recommender-recommenderconfig
@@ -7452,7 +7452,7 @@ branches:
       kind: RecommenderRecommenderConfig
       package: google.cloud.recommender.v1
       proto: RecommenderConfig
-      proto-path: google.cloud.recommender.v1.RecommenderConfig
+      proto-msg: google.cloud.recommender.v1.RecommenderConfig
       notes: []
     - name: recommender-insighttype
       local: resource-recommender-insighttype
@@ -7464,7 +7464,7 @@ branches:
       kind: RecommenderInsightType
       package: google.cloud.recommender.v1beta1
       proto: InsightType
-      proto-path: google.cloud.recommender.v1beta1.InsightType
+      proto-msg: google.cloud.recommender.v1beta1.InsightType
       notes:
         - No gcloud command found
     - name: recommender-recommendertype
@@ -7477,7 +7477,7 @@ branches:
       kind: RecommenderRecommenderType
       package: google.cloud.recommender.v1beta1
       proto: RecommenderType
-      proto-path: google.cloud.recommender.v1beta1.RecommenderType
+      proto-msg: google.cloud.recommender.v1beta1.RecommenderType
       notes:
         - No gcloud command found
     - name: redis-cluster
@@ -7490,7 +7490,7 @@ branches:
       kind: RedisCluster
       package: google.cloud.redis.cluster.v1
       proto: Cluster
-      proto-path: google.cloud.redis.cluster.v1.Cluster
+      proto-msg: google.cloud.redis.cluster.v1.Cluster
       notes: []
     - name: redis-backupcollection
       local: resource-redis-backupcollection
@@ -7502,7 +7502,7 @@ branches:
       kind: RedisBackupCollection
       package: google.cloud.redis.cluster.v1
       proto: BackupCollection
-      proto-path: google.cloud.redis.cluster.v1.BackupCollection
+      proto-msg: google.cloud.redis.cluster.v1.BackupCollection
       notes:
         - No gcloud command found
     - name: redis-backup
@@ -7515,7 +7515,7 @@ branches:
       kind: RedisBackup
       package: google.cloud.redis.cluster.v1
       proto: Backup
-      proto-path: google.cloud.redis.cluster.v1.Backup
+      proto-msg: google.cloud.redis.cluster.v1.Backup
       notes:
         - No gcloud command found
     - name: redis-certificateauthority
@@ -7528,7 +7528,7 @@ branches:
       kind: RedisCertificateAuthority
       package: google.cloud.redis.cluster.v1
       proto: CertificateAuthority
-      proto-path: google.cloud.redis.cluster.v1.CertificateAuthority
+      proto-msg: google.cloud.redis.cluster.v1.CertificateAuthority
       notes:
         - No gcloud command found
     - name: redis-instance
@@ -7541,7 +7541,7 @@ branches:
       kind: RedisInstance
       package: google.cloud.redis.v1
       proto: Instance
-      proto-path: google.cloud.redis.v1.Instance
+      proto-msg: google.cloud.redis.v1.Instance
       notes: []
     - name: resourcemanager-folder
       local: resource-resourcemanager-folder
@@ -7553,7 +7553,7 @@ branches:
       kind: ResourceManagerFolder
       package: google.cloud.resourcemanager.v3
       proto: Folder
-      proto-path: google.cloud.resourcemanager.v3.Folder
+      proto-msg: google.cloud.resourcemanager.v3.Folder
       notes: []
     - name: resourcemanager-organization
       local: resource-resourcemanager-organization
@@ -7565,7 +7565,7 @@ branches:
       kind: ResourceManagerOrganization
       package: google.cloud.resourcemanager.v3
       proto: Organization
-      proto-path: google.cloud.resourcemanager.v3.Organization
+      proto-msg: google.cloud.resourcemanager.v3.Organization
       notes:
         - No gcloud command found
     - name: resourcemanager-project
@@ -7578,7 +7578,7 @@ branches:
       kind: ResourceManagerProject
       package: google.cloud.resourcemanager.v3
       proto: Project
-      proto-path: google.cloud.resourcemanager.v3.Project
+      proto-msg: google.cloud.resourcemanager.v3.Project
       notes:
         - No gcloud command found
     - name: resourcemanager-tagbinding
@@ -7591,7 +7591,7 @@ branches:
       kind: ResourceManagerTagBinding
       package: google.cloud.resourcemanager.v3
       proto: TagBinding
-      proto-path: google.cloud.resourcemanager.v3.TagBinding
+      proto-msg: google.cloud.resourcemanager.v3.TagBinding
       notes:
         - No gcloud command found
     - name: resourcemanager-taghold
@@ -7604,7 +7604,7 @@ branches:
       kind: ResourceManagerTagHold
       package: google.cloud.resourcemanager.v3
       proto: TagHold
-      proto-path: google.cloud.resourcemanager.v3.TagHold
+      proto-msg: google.cloud.resourcemanager.v3.TagHold
       notes:
         - No gcloud command found
     - name: resourcemanager-tagkey
@@ -7617,7 +7617,7 @@ branches:
       kind: ResourceManagerTagKey
       package: google.cloud.resourcemanager.v3
       proto: TagKey
-      proto-path: google.cloud.resourcemanager.v3.TagKey
+      proto-msg: google.cloud.resourcemanager.v3.TagKey
       notes:
         - No gcloud command found
     - name: resourcemanager-tagvalue
@@ -7630,7 +7630,7 @@ branches:
       kind: ResourceManagerTagValue
       package: google.cloud.resourcemanager.v3
       proto: TagValue
-      proto-path: google.cloud.resourcemanager.v3.TagValue
+      proto-msg: google.cloud.resourcemanager.v3.TagValue
       notes:
         - No gcloud command found
     - name: resourcesettings-setting
@@ -7643,7 +7643,7 @@ branches:
       kind: ResourceSettingsSetting
       package: google.cloud.resourcesettings.v1
       proto: Setting
-      proto-path: google.cloud.resourcesettings.v1.Setting
+      proto-msg: google.cloud.resourcesettings.v1.Setting
       notes:
         - No gcloud command found
     - name: retail-attributesconfig
@@ -7656,7 +7656,7 @@ branches:
       kind: RetailAttributesConfig
       package: google.cloud.retail.v2
       proto: AttributesConfig
-      proto-path: google.cloud.retail.v2.AttributesConfig
+      proto-msg: google.cloud.retail.v2.AttributesConfig
       notes:
         - No gcloud command found
     - name: retail-completionconfig
@@ -7669,7 +7669,7 @@ branches:
       kind: RetailCompletionConfig
       package: google.cloud.retail.v2
       proto: CompletionConfig
-      proto-path: google.cloud.retail.v2.CompletionConfig
+      proto-msg: google.cloud.retail.v2.CompletionConfig
       notes:
         - No gcloud command found
     - name: retail-catalog
@@ -7682,7 +7682,7 @@ branches:
       kind: RetailCatalog
       package: google.cloud.retail.v2
       proto: Catalog
-      proto-path: google.cloud.retail.v2.Catalog
+      proto-msg: google.cloud.retail.v2.Catalog
       notes:
         - No gcloud command found
     - name: retail-control
@@ -7695,7 +7695,7 @@ branches:
       kind: RetailControl
       package: google.cloud.retail.v2
       proto: Control
-      proto-path: google.cloud.retail.v2.Control
+      proto-msg: google.cloud.retail.v2.Control
       notes:
         - No gcloud command found
     - name: retail-model
@@ -7708,7 +7708,7 @@ branches:
       kind: RetailModel
       package: google.cloud.retail.v2
       proto: Model
-      proto-path: google.cloud.retail.v2.Model
+      proto-msg: google.cloud.retail.v2.Model
       notes:
         - No gcloud command found
     - name: retail-product
@@ -7721,7 +7721,7 @@ branches:
       kind: RetailProduct
       package: google.cloud.retail.v2
       proto: Product
-      proto-path: google.cloud.retail.v2.Product
+      proto-msg: google.cloud.retail.v2.Product
       notes:
         - No gcloud command found
     - name: retail-servingconfig
@@ -7734,7 +7734,7 @@ branches:
       kind: RetailServingConfig
       package: google.cloud.retail.v2
       proto: ServingConfig
-      proto-path: google.cloud.retail.v2.ServingConfig
+      proto-msg: google.cloud.retail.v2.ServingConfig
       notes:
         - No gcloud command found
     - name: retail-alertconfig
@@ -7747,7 +7747,7 @@ branches:
       kind: RetailAlertConfig
       package: google.cloud.retail.v2beta
       proto: AlertConfig
-      proto-path: google.cloud.retail.v2beta.AlertConfig
+      proto-msg: google.cloud.retail.v2beta.AlertConfig
       notes:
         - No gcloud command found
     - name: run-execution
@@ -7760,7 +7760,7 @@ branches:
       kind: RunExecution
       package: google.cloud.run.v2
       proto: Execution
-      proto-path: google.cloud.run.v2.Execution
+      proto-msg: google.cloud.run.v2.Execution
       notes:
         - No gcloud command found
     - name: run-job
@@ -7773,7 +7773,7 @@ branches:
       kind: RunJob
       package: google.cloud.run.v2
       proto: Job
-      proto-path: google.cloud.run.v2.Job
+      proto-msg: google.cloud.run.v2.Job
       notes: []
     - name: run-revision
       local: resource-run-revision
@@ -7785,7 +7785,7 @@ branches:
       kind: RunRevision
       package: google.cloud.run.v2
       proto: Revision
-      proto-path: google.cloud.run.v2.Revision
+      proto-msg: google.cloud.run.v2.Revision
       notes: []
     - name: run-service
       local: resource-run-service
@@ -7797,7 +7797,7 @@ branches:
       kind: RunService
       package: google.cloud.run.v2
       proto: Service
-      proto-path: google.cloud.run.v2.Service
+      proto-msg: google.cloud.run.v2.Service
       notes: []
     - name: run-task
       local: resource-run-task
@@ -7809,7 +7809,7 @@ branches:
       kind: RunTask
       package: google.cloud.run.v2
       proto: Task
-      proto-path: google.cloud.run.v2.Task
+      proto-msg: google.cloud.run.v2.Task
       notes:
         - No gcloud command found
     - name: scheduler-job
@@ -7822,7 +7822,7 @@ branches:
       kind: SchedulerJob
       package: google.cloud.scheduler.v1
       proto: Job
-      proto-path: google.cloud.scheduler.v1.Job
+      proto-msg: google.cloud.scheduler.v1.Job
       notes: []
     - name: secretmanager-secret
       local: resource-secretmanager-secret
@@ -7834,7 +7834,7 @@ branches:
       kind: SecretManagerSecret
       package: google.cloud.secretmanager.v1
       proto: Secret
-      proto-path: google.cloud.secretmanager.v1.Secret
+      proto-msg: google.cloud.secretmanager.v1.Secret
       notes: []
     - name: secretmanager-secretversion
       local: resource-secretmanager-secretversion
@@ -7846,7 +7846,7 @@ branches:
       kind: SecretManagerSecretVersion
       package: google.cloud.secretmanager.v1
       proto: SecretVersion
-      proto-path: google.cloud.secretmanager.v1.SecretVersion
+      proto-msg: google.cloud.secretmanager.v1.SecretVersion
       notes: []
     - name: secretmanager-topic
       local: resource-secretmanager-topic
@@ -7858,7 +7858,7 @@ branches:
       kind: SecretManagerTopic
       package: google.cloud.secretmanager.v1
       proto: Topic
-      proto-path: google.cloud.secretmanager.v1.Topic
+      proto-msg: google.cloud.secretmanager.v1.Topic
       notes:
         - No gcloud command found
     - name: secrets-secret
@@ -7871,7 +7871,7 @@ branches:
       kind: SecretsSecret
       package: google.cloud.secrets.v1beta1
       proto: Secret
-      proto-path: google.cloud.secrets.v1beta1.Secret
+      proto-msg: google.cloud.secrets.v1beta1.Secret
       notes: []
     - name: secrets-secretversion
       local: resource-secrets-secretversion
@@ -7883,7 +7883,7 @@ branches:
       kind: SecretsSecretVersion
       package: google.cloud.secrets.v1beta1
       proto: SecretVersion
-      proto-path: google.cloud.secrets.v1beta1.SecretVersion
+      proto-msg: google.cloud.secrets.v1beta1.SecretVersion
       notes: []
     - name: securesourcemanager-instance
       local: resource-securesourcemanager-instance
@@ -7895,7 +7895,7 @@ branches:
       kind: SecureSourceManagerInstance
       package: google.cloud.securesourcemanager.v1
       proto: Instance
-      proto-path: google.cloud.securesourcemanager.v1.Instance
+      proto-msg: google.cloud.securesourcemanager.v1.Instance
       notes:
         - No gcloud command found
     - name: securesourcemanager-repository
@@ -7908,7 +7908,7 @@ branches:
       kind: SecureSourceManagerRepository
       package: google.cloud.securesourcemanager.v1
       proto: Repository
-      proto-path: google.cloud.securesourcemanager.v1.Repository
+      proto-msg: google.cloud.securesourcemanager.v1.Repository
       notes:
         - No gcloud command found
     - name: securesourcemanager-branchrule
@@ -7921,7 +7921,7 @@ branches:
       kind: SecureSourceManagerBranchRule
       package: google.cloud.securesourcemanager.v1
       proto: BranchRule
-      proto-path: google.cloud.securesourcemanager.v1.BranchRule
+      proto-msg: google.cloud.securesourcemanager.v1.BranchRule
       notes:
         - No gcloud command found
     - name: security-certificateauthority
@@ -7934,7 +7934,7 @@ branches:
       kind: SecurityCertificateAuthority
       package: google.cloud.security.privateca.v1
       proto: CertificateAuthority
-      proto-path: google.cloud.security.privateca.v1.CertificateAuthority
+      proto-msg: google.cloud.security.privateca.v1.CertificateAuthority
       notes:
         - No gcloud command found
     - name: security-capool
@@ -7947,7 +7947,7 @@ branches:
       kind: SecurityCaPool
       package: google.cloud.security.privateca.v1
       proto: CaPool
-      proto-path: google.cloud.security.privateca.v1.CaPool
+      proto-msg: google.cloud.security.privateca.v1.CaPool
       notes:
         - No gcloud command found
     - name: security-certificaterevocationlist
@@ -7960,7 +7960,7 @@ branches:
       kind: SecurityCertificateRevocationList
       package: google.cloud.security.privateca.v1
       proto: CertificateRevocationList
-      proto-path: google.cloud.security.privateca.v1.CertificateRevocationList
+      proto-msg: google.cloud.security.privateca.v1.CertificateRevocationList
       notes:
         - No gcloud command found
     - name: security-certificate
@@ -7973,7 +7973,7 @@ branches:
       kind: SecurityCertificate
       package: google.cloud.security.privateca.v1
       proto: Certificate
-      proto-path: google.cloud.security.privateca.v1.Certificate
+      proto-msg: google.cloud.security.privateca.v1.Certificate
       notes:
         - No gcloud command found
     - name: security-certificatetemplate
@@ -7986,7 +7986,7 @@ branches:
       kind: SecurityCertificateTemplate
       package: google.cloud.security.privateca.v1
       proto: CertificateTemplate
-      proto-path: google.cloud.security.privateca.v1.CertificateTemplate
+      proto-msg: google.cloud.security.privateca.v1.CertificateTemplate
       notes:
         - No gcloud command found
     - name: security-reusableconfig
@@ -7999,7 +7999,7 @@ branches:
       kind: SecurityReusableConfig
       package: google.cloud.security.privateca.v1beta1
       proto: ReusableConfig
-      proto-path: google.cloud.security.privateca.v1beta1.ReusableConfig
+      proto-msg: google.cloud.security.privateca.v1beta1.ReusableConfig
       notes:
         - No gcloud command found
     - name: security-externalaccountkey
@@ -8012,7 +8012,7 @@ branches:
       kind: SecurityExternalAccountKey
       package: google.cloud.security.publicca.v1
       proto: ExternalAccountKey
-      proto-path: google.cloud.security.publicca.v1.ExternalAccountKey
+      proto-msg: google.cloud.security.publicca.v1.ExternalAccountKey
       notes:
         - No gcloud command found
     - name: securitycenter-componentsettings
@@ -8025,7 +8025,7 @@ branches:
       kind: SecurityCenterComponentSettings
       package: google.cloud.securitycenter.settings.v1beta1
       proto: ComponentSettings
-      proto-path: google.cloud.securitycenter.settings.v1beta1.ComponentSettings
+      proto-msg: google.cloud.securitycenter.settings.v1beta1.ComponentSettings
       notes:
         - No gcloud command found
     - name: securitycenter-serviceaccount
@@ -8038,7 +8038,7 @@ branches:
       kind: SecurityCenterServiceAccount
       package: google.cloud.securitycenter.settings.v1beta1
       proto: ServiceAccount
-      proto-path: google.cloud.securitycenter.settings.v1beta1.ServiceAccount
+      proto-msg: google.cloud.securitycenter.settings.v1beta1.ServiceAccount
       notes:
         - No gcloud command found
     - name: securitycenter-settings
@@ -8051,7 +8051,7 @@ branches:
       kind: SecurityCenterSettings
       package: google.cloud.securitycenter.settings.v1beta1
       proto: Settings
-      proto-path: google.cloud.securitycenter.settings.v1beta1.Settings
+      proto-msg: google.cloud.securitycenter.settings.v1beta1.Settings
       notes:
         - No gcloud command found
     - name: securitycenter-asset
@@ -8064,7 +8064,7 @@ branches:
       kind: SecurityCenterAsset
       package: google.cloud.securitycenter.v1
       proto: Asset
-      proto-path: google.cloud.securitycenter.v1.Asset
+      proto-msg: google.cloud.securitycenter.v1.Asset
       notes: []
     - name: securitycenter-effectiveeventthreatdetectioncustommodule
       local: resource-securitycenter-effectiveeventthreatdetectioncustommodule
@@ -8076,7 +8076,7 @@ branches:
       kind: SecurityCenterEffectiveEventThreatDetectionCustomModule
       package: google.cloud.securitycenter.v1
       proto: EffectiveEventThreatDetectionCustomModule
-      proto-path: google.cloud.securitycenter.v1.EffectiveEventThreatDetectionCustomModule
+      proto-msg: google.cloud.securitycenter.v1.EffectiveEventThreatDetectionCustomModule
       notes:
         - No gcloud command found
     - name: securitycenter-effectivesecurityhealthanalyticscustommodule
@@ -8089,7 +8089,7 @@ branches:
       kind: SecurityCenterEffectiveSecurityHealthAnalyticsCustomModule
       package: google.cloud.securitycenter.v1
       proto: EffectiveSecurityHealthAnalyticsCustomModule
-      proto-path: google.cloud.securitycenter.v1.EffectiveSecurityHealthAnalyticsCustomModule
+      proto-msg: google.cloud.securitycenter.v1.EffectiveSecurityHealthAnalyticsCustomModule
       notes:
         - No gcloud command found
     - name: securitycenter-eventthreatdetectioncustommodule
@@ -8102,7 +8102,7 @@ branches:
       kind: SecurityCenterEventThreatDetectionCustomModule
       package: google.cloud.securitycenter.v1
       proto: EventThreatDetectionCustomModule
-      proto-path: google.cloud.securitycenter.v1.EventThreatDetectionCustomModule
+      proto-msg: google.cloud.securitycenter.v1.EventThreatDetectionCustomModule
       notes:
         - No gcloud command found
     - name: securitycenter-organizationsettings
@@ -8115,7 +8115,7 @@ branches:
       kind: SecurityCenterOrganizationSettings
       package: google.cloud.securitycenter.v1
       proto: OrganizationSettings
-      proto-path: google.cloud.securitycenter.v1.OrganizationSettings
+      proto-msg: google.cloud.securitycenter.v1.OrganizationSettings
       notes:
         - No gcloud command found
     - name: securitycenter-securityhealthanalyticscustommodule
@@ -8128,7 +8128,7 @@ branches:
       kind: SecurityCenterSecurityHealthAnalyticsCustomModule
       package: google.cloud.securitycenter.v1
       proto: SecurityHealthAnalyticsCustomModule
-      proto-path: google.cloud.securitycenter.v1.SecurityHealthAnalyticsCustomModule
+      proto-msg: google.cloud.securitycenter.v1.SecurityHealthAnalyticsCustomModule
       notes:
         - No gcloud command found
     - name: securitycenter-attackpath
@@ -8141,7 +8141,7 @@ branches:
       kind: SecurityCenterAttackPath
       package: google.cloud.securitycenter.v2
       proto: AttackPath
-      proto-path: google.cloud.securitycenter.v2.AttackPath
+      proto-msg: google.cloud.securitycenter.v2.AttackPath
       notes:
         - No gcloud command found
     - name: securitycenter-bigqueryexport
@@ -8154,7 +8154,7 @@ branches:
       kind: SecurityCenterBigQueryExport
       package: google.cloud.securitycenter.v2
       proto: BigQueryExport
-      proto-path: google.cloud.securitycenter.v2.BigQueryExport
+      proto-msg: google.cloud.securitycenter.v2.BigQueryExport
       notes: []
     - name: securitycenter-externalsystem
       local: resource-securitycenter-externalsystem
@@ -8166,7 +8166,7 @@ branches:
       kind: SecurityCenterExternalSystem
       package: google.cloud.securitycenter.v2
       proto: ExternalSystem
-      proto-path: google.cloud.securitycenter.v2.ExternalSystem
+      proto-msg: google.cloud.securitycenter.v2.ExternalSystem
       notes:
         - No gcloud command found
     - name: securitycenter-finding
@@ -8179,7 +8179,7 @@ branches:
       kind: SecurityCenterFinding
       package: google.cloud.securitycenter.v2
       proto: Finding
-      proto-path: google.cloud.securitycenter.v2.Finding
+      proto-msg: google.cloud.securitycenter.v2.Finding
       notes: []
     - name: securitycenter-muteconfig
       local: resource-securitycenter-muteconfig
@@ -8191,7 +8191,7 @@ branches:
       kind: SecurityCenterMuteConfig
       package: google.cloud.securitycenter.v2
       proto: MuteConfig
-      proto-path: google.cloud.securitycenter.v2.MuteConfig
+      proto-msg: google.cloud.securitycenter.v2.MuteConfig
       notes: []
     - name: securitycenter-notificationconfig
       local: resource-securitycenter-notificationconfig
@@ -8203,7 +8203,7 @@ branches:
       kind: SecurityCenterNotificationConfig
       package: google.cloud.securitycenter.v2
       proto: NotificationConfig
-      proto-path: google.cloud.securitycenter.v2.NotificationConfig
+      proto-msg: google.cloud.securitycenter.v2.NotificationConfig
       notes:
         - No gcloud command found
     - name: securitycenter-orgpolicy
@@ -8216,7 +8216,7 @@ branches:
       kind: SecurityCenterOrgPolicy
       package: google.cloud.securitycenter.v2
       proto: OrgPolicy
-      proto-path: google.cloud.securitycenter.v2.OrgPolicy
+      proto-msg: google.cloud.securitycenter.v2.OrgPolicy
       notes:
         - No gcloud command found
     - name: securitycenter-resourcevalueconfig
@@ -8229,7 +8229,7 @@ branches:
       kind: SecurityCenterResourceValueConfig
       package: google.cloud.securitycenter.v2
       proto: ResourceValueConfig
-      proto-path: google.cloud.securitycenter.v2.ResourceValueConfig
+      proto-msg: google.cloud.securitycenter.v2.ResourceValueConfig
       notes:
         - No gcloud command found
     - name: securitycenter-securitymarks
@@ -8242,7 +8242,7 @@ branches:
       kind: SecurityCenterSecurityMarks
       package: google.cloud.securitycenter.v2
       proto: SecurityMarks
-      proto-path: google.cloud.securitycenter.v2.SecurityMarks
+      proto-msg: google.cloud.securitycenter.v2.SecurityMarks
       notes:
         - No gcloud command found
     - name: securitycenter-simulation
@@ -8255,7 +8255,7 @@ branches:
       kind: SecurityCenterSimulation
       package: google.cloud.securitycenter.v2
       proto: Simulation
-      proto-path: google.cloud.securitycenter.v2.Simulation
+      proto-msg: google.cloud.securitycenter.v2.Simulation
       notes:
         - No gcloud command found
     - name: securitycenter-valuedresource
@@ -8268,7 +8268,7 @@ branches:
       kind: SecurityCenterValuedResource
       package: google.cloud.securitycenter.v2
       proto: ValuedResource
-      proto-path: google.cloud.securitycenter.v2.ValuedResource
+      proto-msg: google.cloud.securitycenter.v2.ValuedResource
       notes:
         - No gcloud command found
     - name: securitycentermanagement-securitycenterservice
@@ -8281,7 +8281,7 @@ branches:
       kind: SecurityCentermanagementSecurityCenterService
       package: google.cloud.securitycentermanagement.v1
       proto: SecurityCenterService
-      proto-path: google.cloud.securitycentermanagement.v1.SecurityCenterService
+      proto-msg: google.cloud.securitycentermanagement.v1.SecurityCenterService
       notes:
         - No gcloud command found
     - name: securitycentermanagement-effectivesecurityhealthanalyticscustommodule
@@ -8294,7 +8294,7 @@ branches:
       kind: SecurityCentermanagementEffectiveSecurityHealthAnalyticsCustomModule
       package: google.cloud.securitycentermanagement.v1
       proto: EffectiveSecurityHealthAnalyticsCustomModule
-      proto-path: google.cloud.securitycentermanagement.v1.EffectiveSecurityHealthAnalyticsCustomModule
+      proto-msg: google.cloud.securitycentermanagement.v1.EffectiveSecurityHealthAnalyticsCustomModule
       notes:
         - No gcloud command found
     - name: securitycentermanagement-securityhealthanalyticscustommodule
@@ -8307,7 +8307,7 @@ branches:
       kind: SecurityCentermanagementSecurityHealthAnalyticsCustomModule
       package: google.cloud.securitycentermanagement.v1
       proto: SecurityHealthAnalyticsCustomModule
-      proto-path: google.cloud.securitycentermanagement.v1.SecurityHealthAnalyticsCustomModule
+      proto-msg: google.cloud.securitycentermanagement.v1.SecurityHealthAnalyticsCustomModule
       notes:
         - No gcloud command found
     - name: securitycentermanagement-simulatedfinding
@@ -8320,7 +8320,7 @@ branches:
       kind: SecurityCentermanagementSimulatedFinding
       package: google.cloud.securitycentermanagement.v1
       proto: SimulatedFinding
-      proto-path: google.cloud.securitycentermanagement.v1.SimulatedFinding
+      proto-msg: google.cloud.securitycentermanagement.v1.SimulatedFinding
       notes:
         - No gcloud command found
     - name: securitycentermanagement-effectiveeventthreatdetectioncustommodule
@@ -8333,7 +8333,7 @@ branches:
       kind: SecurityCentermanagementEffectiveEventThreatDetectionCustomModule
       package: google.cloud.securitycentermanagement.v1
       proto: EffectiveEventThreatDetectionCustomModule
-      proto-path: google.cloud.securitycentermanagement.v1.EffectiveEventThreatDetectionCustomModule
+      proto-msg: google.cloud.securitycentermanagement.v1.EffectiveEventThreatDetectionCustomModule
       notes:
         - No gcloud command found
     - name: securitycentermanagement-eventthreatdetectioncustommodule
@@ -8346,7 +8346,7 @@ branches:
       kind: SecurityCentermanagementEventThreatDetectionCustomModule
       package: google.cloud.securitycentermanagement.v1
       proto: EventThreatDetectionCustomModule
-      proto-path: google.cloud.securitycentermanagement.v1.EventThreatDetectionCustomModule
+      proto-msg: google.cloud.securitycentermanagement.v1.EventThreatDetectionCustomModule
       notes:
         - No gcloud command found
     - name: securityposture-posture
@@ -8359,7 +8359,7 @@ branches:
       kind: SecurityPosturePosture
       package: google.cloud.securityposture.v1
       proto: Posture
-      proto-path: google.cloud.securityposture.v1.Posture
+      proto-msg: google.cloud.securityposture.v1.Posture
       notes:
         - No gcloud command found
     - name: securityposture-posturedeployment
@@ -8372,7 +8372,7 @@ branches:
       kind: SecurityPosturePostureDeployment
       package: google.cloud.securityposture.v1
       proto: PostureDeployment
-      proto-path: google.cloud.securityposture.v1.PostureDeployment
+      proto-msg: google.cloud.securityposture.v1.PostureDeployment
       notes:
         - No gcloud command found
     - name: securityposture-posturetemplate
@@ -8385,7 +8385,7 @@ branches:
       kind: SecurityPosturePostureTemplate
       package: google.cloud.securityposture.v1
       proto: PostureTemplate
-      proto-path: google.cloud.securityposture.v1.PostureTemplate
+      proto-msg: google.cloud.securityposture.v1.PostureTemplate
       notes:
         - No gcloud command found
     - name: servicedirectory-endpoint
@@ -8398,7 +8398,7 @@ branches:
       kind: ServiceDirectoryEndpoint
       package: google.cloud.servicedirectory.v1
       proto: Endpoint
-      proto-path: google.cloud.servicedirectory.v1.Endpoint
+      proto-msg: google.cloud.servicedirectory.v1.Endpoint
       notes: []
     - name: servicedirectory-namespace
       local: resource-servicedirectory-namespace
@@ -8410,7 +8410,7 @@ branches:
       kind: ServiceDirectoryNamespace
       package: google.cloud.servicedirectory.v1
       proto: Namespace
-      proto-path: google.cloud.servicedirectory.v1.Namespace
+      proto-msg: google.cloud.servicedirectory.v1.Namespace
       notes: []
     - name: servicedirectory-service
       local: resource-servicedirectory-service
@@ -8422,7 +8422,7 @@ branches:
       kind: ServiceDirectoryService
       package: google.cloud.servicedirectory.v1
       proto: Service
-      proto-path: google.cloud.servicedirectory.v1.Service
+      proto-msg: google.cloud.servicedirectory.v1.Service
       notes: []
     - name: servicehealth-event
       local: resource-servicehealth-event
@@ -8434,7 +8434,7 @@ branches:
       kind: ServiceHealthEvent
       package: google.cloud.servicehealth.v1
       proto: Event
-      proto-path: google.cloud.servicehealth.v1.Event
+      proto-msg: google.cloud.servicehealth.v1.Event
       notes:
         - No gcloud command found
     - name: servicehealth-organizationevent
@@ -8447,7 +8447,7 @@ branches:
       kind: ServiceHealthOrganizationEvent
       package: google.cloud.servicehealth.v1
       proto: OrganizationEvent
-      proto-path: google.cloud.servicehealth.v1.OrganizationEvent
+      proto-msg: google.cloud.servicehealth.v1.OrganizationEvent
       notes:
         - No gcloud command found
     - name: servicehealth-organizationimpact
@@ -8460,7 +8460,7 @@ branches:
       kind: ServiceHealthOrganizationImpact
       package: google.cloud.servicehealth.v1
       proto: OrganizationImpact
-      proto-path: google.cloud.servicehealth.v1.OrganizationImpact
+      proto-msg: google.cloud.servicehealth.v1.OrganizationImpact
       notes:
         - No gcloud command found
     - name: shell-environment
@@ -8473,7 +8473,7 @@ branches:
       kind: ShellEnvironment
       package: google.cloud.shell.v1
       proto: Environment
-      proto-path: google.cloud.shell.v1.Environment
+      proto-msg: google.cloud.shell.v1.Environment
       notes:
         - No gcloud command found
     - name: speech-recognizer
@@ -8486,7 +8486,7 @@ branches:
       kind: SpeechRecognizer
       package: google.cloud.speech.v2
       proto: Recognizer
-      proto-path: google.cloud.speech.v2.Recognizer
+      proto-msg: google.cloud.speech.v2.Recognizer
       notes: []
     - name: speech-config
       local: resource-speech-config
@@ -8498,7 +8498,7 @@ branches:
       kind: SpeechConfig
       package: google.cloud.speech.v2
       proto: Config
-      proto-path: google.cloud.speech.v2.Config
+      proto-msg: google.cloud.speech.v2.Config
       notes:
         - No gcloud command found
     - name: speech-customclass
@@ -8511,7 +8511,7 @@ branches:
       kind: SpeechCustomClass
       package: google.cloud.speech.v2
       proto: CustomClass
-      proto-path: google.cloud.speech.v2.CustomClass
+      proto-msg: google.cloud.speech.v2.CustomClass
       notes:
         - No gcloud command found
     - name: speech-phraseset
@@ -8524,7 +8524,7 @@ branches:
       kind: SpeechPhraseSet
       package: google.cloud.speech.v2
       proto: PhraseSet
-      proto-path: google.cloud.speech.v2.PhraseSet
+      proto-msg: google.cloud.speech.v2.PhraseSet
       notes:
         - No gcloud command found
     - name: storageinsights-reportdetail
@@ -8537,7 +8537,7 @@ branches:
       kind: StorageInsightsReportDetail
       package: google.cloud.storageinsights.v1
       proto: ReportDetail
-      proto-path: google.cloud.storageinsights.v1.ReportDetail
+      proto-msg: google.cloud.storageinsights.v1.ReportDetail
       notes:
         - No gcloud command found
     - name: storageinsights-reportconfig
@@ -8550,7 +8550,7 @@ branches:
       kind: StorageInsightsReportConfig
       package: google.cloud.storageinsights.v1
       proto: ReportConfig
-      proto-path: google.cloud.storageinsights.v1.ReportConfig
+      proto-msg: google.cloud.storageinsights.v1.ReportConfig
       notes:
         - No gcloud command found
     - name: support-attachment
@@ -8563,7 +8563,7 @@ branches:
       kind: SupportAttachment
       package: google.cloud.support.v2
       proto: Attachment
-      proto-path: google.cloud.support.v2.Attachment
+      proto-msg: google.cloud.support.v2.Attachment
       notes:
         - No gcloud command found
     - name: support-case
@@ -8576,7 +8576,7 @@ branches:
       kind: SupportCase
       package: google.cloud.support.v2
       proto: Case
-      proto-path: google.cloud.support.v2.Case
+      proto-msg: google.cloud.support.v2.Case
       notes:
         - No gcloud command found
     - name: support-comment
@@ -8589,7 +8589,7 @@ branches:
       kind: SupportComment
       package: google.cloud.support.v2
       proto: Comment
-      proto-path: google.cloud.support.v2.Comment
+      proto-msg: google.cloud.support.v2.Comment
       notes:
         - No gcloud command found
     - name: talent-company
@@ -8602,7 +8602,7 @@ branches:
       kind: TalentCompany
       package: google.cloud.talent.v4
       proto: Company
-      proto-path: google.cloud.talent.v4.Company
+      proto-msg: google.cloud.talent.v4.Company
       notes:
         - No gcloud command found
     - name: talent-job
@@ -8615,7 +8615,7 @@ branches:
       kind: TalentJob
       package: google.cloud.talent.v4
       proto: Job
-      proto-path: google.cloud.talent.v4.Job
+      proto-msg: google.cloud.talent.v4.Job
       notes:
         - No gcloud command found
     - name: talent-tenant
@@ -8628,7 +8628,7 @@ branches:
       kind: TalentTenant
       package: google.cloud.talent.v4
       proto: Tenant
-      proto-path: google.cloud.talent.v4.Tenant
+      proto-msg: google.cloud.talent.v4.Tenant
       notes:
         - No gcloud command found
     - name: tasks-queue
@@ -8641,7 +8641,7 @@ branches:
       kind: TasksQueue
       package: google.cloud.tasks.v2
       proto: Queue
-      proto-path: google.cloud.tasks.v2.Queue
+      proto-msg: google.cloud.tasks.v2.Queue
       notes: []
     - name: tasks-task
       local: resource-tasks-task
@@ -8653,7 +8653,7 @@ branches:
       kind: TasksTask
       package: google.cloud.tasks.v2
       proto: Task
-      proto-path: google.cloud.tasks.v2.Task
+      proto-msg: google.cloud.tasks.v2.Task
       notes: []
     - name: telcoautomation-orchestrationcluster
       local: resource-telcoautomation-orchestrationcluster
@@ -8665,7 +8665,7 @@ branches:
       kind: TelcoAutomationOrchestrationCluster
       package: google.cloud.telcoautomation.v1
       proto: OrchestrationCluster
-      proto-path: google.cloud.telcoautomation.v1.OrchestrationCluster
+      proto-msg: google.cloud.telcoautomation.v1.OrchestrationCluster
       notes: []
     - name: telcoautomation-edgeslm
       local: resource-telcoautomation-edgeslm
@@ -8677,7 +8677,7 @@ branches:
       kind: TelcoAutomationEdgeSlm
       package: google.cloud.telcoautomation.v1
       proto: EdgeSlm
-      proto-path: google.cloud.telcoautomation.v1.EdgeSlm
+      proto-msg: google.cloud.telcoautomation.v1.EdgeSlm
       notes:
         - No gcloud command found
     - name: telcoautomation-blueprint
@@ -8690,7 +8690,7 @@ branches:
       kind: TelcoAutomationBlueprint
       package: google.cloud.telcoautomation.v1
       proto: Blueprint
-      proto-path: google.cloud.telcoautomation.v1.Blueprint
+      proto-msg: google.cloud.telcoautomation.v1.Blueprint
       notes:
         - No gcloud command found
     - name: telcoautomation-publicblueprint
@@ -8703,7 +8703,7 @@ branches:
       kind: TelcoAutomationPublicBlueprint
       package: google.cloud.telcoautomation.v1
       proto: PublicBlueprint
-      proto-path: google.cloud.telcoautomation.v1.PublicBlueprint
+      proto-msg: google.cloud.telcoautomation.v1.PublicBlueprint
       notes:
         - No gcloud command found
     - name: telcoautomation-deployment
@@ -8716,7 +8716,7 @@ branches:
       kind: TelcoAutomationDeployment
       package: google.cloud.telcoautomation.v1
       proto: Deployment
-      proto-path: google.cloud.telcoautomation.v1.Deployment
+      proto-msg: google.cloud.telcoautomation.v1.Deployment
       notes:
         - No gcloud command found
     - name: telcoautomation-hydrateddeployment
@@ -8729,7 +8729,7 @@ branches:
       kind: TelcoAutomationHydratedDeployment
       package: google.cloud.telcoautomation.v1
       proto: HydratedDeployment
-      proto-path: google.cloud.telcoautomation.v1.HydratedDeployment
+      proto-msg: google.cloud.telcoautomation.v1.HydratedDeployment
       notes:
         - No gcloud command found
     - name: timeseriesinsights-dataset
@@ -8742,7 +8742,7 @@ branches:
       kind: TimeseriesInsightsDataSet
       package: google.cloud.timeseriesinsights.v1
       proto: DataSet
-      proto-path: google.cloud.timeseriesinsights.v1.DataSet
+      proto-msg: google.cloud.timeseriesinsights.v1.DataSet
       notes:
         - No gcloud command found
     - name: tpu-tensorflowversion
@@ -8755,7 +8755,7 @@ branches:
       kind: TPUTensorFlowVersion
       package: google.cloud.tpu.v1
       proto: TensorFlowVersion
-      proto-path: google.cloud.tpu.v1.TensorFlowVersion
+      proto-msg: google.cloud.tpu.v1.TensorFlowVersion
       notes:
         - No gcloud command found
     - name: tpu-node
@@ -8768,7 +8768,7 @@ branches:
       kind: TPUNode
       package: google.cloud.tpu.v2
       proto: Node
-      proto-path: google.cloud.tpu.v2.Node
+      proto-msg: google.cloud.tpu.v2.Node
       notes: []
     - name: tpu-queuedresource
       local: resource-tpu-queuedresource
@@ -8780,7 +8780,7 @@ branches:
       kind: TPUQueuedResource
       package: google.cloud.tpu.v2
       proto: QueuedResource
-      proto-path: google.cloud.tpu.v2.QueuedResource
+      proto-msg: google.cloud.tpu.v2.QueuedResource
       notes: []
     - name: tpu-acceleratortype
       local: resource-tpu-acceleratortype
@@ -8792,7 +8792,7 @@ branches:
       kind: TPUAcceleratorType
       package: google.cloud.tpu.v2
       proto: AcceleratorType
-      proto-path: google.cloud.tpu.v2.AcceleratorType
+      proto-msg: google.cloud.tpu.v2.AcceleratorType
       notes: []
     - name: tpu-runtimeversion
       local: resource-tpu-runtimeversion
@@ -8804,7 +8804,7 @@ branches:
       kind: TPURuntimeVersion
       package: google.cloud.tpu.v2
       proto: RuntimeVersion
-      proto-path: google.cloud.tpu.v2.RuntimeVersion
+      proto-msg: google.cloud.tpu.v2.RuntimeVersion
       notes:
         - No gcloud command found
     - name: translation-adaptivemtdataset
@@ -8817,7 +8817,7 @@ branches:
       kind: TranslationAdaptiveMtDataset
       package: google.cloud.translation.v3
       proto: AdaptiveMtDataset
-      proto-path: google.cloud.translation.v3.AdaptiveMtDataset
+      proto-msg: google.cloud.translation.v3.AdaptiveMtDataset
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8831,7 +8831,7 @@ branches:
       kind: TranslationAdaptiveMtFile
       package: google.cloud.translation.v3
       proto: AdaptiveMtFile
-      proto-path: google.cloud.translation.v3.AdaptiveMtFile
+      proto-msg: google.cloud.translation.v3.AdaptiveMtFile
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8845,7 +8845,7 @@ branches:
       kind: TranslationAdaptiveMtSentence
       package: google.cloud.translation.v3
       proto: AdaptiveMtSentence
-      proto-path: google.cloud.translation.v3.AdaptiveMtSentence
+      proto-msg: google.cloud.translation.v3.AdaptiveMtSentence
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8859,7 +8859,7 @@ branches:
       kind: TranslationExample
       package: google.cloud.translation.v3
       proto: Example
-      proto-path: google.cloud.translation.v3.Example
+      proto-msg: google.cloud.translation.v3.Example
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8873,7 +8873,7 @@ branches:
       kind: TranslationDataset
       package: google.cloud.translation.v3
       proto: Dataset
-      proto-path: google.cloud.translation.v3.Dataset
+      proto-msg: google.cloud.translation.v3.Dataset
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8887,7 +8887,7 @@ branches:
       kind: TranslationModel
       package: google.cloud.translation.v3
       proto: Model
-      proto-path: google.cloud.translation.v3.Model
+      proto-msg: google.cloud.translation.v3.Model
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8901,7 +8901,7 @@ branches:
       kind: TranslationGlossaryEntry
       package: google.cloud.translation.v3
       proto: GlossaryEntry
-      proto-path: google.cloud.translation.v3.GlossaryEntry
+      proto-msg: google.cloud.translation.v3.GlossaryEntry
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8915,7 +8915,7 @@ branches:
       kind: TranslationGlossary
       package: google.cloud.translation.v3
       proto: Glossary
-      proto-path: google.cloud.translation.v3.Glossary
+      proto-msg: google.cloud.translation.v3.Glossary
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -8929,7 +8929,7 @@ branches:
       kind: VideoInput
       package: google.cloud.video.livestream.v1
       proto: Input
-      proto-path: google.cloud.video.livestream.v1.Input
+      proto-msg: google.cloud.video.livestream.v1.Input
       notes:
         - No gcloud command found
     - name: video-channel
@@ -8942,7 +8942,7 @@ branches:
       kind: VideoChannel
       package: google.cloud.video.livestream.v1
       proto: Channel
-      proto-path: google.cloud.video.livestream.v1.Channel
+      proto-msg: google.cloud.video.livestream.v1.Channel
       notes:
         - No gcloud command found
     - name: video-event
@@ -8955,7 +8955,7 @@ branches:
       kind: VideoEvent
       package: google.cloud.video.livestream.v1
       proto: Event
-      proto-path: google.cloud.video.livestream.v1.Event
+      proto-msg: google.cloud.video.livestream.v1.Event
       notes:
         - No gcloud command found
     - name: video-clip
@@ -8968,7 +8968,7 @@ branches:
       kind: VideoClip
       package: google.cloud.video.livestream.v1
       proto: Clip
-      proto-path: google.cloud.video.livestream.v1.Clip
+      proto-msg: google.cloud.video.livestream.v1.Clip
       notes:
         - No gcloud command found
     - name: video-asset
@@ -8981,7 +8981,7 @@ branches:
       kind: VideoAsset
       package: google.cloud.video.livestream.v1
       proto: Asset
-      proto-path: google.cloud.video.livestream.v1.Asset
+      proto-msg: google.cloud.video.livestream.v1.Asset
       notes:
         - No gcloud command found
     - name: video-pool
@@ -8994,7 +8994,7 @@ branches:
       kind: VideoPool
       package: google.cloud.video.livestream.v1
       proto: Pool
-      proto-path: google.cloud.video.livestream.v1.Pool
+      proto-msg: google.cloud.video.livestream.v1.Pool
       notes:
         - No gcloud command found
     - name: video-liveadtagdetail
@@ -9007,7 +9007,7 @@ branches:
       kind: VideoLiveAdTagDetail
       package: google.cloud.video.stitcher.v1
       proto: LiveAdTagDetail
-      proto-path: google.cloud.video.stitcher.v1.LiveAdTagDetail
+      proto-msg: google.cloud.video.stitcher.v1.LiveAdTagDetail
       notes:
         - No gcloud command found
     - name: video-vodadtagdetail
@@ -9020,7 +9020,7 @@ branches:
       kind: VideoVodAdTagDetail
       package: google.cloud.video.stitcher.v1
       proto: VodAdTagDetail
-      proto-path: google.cloud.video.stitcher.v1.VodAdTagDetail
+      proto-msg: google.cloud.video.stitcher.v1.VodAdTagDetail
       notes:
         - No gcloud command found
     - name: video-cdnkey
@@ -9033,7 +9033,7 @@ branches:
       kind: VideoCdnKey
       package: google.cloud.video.stitcher.v1
       proto: CdnKey
-      proto-path: google.cloud.video.stitcher.v1.CdnKey
+      proto-msg: google.cloud.video.stitcher.v1.CdnKey
       notes:
         - No gcloud command found
     - name: video-liveconfig
@@ -9046,7 +9046,7 @@ branches:
       kind: VideoLiveConfig
       package: google.cloud.video.stitcher.v1
       proto: LiveConfig
-      proto-path: google.cloud.video.stitcher.v1.LiveConfig
+      proto-msg: google.cloud.video.stitcher.v1.LiveConfig
       notes:
         - No gcloud command found
     - name: video-vodsession
@@ -9059,7 +9059,7 @@ branches:
       kind: VideoVodSession
       package: google.cloud.video.stitcher.v1
       proto: VodSession
-      proto-path: google.cloud.video.stitcher.v1.VodSession
+      proto-msg: google.cloud.video.stitcher.v1.VodSession
       notes:
         - No gcloud command found
     - name: video-livesession
@@ -9072,7 +9072,7 @@ branches:
       kind: VideoLiveSession
       package: google.cloud.video.stitcher.v1
       proto: LiveSession
-      proto-path: google.cloud.video.stitcher.v1.LiveSession
+      proto-msg: google.cloud.video.stitcher.v1.LiveSession
       notes: []
     - name: video-slate
       local: resource-video-slate
@@ -9084,7 +9084,7 @@ branches:
       kind: VideoSlate
       package: google.cloud.video.stitcher.v1
       proto: Slate
-      proto-path: google.cloud.video.stitcher.v1.Slate
+      proto-msg: google.cloud.video.stitcher.v1.Slate
       notes:
         - No gcloud command found
     - name: video-vodstitchdetail
@@ -9097,7 +9097,7 @@ branches:
       kind: VideoVodStitchDetail
       package: google.cloud.video.stitcher.v1
       proto: VodStitchDetail
-      proto-path: google.cloud.video.stitcher.v1.VodStitchDetail
+      proto-msg: google.cloud.video.stitcher.v1.VodStitchDetail
       notes:
         - No gcloud command found
     - name: video-vodconfig
@@ -9110,7 +9110,7 @@ branches:
       kind: VideoVodConfig
       package: google.cloud.video.stitcher.v1
       proto: VodConfig
-      proto-path: google.cloud.video.stitcher.v1.VodConfig
+      proto-msg: google.cloud.video.stitcher.v1.VodConfig
       notes:
         - No gcloud command found
     - name: video-job
@@ -9123,7 +9123,7 @@ branches:
       kind: VideoJob
       package: google.cloud.video.transcoder.v1
       proto: Job
-      proto-path: google.cloud.video.transcoder.v1.Job
+      proto-msg: google.cloud.video.transcoder.v1.Job
       notes:
         - No gcloud command found
     - name: video-jobtemplate
@@ -9136,7 +9136,7 @@ branches:
       kind: VideoJobTemplate
       package: google.cloud.video.transcoder.v1
       proto: JobTemplate
-      proto-path: google.cloud.video.transcoder.v1.JobTemplate
+      proto-msg: google.cloud.video.transcoder.v1.JobTemplate
       notes:
         - No gcloud command found
     - name: vision-product
@@ -9149,7 +9149,7 @@ branches:
       kind: VisionProduct
       package: google.cloud.vision.v1
       proto: Product
-      proto-path: google.cloud.vision.v1.Product
+      proto-msg: google.cloud.vision.v1.Product
       notes:
         - No gcloud command found
     - name: vision-productset
@@ -9162,7 +9162,7 @@ branches:
       kind: VisionProductSet
       package: google.cloud.vision.v1
       proto: ProductSet
-      proto-path: google.cloud.vision.v1.ProductSet
+      proto-msg: google.cloud.vision.v1.ProductSet
       notes:
         - No gcloud command found
     - name: vision-referenceimage
@@ -9175,7 +9175,7 @@ branches:
       kind: VisionReferenceImage
       package: google.cloud.vision.v1
       proto: ReferenceImage
-      proto-path: google.cloud.vision.v1.ReferenceImage
+      proto-msg: google.cloud.vision.v1.ReferenceImage
       notes:
         - No gcloud command found
     - name: visionai-cluster
@@ -9188,7 +9188,7 @@ branches:
       kind: VisionAICluster
       package: google.cloud.visionai.v1
       proto: Cluster
-      proto-path: google.cloud.visionai.v1.Cluster
+      proto-msg: google.cloud.visionai.v1.Cluster
       notes:
         - No gcloud command found
     - name: visionai-operator
@@ -9201,7 +9201,7 @@ branches:
       kind: VisionAIOperator
       package: google.cloud.visionai.v1
       proto: Operator
-      proto-path: google.cloud.visionai.v1.Operator
+      proto-msg: google.cloud.visionai.v1.Operator
       notes:
         - No gcloud command found
     - name: visionai-analysis
@@ -9214,7 +9214,7 @@ branches:
       kind: VisionAIAnalysis
       package: google.cloud.visionai.v1
       proto: Analysis
-      proto-path: google.cloud.visionai.v1.Analysis
+      proto-msg: google.cloud.visionai.v1.Analysis
       notes:
         - No gcloud command found
     - name: visionai-process
@@ -9227,7 +9227,7 @@ branches:
       kind: VisionAIProcess
       package: google.cloud.visionai.v1
       proto: Process
-      proto-path: google.cloud.visionai.v1.Process
+      proto-msg: google.cloud.visionai.v1.Process
       notes:
         - No gcloud command found
     - name: visionai-application
@@ -9240,7 +9240,7 @@ branches:
       kind: VisionAIApplication
       package: google.cloud.visionai.v1
       proto: Application
-      proto-path: google.cloud.visionai.v1.Application
+      proto-msg: google.cloud.visionai.v1.Application
       notes:
         - No gcloud command found
     - name: visionai-draft
@@ -9253,7 +9253,7 @@ branches:
       kind: VisionAIDraft
       package: google.cloud.visionai.v1
       proto: Draft
-      proto-path: google.cloud.visionai.v1.Draft
+      proto-msg: google.cloud.visionai.v1.Draft
       notes:
         - No gcloud command found
     - name: visionai-instance
@@ -9266,7 +9266,7 @@ branches:
       kind: VisionAIInstance
       package: google.cloud.visionai.v1
       proto: Instance
-      proto-path: google.cloud.visionai.v1.Instance
+      proto-msg: google.cloud.visionai.v1.Instance
       notes:
         - No gcloud command found
     - name: visionai-processor
@@ -9279,7 +9279,7 @@ branches:
       kind: VisionAIProcessor
       package: google.cloud.visionai.v1
       proto: Processor
-      proto-path: google.cloud.visionai.v1.Processor
+      proto-msg: google.cloud.visionai.v1.Processor
       notes:
         - No gcloud command found
     - name: visionai-stream
@@ -9292,7 +9292,7 @@ branches:
       kind: VisionAIStream
       package: google.cloud.visionai.v1
       proto: Stream
-      proto-path: google.cloud.visionai.v1.Stream
+      proto-msg: google.cloud.visionai.v1.Stream
       notes:
         - No gcloud command found
     - name: visionai-event
@@ -9305,7 +9305,7 @@ branches:
       kind: VisionAIEvent
       package: google.cloud.visionai.v1
       proto: Event
-      proto-path: google.cloud.visionai.v1.Event
+      proto-msg: google.cloud.visionai.v1.Event
       notes:
         - No gcloud command found
     - name: visionai-series
@@ -9318,7 +9318,7 @@ branches:
       kind: VisionAISeries
       package: google.cloud.visionai.v1
       proto: Series
-      proto-path: google.cloud.visionai.v1.Series
+      proto-msg: google.cloud.visionai.v1.Series
       notes:
         - No gcloud command found
     - name: visionai-channel
@@ -9331,7 +9331,7 @@ branches:
       kind: VisionAIChannel
       package: google.cloud.visionai.v1
       proto: Channel
-      proto-path: google.cloud.visionai.v1.Channel
+      proto-msg: google.cloud.visionai.v1.Channel
       notes:
         - No gcloud command found
     - name: visionai-asset
@@ -9344,7 +9344,7 @@ branches:
       kind: VisionAIAsset
       package: google.cloud.visionai.v1
       proto: Asset
-      proto-path: google.cloud.visionai.v1.Asset
+      proto-msg: google.cloud.visionai.v1.Asset
       notes:
         - No gcloud command found
     - name: visionai-collection
@@ -9357,7 +9357,7 @@ branches:
       kind: VisionAICollection
       package: google.cloud.visionai.v1
       proto: Collection
-      proto-path: google.cloud.visionai.v1.Collection
+      proto-msg: google.cloud.visionai.v1.Collection
       notes:
         - No gcloud command found
     - name: visionai-index
@@ -9370,7 +9370,7 @@ branches:
       kind: VisionAIIndex
       package: google.cloud.visionai.v1
       proto: Index
-      proto-path: google.cloud.visionai.v1.Index
+      proto-msg: google.cloud.visionai.v1.Index
       notes:
         - No gcloud command found
     - name: visionai-corpus
@@ -9383,7 +9383,7 @@ branches:
       kind: VisionAICorpus
       package: google.cloud.visionai.v1
       proto: Corpus
-      proto-path: google.cloud.visionai.v1.Corpus
+      proto-msg: google.cloud.visionai.v1.Corpus
       notes:
         - No gcloud command found
     - name: visionai-dataschema
@@ -9396,7 +9396,7 @@ branches:
       kind: VisionAIDataSchema
       package: google.cloud.visionai.v1
       proto: DataSchema
-      proto-path: google.cloud.visionai.v1.DataSchema
+      proto-msg: google.cloud.visionai.v1.DataSchema
       notes:
         - No gcloud command found
     - name: visionai-annotation
@@ -9409,7 +9409,7 @@ branches:
       kind: VisionAIAnnotation
       package: google.cloud.visionai.v1
       proto: Annotation
-      proto-path: google.cloud.visionai.v1.Annotation
+      proto-msg: google.cloud.visionai.v1.Annotation
       notes:
         - No gcloud command found
     - name: visionai-searchconfig
@@ -9422,7 +9422,7 @@ branches:
       kind: VisionAISearchConfig
       package: google.cloud.visionai.v1
       proto: SearchConfig
-      proto-path: google.cloud.visionai.v1.SearchConfig
+      proto-msg: google.cloud.visionai.v1.SearchConfig
       notes:
         - No gcloud command found
     - name: visionai-indexendpoint
@@ -9435,7 +9435,7 @@ branches:
       kind: VisionAIIndexEndpoint
       package: google.cloud.visionai.v1
       proto: IndexEndpoint
-      proto-path: google.cloud.visionai.v1.IndexEndpoint
+      proto-msg: google.cloud.visionai.v1.IndexEndpoint
       notes:
         - No gcloud command found
     - name: visionai-searchhypernym
@@ -9448,7 +9448,7 @@ branches:
       kind: VisionAISearchHypernym
       package: google.cloud.visionai.v1
       proto: SearchHypernym
-      proto-path: google.cloud.visionai.v1.SearchHypernym
+      proto-msg: google.cloud.visionai.v1.SearchHypernym
       notes:
         - No gcloud command found
     - name: vmmigration-replicationcycle
@@ -9461,7 +9461,7 @@ branches:
       kind: VMMigrationReplicationCycle
       package: google.cloud.vmmigration.v1
       proto: ReplicationCycle
-      proto-path: google.cloud.vmmigration.v1.ReplicationCycle
+      proto-msg: google.cloud.vmmigration.v1.ReplicationCycle
       notes: []
     - name: vmmigration-migratingvm
       local: resource-vmmigration-migratingvm
@@ -9473,7 +9473,7 @@ branches:
       kind: VMMigrationMigratingVm
       package: google.cloud.vmmigration.v1
       proto: MigratingVm
-      proto-path: google.cloud.vmmigration.v1.MigratingVm
+      proto-msg: google.cloud.vmmigration.v1.MigratingVm
       notes:
         - No gcloud command found
     - name: vmmigration-clonejob
@@ -9486,7 +9486,7 @@ branches:
       kind: VMMigrationCloneJob
       package: google.cloud.vmmigration.v1
       proto: CloneJob
-      proto-path: google.cloud.vmmigration.v1.CloneJob
+      proto-msg: google.cloud.vmmigration.v1.CloneJob
       notes:
         - No gcloud command found
     - name: vmmigration-cutoverjob
@@ -9499,7 +9499,7 @@ branches:
       kind: VMMigrationCutoverJob
       package: google.cloud.vmmigration.v1
       proto: CutoverJob
-      proto-path: google.cloud.vmmigration.v1.CutoverJob
+      proto-msg: google.cloud.vmmigration.v1.CutoverJob
       notes:
         - No gcloud command found
     - name: vmmigration-source
@@ -9512,7 +9512,7 @@ branches:
       kind: VMMigrationSource
       package: google.cloud.vmmigration.v1
       proto: Source
-      proto-path: google.cloud.vmmigration.v1.Source
+      proto-msg: google.cloud.vmmigration.v1.Source
       notes:
         - No gcloud command found
     - name: vmmigration-datacenterconnector
@@ -9525,7 +9525,7 @@ branches:
       kind: VMMigrationDatacenterConnector
       package: google.cloud.vmmigration.v1
       proto: DatacenterConnector
-      proto-path: google.cloud.vmmigration.v1.DatacenterConnector
+      proto-msg: google.cloud.vmmigration.v1.DatacenterConnector
       notes:
         - No gcloud command found
     - name: vmmigration-utilizationreport
@@ -9538,7 +9538,7 @@ branches:
       kind: VMMigrationUtilizationReport
       package: google.cloud.vmmigration.v1
       proto: UtilizationReport
-      proto-path: google.cloud.vmmigration.v1.UtilizationReport
+      proto-msg: google.cloud.vmmigration.v1.UtilizationReport
       notes:
         - No gcloud command found
     - name: vmmigration-targetproject
@@ -9551,7 +9551,7 @@ branches:
       kind: VMMigrationTargetProject
       package: google.cloud.vmmigration.v1
       proto: TargetProject
-      proto-path: google.cloud.vmmigration.v1.TargetProject
+      proto-msg: google.cloud.vmmigration.v1.TargetProject
       notes:
         - No gcloud command found
     - name: vmmigration-group
@@ -9564,7 +9564,7 @@ branches:
       kind: VMMigrationGroup
       package: google.cloud.vmmigration.v1
       proto: Group
-      proto-path: google.cloud.vmmigration.v1.Group
+      proto-msg: google.cloud.vmmigration.v1.Group
       notes:
         - No gcloud command found
     - name: vmwareengine-privatecloud
@@ -9577,7 +9577,7 @@ branches:
       kind: VMwareEnginePrivateCloud
       package: google.cloud.vmwareengine.v1
       proto: PrivateCloud
-      proto-path: google.cloud.vmwareengine.v1.PrivateCloud
+      proto-msg: google.cloud.vmwareengine.v1.PrivateCloud
       notes: []
     - name: vmwareengine-cluster
       local: resource-vmwareengine-cluster
@@ -9589,7 +9589,7 @@ branches:
       kind: VMwareEngineCluster
       package: google.cloud.vmwareengine.v1
       proto: Cluster
-      proto-path: google.cloud.vmwareengine.v1.Cluster
+      proto-msg: google.cloud.vmwareengine.v1.Cluster
       notes:
         - No gcloud command found
     - name: vmwareengine-node
@@ -9602,7 +9602,7 @@ branches:
       kind: VMwareEngineNode
       package: google.cloud.vmwareengine.v1
       proto: Node
-      proto-path: google.cloud.vmwareengine.v1.Node
+      proto-msg: google.cloud.vmwareengine.v1.Node
       notes:
         - No gcloud command found
     - name: vmwareengine-externaladdress
@@ -9615,7 +9615,7 @@ branches:
       kind: VMwareEngineExternalAddress
       package: google.cloud.vmwareengine.v1
       proto: ExternalAddress
-      proto-path: google.cloud.vmwareengine.v1.ExternalAddress
+      proto-msg: google.cloud.vmwareengine.v1.ExternalAddress
       notes:
         - No gcloud command found
     - name: vmwareengine-subnet
@@ -9628,7 +9628,7 @@ branches:
       kind: VMwareEngineSubnet
       package: google.cloud.vmwareengine.v1
       proto: Subnet
-      proto-path: google.cloud.vmwareengine.v1.Subnet
+      proto-msg: google.cloud.vmwareengine.v1.Subnet
       notes:
         - No gcloud command found
     - name: vmwareengine-externalaccessrule
@@ -9641,7 +9641,7 @@ branches:
       kind: VMwareEngineExternalAccessRule
       package: google.cloud.vmwareengine.v1
       proto: ExternalAccessRule
-      proto-path: google.cloud.vmwareengine.v1.ExternalAccessRule
+      proto-msg: google.cloud.vmwareengine.v1.ExternalAccessRule
       notes:
         - No gcloud command found
     - name: vmwareengine-loggingserver
@@ -9654,7 +9654,7 @@ branches:
       kind: VMwareEngineLoggingServer
       package: google.cloud.vmwareengine.v1
       proto: LoggingServer
-      proto-path: google.cloud.vmwareengine.v1.LoggingServer
+      proto-msg: google.cloud.vmwareengine.v1.LoggingServer
       notes:
         - No gcloud command found
     - name: vmwareengine-nodetype
@@ -9667,7 +9667,7 @@ branches:
       kind: VMwareEngineNodeType
       package: google.cloud.vmwareengine.v1
       proto: NodeType
-      proto-path: google.cloud.vmwareengine.v1.NodeType
+      proto-msg: google.cloud.vmwareengine.v1.NodeType
       notes: []
     - name: vmwareengine-hcxactivationkey
       local: resource-vmwareengine-hcxactivationkey
@@ -9679,7 +9679,7 @@ branches:
       kind: VMwareEngineHcxActivationKey
       package: google.cloud.vmwareengine.v1
       proto: HcxActivationKey
-      proto-path: google.cloud.vmwareengine.v1.HcxActivationKey
+      proto-msg: google.cloud.vmwareengine.v1.HcxActivationKey
       notes:
         - No gcloud command found
     - name: vmwareengine-dnsforwarding
@@ -9692,7 +9692,7 @@ branches:
       kind: VMwareEngineDNSForwarding
       package: google.cloud.vmwareengine.v1
       proto: DnsForwarding
-      proto-path: google.cloud.vmwareengine.v1.DnsForwarding
+      proto-msg: google.cloud.vmwareengine.v1.DnsForwarding
       notes:
         - No gcloud command found
     - name: vmwareengine-networkpeering
@@ -9705,7 +9705,7 @@ branches:
       kind: VMwareEngineNetworkPeering
       package: google.cloud.vmwareengine.v1
       proto: NetworkPeering
-      proto-path: google.cloud.vmwareengine.v1.NetworkPeering
+      proto-msg: google.cloud.vmwareengine.v1.NetworkPeering
       notes: []
     - name: vmwareengine-networkpolicy
       local: resource-vmwareengine-networkpolicy
@@ -9717,7 +9717,7 @@ branches:
       kind: VMwareEngineNetworkPolicy
       package: google.cloud.vmwareengine.v1
       proto: NetworkPolicy
-      proto-path: google.cloud.vmwareengine.v1.NetworkPolicy
+      proto-msg: google.cloud.vmwareengine.v1.NetworkPolicy
       notes: []
     - name: vmwareengine-managementdnszonebinding
       local: resource-vmwareengine-managementdnszonebinding
@@ -9729,7 +9729,7 @@ branches:
       kind: VMwareEngineManagementDnsZoneBinding
       package: google.cloud.vmwareengine.v1
       proto: ManagementDnsZoneBinding
-      proto-path: google.cloud.vmwareengine.v1.ManagementDnsZoneBinding
+      proto-msg: google.cloud.vmwareengine.v1.ManagementDnsZoneBinding
       notes:
         - No gcloud command found
     - name: vmwareengine-vmwareenginenetwork
@@ -9742,7 +9742,7 @@ branches:
       kind: VMwareEngineVmwareEngineNetwork
       package: google.cloud.vmwareengine.v1
       proto: VmwareEngineNetwork
-      proto-path: google.cloud.vmwareengine.v1.VmwareEngineNetwork
+      proto-msg: google.cloud.vmwareengine.v1.VmwareEngineNetwork
       notes:
         - No gcloud command found
     - name: vmwareengine-privateconnection
@@ -9755,7 +9755,7 @@ branches:
       kind: VMwareEnginePrivateConnection
       package: google.cloud.vmwareengine.v1
       proto: PrivateConnection
-      proto-path: google.cloud.vmwareengine.v1.PrivateConnection
+      proto-msg: google.cloud.vmwareengine.v1.PrivateConnection
       notes: []
     - name: vmwareengine-dnsbindpermission
       local: resource-vmwareengine-dnsbindpermission
@@ -9767,7 +9767,7 @@ branches:
       kind: VMwareEngineDnsBindPermission
       package: google.cloud.vmwareengine.v1
       proto: DnsBindPermission
-      proto-path: google.cloud.vmwareengine.v1.DnsBindPermission
+      proto-msg: google.cloud.vmwareengine.v1.DnsBindPermission
       notes: []
     - name: vpcaccess-connector
       local: resource-vpcaccess-connector
@@ -9779,7 +9779,7 @@ branches:
       kind: VPCAccessConnector
       package: google.cloud.vpcaccess.v1
       proto: Connector
-      proto-path: google.cloud.vpcaccess.v1.Connector
+      proto-msg: google.cloud.vpcaccess.v1.Connector
       notes:
         - No gcloud command found
     - name: websecurityscanner-finding
@@ -9792,7 +9792,7 @@ branches:
       kind: WebSecurityScannerFinding
       package: google.cloud.websecurityscanner.v1
       proto: Finding
-      proto-path: google.cloud.websecurityscanner.v1.Finding
+      proto-msg: google.cloud.websecurityscanner.v1.Finding
       notes:
         - No gcloud command found
     - name: websecurityscanner-scanconfig
@@ -9805,7 +9805,7 @@ branches:
       kind: WebSecurityScannerScanConfig
       package: google.cloud.websecurityscanner.v1beta
       proto: ScanConfig
-      proto-path: google.cloud.websecurityscanner.v1beta.ScanConfig
+      proto-msg: google.cloud.websecurityscanner.v1beta.ScanConfig
       notes: []
     - name: websecurityscanner-scanrun
       local: resource-websecurityscanner-scanrun
@@ -9817,7 +9817,7 @@ branches:
       kind: WebSecurityScannerScanRun
       package: google.cloud.websecurityscanner.v1beta
       proto: ScanRun
-      proto-path: google.cloud.websecurityscanner.v1beta.ScanRun
+      proto-msg: google.cloud.websecurityscanner.v1beta.ScanRun
       notes: []
     - name: workflows-execution
       local: resource-workflows-execution
@@ -9829,7 +9829,7 @@ branches:
       kind: WorkflowsExecution
       package: google.cloud.workflows.executions.v1
       proto: Execution
-      proto-path: google.cloud.workflows.executions.v1.Execution
+      proto-msg: google.cloud.workflows.executions.v1.Execution
       notes: []
     - name: workstations-workstationcluster
       local: resource-workstations-workstationcluster
@@ -9841,7 +9841,7 @@ branches:
       kind: WorkstationsWorkstationCluster
       package: google.cloud.workstations.v1
       proto: WorkstationCluster
-      proto-path: google.cloud.workstations.v1.WorkstationCluster
+      proto-msg: google.cloud.workstations.v1.WorkstationCluster
       notes: []
     - name: workstations-workstationconfig
       local: resource-workstations-workstationconfig
@@ -9853,7 +9853,7 @@ branches:
       kind: WorkstationsWorkstationConfig
       package: google.cloud.workstations.v1
       proto: WorkstationConfig
-      proto-path: google.cloud.workstations.v1.WorkstationConfig
+      proto-msg: google.cloud.workstations.v1.WorkstationConfig
       notes: []
     - name: workstations-workstation
       local: resource-workstations-workstation
@@ -9865,7 +9865,7 @@ branches:
       kind: WorkstationsWorkstation
       package: google.cloud.workstations.v1
       proto: Workstation
-      proto-path: google.cloud.workstations.v1.Workstation
+      proto-msg: google.cloud.workstations.v1.Workstation
       notes: []
     - name: artifactregistry-aptartifact
       local: resource-artifactregistry-aptartifact
@@ -9877,7 +9877,7 @@ branches:
       kind: ArtifactRegistryAptArtifact
       package: google.devtools.artifactregistry.v1
       proto: AptArtifact
-      proto-path: google.devtools.artifactregistry.v1.AptArtifact
+      proto-msg: google.devtools.artifactregistry.v1.AptArtifact
       notes:
         - No gcloud command found
     - name: artifactregistry-dockerimage
@@ -9890,7 +9890,7 @@ branches:
       kind: ArtifactRegistryDockerImage
       package: google.devtools.artifactregistry.v1
       proto: DockerImage
-      proto-path: google.devtools.artifactregistry.v1.DockerImage
+      proto-msg: google.devtools.artifactregistry.v1.DockerImage
       notes:
         - No gcloud command found
     - name: artifactregistry-mavenartifact
@@ -9903,7 +9903,7 @@ branches:
       kind: ArtifactRegistryMavenArtifact
       package: google.devtools.artifactregistry.v1
       proto: MavenArtifact
-      proto-path: google.devtools.artifactregistry.v1.MavenArtifact
+      proto-msg: google.devtools.artifactregistry.v1.MavenArtifact
       notes:
         - No gcloud command found
     - name: artifactregistry-npmpackage
@@ -9916,7 +9916,7 @@ branches:
       kind: ArtifactRegistryNpmPackage
       package: google.devtools.artifactregistry.v1
       proto: NpmPackage
-      proto-path: google.devtools.artifactregistry.v1.NpmPackage
+      proto-msg: google.devtools.artifactregistry.v1.NpmPackage
       notes:
         - No gcloud command found
     - name: artifactregistry-pythonpackage
@@ -9929,7 +9929,7 @@ branches:
       kind: ArtifactRegistryPythonPackage
       package: google.devtools.artifactregistry.v1
       proto: PythonPackage
-      proto-path: google.devtools.artifactregistry.v1.PythonPackage
+      proto-msg: google.devtools.artifactregistry.v1.PythonPackage
       notes:
         - No gcloud command found
     - name: artifactregistry-attachment
@@ -9942,7 +9942,7 @@ branches:
       kind: ArtifactRegistryAttachment
       package: google.devtools.artifactregistry.v1
       proto: Attachment
-      proto-path: google.devtools.artifactregistry.v1.Attachment
+      proto-msg: google.devtools.artifactregistry.v1.Attachment
       notes:
         - No gcloud command found
     - name: artifactregistry-file
@@ -9955,7 +9955,7 @@ branches:
       kind: ArtifactRegistryFile
       package: google.devtools.artifactregistry.v1
       proto: File
-      proto-path: google.devtools.artifactregistry.v1.File
+      proto-msg: google.devtools.artifactregistry.v1.File
       notes:
         - No gcloud command found
     - name: artifactregistry-genericartifact
@@ -9968,7 +9968,7 @@ branches:
       kind: ArtifactRegistryGenericArtifact
       package: google.devtools.artifactregistry.v1
       proto: GenericArtifact
-      proto-path: google.devtools.artifactregistry.v1.GenericArtifact
+      proto-msg: google.devtools.artifactregistry.v1.GenericArtifact
       notes:
         - No gcloud command found
     - name: artifactregistry-package
@@ -9981,7 +9981,7 @@ branches:
       kind: ArtifactRegistryPackage
       package: google.devtools.artifactregistry.v1
       proto: Package
-      proto-path: google.devtools.artifactregistry.v1.Package
+      proto-msg: google.devtools.artifactregistry.v1.Package
       notes:
         - No gcloud command found
     - name: artifactregistry-repository
@@ -9994,7 +9994,7 @@ branches:
       kind: ArtifactRegistryRepository
       package: google.devtools.artifactregistry.v1
       proto: Repository
-      proto-path: google.devtools.artifactregistry.v1.Repository
+      proto-msg: google.devtools.artifactregistry.v1.Repository
       notes: []
     - name: artifactregistry-rule
       local: resource-artifactregistry-rule
@@ -10006,7 +10006,7 @@ branches:
       kind: ArtifactRegistryRule
       package: google.devtools.artifactregistry.v1
       proto: Rule
-      proto-path: google.devtools.artifactregistry.v1.Rule
+      proto-msg: google.devtools.artifactregistry.v1.Rule
       notes:
         - No gcloud command found
     - name: artifactregistry-projectsettings
@@ -10019,7 +10019,7 @@ branches:
       kind: ArtifactRegistryProjectSettings
       package: google.devtools.artifactregistry.v1
       proto: ProjectSettings
-      proto-path: google.devtools.artifactregistry.v1.ProjectSettings
+      proto-msg: google.devtools.artifactregistry.v1.ProjectSettings
       notes:
         - No gcloud command found
     - name: artifactregistry-tag
@@ -10032,7 +10032,7 @@ branches:
       kind: ArtifactRegistryTag
       package: google.devtools.artifactregistry.v1
       proto: Tag
-      proto-path: google.devtools.artifactregistry.v1.Tag
+      proto-msg: google.devtools.artifactregistry.v1.Tag
       notes:
         - No gcloud command found
     - name: artifactregistry-version
@@ -10045,7 +10045,7 @@ branches:
       kind: ArtifactRegistryVersion
       package: google.devtools.artifactregistry.v1
       proto: Version
-      proto-path: google.devtools.artifactregistry.v1.Version
+      proto-msg: google.devtools.artifactregistry.v1.Version
       notes:
         - No gcloud command found
     - name: artifactregistry-vpcscconfig
@@ -10058,7 +10058,7 @@ branches:
       kind: ArtifactRegistryVPCSCConfig
       package: google.devtools.artifactregistry.v1
       proto: VPCSCConfig
-      proto-path: google.devtools.artifactregistry.v1.VPCSCConfig
+      proto-msg: google.devtools.artifactregistry.v1.VPCSCConfig
       notes:
         - No gcloud command found
     - name: artifactregistry-yumartifact
@@ -10071,7 +10071,7 @@ branches:
       kind: ArtifactRegistryYumArtifact
       package: google.devtools.artifactregistry.v1
       proto: YumArtifact
-      proto-path: google.devtools.artifactregistry.v1.YumArtifact
+      proto-msg: google.devtools.artifactregistry.v1.YumArtifact
       notes:
         - No gcloud command found
     - name: cloudbuild-build
@@ -10084,7 +10084,7 @@ branches:
       kind: CloudBuildBuild
       package: google.devtools.cloudbuild.v1
       proto: Build
-      proto-path: google.devtools.cloudbuild.v1.Build
+      proto-msg: google.devtools.cloudbuild.v1.Build
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -10098,7 +10098,7 @@ branches:
       kind: CloudBuildBuildTrigger
       package: google.devtools.cloudbuild.v1
       proto: BuildTrigger
-      proto-path: google.devtools.cloudbuild.v1.BuildTrigger
+      proto-msg: google.devtools.cloudbuild.v1.BuildTrigger
       notes:
         - No matching generated proto
     - name: cloudbuild-githubenterpriseconfig
@@ -10111,7 +10111,7 @@ branches:
       kind: CloudBuildGitHubEnterpriseConfig
       package: google.devtools.cloudbuild.v1
       proto: GitHubEnterpriseConfig
-      proto-path: google.devtools.cloudbuild.v1.GitHubEnterpriseConfig
+      proto-msg: google.devtools.cloudbuild.v1.GitHubEnterpriseConfig
       notes:
         - No gcloud command found
         - No matching generated proto
@@ -10125,7 +10125,7 @@ branches:
       kind: CloudBuildWorkerPool
       package: google.devtools.cloudbuild.v1
       proto: WorkerPool
-      proto-path: google.devtools.cloudbuild.v1.WorkerPool
+      proto-msg: google.devtools.cloudbuild.v1.WorkerPool
       notes: []
     - name: cloudbuild-connection
       local: resource-cloudbuild-connection
@@ -10137,7 +10137,7 @@ branches:
       kind: CloudBuildConnection
       package: google.devtools.cloudbuild.v2
       proto: Connection
-      proto-path: google.devtools.cloudbuild.v2.Connection
+      proto-msg: google.devtools.cloudbuild.v2.Connection
       notes:
         - No matching generated proto
     - name: cloudbuild-repository
@@ -10150,7 +10150,7 @@ branches:
       kind: CloudBuildRepository
       package: google.devtools.cloudbuild.v2
       proto: Repository
-      proto-path: google.devtools.cloudbuild.v2.Repository
+      proto-msg: google.devtools.cloudbuild.v2.Repository
       notes:
         - No matching generated proto
     - name: clouderrorreporting-errorgroup
@@ -10163,7 +10163,7 @@ branches:
       kind: CloudErrorReportingErrorGroup
       package: google.devtools.clouderrorreporting.v1beta1
       proto: ErrorGroup
-      proto-path: google.devtools.clouderrorreporting.v1beta1.ErrorGroup
+      proto-msg: google.devtools.clouderrorreporting.v1beta1.ErrorGroup
       notes:
         - No gcloud command found
     - name: cloudprofiler-profile
@@ -10176,7 +10176,7 @@ branches:
       kind: CloudProfilerProfile
       package: google.devtools.cloudprofiler.v2
       proto: Profile
-      proto-path: google.devtools.cloudprofiler.v2.Profile
+      proto-msg: google.devtools.cloudprofiler.v2.Profile
       notes:
         - No gcloud command found
     - name: cloudtrace-span
@@ -10189,7 +10189,7 @@ branches:
       kind: CloudTraceSpan
       package: google.devtools.cloudtrace.v2
       proto: Span
-      proto-path: google.devtools.cloudtrace.v2.Span
+      proto-msg: google.devtools.cloudtrace.v2.Span
       notes:
         - No gcloud command found
     - name: remoteworkers-botsession
@@ -10202,7 +10202,7 @@ branches:
       kind: RemoteWorkersBotSession
       package: google.devtools.remoteworkers.v1test2
       proto: BotSession
-      proto-path: google.devtools.remoteworkers.v1test2.BotSession
+      proto-msg: google.devtools.remoteworkers.v1test2.BotSession
       notes:
         - No gcloud command found
     - name: resultstore-action
@@ -10215,7 +10215,7 @@ branches:
       kind: ResultStoreAction
       package: google.devtools.resultstore.v2
       proto: Action
-      proto-path: google.devtools.resultstore.v2.Action
+      proto-msg: google.devtools.resultstore.v2.Action
       notes:
         - No gcloud command found
     - name: resultstore-configuration
@@ -10228,7 +10228,7 @@ branches:
       kind: ResultStoreConfiguration
       package: google.devtools.resultstore.v2
       proto: Configuration
-      proto-path: google.devtools.resultstore.v2.Configuration
+      proto-msg: google.devtools.resultstore.v2.Configuration
       notes:
         - No gcloud command found
     - name: resultstore-configuredtarget
@@ -10241,7 +10241,7 @@ branches:
       kind: ResultStoreConfiguredTarget
       package: google.devtools.resultstore.v2
       proto: ConfiguredTarget
-      proto-path: google.devtools.resultstore.v2.ConfiguredTarget
+      proto-msg: google.devtools.resultstore.v2.ConfiguredTarget
       notes:
         - No gcloud command found
     - name: resultstore-downloadmetadata
@@ -10254,7 +10254,7 @@ branches:
       kind: ResultStoreDownloadMetadata
       package: google.devtools.resultstore.v2
       proto: DownloadMetadata
-      proto-path: google.devtools.resultstore.v2.DownloadMetadata
+      proto-msg: google.devtools.resultstore.v2.DownloadMetadata
       notes:
         - No gcloud command found
     - name: resultstore-fileset
@@ -10267,7 +10267,7 @@ branches:
       kind: ResultStoreFileSet
       package: google.devtools.resultstore.v2
       proto: FileSet
-      proto-path: google.devtools.resultstore.v2.FileSet
+      proto-msg: google.devtools.resultstore.v2.FileSet
       notes:
         - No gcloud command found
     - name: resultstore-invocation
@@ -10280,7 +10280,7 @@ branches:
       kind: ResultStoreInvocation
       package: google.devtools.resultstore.v2
       proto: Invocation
-      proto-path: google.devtools.resultstore.v2.Invocation
+      proto-msg: google.devtools.resultstore.v2.Invocation
       notes:
         - No gcloud command found
     - name: resultstore-target
@@ -10293,7 +10293,7 @@ branches:
       kind: ResultStoreTarget
       package: google.devtools.resultstore.v2
       proto: Target
-      proto-path: google.devtools.resultstore.v2.Target
+      proto-msg: google.devtools.resultstore.v2.Target
       notes:
         - No gcloud command found
     - name: resultstore-uploadmetadata
@@ -10306,7 +10306,7 @@ branches:
       kind: ResultStoreUploadMetadata
       package: google.devtools.resultstore.v2
       proto: UploadMetadata
-      proto-path: google.devtools.resultstore.v2.UploadMetadata
+      proto-msg: google.devtools.resultstore.v2.UploadMetadata
       notes:
         - No gcloud command found
     - name: testing-devicesession
@@ -10319,7 +10319,7 @@ branches:
       kind: TestingDeviceSession
       package: google.devtools.testing.v1
       proto: DeviceSession
-      proto-path: google.devtools.testing.v1.DeviceSession
+      proto-msg: google.devtools.testing.v1.DeviceSession
       notes:
         - No gcloud command found
     - name: example-book
@@ -10332,7 +10332,7 @@ branches:
       kind: ExampleBook
       package: google.example.library.v1
       proto: Book
-      proto-path: google.example.library.v1.Book
+      proto-msg: google.example.library.v1.Book
       notes:
         - No gcloud command found
     - name: example-shelf
@@ -10345,7 +10345,7 @@ branches:
       kind: ExampleShelf
       package: google.example.library.v1
       proto: Shelf
-      proto-path: google.example.library.v1.Shelf
+      proto-msg: google.example.library.v1.Shelf
       notes:
         - No gcloud command found
     - name: firestore-backup
@@ -10358,7 +10358,7 @@ branches:
       kind: FirestoreBackup
       package: google.firestore.admin.v1
       proto: Backup
-      proto-path: google.firestore.admin.v1.Backup
+      proto-msg: google.firestore.admin.v1.Backup
       notes: []
     - name: firestore-database
       local: resource-firestore-database
@@ -10370,7 +10370,7 @@ branches:
       kind: FirestoreDatabase
       package: google.firestore.admin.v1
       proto: Database
-      proto-path: google.firestore.admin.v1.Database
+      proto-msg: google.firestore.admin.v1.Database
       notes: []
     - name: firestore-field
       local: resource-firestore-field
@@ -10382,7 +10382,7 @@ branches:
       kind: FirestoreField
       package: google.firestore.admin.v1
       proto: Field
-      proto-path: google.firestore.admin.v1.Field
+      proto-msg: google.firestore.admin.v1.Field
       notes: []
     - name: firestore-index
       local: resource-firestore-index
@@ -10394,7 +10394,7 @@ branches:
       kind: FirestoreIndex
       package: google.firestore.admin.v1
       proto: Index
-      proto-path: google.firestore.admin.v1.Index
+      proto-msg: google.firestore.admin.v1.Index
       notes: []
     - name: firestore-backupschedule
       local: resource-firestore-backupschedule
@@ -10406,7 +10406,7 @@ branches:
       kind: FirestoreBackupSchedule
       package: google.firestore.admin.v1
       proto: BackupSchedule
-      proto-path: google.firestore.admin.v1.BackupSchedule
+      proto-msg: google.firestore.admin.v1.BackupSchedule
       notes:
         - No gcloud command found
     - name: iam-serviceaccount
@@ -10419,7 +10419,7 @@ branches:
       kind: IAMServiceAccount
       package: google.iam.admin.v1
       proto: ServiceAccount
-      proto-path: google.iam.admin.v1.ServiceAccount
+      proto-msg: google.iam.admin.v1.ServiceAccount
       notes: []
     - name: iam-serviceaccountkey
       local: resource-iam-serviceaccountkey
@@ -10431,7 +10431,7 @@ branches:
       kind: IAMServiceAccountKey
       package: google.iam.admin.v1
       proto: ServiceAccountKey
-      proto-path: google.iam.admin.v1.ServiceAccountKey
+      proto-msg: google.iam.admin.v1.ServiceAccountKey
       notes: []
     - name: iam-workloadidentitypool
       local: resource-iam-workloadidentitypool
@@ -10443,7 +10443,7 @@ branches:
       kind: IAMWorkloadIdentityPool
       package: google.iam.v1beta
       proto: WorkloadIdentityPool
-      proto-path: google.iam.v1beta.WorkloadIdentityPool
+      proto-msg: google.iam.v1beta.WorkloadIdentityPool
       notes: []
     - name: iam-workloadidentitypoolprovider
       local: resource-iam-workloadidentitypoolprovider
@@ -10455,7 +10455,7 @@ branches:
       kind: IAMWorkloadIdentityPoolProvider
       package: google.iam.v1beta
       proto: WorkloadIdentityPoolProvider
-      proto-path: google.iam.v1beta.WorkloadIdentityPoolProvider
+      proto-msg: google.iam.v1beta.WorkloadIdentityPoolProvider
       notes: []
     - name: iam-policybinding
       local: resource-iam-policybinding
@@ -10467,7 +10467,7 @@ branches:
       kind: IAMPolicyBinding
       package: google.iam.v3
       proto: PolicyBinding
-      proto-path: google.iam.v3.PolicyBinding
+      proto-msg: google.iam.v3.PolicyBinding
       notes: []
     - name: iam-principalaccessboundarypolicy
       local: resource-iam-principalaccessboundarypolicy
@@ -10479,7 +10479,7 @@ branches:
       kind: IAMPrincipalAccessBoundaryPolicy
       package: google.iam.v3
       proto: PrincipalAccessBoundaryPolicy
-      proto-path: google.iam.v3.PrincipalAccessBoundaryPolicy
+      proto-msg: google.iam.v3.PrincipalAccessBoundaryPolicy
       notes: []
     - name: identity-accesslevel
       local: resource-identity-accesslevel
@@ -10491,7 +10491,7 @@ branches:
       kind: IdentityAccessLevel
       package: google.identity.accesscontextmanager.v1
       proto: AccessLevel
-      proto-path: google.identity.accesscontextmanager.v1.AccessLevel
+      proto-msg: google.identity.accesscontextmanager.v1.AccessLevel
       notes:
         - No gcloud command found
     - name: identity-accesspolicy
@@ -10504,7 +10504,7 @@ branches:
       kind: IdentityAccessPolicy
       package: google.identity.accesscontextmanager.v1
       proto: AccessPolicy
-      proto-path: google.identity.accesscontextmanager.v1.AccessPolicy
+      proto-msg: google.identity.accesscontextmanager.v1.AccessPolicy
       notes:
         - No gcloud command found
     - name: identity-gcpuseraccessbinding
@@ -10517,7 +10517,7 @@ branches:
       kind: IdentityGcpUserAccessBinding
       package: google.identity.accesscontextmanager.v1
       proto: GcpUserAccessBinding
-      proto-path: google.identity.accesscontextmanager.v1.GcpUserAccessBinding
+      proto-msg: google.identity.accesscontextmanager.v1.GcpUserAccessBinding
       notes:
         - No gcloud command found
     - name: identity-serviceperimeter
@@ -10530,7 +10530,7 @@ branches:
       kind: IdentityServicePerimeter
       package: google.identity.accesscontextmanager.v1
       proto: ServicePerimeter
-      proto-path: google.identity.accesscontextmanager.v1.ServicePerimeter
+      proto-msg: google.identity.accesscontextmanager.v1.ServicePerimeter
       notes:
         - No gcloud command found
     - name: logging-logentry
@@ -10543,7 +10543,7 @@ branches:
       kind: LoggingLogEntry
       package: google.logging.v2
       proto: LogEntry
-      proto-path: google.logging.v2.LogEntry
+      proto-msg: google.logging.v2.LogEntry
       notes:
         - No gcloud command found
     - name: logging-logbucket
@@ -10556,7 +10556,7 @@ branches:
       kind: LoggingLogBucket
       package: google.logging.v2
       proto: LogBucket
-      proto-path: google.logging.v2.LogBucket
+      proto-msg: google.logging.v2.LogBucket
       notes: []
     - name: logging-logview
       local: resource-logging-logview
@@ -10568,7 +10568,7 @@ branches:
       kind: LoggingLogView
       package: google.logging.v2
       proto: LogView
-      proto-path: google.logging.v2.LogView
+      proto-msg: google.logging.v2.LogView
       notes:
         - No gcloud command found
     - name: logging-logsink
@@ -10581,7 +10581,7 @@ branches:
       kind: LoggingLogSink
       package: google.logging.v2
       proto: LogSink
-      proto-path: google.logging.v2.LogSink
+      proto-msg: google.logging.v2.LogSink
       notes: []
     - name: logging-link
       local: resource-logging-link
@@ -10593,7 +10593,7 @@ branches:
       kind: LoggingLink
       package: google.logging.v2
       proto: Link
-      proto-path: google.logging.v2.Link
+      proto-msg: google.logging.v2.Link
       notes: []
     - name: logging-logexclusion
       local: resource-logging-logexclusion
@@ -10605,7 +10605,7 @@ branches:
       kind: LoggingLogExclusion
       package: google.logging.v2
       proto: LogExclusion
-      proto-path: google.logging.v2.LogExclusion
+      proto-msg: google.logging.v2.LogExclusion
       notes:
         - No gcloud command found
     - name: logging-cmeksettings
@@ -10618,7 +10618,7 @@ branches:
       kind: LoggingCmekSettings
       package: google.logging.v2
       proto: CmekSettings
-      proto-path: google.logging.v2.CmekSettings
+      proto-msg: google.logging.v2.CmekSettings
       notes:
         - No gcloud command found
     - name: logging-settings
@@ -10631,7 +10631,7 @@ branches:
       kind: LoggingSettings
       package: google.logging.v2
       proto: Settings
-      proto-path: google.logging.v2.Settings
+      proto-msg: google.logging.v2.Settings
       notes: []
     - name: logging-logmetric
       local: resource-logging-logmetric
@@ -10643,7 +10643,7 @@ branches:
       kind: LoggingLogMetric
       package: google.logging.v2
       proto: LogMetric
-      proto-path: google.logging.v2.LogMetric
+      proto-msg: google.logging.v2.LogMetric
       notes: []
     - name: monitoring-alertchart
       local: resource-monitoring-alertchart
@@ -10655,7 +10655,7 @@ branches:
       kind: MonitoringAlertChart
       package: google.monitoring.dashboard.v1
       proto: AlertChart
-      proto-path: google.monitoring.dashboard.v1.AlertChart
+      proto-msg: google.monitoring.dashboard.v1.AlertChart
       notes:
         - No gcloud command found
     - name: monitoring-dashboard
@@ -10668,7 +10668,7 @@ branches:
       kind: MonitoringDashboard
       package: google.monitoring.dashboard.v1
       proto: Dashboard
-      proto-path: google.monitoring.dashboard.v1.Dashboard
+      proto-msg: google.monitoring.dashboard.v1.Dashboard
       notes: []
     - name: monitoring-metricsscope
       local: resource-monitoring-metricsscope
@@ -10680,7 +10680,7 @@ branches:
       kind: MonitoringMetricsScope
       package: google.monitoring.metricsscope.v1
       proto: MetricsScope
-      proto-path: google.monitoring.metricsscope.v1.MetricsScope
+      proto-msg: google.monitoring.metricsscope.v1.MetricsScope
       notes:
         - No gcloud command found
     - name: monitoring-monitoredproject
@@ -10693,7 +10693,7 @@ branches:
       kind: MonitoringMonitoredProject
       package: google.monitoring.metricsscope.v1
       proto: MonitoredProject
-      proto-path: google.monitoring.metricsscope.v1.MonitoredProject
+      proto-msg: google.monitoring.metricsscope.v1.MonitoredProject
       notes: []
     - name: monitoring-alertpolicy
       local: resource-monitoring-alertpolicy
@@ -10705,7 +10705,7 @@ branches:
       kind: MonitoringAlertPolicy
       package: google.monitoring.v3
       proto: AlertPolicy
-      proto-path: google.monitoring.v3.AlertPolicy
+      proto-msg: google.monitoring.v3.AlertPolicy
       notes:
         - No gcloud command found
     - name: monitoring-group
@@ -10718,7 +10718,7 @@ branches:
       kind: MonitoringGroup
       package: google.monitoring.v3
       proto: Group
-      proto-path: google.monitoring.v3.Group
+      proto-msg: google.monitoring.v3.Group
       notes: []
     - name: monitoring-notificationchanneldescriptor
       local: resource-monitoring-notificationchanneldescriptor
@@ -10730,7 +10730,7 @@ branches:
       kind: MonitoringNotificationChannelDescriptor
       package: google.monitoring.v3
       proto: NotificationChannelDescriptor
-      proto-path: google.monitoring.v3.NotificationChannelDescriptor
+      proto-msg: google.monitoring.v3.NotificationChannelDescriptor
       notes:
         - No gcloud command found
     - name: monitoring-notificationchannel
@@ -10743,7 +10743,7 @@ branches:
       kind: MonitoringNotificationChannel
       package: google.monitoring.v3
       proto: NotificationChannel
-      proto-path: google.monitoring.v3.NotificationChannel
+      proto-msg: google.monitoring.v3.NotificationChannel
       notes: []
     - name: monitoring-service
       local: resource-monitoring-service
@@ -10755,7 +10755,7 @@ branches:
       kind: MonitoringService
       package: google.monitoring.v3
       proto: Service
-      proto-path: google.monitoring.v3.Service
+      proto-msg: google.monitoring.v3.Service
       notes: []
     - name: monitoring-servicelevelobjective
       local: resource-monitoring-servicelevelobjective
@@ -10767,7 +10767,7 @@ branches:
       kind: MonitoringServiceLevelObjective
       package: google.monitoring.v3
       proto: ServiceLevelObjective
-      proto-path: google.monitoring.v3.ServiceLevelObjective
+      proto-msg: google.monitoring.v3.ServiceLevelObjective
       notes: []
     - name: monitoring-snooze
       local: resource-monitoring-snooze
@@ -10779,7 +10779,7 @@ branches:
       kind: MonitoringSnooze
       package: google.monitoring.v3
       proto: Snooze
-      proto-path: google.monitoring.v3.Snooze
+      proto-msg: google.monitoring.v3.Snooze
       notes: []
     - name: monitoring-uptimecheckconfig
       local: resource-monitoring-uptimecheckconfig
@@ -10791,7 +10791,7 @@ branches:
       kind: MonitoringUptimeCheckConfig
       package: google.monitoring.v3
       proto: UptimeCheckConfig
-      proto-path: google.monitoring.v3.UptimeCheckConfig
+      proto-msg: google.monitoring.v3.UptimeCheckConfig
       notes: []
     - name: privacy-finding
       local: resource-privacy-finding
@@ -10803,7 +10803,7 @@ branches:
       kind: PrivacyFinding
       package: google.privacy.dlp.v2
       proto: Finding
-      proto-path: google.privacy.dlp.v2.Finding
+      proto-msg: google.privacy.dlp.v2.Finding
       notes:
         - No gcloud command found
     - name: privacy-inspecttemplate
@@ -10816,7 +10816,7 @@ branches:
       kind: PrivacyInspectTemplate
       package: google.privacy.dlp.v2
       proto: InspectTemplate
-      proto-path: google.privacy.dlp.v2.InspectTemplate
+      proto-msg: google.privacy.dlp.v2.InspectTemplate
       notes:
         - No gcloud command found
     - name: privacy-deidentifytemplate
@@ -10829,7 +10829,7 @@ branches:
       kind: PrivacyDeidentifyTemplate
       package: google.privacy.dlp.v2
       proto: DeidentifyTemplate
-      proto-path: google.privacy.dlp.v2.DeidentifyTemplate
+      proto-msg: google.privacy.dlp.v2.DeidentifyTemplate
       notes:
         - No gcloud command found
     - name: privacy-jobtrigger
@@ -10842,7 +10842,7 @@ branches:
       kind: PrivacyJobTrigger
       package: google.privacy.dlp.v2
       proto: JobTrigger
-      proto-path: google.privacy.dlp.v2.JobTrigger
+      proto-msg: google.privacy.dlp.v2.JobTrigger
       notes:
         - No gcloud command found
     - name: privacy-discoveryconfig
@@ -10855,7 +10855,7 @@ branches:
       kind: PrivacyDiscoveryConfig
       package: google.privacy.dlp.v2
       proto: DiscoveryConfig
-      proto-path: google.privacy.dlp.v2.DiscoveryConfig
+      proto-msg: google.privacy.dlp.v2.DiscoveryConfig
       notes:
         - No gcloud command found
     - name: privacy-dlpjob
@@ -10868,7 +10868,7 @@ branches:
       kind: PrivacyDlpJob
       package: google.privacy.dlp.v2
       proto: DlpJob
-      proto-path: google.privacy.dlp.v2.DlpJob
+      proto-msg: google.privacy.dlp.v2.DlpJob
       notes:
         - No gcloud command found
     - name: privacy-storedinfotype
@@ -10881,7 +10881,7 @@ branches:
       kind: PrivacyStoredInfoType
       package: google.privacy.dlp.v2
       proto: StoredInfoType
-      proto-path: google.privacy.dlp.v2.StoredInfoType
+      proto-msg: google.privacy.dlp.v2.StoredInfoType
       notes:
         - No gcloud command found
     - name: privacy-projectdataprofile
@@ -10894,7 +10894,7 @@ branches:
       kind: PrivacyProjectDataProfile
       package: google.privacy.dlp.v2
       proto: ProjectDataProfile
-      proto-path: google.privacy.dlp.v2.ProjectDataProfile
+      proto-msg: google.privacy.dlp.v2.ProjectDataProfile
       notes:
         - No gcloud command found
     - name: privacy-tabledataprofile
@@ -10907,7 +10907,7 @@ branches:
       kind: PrivacyTableDataProfile
       package: google.privacy.dlp.v2
       proto: TableDataProfile
-      proto-path: google.privacy.dlp.v2.TableDataProfile
+      proto-msg: google.privacy.dlp.v2.TableDataProfile
       notes:
         - No gcloud command found
     - name: privacy-columndataprofile
@@ -10920,7 +10920,7 @@ branches:
       kind: PrivacyColumnDataProfile
       package: google.privacy.dlp.v2
       proto: ColumnDataProfile
-      proto-path: google.privacy.dlp.v2.ColumnDataProfile
+      proto-msg: google.privacy.dlp.v2.ColumnDataProfile
       notes:
         - No gcloud command found
     - name: privacy-filestoredataprofile
@@ -10933,7 +10933,7 @@ branches:
       kind: PrivacyFileStoreDataProfile
       package: google.privacy.dlp.v2
       proto: FileStoreDataProfile
-      proto-path: google.privacy.dlp.v2.FileStoreDataProfile
+      proto-msg: google.privacy.dlp.v2.FileStoreDataProfile
       notes:
         - No gcloud command found
     - name: privacy-connection
@@ -10946,7 +10946,7 @@ branches:
       kind: PrivacyConnection
       package: google.privacy.dlp.v2
       proto: Connection
-      proto-path: google.privacy.dlp.v2.Connection
+      proto-msg: google.privacy.dlp.v2.Connection
       notes:
         - No gcloud command found
     - name: pubsub-topic
@@ -10959,7 +10959,7 @@ branches:
       kind: PubSubTopic
       package: google.pubsub.v1
       proto: Topic
-      proto-path: google.pubsub.v1.Topic
+      proto-msg: google.pubsub.v1.Topic
       notes: []
     - name: pubsub-subscription
       local: resource-pubsub-subscription
@@ -10971,7 +10971,7 @@ branches:
       kind: PubSubSubscription
       package: google.pubsub.v1
       proto: Subscription
-      proto-path: google.pubsub.v1.Subscription
+      proto-msg: google.pubsub.v1.Subscription
       notes: []
     - name: pubsub-snapshot
       local: resource-pubsub-snapshot
@@ -10983,7 +10983,7 @@ branches:
       kind: PubSubSnapshot
       package: google.pubsub.v1
       proto: Snapshot
-      proto-path: google.pubsub.v1.Snapshot
+      proto-msg: google.pubsub.v1.Snapshot
       notes: []
     - name: pubsub-schema
       local: resource-pubsub-schema
@@ -10995,7 +10995,7 @@ branches:
       kind: PubSubSchema
       package: google.pubsub.v1
       proto: Schema
-      proto-path: google.pubsub.v1.Schema
+      proto-msg: google.pubsub.v1.Schema
       notes: []
     - name: spanner-backup
       local: resource-spanner-backup
@@ -11007,7 +11007,7 @@ branches:
       kind: SpannerBackup
       package: google.spanner.admin.database.v1
       proto: Backup
-      proto-path: google.spanner.admin.database.v1.Backup
+      proto-msg: google.spanner.admin.database.v1.Backup
       notes: []
     - name: spanner-backupschedule
       local: resource-spanner-backupschedule
@@ -11019,7 +11019,7 @@ branches:
       kind: SpannerBackupSchedule
       package: google.spanner.admin.database.v1
       proto: BackupSchedule
-      proto-path: google.spanner.admin.database.v1.BackupSchedule
+      proto-msg: google.spanner.admin.database.v1.BackupSchedule
       notes: []
     - name: spanner-database
       local: resource-spanner-database
@@ -11031,7 +11031,7 @@ branches:
       kind: SpannerDatabase
       package: google.spanner.admin.database.v1
       proto: Database
-      proto-path: google.spanner.admin.database.v1.Database
+      proto-msg: google.spanner.admin.database.v1.Database
       notes: []
     - name: spanner-databaserole
       local: resource-spanner-databaserole
@@ -11043,7 +11043,7 @@ branches:
       kind: SpannerDatabaseRole
       package: google.spanner.admin.database.v1
       proto: DatabaseRole
-      proto-path: google.spanner.admin.database.v1.DatabaseRole
+      proto-msg: google.spanner.admin.database.v1.DatabaseRole
       notes:
         - No gcloud command found
     - name: spanner-instanceconfig
@@ -11056,7 +11056,7 @@ branches:
       kind: SpannerInstanceConfig
       package: google.spanner.admin.instance.v1
       proto: InstanceConfig
-      proto-path: google.spanner.admin.instance.v1.InstanceConfig
+      proto-msg: google.spanner.admin.instance.v1.InstanceConfig
       notes: []
     - name: spanner-instance
       local: resource-spanner-instance
@@ -11068,7 +11068,7 @@ branches:
       kind: SpannerInstance
       package: google.spanner.admin.instance.v1
       proto: Instance
-      proto-path: google.spanner.admin.instance.v1.Instance
+      proto-msg: google.spanner.admin.instance.v1.Instance
       notes: []
     - name: spanner-instancepartition
       local: resource-spanner-instancepartition
@@ -11080,7 +11080,7 @@ branches:
       kind: SpannerInstancePartition
       package: google.spanner.admin.instance.v1
       proto: InstancePartition
-      proto-path: google.spanner.admin.instance.v1.InstancePartition
+      proto-msg: google.spanner.admin.instance.v1.InstancePartition
       notes:
         - No gcloud command found
     - name: spanner-session
@@ -11093,7 +11093,7 @@ branches:
       kind: SpannerSession
       package: google.spanner.v1
       proto: Session
-      proto-path: google.spanner.v1.Session
+      proto-msg: google.spanner.v1.Session
       notes:
         - No gcloud command found
     - name: storage-folder
@@ -11106,7 +11106,7 @@ branches:
       kind: StorageFolder
       package: google.storage.control.v2
       proto: Folder
-      proto-path: google.storage.control.v2.Folder
+      proto-msg: google.storage.control.v2.Folder
       notes: []
     - name: storage-storagelayout
       local: resource-storage-storagelayout
@@ -11118,7 +11118,7 @@ branches:
       kind: StorageStorageLayout
       package: google.storage.control.v2
       proto: StorageLayout
-      proto-path: google.storage.control.v2.StorageLayout
+      proto-msg: google.storage.control.v2.StorageLayout
       notes:
         - No gcloud command found
     - name: storage-managedfolder
@@ -11131,7 +11131,7 @@ branches:
       kind: StorageManagedFolder
       package: google.storage.control.v2
       proto: ManagedFolder
-      proto-path: google.storage.control.v2.ManagedFolder
+      proto-msg: google.storage.control.v2.ManagedFolder
       notes: []
     - name: storage-bucket
       local: resource-storage-bucket
@@ -11143,7 +11143,7 @@ branches:
       kind: StorageBucket
       package: google.storage.v2
       proto: Bucket
-      proto-path: google.storage.v2.Bucket
+      proto-msg: google.storage.v2.Bucket
       notes: []
     - name: storagetransfer-agentpool
       local: resource-storagetransfer-agentpool
@@ -11155,7 +11155,7 @@ branches:
       kind: StorageTransferAgentPool
       package: google.storagetransfer.v1
       proto: AgentPool
-      proto-path: google.storagetransfer.v1.AgentPool
+      proto-msg: google.storagetransfer.v1.AgentPool
       notes: []
     - name: ai-customjobs
       local: resource-ai-customjobs
@@ -11167,7 +11167,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-endpoints
       local: resource-ai-endpoints
@@ -11179,7 +11179,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-hptuningjobs
       local: resource-ai-hptuningjobs
@@ -11191,7 +11191,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-indexendpoints
       local: resource-ai-indexendpoints
@@ -11203,7 +11203,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-indexes
       local: resource-ai-indexes
@@ -11215,7 +11215,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-modelmonitoringjobs
       local: resource-ai-modelmonitoringjobs
@@ -11227,7 +11227,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-operations
       local: resource-ai-operations
@@ -11239,7 +11239,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-persistentresources
       local: resource-ai-persistentresources
@@ -11251,7 +11251,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: ai-tensorboards
       local: resource-ai-tensorboards
@@ -11263,7 +11263,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: aiplatform-jobs
       local: resource-aiplatform-jobs
@@ -11275,7 +11275,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: aiplatform-local
       local: resource-aiplatform-local
@@ -11287,7 +11287,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: aiplatform-operations
       local: resource-aiplatform-operations
@@ -11299,7 +11299,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: aiplatform-versions
       local: resource-aiplatform-versions
@@ -11311,7 +11311,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: alloydb-operations
       local: resource-alloydb-operations
@@ -11323,7 +11323,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigeeregistry-applications
       local: resource-apigeeregistry-applications
@@ -11335,7 +11335,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigeeregistry-deployments
       local: resource-apigeeregistry-deployments
@@ -11347,7 +11347,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigeeregistry-developers
       local: resource-apigeeregistry-developers
@@ -11359,7 +11359,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-domainmappings
       local: resource-appengine-domainmappings
@@ -11371,7 +11371,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-firewallrules
       local: resource-appengine-firewallrules
@@ -11383,7 +11383,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-logs
       local: resource-appengine-logs
@@ -11395,7 +11395,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-operations
       local: resource-appengine-operations
@@ -11407,7 +11407,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-regions
       local: resource-appengine-regions
@@ -11419,7 +11419,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-runtimes
       local: resource-appengine-runtimes
@@ -11431,7 +11431,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-services
       local: resource-appengine-services
@@ -11443,7 +11443,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-sslcertificates
       local: resource-appengine-sslcertificates
@@ -11455,7 +11455,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apphub-versions
       local: resource-apphub-versions
@@ -11467,7 +11467,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apphub-locations
       local: resource-apphub-locations
@@ -11479,7 +11479,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apphub-operations
       local: resource-apphub-operations
@@ -11491,7 +11491,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apphub-serviceprojects
       local: resource-apphub-serviceprojects
@@ -11503,7 +11503,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: asset-operations
       local: resource-asset-operations
@@ -11515,7 +11515,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: assuredworkloads-operations
       local: resource-assuredworkloads-operations
@@ -11527,7 +11527,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: backupdr-locations
       local: resource-backupdr-locations
@@ -11539,7 +11539,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: backupdr-operations
       local: resource-backupdr-operations
@@ -11551,7 +11551,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: baremetalsolution-operations
       local: resource-baremetalsolution-operations
@@ -11563,7 +11563,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: beyondcorp-app
       local: resource-beyondcorp-app
@@ -11575,7 +11575,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-datasets
       local: resource-bigquery-datasets
@@ -11587,7 +11587,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-jobs
       local: resource-bigquery-jobs
@@ -11599,7 +11599,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigtable-operations
       local: resource-bigtable-operations
@@ -11611,7 +11611,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: billing-projects
       local: resource-billing-projects
@@ -11623,7 +11623,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-maps
       local: resource-certificatemanager-maps
@@ -11635,7 +11635,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-operations
       local: resource-certificatemanager-operations
@@ -11647,7 +11647,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudbuild-workerpools
       local: resource-cloudbuild-workerpools
@@ -11659,7 +11659,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes:
         - No matching generated proto
     - name: clouddms-objects
@@ -11672,7 +11672,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: clouddms-operations
       local: resource-clouddms-operations
@@ -11684,7 +11684,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: config-configurations
       local: resource-config-configurations
@@ -11696,7 +11696,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-clusters
       local: resource-dataproc-clusters
@@ -11708,7 +11708,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-jobs
       local: resource-dataproc-jobs
@@ -11720,7 +11720,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-operations
       local: resource-dataproc-operations
@@ -11732,7 +11732,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-locations
       local: resource-datastream-locations
@@ -11744,7 +11744,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-objects
       local: resource-datastream-objects
@@ -11756,7 +11756,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-operations
       local: resource-datastream-operations
@@ -11768,7 +11768,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: developerconnect-operations
       local: resource-developerconnect-operations
@@ -11780,7 +11780,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-operations
       local: resource-edgecontainer-operations
@@ -11792,7 +11792,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-regions
       local: resource-edgecontainer-regions
@@ -11804,7 +11804,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-zones
       local: resource-edgecontainer-zones
@@ -11816,7 +11816,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgenetwork-operations
       local: resource-edgenetwork-operations
@@ -11828,7 +11828,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: eventarc-auditlogsprovider
       local: resource-eventarc-auditlogsprovider
@@ -11840,7 +11840,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: eventarc-googlechannels
       local: resource-eventarc-googlechannels
@@ -11852,7 +11852,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: eventarc-locations
       local: resource-eventarc-locations
@@ -11864,7 +11864,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-locations
       local: resource-filestore-locations
@@ -11876,7 +11876,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-operations
       local: resource-filestore-operations
@@ -11888,7 +11888,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-regions
       local: resource-filestore-regions
@@ -11900,7 +11900,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-zones
       local: resource-filestore-zones
@@ -11912,7 +11912,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firestore-databases
       local: resource-firestore-databases
@@ -11924,7 +11924,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firestore-locations
       local: resource-firestore-locations
@@ -11936,7 +11936,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firestore-operations
       local: resource-firestore-operations
@@ -11948,7 +11948,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: functions-eventtypes
       local: resource-functions-eventtypes
@@ -11960,7 +11960,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: functions-logs
       local: resource-functions-logs
@@ -11972,7 +11972,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: functions-regions
       local: resource-functions-regions
@@ -11984,7 +11984,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: functions-runtimes
       local: resource-functions-runtimes
@@ -11996,7 +11996,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkebackup-locations
       local: resource-gkebackup-locations
@@ -12008,7 +12008,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkebackup-operations
       local: resource-gkebackup-operations
@@ -12020,7 +12020,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-oauthclient
       local: resource-iam-oauthclient
@@ -12032,7 +12032,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-policy
       local: resource-iam-policy
@@ -12044,7 +12044,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-role
       local: resource-iam-role
@@ -12056,7 +12056,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-simulator
       local: resource-iam-simulator
@@ -12068,7 +12068,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-workforcepool
       local: resource-iam-workforcepool
@@ -12080,7 +12080,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-oauthbrands
       local: resource-iap-oauthbrands
@@ -12092,7 +12092,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-oauthclients
       local: resource-iap-oauthclients
@@ -12104,7 +12104,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-settings
       local: resource-iap-settings
@@ -12116,7 +12116,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-tcp
       local: resource-iap-tcp
@@ -12128,7 +12128,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-web
       local: resource-iap-web
@@ -12140,7 +12140,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identity-group
       local: resource-identity-group
@@ -12152,7 +12152,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: kms-inventory
       local: resource-kms-inventory
@@ -12164,7 +12164,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: kms-location
       local: resource-kms-location
@@ -12176,7 +12176,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-buckets
       local: resource-logging-buckets
@@ -12188,7 +12188,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-locations
       local: resource-logging-locations
@@ -12200,7 +12200,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-logs
       local: resource-logging-logs
@@ -12212,7 +12212,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-metrics
       local: resource-logging-metrics
@@ -12224,7 +12224,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-operations
       local: resource-logging-operations
@@ -12236,7 +12236,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-resourcedescriptors
       local: resource-logging-resourcedescriptors
@@ -12248,7 +12248,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-scopes
       local: resource-logging-scopes
@@ -12260,7 +12260,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-sinks
       local: resource-logging-sinks
@@ -12272,7 +12272,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: logging-views
       local: resource-logging-views
@@ -12284,7 +12284,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: memcache-operations
       local: resource-memcache-operations
@@ -12296,7 +12296,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: memcache-regions
       local: resource-memcache-regions
@@ -12308,7 +12308,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: memorystore-operations
       local: resource-memorystore-operations
@@ -12320,7 +12320,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: metastore-locations
       local: resource-metastore-locations
@@ -12332,7 +12332,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: metastore-operations
       local: resource-metastore-operations
@@ -12344,7 +12344,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: monitoring-uptime
       local: resource-monitoring-uptime
@@ -12356,7 +12356,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: netapp-location
       local: resource-netapp-location
@@ -12368,7 +12368,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: netapp-operation
       local: resource-netapp-operation
@@ -12380,7 +12380,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-internalranges
       local: resource-networkconnectivity-internalranges
@@ -12392,7 +12392,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-locations
       local: resource-networkconnectivity-locations
@@ -12404,7 +12404,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-operations
       local: resource-networkconnectivity-operations
@@ -12416,7 +12416,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-regionalendpoints
       local: resource-networkconnectivity-regionalendpoints
@@ -12428,7 +12428,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkmanagement-operations
       local: resource-networkmanagement-operations
@@ -12440,7 +12440,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-addressgroups
       local: resource-networksecurity-addressgroups
@@ -12452,7 +12452,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-firewallendpointassociations
       local: resource-networksecurity-firewallendpointassociations
@@ -12464,7 +12464,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-firewallendpoints
       local: resource-networksecurity-firewallendpoints
@@ -12476,7 +12476,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-gatewaysecuritypolicies
       local: resource-networksecurity-gatewaysecuritypolicies
@@ -12488,7 +12488,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-orgaddressgroups
       local: resource-networksecurity-orgaddressgroups
@@ -12500,7 +12500,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-securityprofilegroups
       local: resource-networksecurity-securityprofilegroups
@@ -12512,7 +12512,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-securityprofiles
       local: resource-networksecurity-securityprofiles
@@ -12524,7 +12524,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-tlsinspectionpolicies
       local: resource-networksecurity-tlsinspectionpolicies
@@ -12536,7 +12536,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-urllists
       local: resource-networksecurity-urllists
@@ -12548,7 +12548,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-routeviews
       local: resource-networkservices-routeviews
@@ -12560,7 +12560,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-servicelbpolicies
       local: resource-networkservices-servicelbpolicies
@@ -12572,7 +12572,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: notebooks-locations
       local: resource-notebooks-locations
@@ -12584,7 +12584,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: oracledatabase-operations
       local: resource-oracledatabase-operations
@@ -12596,7 +12596,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: osconfig-projectfeaturesettings
       local: resource-osconfig-projectfeaturesettings
@@ -12608,7 +12608,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: parallelstore-locations
       local: resource-parallelstore-locations
@@ -12620,7 +12620,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: parallelstore-operations
       local: resource-parallelstore-operations
@@ -12632,7 +12632,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privilegedaccessmanager-entitlements
       local: resource-privilegedaccessmanager-entitlements
@@ -12644,7 +12644,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privilegedaccessmanager-operations
       local: resource-privilegedaccessmanager-operations
@@ -12656,7 +12656,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: pubsub-liteoperations
       local: resource-pubsub-liteoperations
@@ -12668,7 +12668,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: pubsub-litereservations
       local: resource-pubsub-litereservations
@@ -12680,7 +12680,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: pubsub-litesubscriptions
       local: resource-pubsub-litesubscriptions
@@ -12692,7 +12692,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: pubsub-litetopics
       local: resource-pubsub-litetopics
@@ -12704,7 +12704,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: pubsub-schemas
       local: resource-pubsub-schemas
@@ -12716,7 +12716,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: redis-operations
       local: resource-redis-operations
@@ -12728,7 +12728,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: redis-regions
       local: resource-redis-regions
@@ -12740,7 +12740,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: redis-zones
       local: resource-redis-zones
@@ -12752,7 +12752,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: resourcemanager-orgpolicies
       local: resource-resourcemanager-orgpolicies
@@ -12764,7 +12764,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: resourcemanager-tags
       local: resource-resourcemanager-tags
@@ -12776,7 +12776,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: run-domainmappings
       local: resource-run-domainmappings
@@ -12788,7 +12788,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: run-regions
       local: resource-run-regions
@@ -12800,7 +12800,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: scheduler-locations
       local: resource-scheduler-locations
@@ -12812,7 +12812,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: secrets-locations
       local: resource-secrets-locations
@@ -12824,7 +12824,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: secrets-replication
       local: resource-secrets-replication
@@ -12836,7 +12836,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-custommodules
       local: resource-securitycenter-custommodules
@@ -12848,7 +12848,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-iacvalidationreports
       local: resource-securitycenter-iacvalidationreports
@@ -12860,7 +12860,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-manage
       local: resource-securitycenter-manage
@@ -12872,7 +12872,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-notifications
       local: resource-securitycenter-notifications
@@ -12884,7 +12884,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-operations
       local: resource-securitycenter-operations
@@ -12896,7 +12896,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-posturedeployments
       local: resource-securitycenter-posturedeployments
@@ -12908,7 +12908,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-postureoperations
       local: resource-securitycenter-postureoperations
@@ -12920,7 +12920,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-posturetemplates
       local: resource-securitycenter-posturetemplates
@@ -12932,7 +12932,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-postures
       local: resource-securitycenter-postures
@@ -12944,7 +12944,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securitycenter-source
       local: resource-securitycenter-source
@@ -12956,7 +12956,7 @@ branches:
       kind: SecurityCenterSource
       package: google.cloud.securitycenter.v2
       proto: Source
-      proto-path: google.cloud.securitycenter.v2.Source
+      proto-msg: google.cloud.securitycenter.v2.Source
       notes: []
     - name: servicedirectory-locations
       local: resource-servicedirectory-locations
@@ -12968,7 +12968,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: spanner-operation
       local: resource-spanner-operation
@@ -12980,7 +12980,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: spanner-row
       local: resource-spanner-row
@@ -12992,7 +12992,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: spanner-sample
       local: resource-spanner-sample
@@ -13004,7 +13004,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: speech-operations
       local: resource-speech-operations
@@ -13016,7 +13016,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-hmac
       local: resource-storage-hmac
@@ -13028,7 +13028,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-insight
       local: resource-storage-insight
@@ -13040,7 +13040,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-object
       local: resource-storage-object
@@ -13052,7 +13052,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-operation
       local: resource-storage-operation
@@ -13064,7 +13064,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storagetransfer-agents
       local: resource-storagetransfer-agents
@@ -13076,7 +13076,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storagetransfer-jobs
       local: resource-storagetransfer-jobs
@@ -13088,7 +13088,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storagetransfer-operations
       local: resource-storagetransfer-operations
@@ -13100,7 +13100,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tasks-cmekconfig
       local: resource-tasks-cmekconfig
@@ -13112,7 +13112,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tasks-locations
       local: resource-tasks-locations
@@ -13124,7 +13124,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: telcoautomation-operations
       local: resource-telcoautomation-operations
@@ -13136,7 +13136,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tpu-executiongroup
       local: resource-tpu-executiongroup
@@ -13148,7 +13148,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tpu-location
       local: resource-tpu-location
@@ -13160,7 +13160,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tpu-topology
       local: resource-tpu-topology
@@ -13172,7 +13172,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tpu-vm
       local: resource-tpu-vm
@@ -13184,7 +13184,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tpu-version
       local: resource-tpu-version
@@ -13196,7 +13196,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vmwareengine-locations
       local: resource-vmwareengine-locations
@@ -13208,7 +13208,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vmwareengine-networks
       local: resource-vmwareengine-networks
@@ -13220,7 +13220,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vmwareengine-operations
       local: resource-vmwareengine-operations
@@ -13232,7 +13232,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanageraccesslevelconditions
       local: resource-accesscontextmanager-accesscontextmanageraccesslevelconditions
@@ -13244,7 +13244,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanageraccesslevels
       local: resource-accesscontextmanager-accesscontextmanageraccesslevels
@@ -13256,7 +13256,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanageraccesspolicies
       local: resource-accesscontextmanager-accesscontextmanageraccesspolicies
@@ -13268,7 +13268,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanagergcpuseraccessbindings
       local: resource-accesscontextmanager-accesscontextmanagergcpuseraccessbindings
@@ -13280,7 +13280,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanagerserviceperimeterresources
       local: resource-accesscontextmanager-accesscontextmanagerserviceperimeterresources
@@ -13292,7 +13292,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: accesscontextmanager-accesscontextmanagerserviceperimeters
       local: resource-accesscontextmanager-accesscontextmanagerserviceperimeters
@@ -13304,7 +13304,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: alloydb-alloydbbackups
       local: resource-alloydb-alloydbbackups
@@ -13316,7 +13316,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: alloydb-alloydbclusters
       local: resource-alloydb-alloydbclusters
@@ -13328,7 +13328,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: alloydb-alloydbusers
       local: resource-alloydb-alloydbusers
@@ -13340,7 +13340,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigateway-apigatewayapiconfigs
       local: resource-apigateway-apigatewayapiconfigs
@@ -13352,7 +13352,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigateway-apigatewayapis
       local: resource-apigateway-apigatewayapis
@@ -13364,7 +13364,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigateway-apigatewaygateways
       local: resource-apigateway-apigatewaygateways
@@ -13376,7 +13376,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeaddonsconfigs
       local: resource-apigee-apigeeaddonsconfigs
@@ -13388,7 +13388,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeendpointattachments
       local: resource-apigee-apigeeendpointattachments
@@ -13400,7 +13400,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeinstanceattachments
       local: resource-apigee-apigeeinstanceattachments
@@ -13412,7 +13412,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeenataddresses
       local: resource-apigee-apigeenataddresses
@@ -13424,7 +13424,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeesyncauthorizations
       local: resource-apigee-apigeesyncauthorizations
@@ -13436,7 +13436,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apikeys-apikeyskeys
       local: resource-apikeys-apikeyskeys
@@ -13448,7 +13448,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-appenginedomainmappings
       local: resource-appengine-appenginedomainmappings
@@ -13460,7 +13460,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-appenginefirewallrules
       local: resource-appengine-appenginefirewallrules
@@ -13472,7 +13472,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-appengineflexibleappversions
       local: resource-appengine-appengineflexibleappversions
@@ -13484,7 +13484,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-appengineservicesplittraffics
       local: resource-appengine-appengineservicesplittraffics
@@ -13496,7 +13496,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: appengine-appenginestandardappversion
       local: resource-appengine-appenginestandardappversion
@@ -13508,7 +13508,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: beyondcorp-beyondcorpappconnections
       local: resource-beyondcorp-beyondcorpappconnections
@@ -13520,7 +13520,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: beyondcorp-beyondcorpappconnectors
       local: resource-beyondcorp-beyondcorpappconnectors
@@ -13532,7 +13532,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: beyondcorp-beyondcorpappgateways
       local: resource-beyondcorp-beyondcorpappgateways
@@ -13544,7 +13544,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquerydatapolicy-bigquerydatapolicydatapolicies
       local: resource-bigquerydatapolicy-bigquerydatapolicydatapolicies
@@ -13556,7 +13556,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-bigquerydatasetaccesses
       local: resource-bigquery-bigquerydatasetaccesses
@@ -13568,7 +13568,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-bigquerydatasets
       local: resource-bigquery-bigquerydatasets
@@ -13580,7 +13580,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-bigqueryjobs
       local: resource-bigquery-bigqueryjobs
@@ -13592,7 +13592,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigqueryreservation-bigqueryreservationcapacitycommitments
       local: resource-bigqueryreservation-bigqueryreservationcapacitycommitments
@@ -13604,7 +13604,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigqueryreservation-bigqueryreservationreservations
       local: resource-bigqueryreservation-bigqueryreservationreservations
@@ -13616,7 +13616,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-bigqueryroutines
       local: resource-bigquery-bigqueryroutines
@@ -13628,7 +13628,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquery-bigquerytables
       local: resource-bigquery-bigquerytables
@@ -13640,7 +13640,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigtable-bigtableappprofiles
       local: resource-bigtable-bigtableappprofiles
@@ -13652,7 +13652,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigtable-bigtablegcpolicies
       local: resource-bigtable-bigtablegcpolicies
@@ -13664,7 +13664,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigtable-bigtableinstances
       local: resource-bigtable-bigtableinstances
@@ -13676,7 +13676,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigtable-bigtabletables
       local: resource-bigtable-bigtabletables
@@ -13688,7 +13688,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-certificatemanagercertificatemapentries
       local: resource-certificatemanager-certificatemanagercertificatemapentries
@@ -13700,7 +13700,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-certificatemanagercertificatemaps
       local: resource-certificatemanager-certificatemanagercertificatemaps
@@ -13712,7 +13712,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-certificatemanagercertificates
       local: resource-certificatemanager-certificatemanagercertificates
@@ -13724,7 +13724,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudasset-cloudassetfolderfeeds
       local: resource-cloudasset-cloudassetfolderfeeds
@@ -13736,7 +13736,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudasset-cloudassetorganizationfeeds
       local: resource-cloudasset-cloudassetorganizationfeeds
@@ -13748,7 +13748,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudasset-cloudassetprojectfeeds
       local: resource-cloudasset-cloudassetprojectfeeds
@@ -13760,7 +13760,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudbuild-triggers
       local: resource-cloudbuild-triggers
@@ -13772,7 +13772,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudfunctions2-cloudfunctions2functions
       local: resource-cloudfunctions2-cloudfunctions2functions
@@ -13784,7 +13784,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudidentity-cloudidentitygroup
       local: resource-cloudidentity-cloudidentitygroup
@@ -13796,7 +13796,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudids-cloudidsendpoints
       local: resource-cloudids-cloudidsendpoints
@@ -13808,7 +13808,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudiot-cloudiotdeviceregistries
       local: resource-cloudiot-cloudiotdeviceregistries
@@ -13820,7 +13820,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudiot-cloudiotdevices
       local: resource-cloudiot-cloudiotdevices
@@ -13832,7 +13832,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudtasks-cloudtasksqueues
       local: resource-cloudtasks-cloudtasksqueues
@@ -13844,7 +13844,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeaddresses
       local: resource-compute-computeaddresses
@@ -13856,7 +13856,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeautoscalers
       local: resource-compute-computeautoscalers
@@ -13868,7 +13868,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computebackendbuckets
       local: resource-compute-computebackendbuckets
@@ -13880,7 +13880,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computebackendbucketsignedurlkeys
       local: resource-compute-computebackendbucketsignedurlkeys
@@ -13892,7 +13892,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computebackendservice
       local: resource-compute-computebackendservice
@@ -13904,7 +13904,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computebackendservicesignedurlkeys
       local: resource-compute-computebackendservicesignedurlkeys
@@ -13916,7 +13916,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computediskresourcepolicyattachments
       local: resource-compute-computediskresourcepolicyattachments
@@ -13928,7 +13928,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computedisks
       local: resource-compute-computedisks
@@ -13940,7 +13940,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeexternalvpngateways
       local: resource-compute-computeexternalvpngateways
@@ -13952,7 +13952,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computefirewalls
       local: resource-compute-computefirewalls
@@ -13964,7 +13964,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeforwardingrules
       local: resource-compute-computeforwardingrules
@@ -13976,7 +13976,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeglobalnetworkendpointgroups
       local: resource-compute-computeglobalnetworkendpointgroups
@@ -13988,7 +13988,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeglobalnetworkendpoints
       local: resource-compute-computeglobalnetworkendpoints
@@ -14000,7 +14000,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computehealthchecks
       local: resource-compute-computehealthchecks
@@ -14012,7 +14012,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computehttphealthchecks
       local: resource-compute-computehttphealthchecks
@@ -14024,7 +14024,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computehttpshealthchecks
       local: resource-compute-computehttpshealthchecks
@@ -14036,7 +14036,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeimages
       local: resource-compute-computeimages
@@ -14048,7 +14048,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinstancegroupnamedports
       local: resource-compute-computeinstancegroupnamedports
@@ -14060,7 +14060,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinstancegroups
       local: resource-compute-computeinstancegroups
@@ -14072,7 +14072,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinstances
       local: resource-compute-computeinstances
@@ -14084,7 +14084,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinstancetemplates
       local: resource-compute-computeinstancetemplates
@@ -14096,7 +14096,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinterconnectattachments
       local: resource-compute-computeinterconnectattachments
@@ -14108,7 +14108,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computemachineimages
       local: resource-compute-computemachineimages
@@ -14120,7 +14120,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computemanagedsslcertificates
       local: resource-compute-computemanagedsslcertificates
@@ -14132,7 +14132,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkendpointgroups
       local: resource-compute-computenetworkendpointgroups
@@ -14144,7 +14144,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkendpoints
       local: resource-compute-computenetworkendpoints
@@ -14156,7 +14156,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkfirewallpolicies
       local: resource-compute-computenetworkfirewallpolicies
@@ -14168,7 +14168,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkfirewallpolicyassociations
       local: resource-compute-computenetworkfirewallpolicyassociations
@@ -14180,7 +14180,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkfirewallpolicyrules
       local: resource-compute-computenetworkfirewallpolicyrules
@@ -14192,7 +14192,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkpeeringroutesconfigs
       local: resource-compute-computenetworkpeeringroutesconfigs
@@ -14204,7 +14204,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworkpeerings
       local: resource-compute-computenetworkpeerings
@@ -14216,7 +14216,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenetworks
       local: resource-compute-computenetworks
@@ -14228,7 +14228,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenodegroups
       local: resource-compute-computenodegroups
@@ -14240,7 +14240,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computenodetemplates
       local: resource-compute-computenodetemplates
@@ -14252,7 +14252,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeorganizationsecuritypolicies
       local: resource-compute-computeorganizationsecuritypolicies
@@ -14264,7 +14264,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeorganizationsecuritypolicyassociations
       local: resource-compute-computeorganizationsecuritypolicyassociations
@@ -14276,7 +14276,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeorganizationsecuritypolicyrules
       local: resource-compute-computeorganizationsecuritypolicyrules
@@ -14288,7 +14288,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeperinstanceconfigs
       local: resource-compute-computeperinstanceconfigs
@@ -14300,7 +14300,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeprojectmetadatas
       local: resource-compute-computeprojectmetadatas
@@ -14312,7 +14312,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeregionautoscalers
       local: resource-compute-computeregionautoscalers
@@ -14324,7 +14324,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeregiondiskresourcepolicyattachments
       local: resource-compute-computeregiondiskresourcepolicyattachments
@@ -14336,7 +14336,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeregionnetworkendpointgroups
       local: resource-compute-computeregionnetworkendpointgroups
@@ -14348,7 +14348,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeregionperinstanceconfigs
       local: resource-compute-computeregionperinstanceconfigs
@@ -14360,7 +14360,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeregionsslpolicies
       local: resource-compute-computeregionsslpolicies
@@ -14372,7 +14372,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computereservations
       local: resource-compute-computereservations
@@ -14384,7 +14384,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeresourcepolicies
       local: resource-compute-computeresourcepolicies
@@ -14396,7 +14396,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computerouterinterfaces
       local: resource-compute-computerouterinterfaces
@@ -14408,7 +14408,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computerouternats
       local: resource-compute-computerouternats
@@ -14420,7 +14420,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computerouterpeers
       local: resource-compute-computerouterpeers
@@ -14432,7 +14432,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computerouters
       local: resource-compute-computerouters
@@ -14444,7 +14444,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeroutes
       local: resource-compute-computeroutes
@@ -14456,7 +14456,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesecuritypolicies
       local: resource-compute-computesecuritypolicies
@@ -14468,7 +14468,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesharedvpchostprojects
       local: resource-compute-computesharedvpchostprojects
@@ -14480,7 +14480,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesharedvpcserviceprojects
       local: resource-compute-computesharedvpcserviceprojects
@@ -14492,7 +14492,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesnapshots
       local: resource-compute-computesnapshots
@@ -14504,7 +14504,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesslcertificates
       local: resource-compute-computesslcertificates
@@ -14516,7 +14516,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesslpolicies
       local: resource-compute-computesslpolicies
@@ -14528,7 +14528,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computesubnetworks
       local: resource-compute-computesubnetworks
@@ -14540,7 +14540,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargetgrpcproxies
       local: resource-compute-computetargetgrpcproxies
@@ -14552,7 +14552,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargethttpproxies
       local: resource-compute-computetargethttpproxies
@@ -14564,7 +14564,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargethttpsproxies
       local: resource-compute-computetargethttpsproxies
@@ -14576,7 +14576,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargetinstances
       local: resource-compute-computetargetinstances
@@ -14588,7 +14588,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargetpools
       local: resource-compute-computetargetpools
@@ -14600,7 +14600,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargetsslproxies
       local: resource-compute-computetargetsslproxies
@@ -14612,7 +14612,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargettcpproxies
       local: resource-compute-computetargettcpproxies
@@ -14624,7 +14624,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computetargetvpngateways
       local: resource-compute-computetargetvpngateways
@@ -14636,7 +14636,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeurlmaps
       local: resource-compute-computeurlmaps
@@ -14648,7 +14648,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computevpngateways
       local: resource-compute-computevpngateways
@@ -14660,7 +14660,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computevpntunnels
       local: resource-compute-computevpntunnels
@@ -14672,7 +14672,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: containeranalysis-containeranalysisoccurrences
       local: resource-containeranalysis-containeranalysisoccurrences
@@ -14684,7 +14684,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: containerattached-containerattachedclusters
       local: resource-containerattached-containerattachedclusters
@@ -14696,7 +14696,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: container-containerclusters
       local: resource-container-containerclusters
@@ -14708,7 +14708,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: container-containernodepools
       local: resource-container-containernodepools
@@ -14720,7 +14720,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogentries
       local: resource-datacatalog-datacatalogentries
@@ -14732,7 +14732,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogentrygroups
       local: resource-datacatalog-datacatalogentrygroups
@@ -14744,7 +14744,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogpolicytags
       local: resource-datacatalog-datacatalogpolicytags
@@ -14756,7 +14756,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogtags
       local: resource-datacatalog-datacatalogtags
@@ -14768,7 +14768,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogtagtemplates
       local: resource-datacatalog-datacatalogtagtemplates
@@ -14780,7 +14780,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datacatalog-datacatalogtaxonomies
       local: resource-datacatalog-datacatalogtaxonomies
@@ -14792,7 +14792,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataflow-dataflowflextemplatejobs
       local: resource-dataflow-dataflowflextemplatejobs
@@ -14804,7 +14804,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataflow-dataflowjobs
       local: resource-dataflow-dataflowjobs
@@ -14816,7 +14816,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastore-datastoreindexes
       local: resource-datastore-datastoreindexes
@@ -14828,7 +14828,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-datastreamconnectionprofiles
       local: resource-datastream-datastreamconnectionprofiles
@@ -14840,7 +14840,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-datastreamprivateconnections
       local: resource-datastream-datastreamprivateconnections
@@ -14852,7 +14852,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datastream-datastreamstreams
       local: resource-datastream-datastreamstreams
@@ -14864,7 +14864,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: deploymentmanager-deploymentmanagerdeployments
       local: resource-deploymentmanager-deploymentmanagerdeployments
@@ -14876,7 +14876,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflow-dialogflowagents
       local: resource-dialogflow-dialogflowagents
@@ -14888,7 +14888,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxagents
       local: resource-dialogflowcx-dialogflowcxagents
@@ -14900,7 +14900,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxentitytypes
       local: resource-dialogflowcx-dialogflowcxentitytypes
@@ -14912,7 +14912,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxflows
       local: resource-dialogflowcx-dialogflowcxflows
@@ -14924,7 +14924,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxintents
       local: resource-dialogflowcx-dialogflowcxintents
@@ -14936,7 +14936,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxpages
       local: resource-dialogflowcx-dialogflowcxpages
@@ -14948,7 +14948,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflowcx-dialogflowcxwebhooks
       local: resource-dialogflowcx-dialogflowcxwebhooks
@@ -14960,7 +14960,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflow-dialogflowentitytypes
       local: resource-dialogflow-dialogflowentitytypes
@@ -14972,7 +14972,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflow-dialogflowfulfillments
       local: resource-dialogflow-dialogflowfulfillments
@@ -14984,7 +14984,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dialogflow-dialogflowintents
       local: resource-dialogflow-dialogflowintents
@@ -14996,7 +14996,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dns-dnsmanagedzones
       local: resource-dns-dnsmanagedzones
@@ -15008,7 +15008,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dns-dnspolicies
       local: resource-dns-dnspolicies
@@ -15020,7 +15020,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dns-dnsrecordsets
       local: resource-dns-dnsrecordsets
@@ -15032,7 +15032,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dns-dnsresponsepolicies
       local: resource-dns-dnsresponsepolicies
@@ -15044,7 +15044,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dns-dnsresponsepolicyrules
       local: resource-dns-dnsresponsepolicyrules
@@ -15056,7 +15056,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: documentai-documentaiprocessordefaultversions
       local: resource-documentai-documentaiprocessordefaultversions
@@ -15068,7 +15068,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: documentai-documentaiprocessors
       local: resource-documentai-documentaiprocessors
@@ -15080,7 +15080,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-edgecontainerclusters
       local: resource-edgecontainer-edgecontainerclusters
@@ -15092,7 +15092,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-edgecontainernodepools
       local: resource-edgecontainer-edgecontainernodepools
@@ -15104,7 +15104,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgecontainer-edgecontainervpnconnections
       local: resource-edgecontainer-edgecontainervpnconnections
@@ -15116,7 +15116,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgenetwork-edgenetworknetworks
       local: resource-edgenetwork-edgenetworknetworks
@@ -15128,7 +15128,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: edgenetwork-edgenetworksubnets
       local: resource-edgenetwork-edgenetworksubnets
@@ -15140,7 +15140,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: essentialcontacts-essentialcontactscontacts
       local: resource-essentialcontacts-essentialcontactscontacts
@@ -15152,7 +15152,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-filestoresnapshots
       local: resource-filestore-filestoresnapshots
@@ -15164,7 +15164,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebase-firebaseandroidapps
       local: resource-firebase-firebaseandroidapps
@@ -15176,7 +15176,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebasedatabase-firebasedatabaseinstances
       local: resource-firebasedatabase-firebasedatabaseinstances
@@ -15188,7 +15188,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebasehosting-firebasehostingchannels
       local: resource-firebasehosting-firebasehostingchannels
@@ -15200,7 +15200,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebasehosting-firebasehostingsites
       local: resource-firebasehosting-firebasehostingsites
@@ -15212,7 +15212,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebase-firebaseprojects
       local: resource-firebase-firebaseprojects
@@ -15224,7 +15224,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebasestorage-firebasestoragebucket
       local: resource-firebasestorage-firebasestoragebucket
@@ -15236,7 +15236,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firebase-firebasewebapps
       local: resource-firebase-firebasewebapps
@@ -15248,7 +15248,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: firestore-firestoreindexes
       local: resource-firestore-firestoreindexes
@@ -15260,7 +15260,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkebackup-gkebackupbackupplans
       local: resource-gkebackup-gkebackupbackupplans
@@ -15272,7 +15272,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: healthcare-healthcareconsentstores
       local: resource-healthcare-healthcareconsentstores
@@ -15284,7 +15284,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: healthcare-healthcaredatasets
       local: resource-healthcare-healthcaredatasets
@@ -15296,7 +15296,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: healthcare-healthcaredicomstores
       local: resource-healthcare-healthcaredicomstores
@@ -15308,7 +15308,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: healthcare-healthcarefhirstores
       local: resource-healthcare-healthcarefhirstores
@@ -15320,7 +15320,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: healthcare-healthcarehl7v2stores
       local: resource-healthcare-healthcarehl7v2stores
@@ -15332,7 +15332,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-accessboundarypolicy
       local: resource-iam-accessboundarypolicy
@@ -15344,7 +15344,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-customrole
       local: resource-iam-customrole
@@ -15356,7 +15356,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformdefaultsupportedidpconfigs
       local: resource-identityplatform-identityplatformdefaultsupportedidpconfigs
@@ -15368,7 +15368,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatforminboundsamlconfigs
       local: resource-identityplatform-identityplatforminboundsamlconfigs
@@ -15380,7 +15380,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformprojectdefaultconfigs
       local: resource-identityplatform-identityplatformprojectdefaultconfigs
@@ -15392,7 +15392,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformtenantdefaultsupportedidpconfigs
       local: resource-identityplatform-identityplatformtenantdefaultsupportedidpconfigs
@@ -15404,7 +15404,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformtenantinboundsamlconfigs
       local: resource-identityplatform-identityplatformtenantinboundsamlconfigs
@@ -15416,7 +15416,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: kms-keyringimportjob
       local: resource-kms-keyringimportjob
@@ -15428,7 +15428,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: kms-kmsecretciphertext
       local: resource-kms-secretciphertext
@@ -15440,7 +15440,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: memcache-memcacheinstances
       local: resource-memcache-memcacheinstances
@@ -15452,7 +15452,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: mlengine-mlenginemodels
       local: resource-mlengine-mlenginemodels
@@ -15464,7 +15464,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: monitoring-alertpolicies
       local: resource-monitoring-alertpolicies
@@ -15476,7 +15476,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkmanagement-networkmanagementconnectivitytests
       local: resource-networkmanagement-networkmanagementconnectivitytests
@@ -15488,7 +15488,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesedgecachekeysets
       local: resource-networkservices-networkservicesedgecachekeysets
@@ -15500,7 +15500,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesedgecacheorigins
       local: resource-networkservices-networkservicesedgecacheorigins
@@ -15512,7 +15512,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesedgecacheservices
       local: resource-networkservices-networkservicesedgecacheservices
@@ -15524,7 +15524,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: notebooks-notebooksenvironments
       local: resource-notebooks-notebooksenvironments
@@ -15536,7 +15536,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: orgpolicy-orgpolicycustomconstraints
       local: resource-orgpolicy-orgpolicycustomconstraints
@@ -15548,7 +15548,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: osconfig-osconfigpatchdeployments
       local: resource-osconfig-osconfigpatchdeployments
@@ -15560,7 +15560,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: resourcemanager-projects
       local: resource-resourcemanager-projects
@@ -15572,7 +15572,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: resourcemanager-resourcemanagerliens
       local: resource-resourcemanager-resourcemanagerliens
@@ -15584,7 +15584,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: resourcemanager-resourcemanagerpolicies
       local: resource-resourcemanager-resourcemanagerpolicies
@@ -15596,7 +15596,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: run-runjobs
       local: resource-run-runjobs
@@ -15608,7 +15608,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: run-runservices
       local: resource-run-runservices
@@ -15620,7 +15620,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: servicedirectory-servicedirectoryendpoints
       local: resource-servicedirectory-servicedirectoryendpoints
@@ -15632,7 +15632,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: servicedirectory-servicedirectorynamespaces
       local: resource-servicedirectory-servicedirectorynamespaces
@@ -15644,7 +15644,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: servicedirectory-servicedirectoryservices
       local: resource-servicedirectory-servicedirectoryservices
@@ -15656,7 +15656,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: serviceusage-serviceidentities
       local: resource-serviceusage-serviceidentities
@@ -15668,7 +15668,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: servicenetworking-servicenetworkingconnections
       local: resource-servicenetworking-servicenetworkingconnections
@@ -15680,7 +15680,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: serviceusage-services
       local: resource-serviceusage-services
@@ -15692,7 +15692,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: serviceusage-serviceusageconsumerquotaoverrides
       local: resource-serviceusage-serviceusageconsumerquotaoverrides
@@ -15704,7 +15704,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: sourcerepo-sourcereporepositories
       local: resource-sourcerepo-sourcereporepositories
@@ -15716,7 +15716,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: sql-sqldatabases
       local: resource-sql-sqldatabases
@@ -15728,7 +15728,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: sql-sqlsslcerts
       local: resource-sql-sqlsslcerts
@@ -15740,7 +15740,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: sql-sqlusers
       local: resource-sql-sqlusers
@@ -15752,7 +15752,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-bucketaccesscontrol
       local: resource-storage-bucketaccesscontrol
@@ -15764,7 +15764,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-defaultobjectaccesscontrol
       local: resource-storage-defaultobjectaccesscontrol
@@ -15776,7 +15776,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-hmackey
       local: resource-storage-hmackey
@@ -15788,7 +15788,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storage-notification
       local: resource-storage-notification
@@ -15800,7 +15800,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storagetransfer-storagetransferagentpools
       local: resource-storagetransfer-storagetransferagentpools
@@ -15812,7 +15812,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: storagetransfer-storagetransferjobs
       local: resource-storagetransfer-storagetransferjobs
@@ -15824,7 +15824,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tags-tagslocationtagbindings
       local: resource-tags-tagslocationtagbindings
@@ -15836,7 +15836,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tags-tagstagbindings
       local: resource-tags-tagstagbindings
@@ -15848,7 +15848,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tags-tagstagkeys
       local: resource-tags-tagstagkeys
@@ -15860,7 +15860,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: tags-tagstagvalues
       local: resource-tags-tagstagvalues
@@ -15872,7 +15872,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaidatasets
       local: resource-vertexai-vertexaidatasets
@@ -15884,7 +15884,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaiendpoints
       local: resource-vertexai-vertexaiendpoints
@@ -15896,7 +15896,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaifeaturestoreentitytypefeatures
       local: resource-vertexai-vertexaifeaturestoreentitytypefeatures
@@ -15908,7 +15908,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaifeaturestoreentitytypes
       local: resource-vertexai-vertexaifeaturestoreentitytypes
@@ -15920,7 +15920,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaifeaturestores
       local: resource-vertexai-vertexaifeaturestores
@@ -15932,7 +15932,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaiindexendpoints
       local: resource-vertexai-vertexaiindexendpoints
@@ -15944,7 +15944,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaiindexes
       local: resource-vertexai-vertexaiindexes
@@ -15956,7 +15956,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaimetadatastores
       local: resource-vertexai-vertexaimetadatastores
@@ -15968,7 +15968,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vertexai-vertexaitensorboards
       local: resource-vertexai-vertexaitensorboards
@@ -15980,7 +15980,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: vpcaccess-vpcaccessconnectors
       local: resource-vpcaccess-vpcaccessconnectors
@@ -15992,7 +15992,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: workflows-workflow
       local: resource-workflows-workflow
@@ -16004,7 +16004,7 @@ branches:
       kind: WorkflowsWorkflow
       package: google.cloud.workflows.v1
       proto: Workflow
-      proto-path: google.cloud.workflows.v1.Workflow
+      proto-msg: google.cloud.workflows.v1.Workflow
       notes: []
     - name: apigee-apigeeenvironments
       local: resource-apigee-apigeeenvironments
@@ -16016,7 +16016,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeorganizations
       local: resource-apigee-apigeeorganizations
@@ -16028,7 +16028,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: billingbudgets-billingbudgetsbudgets
       local: resource-billingbudgets-billingbudgetsbudgets
@@ -16040,7 +16040,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: binaryauthorization-binaryauthorizationattestors
       local: resource-binaryauthorization-binaryauthorizationattestors
@@ -16052,7 +16052,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: binaryauthorization-binaryauthorizationpolicies
       local: resource-binaryauthorization-binaryauthorizationpolicies
@@ -16064,7 +16064,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudfunctions-cloudfunctionsfunctions
       local: resource-cloudfunctions-cloudfunctionsfunctions
@@ -16076,7 +16076,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudidentity-cloudidentitymembership
       local: resource-cloudidentity-cloudidentitymembership
@@ -16088,7 +16088,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: cloudscheduler-cloudschedulerjobs
       local: resource-cloudscheduler-cloudschedulerjobs
@@ -16100,7 +16100,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computefirewallpolicies
       local: resource-compute-computefirewallpolicies
@@ -16112,7 +16112,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computefirewallpolicyassociations
       local: resource-compute-computefirewallpolicyassociations
@@ -16124,7 +16124,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeinstancegroupmanagers
       local: resource-compute-computeinstancegroupmanagers
@@ -16136,7 +16136,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computepacketmirrorings
       local: resource-compute-computepacketmirrorings
@@ -16148,7 +16148,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computeserviceattachments
       local: resource-compute-computeserviceattachments
@@ -16160,7 +16160,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: configcontroller-configcontrollerinstances
       local: resource-configcontroller-configcontrollerinstances
@@ -16172,7 +16172,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: containeranalysis-containeranalysisnotes
       local: resource-containeranalysis-containeranalysisnotes
@@ -16184,7 +16184,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: datafusion-datafusioninstances
       local: resource-datafusion-datafusioninstances
@@ -16196,7 +16196,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-dataprocautoscalingpolicies
       local: resource-dataproc-dataprocautoscalingpolicies
@@ -16208,7 +16208,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-dataprocclusters
       local: resource-dataproc-dataprocclusters
@@ -16220,7 +16220,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dataproc-dataprocworkflowtemplates
       local: resource-dataproc-dataprocworkflowtemplates
@@ -16232,7 +16232,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dlp-dlpdeidentifytemplates
       local: resource-dlp-dlpdeidentifytemplates
@@ -16244,7 +16244,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dlp-dlpinspecttemplates
       local: resource-dlp-dlpinspecttemplates
@@ -16256,7 +16256,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dlp-dlpjobtriggers
       local: resource-dlp-dlpjobtriggers
@@ -16268,7 +16268,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: dlp-dlpstoredinfotypes
       local: resource-dlp-dlpstoredinfotypes
@@ -16280,7 +16280,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: eventarc-eventarctriggers
       local: resource-eventarc-eventarctriggers
@@ -16292,7 +16292,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-filestorebackups
       local: resource-filestore-filestorebackups
@@ -16304,7 +16304,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: filestore-filestoreinstances
       local: resource-filestore-filestoreinstances
@@ -16316,7 +16316,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkehub-gkehubfeatures
       local: resource-gkehub-gkehubfeatures
@@ -16328,7 +16328,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkehub-gkehubmemberships
       local: resource-gkehub-gkehubmemberships
@@ -16340,7 +16340,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-iapbrands
       local: resource-iap-iapbrands
@@ -16352,7 +16352,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-iapidentityawareproxyclients
       local: resource-iap-iapidentityawareproxyclients
@@ -16364,7 +16364,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformconfigs
       local: resource-identityplatform-identityplatformconfigs
@@ -16376,7 +16376,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformoauthidpconfigs
       local: resource-identityplatform-identityplatformoauthidpconfigs
@@ -16388,7 +16388,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformtenantoauthidpconfigs
       local: resource-identityplatform-identityplatformtenantoauthidpconfigs
@@ -16400,7 +16400,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: identityplatform-identityplatformtenants
       local: resource-identityplatform-identityplatformtenants
@@ -16412,7 +16412,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: monitoring-metricdescriptor
       local: resource-monitoring-metricdescriptor
@@ -16424,7 +16424,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-networkconnectivityhubs
       local: resource-networkconnectivity-networkconnectivityhubs
@@ -16436,7 +16436,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-networkconnectivityspokes
       local: resource-networkconnectivity-networkconnectivityspokes
@@ -16448,7 +16448,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-networksecurityauthorizationpolicies
       local: resource-networksecurity-networksecurityauthorizationpolicies
@@ -16460,7 +16460,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-networksecurityclienttlspolicies
       local: resource-networksecurity-networksecurityclienttlspolicies
@@ -16472,7 +16472,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networksecurity-networksecurityservertlspolicies
       local: resource-networksecurity-networksecurityservertlspolicies
@@ -16484,7 +16484,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesendpointpolicies
       local: resource-networkservices-networkservicesendpointpolicies
@@ -16496,7 +16496,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesgateways
       local: resource-networkservices-networkservicesgateways
@@ -16508,7 +16508,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesgrpcroutes
       local: resource-networkservices-networkservicesgrpcroutes
@@ -16520,7 +16520,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkserviceshttproutes
       local: resource-networkservices-networkserviceshttproutes
@@ -16532,7 +16532,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicesmeshes
       local: resource-networkservices-networkservicesmeshes
@@ -16544,7 +16544,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicestcproutes
       local: resource-networkservices-networkservicestcproutes
@@ -16556,7 +16556,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkservices-networkservicestlsroutes
       local: resource-networkservices-networkservicestlsroutes
@@ -16568,7 +16568,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: osconfig-osconfigguestpolicies
       local: resource-osconfig-osconfigguestpolicies
@@ -16580,7 +16580,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: osconfig-osconfigospolicyassignments
       local: resource-osconfig-osconfigospolicyassignments
@@ -16592,7 +16592,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privateca-privatecacapools
       local: resource-privateca-privatecacapools
@@ -16604,7 +16604,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privateca-privatecacertificateauthorities
       local: resource-privateca-privatecacertificateauthorities
@@ -16616,7 +16616,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privateca-privatecacertificates
       local: resource-privateca-privatecacertificates
@@ -16628,7 +16628,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: privateca-privatecacertificatetemplates
       local: resource-privateca-privatecacertificatetemplates
@@ -16640,7 +16640,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: recaptchaenterprise-recaptchaenterprisekeys
       local: resource-recaptchaenterprise-recaptchaenterprisekeys
@@ -16652,7 +16652,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: alloydb-alloydbinstances
       local: resource-alloydb-alloydbinstances
@@ -16664,7 +16664,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeenvgroupattachments
       local: resource-apigee-apigeeenvgroupattachments
@@ -16676,7 +16676,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeenvgroups
       local: resource-apigee-apigeeenvgroups
@@ -16688,7 +16688,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: apigee-apigeeinstances
       local: resource-apigee-apigeeinstances
@@ -16700,7 +16700,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigqueryanalyticshub-bigqueryanalyticshubdataexchanges
       local: resource-bigqueryanalyticshub-bigqueryanalyticshubdataexchanges
@@ -16712,7 +16712,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigqueryanalyticshub-bigqueryanalyticshublistings
       local: resource-bigqueryanalyticshub-bigqueryanalyticshublistings
@@ -16724,7 +16724,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigqueryconnection-bigqueryconnectionconnections
       local: resource-bigqueryconnection-bigqueryconnectionconnections
@@ -16736,7 +16736,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: bigquerydatatransfer-bigquerydatatransferconfigs
       local: resource-bigquerydatatransfer-bigquerydatatransferconfigs
@@ -16748,7 +16748,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: certificatemanager-certificatemanagerdnsauthorizations
       local: resource-certificatemanager-certificatemanagerdnsauthorizations
@@ -16760,7 +16760,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: compute-computefirewallpolicyrules
       local: resource-compute-computefirewallpolicyrules
@@ -16772,7 +16772,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: discoveryengine-discoveryenginedatastores
       local: resource-discoveryengine-discoveryenginedatastores
@@ -16784,7 +16784,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: discoveryengine-discoveryenginedatastoretargetsites
       local: resource-discoveryengine-discoveryenginedatastoretargetsites
@@ -16796,7 +16796,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: discoveryengine-discoveryengineengines
       local: resource-discoveryengine-discoveryengineengines
@@ -16808,7 +16808,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: gkehub-gkehubfeaturememberships
       local: resource-gkehub-gkehubfeaturememberships
@@ -16820,7 +16820,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-auditconfig
       local: resource-iam-auditconfig
@@ -16832,7 +16832,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-partialpolicy
       local: resource-iam-partialpolicy
@@ -16844,7 +16844,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-iampolicy
       local: resource-iam-iampolicy
@@ -16856,7 +16856,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iam-policymember
       local: resource-iam-policymember
@@ -16868,7 +16868,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: iap-iapsettings
       local: resource-iap-iapsettings
@@ -16880,7 +16880,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: managedkafka-managedkafkaclusters
       local: resource-managedkafka-managedkafkaclusters
@@ -16892,7 +16892,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: managedkafka-managedkafkatopics
       local: resource-managedkafka-managedkafkatopics
@@ -16904,7 +16904,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: memorystore-memorystoreinstances
       local: resource-memorystore-memorystoreinstances
@@ -16916,7 +16916,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: networkconnectivity-networkconnectivityserviceconnectionpolicies
       local: resource-networkconnectivity-networkconnectivityserviceconnectionpolicies
@@ -16928,7 +16928,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securesourcemanager-securesourcemanagerinstances
       local: resource-securesourcemanager-securesourcemanagerinstances
@@ -16940,7 +16940,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: securesourcemanager-securesourcemanagerrepositories
       local: resource-securesourcemanager-securesourcemanagerrepositories
@@ -16952,7 +16952,7 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []
     - name: sql-sqlinstances
       local: resource-sql-sqlinstances
@@ -16964,5 +16964,5 @@ branches:
       kind: ""
       package: ""
       proto: ""
-      proto-path: ""
+      proto-msg: ""
       notes: []

--- a/experiments/conductor/branches.yaml
+++ b/experiments/conductor/branches.yaml
@@ -23,8 +23,9 @@ branches:
     kind: AccessApprovalApprovalRequest
     package: google.cloud.accessapproval.v1
     proto: ApprovalRequest
-    proto-path: google.cloud.accessapproval.v1.ApprovalRequest
+    proto-path: google.cloud.accessapproval.v1.accessapproval
     proto-service: google.cloud.accessapproval.v1.AccessApproval
+    proto-msg: google.cloud.accessapproval.v1.ApprovalRequest
     host-name: accessapproval.googleapis.com
     notes:
       - No gcloud command found
@@ -39,7 +40,8 @@ branches:
     package: ""
     proto: ""
     proto-path: ""
-    proto-svc: ""
+    proto-service: ""
+    proto-msg:
     host_name: ""
     notes:
   - name: compute-computebackendservice
@@ -52,7 +54,8 @@ branches:
     kind: ""
     package: ""
     proto: BackendService
-    proto-path: google.cloud.compute.v1.BackendService
+    proto-path: google.cloud.compute.v1.Compute
     proto-service: google.cloud.compute.v1.BackendServices
+    proto-msg: google.cloud.compute.v1.BackendService
     host-name: compute.googleapis.com
     notes:

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -101,8 +101,9 @@ type Branch struct {
 	Kind      string `yaml:"kind"`          // AIModel
 	Package   string `yaml:"package"`       // google.ai.generativelanguage.v1beta
 	Proto     string `yaml:"proto"`         // Model
-	ProtoPath string `yaml:"proto-path"`    // google.ai.generativelanguage.v1beta.Model
+	ProtoPath string `yaml:"proto-path"`    // google.ai.generativelanguage.v1beta.model_service
 	ProtoSvc  string `yaml:"proto-service"` // google.ai.generativelanguage.v1beta.ModelService
+	ProtoMsg  string `yaml:"proto-msg"`     // google.ai.generativelanguage.v1beta.Model
 	HostName  string `yaml:"host-name"`     // generativelanguage.googleapis.com
 
 	Notes []string `yaml:"notes"` // Observation goes here
@@ -161,7 +162,6 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 	case 4:
 		for idx, branch := range branches.Branches {
 			log.Printf("Create Script YAML: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
-			// createScriptYamlBash(opts, branch)
 			createScriptYaml(opts, branch)
 		}
 	case 5:
@@ -173,6 +173,16 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		for idx, branch := range branches.Branches {
 			log.Printf("Generate mock Service and Resource go files: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			generateMockGo(opts, branch)
+		}
+	case 7:
+		for idx, branch := range branches.Branches {
+			log.Printf("Add service to mock_http_roundtrip.go: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			addServiceToRoundTrip(opts, branch)
+		}
+	case 8:
+		for idx, branch := range branches.Branches {
+			log.Printf("Add proto to makefile: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			addProtoToMakfile(opts, branch)
 		}
 	default:
 		log.Fatalf("unrecognixed command: %d", opts.command)


### PR DESCRIPTION
### Change description

Added a proto-msg metadata field.
Switch proto-path values to being proto-msg values. Reserved proto-path for the actual proto file path. Added 2 new commands.
Removed the old createScriptYamlBash command as confusing. Added a few new utility methods.

### Tests you have done

./bin/conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/cheftako/k8s-config-connector_branches --branch-conf=branches.yaml --logging-dir=./logs --command=7

./bin/conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/cheftako/k8s-config-connector_branches --branch-conf=branches.yaml --logging-dir=./logs --command=8

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
