### PR TITLE
tool: run conductor within a single workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ log
 # experiments/conductor
 experiments/conductor/logs
 experiments/conductor/branches.yaml
+experiments/conductor/bin

--- a/experiments/conductor/Makefile
+++ b/experiments/conductor/Makefile
@@ -32,3 +32,19 @@ bin:
 .PHONY: clean
 clean:
 	rm -rf bin
+
+
+## ---
+## Build and install development tools
+## ---
+.PHONY: tools
+tools: build controllerbuilder codebot
+	cp bin/conductor $(GOPATH)/bin/
+
+.PHONY: controllerbuilder
+controllerbuilder:
+	cd $(shell git rev-parse --show-toplevel)/dev/tools/controllerbuilder && go build -o $(GOPATH)/bin/controllerbuilder .
+
+.PHONY: codebot
+codebot:
+	cd $(shell git rev-parse --show-toplevel)/dev/tools/controllerbuilder/cmd/codebot && go build -o $(GOPATH)/bin/codebot .

--- a/experiments/conductor/cmd/runner/README.md
+++ b/experiments/conductor/cmd/runner/README.md
@@ -1,0 +1,12 @@
+## Setup your environment.
+```bash
+export GOPATH="$HOME/go"
+export PATH="$GOPATH/bin:$PATH"
+
+make tools
+```
+
+## Run the runner.
+```bash
+conductor runner
+```

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -328,3 +328,13 @@ func executeCommand(cfg CommandConfig, out *strings.Builder, stderr *strings.Bui
 	out.Reset()
 	return err
 }
+
+func repoRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	repoRoot := strings.TrimSpace(string(output))
+	return repoRoot, nil
+}


### PR DESCRIPTION
Enable the conductor tool to run within a single workspace.

- Build and install dependent tools in `$(GOPATH)/bin/`. 
- Set default flag values to eliminate the need for manual specification when running.