### PR TITLE
Fix panic in the conductor tooling and remove ctf from makefile

### DIFF
--- a/dev/tools/controllerbuilder/Makefile
+++ b/dev/tools/controllerbuilder/Makefile
@@ -2,7 +2,7 @@
 all: build
 
 .PHONY: build
-build: codebot controllerbuilder ctf benchmark
+build: codebot controllerbuilder benchmark
 
 .PHONY: controllerbuilder
 controllerbuilder:

--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -73,7 +73,7 @@ func createScriptYaml(opts *RunnerOptions, branch Branch) {
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
 
 	var out strings.Builder
-	checkoutBranch(branch, workDir, out)
+	checkoutBranch(branch, workDir, &out)
 
 	// Check to see if the script file already exists
 	scriptFile := fmt.Sprintf("mock%s/testdata/%s/crud/script.yaml", branch.Group, branch.Resource)
@@ -114,10 +114,10 @@ func createScriptYaml(opts *RunnerOptions, branch Branch) {
 	}
 
 	// Add the new file to the current branch.
-	gitAdd(workDir, out, scriptFile)
+	gitAdd(workDir, &out, scriptFile)
 
 	// Commit the change to the current branch.
-	gitCommit(workDir, out, fmt.Sprintf("Adding LLM/gcloud generated test script.yaml for %s", branch.Name))
+	gitCommit(workDir, &out, fmt.Sprintf("Adding LLM/gcloud generated test script.yaml for %s", branch.Name))
 }
 
 const CAPTURE_HTTP_LOG string = `I need to capture the logs from GCP for running a mockgcp test that I just created.  I then need to create a git commit.
@@ -151,7 +151,7 @@ func captureHttpLog(opts *RunnerOptions, branch Branch) {
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
 
 	var out strings.Builder
-	checkoutBranch(branch, workDir, out)
+	checkoutBranch(branch, workDir, &out)
 
 	// Check to see if the script file exists
 	scriptFile := fmt.Sprintf("mock%s/testdata/%s/crud/script.yaml", branch.Group, branch.Resource)
@@ -197,10 +197,10 @@ func captureHttpLog(opts *RunnerOptions, branch Branch) {
 	}
 
 	// Add the new file to the current branch.
-	gitAdd(workDir, out, logFullPath)
+	gitAdd(workDir, &out, logFullPath)
 
 	// Commit the change to the current branch.
-	gitCommit(workDir, out, fmt.Sprintf("Adding mockgcptests generated _http.log for %s", branch.Name))
+	gitCommit(workDir, &out, fmt.Sprintf("Adding mockgcptests generated _http.log for %s", branch.Name))
 }
 
 const MOCK_SERVICE_GO_GEN string = `mock<SERVICE>/service.go
@@ -219,7 +219,7 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
 
 	var out strings.Builder
-	checkoutBranch(branch, workDir, out)
+	checkoutBranch(branch, workDir, &out)
 
 	// Check to see if the http log file already exists
 	logFile := fmt.Sprintf("mock%s/testdata/%s/crud/_http.log", branch.Group, branch.Resource)
@@ -320,10 +320,10 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 	}
 
 	// Add the new files to the current branch.
-	gitAdd(workDir, out, serviceFile, resourceFile)
+	gitAdd(workDir, &out, serviceFile, resourceFile)
 
 	// Commit the change to the current branch.
-	gitCommit(workDir, out, fmt.Sprintf("Adding mock service and resource for %s", branch.Name))
+	gitCommit(workDir, &out, fmt.Sprintf("Adding mock service and resource for %s", branch.Name))
 }
 
 const ADD_SERVICE_TO_ROUNDTRIP string = `Please add the services in <TICK>mock<SERVICE><TICK> to <TICK>mock_http_roundtrip.go<TICK>
@@ -339,7 +339,7 @@ func addServiceToRoundTrip(opts *RunnerOptions, branch Branch) {
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
 
 	var out strings.Builder
-	checkoutBranch(branch, workDir, out)
+	checkoutBranch(branch, workDir, &out)
 
 	serviceFile := filepath.Join(workDir, fmt.Sprintf("mock%s", branch.Group), "service.go")
 	if _, err := os.Stat(serviceFile); errors.Is(err, os.ErrNotExist) {
@@ -371,10 +371,10 @@ func addServiceToRoundTrip(opts *RunnerOptions, branch Branch) {
 	log.Printf("CODEBOT GENERATE (%v): %q\n", diff, out.String())
 
 	// Add the new files to the current branch.
-	gitAdd(workDir, out, "mock_http_roundtrip.go")
+	gitAdd(workDir, &out, "mock_http_roundtrip.go")
 
 	// Commit the change to the current branch.
-	gitCommit(workDir, out, fmt.Sprintf("Adding service to mock_http_roundtrip.go for %s", branch.Name))
+	gitCommit(workDir, &out, fmt.Sprintf("Adding service to mock_http_roundtrip.go for %s", branch.Name))
 }
 
 const ADD_PROTO_TO_MAKEFILE string = `Please add the generation for <TICK><PROTO_PACKAGE><TICK> to the <TICK>generate-grpc-for-google-protos<TICK> target in <TICK>Makefile<TICK>.
