### PR TITLE
codebot: skip experiments folder when extracting data points

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -83,6 +83,9 @@ func (x *CSVExporter) VisitCodeDir(ctx context.Context, srcDir string) error {
 			return err
 		}
 		if d.IsDir() {
+			if d.Name() == "experiments" { // Skip the experiments directory
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		switch filepath.Ext(p) {


### PR DESCRIPTION
Skip `experiements/` folder when extracting data points. This avoid incorrectly picking up strings in files such as 

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/fdb3f32b63d8424d95f844416e3c6f99e978dfd2/experiments/conductor/cmd/runner/mock_commands.go#L366-L374