### PR TITLE
test: include apigee, secretmanager and vertexai in presubmit

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -174,6 +174,60 @@ jobs:
         with:
           name: artifacts-tests-e2e-fixtures-sql
           path: /tmp/artifacts/
+  tests-e2e-fixtures-vertexai:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock fixtures tests for vertexai service"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-vertexai
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-vertexai
+          path: /tmp/artifacts/
+  tests-e2e-fixtures-apigee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock fixtures tests for apigee service"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-apigee
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-apigee
+          path: /tmp/artifacts/
+  tests-e2e-fixtures-secretmanager:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run mock fixtures tests for secretmanager service"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-secretmanager
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-secretmanager
+          path: /tmp/artifacts/
   pause-tests:
     runs-on: ubuntu-22.04
     timeout-minutes: 90

--- a/scripts/github-actions/tests-e2e-fixtures-apigee
+++ b/scripts/github-actions/tests-e2e-fixtures-apigee
@@ -20,6 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-export ONLY_TEST_APIGROUPS="sql.cnrm.cloud.google.com"
+export ONLY_TEST_APIGROUPS="apigee.cnrm.cloud.google.com"
 
 ${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-vertexai
+++ b/scripts/github-actions/tests-e2e-fixtures-vertexai
@@ -20,6 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-export ONLY_TEST_APIGROUPS="sql.cnrm.cloud.google.com"
+export ONLY_TEST_APIGROUPS="vertexai.cnrm.cloud.google.com"
 
 ${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
They were split into separate test scripts, but are not run by the presubmit.