### PR TITLE
Added a runner for runmockgcptests against mock.

### DIFF
--- a/experiments/conductor/branches-all.yaml
+++ b/experiments/conductor/branches-all.yaml
@@ -17218,11 +17218,11 @@ branches:
       controller: terraform
       kind: ""
       package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
+      proto: BackendService
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.BackendServices
+      proto-msg: google.cloud.compute.v1.BackendService
+      host-name: compute.googleapis.com
       notes: []
     - name: compute-computebackendservicesignedurlkeys
       local: resource-compute-computebackendservicesignedurlkeys

--- a/experiments/conductor/branches.yaml
+++ b/experiments/conductor/branches.yaml
@@ -23,10 +23,10 @@ branches:
     kind: AccessApprovalApprovalRequest
     package: google.cloud.accessapproval.v1
     proto: ApprovalRequest
-    proto-path: google.cloud.accessapproval.v1.accessapproval
-    proto-service: google.cloud.accessapproval.v1.AccessApproval
+    proto-path: google/cloud/accessapproval/v1/accessapproval.proto
+    proto-service: ""
     proto-msg: google.cloud.accessapproval.v1.ApprovalRequest
-    host-name: accessapproval.googleapis.com
+    host-name: ""
     notes:
       - No gcloud command found
   - name: ai-customjobs
@@ -41,9 +41,9 @@ branches:
     proto: ""
     proto-path: ""
     proto-service: ""
-    proto-msg:
-    host_name: ""
-    notes:
+    proto-msg: ""
+    host-name: ""
+    notes: []
   - name: compute-computebackendservice
     local: resource-compute-computebackendservice
     remote: resource-compute-computebackendservice
@@ -54,8 +54,8 @@ branches:
     kind: ""
     package: ""
     proto: BackendService
-    proto-path: google.cloud.compute.v1.Compute
+    proto-path: google/cloud/compute/v1/compute.proto
     proto-service: google.cloud.compute.v1.BackendServices
     proto-msg: google.cloud.compute.v1.BackendService
     host-name: compute.googleapis.com
-    notes:
+    notes: []

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -190,6 +190,11 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 			log.Printf("Add proto to makefile: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			addProtoToMakfile(opts, branch)
 		}
+	case 9:
+		for idx, branch := range branches.Branches {
+			log.Printf("Run mockgcptests on generated mocks: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			runMockgcpTests(opts, branch)
+		}
 	default:
 		log.Fatalf("unrecognixed command: %d", opts.command)
 	}
@@ -205,6 +210,10 @@ func printHelp() {
 	log.Println("\t3 - Delete the local github branches from the metadata")
 	log.Println("\t4 - Create script.yaml for mock gcp generation in each github branch")
 	log.Println("\t5 - Create _http.log for mock gcp generation in each github branch")
+	log.Println("\t6 - Generate mock Service and Resource go files in each github branch")
+	log.Println("\t7 - Add service to mock_http_roundtrip.go in each github branch")
+	log.Println("\t8 - Add proto to makefile in each github branch")
+	log.Println("\t9 - Run mockgcptests on generated mocks in each github branch")
 }
 
 func checkRepoDir(opts *RunnerOptions, branches Branches) {

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -48,14 +48,14 @@ func startBash() (io.WriteCloser, io.ReadCloser, exitBash, error) {
 			log.Fatal(err)
 		}
 
-		log.Printf("BASH ERR %s\r\n", string(errBuffer))
+		log.Printf("BASH ERR %s", string(errBuffer))
 	}()
 	err = cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 	}
 	exit := func() {
-		log.Printf("COMMAND: exit\r\n")
+		log.Printf("COMMAND: exit")
 		if _, err = stdin.Write([]byte("exit\n")); err != nil {
 			log.Fatal(err)
 		}
@@ -63,7 +63,7 @@ func startBash() (io.WriteCloser, io.ReadCloser, exitBash, error) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("BASH DONE\r\n")
+		log.Printf("BASH DONE")
 	}
 	return stdin, stdout, exit, err
 }
