### PR TITLE
Add cmd to add api-enbalement metadata and refactor exec.Command

### DIFF
--- a/experiments/conductor/cmd/runner/crd_generator_commands.go
+++ b/experiments/conductor/cmd/runner/crd_generator_commands.go
@@ -172,7 +172,8 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: controllerBuilderDir,
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err := executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -188,7 +189,8 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: controllerBuilderDir,
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err = executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -204,7 +206,8 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: workDir,
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err = executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -231,7 +234,8 @@ func generateCRD(opts *RunnerOptions, branch Branch) {
 		Cmd:     filepath.Join(workDir, "dev", "tasks", "generate-crds"),
 		WorkDir: workDir,
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err := executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -261,7 +265,8 @@ func generateSpecStatus(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err := executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -291,7 +296,6 @@ func generateFuzzer(opts *RunnerOptions, branch Branch) {
 // proto.message: %s
 `, branch.ProtoMsg)
 
-	var fuzzerOut strings.Builder
 	cfg := CommandConfig{
 		Name:    "Fuzzer generation",
 		Cmd:     "controllerbuilder",
@@ -299,11 +303,12 @@ func generateFuzzer(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	if err := executeCommand(cfg, &fuzzerOut, nil); err != nil {
+	output, _, err := executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := os.WriteFile(fuzzerPath, []byte(fuzzerOut.String()), 0644); err != nil {
+	if err := os.WriteFile(fuzzerPath, []byte(output), 0644); err != nil {
 		log.Fatal(err)
 	}
 
@@ -319,7 +324,8 @@ func generateFuzzer(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	if err := executeCommand(cfg, &out, nil); err != nil {
+	_, _, err = executeCommand(cfg)
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/experiments/conductor/cmd/runner/crd_generator_commands.go
+++ b/experiments/conductor/cmd/runner/crd_generator_commands.go
@@ -172,7 +172,7 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: controllerBuilderDir,
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: controllerBuilderDir,
 	}
-	_, _, err = executeCommand(cfg)
+	_, _, err = executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func generateTypesAndMapper(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir: workDir,
 	}
-	_, _, err = executeCommand(cfg)
+	_, _, err = executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func generateCRD(opts *RunnerOptions, branch Branch) {
 		Cmd:     filepath.Join(workDir, "dev", "tasks", "generate-crds"),
 		WorkDir: workDir,
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func generateSpecStatus(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func generateFuzzer(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	output, _, err := executeCommand(cfg)
+	output, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -324,7 +324,7 @@ func generateFuzzer(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Stdin:   strings.NewReader(stdinInput),
 	}
-	_, _, err = executeCommand(cfg)
+	_, _, err = executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -91,7 +91,7 @@ func createScriptYaml(opts *RunnerOptions, branch Branch) {
 		Args:    []string{"--ui-type=prompt", "--prompt=prompt.txt"},
 		WorkDir: workDir,
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func enableAPIs(opts *RunnerOptions, branch Branch) error {
 			Args:    []string{"services", "enable", api},
 			WorkDir: workDir,
 		}
-		_, _, err := executeCommand(cfg)
+		_, _, err := executeCommand(opts, cfg)
 		if err != nil {
 			return fmt.Errorf("failed to enable API %s: %w", api, err)
 		}
@@ -198,7 +198,7 @@ func captureHttpLog(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Env:     map[string]string{"WRITE_GOLDEN_OUTPUT": "1", "E2E_GCP_TARGET": "real"},
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Printf("TEST GENERATE error: %q\n", err)
 		// Currently ignoring error and just basing on if the _http.log was generated.
@@ -267,7 +267,7 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 			},
 			WorkDir: workDir,
 		}
-		output, _, err := executeCommand(cfg)
+		output, _, err := executeCommand(opts, cfg)
 		if err != nil {
 			log.Printf("MOCK SERVICE GENERATE error: %q\n", err)
 			// Currently ignoring error and just basing on if the _http.log was generated.
@@ -306,7 +306,7 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 			},
 			WorkDir: workDir,
 		}
-		output, _, err := executeCommand(cfg)
+		output, _, err := executeCommand(opts, cfg)
 		if err != nil {
 			log.Printf("MOCK RESOURCE GENERATE error: %q\n", err)
 			// Currently ignoring error and just basing on if the _http.log was generated.
@@ -371,7 +371,7 @@ func addServiceToRoundTrip(opts *RunnerOptions, branch Branch) {
 		Args:    []string{"--ui-type=prompt", "--prompt=roundtrip_prompt.txt"},
 		WorkDir: workDir,
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func addProtoToMakfile(opts *RunnerOptions, branch Branch) {
 		Args:    []string{"--ui-type=prompt", "--prompt=makefile_prompt.txt"},
 		WorkDir: workDir,
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -457,7 +457,7 @@ func runMockgcpTests(opts *RunnerOptions, branch Branch) {
 		WorkDir: workDir,
 		Env:     map[string]string{"WRITE_GOLDEN_OUTPUT": "1", "E2E_GCP_TARGET": "mock"},
 	}
-	_, _, err := executeCommand(cfg)
+	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
 		log.Printf("TEST RUN error: %q\n", err)
 		// Currently ignoring error and just basing on if the _http.log was generated.

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -47,15 +47,16 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdCheckRepo           = 1
 	cmdCreateGitBranch     = 2
 	cmdDeleteGitBranch     = 3
-	cmdCreateScriptYaml    = 4
-	cmdCaptureHttpLog      = 5
-	cmdGenerateMockGo      = 6
-	cmdAddServiceRoundTrip = 7
-	cmdAddProtoMakefile    = 8
-	cmdRunMockTests        = 9
-	cmdGenerateTypes       = 10
-	cmdGenerateCRD         = 11
-	cmdGenerateFuzzer      = 12
+	cmdEnableGCPAPIs       = 4
+	cmdCreateScriptYaml    = 10
+	cmdCaptureHttpLog      = 11
+	cmdGenerateMockGo      = 12
+	cmdAddServiceRoundTrip = 13
+	cmdAddProtoMakefile    = 14
+	cmdRunMockTests        = 15
+	cmdGenerateTypes       = 20
+	cmdGenerateCRD         = 21
+	cmdGenerateFuzzer      = 22
 )
 
 func BuildRunnerCmd() *cobra.Command {
@@ -190,48 +191,53 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 			log.Printf("Delete GitHub Branch: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			deleteGithubBranch(opts, branch)
 		}
-	case cmdCreateScriptYaml: // 4
+	case cmdEnableGCPAPIs: // 4
+		for idx, branch := range branches.Branches {
+			log.Printf("Enable GCP APIs: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
+			enableAPIs(opts, branch)
+		}
+	case cmdCreateScriptYaml: // 10
 		for idx, branch := range branches.Branches {
 			log.Printf("Create Script YAML: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			createScriptYaml(opts, branch)
 		}
-	case cmdCaptureHttpLog: // 5
+	case cmdCaptureHttpLog: // 11
 		for idx, branch := range branches.Branches {
 			log.Printf("Capture HTTP Log: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			captureHttpLog(opts, branch)
 		}
-	case cmdGenerateMockGo: // 6
+	case cmdGenerateMockGo: // 12
 		for idx, branch := range branches.Branches {
 			log.Printf("Generate mock Service and Resource go files: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			generateMockGo(opts, branch)
 		}
-	case cmdAddServiceRoundTrip: // 7
+	case cmdAddServiceRoundTrip: // 13
 		for idx, branch := range branches.Branches {
 			log.Printf("Add service to mock_http_roundtrip.go: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			addServiceToRoundTrip(opts, branch)
 		}
-	case cmdAddProtoMakefile: // 8
+	case cmdAddProtoMakefile: // 14
 		for idx, branch := range branches.Branches {
 			log.Printf("Add proto to makefile: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			addProtoToMakfile(opts, branch)
 		}
-	case cmdRunMockTests: // 9
+	case cmdRunMockTests: // 15
 		for idx, branch := range branches.Branches {
 			log.Printf("Run mockgcptests on generated mocks: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			runMockgcpTests(opts, branch)
 		}
-	case cmdGenerateTypes: // 10
+	case cmdGenerateTypes: // 20
 		for idx, branch := range branches.Branches {
 			log.Printf("Generate Types and Mapper: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			generateTypesAndMapper(opts, branch)
 		}
-	case cmdGenerateCRD: // 11
+	case cmdGenerateCRD: // 21
 		for idx, branch := range branches.Branches {
 			log.Printf("Generate CRD: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			generateCRD(opts, branch)
 			//generateSpecStatus(opts, branch)
 		}
-	case cmdGenerateFuzzer: // 12
+	case cmdGenerateFuzzer: // 22
 		for idx, branch := range branches.Branches {
 			log.Printf("Generate Fuzzer: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
 			generateFuzzer(opts, branch)
@@ -249,15 +255,16 @@ func printHelp() {
 	log.Println("\t1 - [Validate] Repo directory and metadata")
 	log.Println("\t2 - [Branch] Create the local github branches from the metadata")
 	log.Println("\t3 - [Branch] Delete the local github branches from the metadata")
-	log.Println("\t4 - [Mock] Create script.yaml for mock gcp generation in each github branch")
-	log.Println("\t5 - [Mock] Create _http.log for mock gcp generation in each github branch")
-	log.Println("\t6 - [Mock] Generate mock Service and Resource go files in each github branch")
-	log.Println("\t7 - [Mock] Add service to mock_http_roundtrip.go in each github branch")
-	log.Println("\t8 - [Mock] Add proto to makefile in each github branch")
-	log.Println("\t9 - [Mock] Run mockgcptests on generated mocks in each github branch")
-	log.Println("\t10 - [CRD] Generate Types and Mapper for each branch")
-	log.Println("\t11 - [CRD] Generate CRD for each branch")
-	log.Println("\t12 - [Fuzzer] Generate fuzzer for each branch")
+	log.Println("\t4 - [Project] Enable GCP APIs for each branch")
+	log.Println("\t10 - [Mock] Create script.yaml for mock gcp generation in each github branch")
+	log.Println("\t11 - [Mock] Create _http.log for mock gcp generation in each github branch")
+	log.Println("\t12 - [Mock] Generate mock Service and Resource go files in each github branch")
+	log.Println("\t13 - [Mock] Add service to mock_http_roundtrip.go in each github branch")
+	log.Println("\t14 - [Mock] Add proto to makefile in each github branch")
+	log.Println("\t15 - [Mock] Run mockgcptests on generated mocks in each github branch")
+	log.Println("\t20 - [CRD] Generate Types and Mapper for each branch")
+	log.Println("\t21 - [CRD] Generate CRD for each branch")
+	log.Println("\t22 - [Fuzzer] Generate fuzzer for each branch")
 }
 
 func checkRepoDir(opts *RunnerOptions, branches Branches) {

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -128,8 +128,13 @@ type Branch struct {
 	ProtoMsg  string `yaml:"proto-msg"`     // google.ai.generativelanguage.v1beta.Model
 	HostName  string `yaml:"host-name"`     // generativelanguage.googleapis.com
 
-	Notes       []string `yaml:"notes"`        // Observation goes here
-	ApisEnabled []string `yaml:"apis-enabled"` // GCP APIs that need to be enabled
+	Notes []string `yaml:"notes"` // Observation goes here
+
+	// GCP APIs that need to be enabled for the branch.
+	// example:
+	// - eventarc.googleapis.com
+	// - aiplatform.googleapis.com
+	ApisEnabled []string `yaml:"apis-enabled"`
 }
 
 // BranchModifier is a function type that takes a Branch and returns a modified Branch

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -268,9 +268,13 @@ type CommandConfig struct {
 }
 
 // Helper function to execute a command with timing and logging
-func executeCommand(cfg CommandConfig) (string, string, error) {
+func executeCommand(opts *RunnerOptions, cfg CommandConfig) (string, string, error) {
 	if cfg.Timeout == 0 {
-		cfg.Timeout = 5 * time.Minute
+		if opts != nil && opts.timeout != 0 {
+			cfg.Timeout = opts.timeout
+		} else {
+			cfg.Timeout = 5 * time.Minute
+		}
 	}
 
 	log.Printf("Starting command step: %s", cfg.Name)


### PR DESCRIPTION
- refactor fixMetadata to take a function that modifies branchdata
- implement addEnableAPIsModifier branch modifier
- add cmd -3 to invoke fixMetadata with addEnableAPIsModifier
- REFACTOR replace exec.Command calls to use executeCommand util function
   - more modular code
   - consistent logging of inputs, output, err
   - consistent timeout support
 - Add global timeout option
 - Add cmd=4 to enable GCP APIs
 - Moved cmd numbers over to accommodate enable APIs cmd

## Using new command
```shell
cd experiments/conductor
make build

## copy over your branches to branches-user.yaml

## Run the conductor cmd=-3 to create branches-new.yaml with api data
./bin/conductor runner --branch-repo=/usr/local/google/home/barni/workspace/src/github.com/barney-s/vertex-notebook/k8s-config-connector  --branch-conf=branches-user.yaml --logging-dir=logs --command=-3

## review branches-new.yaml and move it to your working file
diff branches-new.yaml branches-user.yaml
mv branches-new.yaml branches-user.yaml
```

## TIPS

* re-run the above command to work on resources that weren't populated in the first run
* It is safe to re-run since we ignore entries that already have apis populated.
* If you see no diff between user and new file, check gcp project in your config. One of the runs changed the project in my configuration
* Inspect logs for cases where you did not see any api being detected.

