### PR TITLE
Non-determinism alert: Tweaking prompt to get better generated files

### DIFF
--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -203,15 +203,15 @@ func captureHttpLog(opts *RunnerOptions, branch Branch) {
 	gitCommit(workDir, out, fmt.Sprintf("Adding mockgcptests generated _http.log for %s", branch.Name))
 }
 
-const MOCK_SERVICE_GO_GEN string = `mock<SERVICE>/service.go
-// +tool:mockgcp-service
+const MOCK_SERVICE_GO_GEN string = `// +tool:mockgcp-service
 // http.host: <HTTP_HOST>
-// proto.service: <PROTO_SERVICE>`
-
-const MOCK_RESOURCE_GO_GEN string = `mock<SERVICE>/<RESOURCE>.go
-// +tool:mockgcp-support
 // proto.service: <PROTO_SERVICE>
-// proto.message: <PROTO_MESSAGE>`
+`
+
+const MOCK_RESOURCE_GO_GEN string = `// +tool:mockgcp-support
+// proto.service: <PROTO_SERVICE>
+// proto.message: <PROTO_MESSAGE>
+`
 
 func generateMockGo(opts *RunnerOptions, branch Branch) {
 	close := setLoggingWriter(opts, branch)


### PR DESCRIPTION
Removing the file name seems to help. Not sure why it was added in the first place. I was seeing some proto blocks in the generate code. Fixed the branches.yaml to include correct paths. That removed a lot of erroneous generated code. But there were still some snippets of proto in the generated code. Modified the prompts and this seems better.
