### PR TITLE
chore: add a TODO to resolve reference fields in VertexAIFeaturestore

### DIFF
--- a/pkg/controller/direct/vertexai/featurestore_controller.go
+++ b/pkg/controller/direct/vertexai/featurestore_controller.go
@@ -125,6 +125,7 @@ func (a *FeaturestoreAdapter) Find(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+// TODO: resolve reference fields in CREATE and UPDATE.
 // Create creates the resource in GCP based on `spec` and update the Config Connector object `status` based on the GCP response.
 func (a *FeaturestoreAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
 	log := klog.FromContext(ctx)


### PR DESCRIPTION
The `KMSKeyRef` need be resolved before making CREATE and UPDATE calls. This was overlooked in the previous PR because the test did not include this field. Let's address this after the KMSRefs refactoring PR (#3836) is merged.