@@ -73,7 +73,7 @@ func cdRepoBranchDirBash(opts *RunnerOptions, subdir string, stdin io.WriteClose
 	if subdir != "" {
 		dir = filepath.Join(dir, subdir)
 	}
-	log.Printf("COMMAND: cd %s and echo\r\n", dir)
+	log.Printf("COMMAND: cd %s and echo", dir)
 	if _, err := stdin.Write([]byte(fmt.Sprintf("cd %s && echo done\n", dir))); err != nil {
 		log.Fatal(err)
 	}
@@ -88,12 +88,12 @@ func cdRepoBranchDirBash(opts *RunnerOptions, subdir string, stdin io.WriteClose
 		msg += string(outBuffer[:length])
 		done = strings.HasSuffix(msg, "done\n")
 	}
-	log.Printf("CD OUT %s\r\n", msg)
+	log.Printf("CD OUT %s", msg)
 	return msg
 }
 
 func checkoutBranch(branch Branch, workDir string, out *strings.Builder) {
-	log.Printf("COMMAND: git checkout %s\r\n", branch.Local)
+	log.Printf("COMMAND: git checkout %s", branch.Local)
 	checkout := exec.Command("git", "checkout", branch.Local)
 	checkout.Dir = workDir
 	checkout.Stdout = out
@@ -112,16 +112,16 @@ func writeTemplateToFile(branch Branch, filePath string, template string) {
 	tmp = strings.ReplaceAll(tmp, "<PROTO_SERVICE>", branch.ProtoSvc)
 	tmp = strings.ReplaceAll(tmp, "<PROTO_MESSAGE>", branch.ProtoMsg)
 	contents := strings.ReplaceAll(tmp, "<RESOURCE>", strings.ToLower(branch.Resource))
-	log.Printf("TEMPLATE %s %s\r\n", filePath, contents)
+	log.Printf("TEMPLATE %s %s", filePath, contents)
 
 	if _, err := os.Stat(filePath); !errors.Is(err, os.ErrNotExist) {
-		log.Printf("COMMAND: cleaning up old %s\r\n", filePath)
+		log.Printf("COMMAND: cleaning up old %s", filePath)
 		err = os.Remove(filePath)
 		if err != nil {
-			log.Printf("Attempt to clean up %s failed with %v\r\n", filePath, err)
+			log.Printf("Attempt to clean up %s failed with %v", filePath, err)
 		}
 	}
-	log.Printf("COMMAND: writing new %s\r\n", filePath)
+	log.Printf("COMMAND: writing new %s", filePath)
 	if err := os.WriteFile(filePath, []byte(contents), 0644); err != nil {
 		log.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func gitAdd(workDir string, out *strings.Builder, files ...string) {
 		}
 		params += file
 	}
-	log.Printf("COMMAND: git add %s\r\n", params)
+	log.Printf("COMMAND: git add %s", params)
 	args := []string{"add"}
 	args = append(args, files...)
 	gitadd := exec.Command("git", args...)
@@ -153,7 +153,7 @@ func gitAdd(workDir string, out *strings.Builder, files ...string) {
 }
 
 func gitCommit(workDir string, out *strings.Builder, msg string) {
-	log.Printf("COMMAND: git commit -m %q\r\n", msg)
+	log.Printf("COMMAND: git commit -m %q", msg)
 	gitcommit := exec.Command("git", "commit", "-m", fmt.Sprintf("%q", msg))
 	gitcommit.Dir = workDir
 	gitcommit.Stdout = out


### PR DESCRIPTION
### Change description

Fixed a few preconditions.
Cleaned up my test sample metadata.
Added missing help commands.
Cleaned up log messages.

### Tests you have done

./bin/conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/cheftako/k8s-config-connector_branches --branch-conf=branches.yaml --logging-dir=./logs --command=9

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