@@ -393,7 +393,7 @@ func addProtoToMakfile(opts *RunnerOptions, branch Branch) {
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
 
 	var out strings.Builder
-	checkoutBranch(branch, workDir, out)
+	checkoutBranch(branch, workDir, &out)
 
 	// TODO: Populate the ProtoPath in branches-all.yaml.
 	// Maybe populate it with the actual filepath?
@@ -430,9 +430,9 @@ func addProtoToMakfile(opts *RunnerOptions, branch Branch) {
 	log.Printf("CODEBOT GENERATE (%v): %q\n", diff, out.String())
 
 	// Add the new files to the current branch.
-	gitAdd(workDir, out, "Makefile")
+	gitAdd(workDir, &out, "Makefile")
 
 	// Commit the change to the current branch.
-	gitCommit(workDir, out, fmt.Sprintf("Adding proto to Makefile for %s", branch.Name))
+	gitCommit(workDir, &out, fmt.Sprintf("Adding proto to Makefile for %s", branch.Name))
 
 }

--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -232,7 +232,7 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 	// Check to see if the script file exists
 	serviceGoFile := fmt.Sprintf("mock%s/service.go", branch.Group)
 	serviceGoFullPath := filepath.Join(workDir, serviceGoFile)
-	if _, err := os.Stat(serviceGoFullPath); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(serviceGoFullPath); !errors.Is(err, os.ErrNotExist) {
 		log.Printf("SKIPPING %s, %s already exists\r\n", branch.Name, serviceGoFullPath)
 		return
 	}

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -92,11 +92,11 @@ func cdRepoBranchDirBash(opts *RunnerOptions, subdir string, stdin io.WriteClose
 	return msg
 }
 
-func checkoutBranch(branch Branch, workDir string, out strings.Builder) {
+func checkoutBranch(branch Branch, workDir string, out *strings.Builder) {
 	log.Printf("COMMAND: git checkout %s\r\n", branch.Local)
 	checkout := exec.Command("git", "checkout", branch.Local)
 	checkout.Dir = workDir
-	checkout.Stdout = &out
+	checkout.Stdout = out
 	if err := checkout.Run(); err != nil {
 		log.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func writeTemplateToFile(branch Branch, filePath string, template string) {
 	}
 }
 
-func gitAdd(workDir string, out strings.Builder, files ...string) {
+func gitAdd(workDir string, out *strings.Builder, files ...string) {
 	params := ""
 	first := true
 	for _, file := range files {
@@ -141,20 +141,20 @@ func gitAdd(workDir string, out strings.Builder, files ...string) {
 	log.Printf("COMMAND: git add %s\r\n", params)
 	gitadd := exec.Command("git", "add", params)
 	gitadd.Dir = workDir
-	gitadd.Stdout = &out
-	gitadd.Stderr = &out
+	gitadd.Stdout = out
+	gitadd.Stderr = out
 	if err := gitadd.Run(); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("BRANCH ADD: %q\n", out.String())
 }
 
-func gitCommit(workDir string, out strings.Builder, msg string) {
+func gitCommit(workDir string, out *strings.Builder, msg string) {
 	log.Printf("COMMAND: git commit -m %q\r\n", msg)
 	gitcommit := exec.Command("git", "commit", "-m", fmt.Sprintf("%q", msg))
 	gitcommit.Dir = workDir
-	gitcommit.Stdout = &out
-	gitcommit.Stderr = &out
+	gitcommit.Stdout = out
+	gitcommit.Stderr = out
 	if err := gitcommit.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -139,11 +139,14 @@ func gitAdd(workDir string, out *strings.Builder, files ...string) {
 		params += file
 	}
 	log.Printf("COMMAND: git add %s\r\n", params)
-	gitadd := exec.Command("git", "add", params)
+	args := []string{"add"}
+	args = append(args, files...)
+	gitadd := exec.Command("git", args...)
 	gitadd.Dir = workDir
 	gitadd.Stdout = out
 	gitadd.Stderr = out
 	if err := gitadd.Run(); err != nil {
+		log.Printf("GIT add error: %q\n", out.String())
 		log.Fatal(err)
 	}
 	log.Printf("BRANCH ADD: %q\n", out.String())
@@ -156,6 +159,7 @@ func gitCommit(workDir string, out *strings.Builder, msg string) {
 	gitcommit.Stdout = out
 	gitcommit.Stderr = out
 	if err := gitcommit.Run(); err != nil {
+		log.Printf("GIT commit error: %q\n", out.String())
 		log.Fatal(err)
 	}
 	log.Printf("BRANCH COMMIT: %q\n", out.String())


### PR DESCRIPTION
Fixes:
* Was seeing a panic in the conductor. Fixing it.
* make ctf fails and is not needed for tooling build. so removing it.
* cmd=6 mocks-go generation was skipped even if file did not exist. fixing logic that checks for file existance
* fix git add vargs passing to allow adding multiple files


```
❯ ./experiments/conductor/bin/conductor runner --branch-repo=/usr/local/google/home/barni/workspace/src/github.com/barney-s/vertex-notebook/k8s-config-connector  --branch-conf=./experiments/conductor/branches.yaml --logging-dir=./logs --command=4
2025/02/27 13:41:05 Running conductor runner with branch config: ./experiments/conductor/branches.yaml
2025/02/27 13:41:05 Starting Runner
2025/02/27 13:41:05 Create Script YAML: 0 name: notebooks-instance, branch: resource-notebooks-instance
panic: strings: illegal use of non-zero Builder copied by value

goroutine 24 [running]:
strings.(*Builder).copyCheck(...)
        /usr/local/google/home/barni/sdk/go1.23.4/src/strings/builder.go:35
...
created by os/exec.(*Cmd).Start in goroutine 1
        /usr/local/google/home/barni/sdk/go1.23.4/src/os/exec/exec.go:732 +0x98b
```