### PR TITLE
Create mock for resource dataproc autoscalingpolicy

### DIFF
--- a/mockgcp/mockdataproc/autoscalingpolicy.go
+++ b/mockgcp/mockdataproc/autoscalingpolicy.go
@@ -1,0 +1,218 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.dataproc.v1.AutoscalingPolicyService
+// proto.message: google.cloud.dataproc.v1.AutoscalingPolicy
+
+package mockdataproc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	pb "cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+)
+
+type autoscalingPolicyServiceServer struct {
+	*MockService
+	pb.UnimplementedAutoscalingPolicyServiceServer
+}
+
+func (s *autoscalingPolicyServiceServer) CreateAutoscalingPolicy(ctx context.Context, req *pb.CreateAutoscalingPolicyRequest) (*pb.AutoscalingPolicy, error) {
+	reqName := fmt.Sprintf("%s/autoscalingPolicies/%s", req.GetParent(), "test-autoscaling-policy")
+	name, err := s.parseAutoscalingPolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := proto.Clone(req.GetPolicy()).(*pb.AutoscalingPolicy)
+	obj.Name = fqn
+	s.populateDefaultsForAutoscalingPolicy(obj)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *autoscalingPolicyServiceServer) GetAutoscalingPolicy(ctx context.Context, req *pb.GetAutoscalingPolicyRequest) (*pb.AutoscalingPolicy, error) {
+	name, err := s.parseAutoscalingPolicyName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.AutoscalingPolicy{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *autoscalingPolicyServiceServer) DeleteAutoscalingPolicy(ctx context.Context, req *pb.DeleteAutoscalingPolicyRequest) (*emptypb.Empty, error) {
+	name, err := s.parseAutoscalingPolicyName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.AutoscalingPolicy{}
+	if err := s.storage.Delete(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (s *autoscalingPolicyServiceServer) UpdateAutoscalingPolicy(ctx context.Context, req *pb.UpdateAutoscalingPolicyRequest) (*pb.AutoscalingPolicy, error) {
+	name, err := s.parseAutoscalingPolicyName(req.Policy.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := req.Policy
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (s *autoscalingPolicyServiceServer) ListAutoscalingPolicy(ctx context.Context, req *pb.ListAutoscalingPoliciesRequest) (*pb.ListAutoscalingPoliciesResponse, error) {
+	name, err := s.parseAutoscalingPolicyName(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &pb.ListAutoscalingPoliciesResponse{}
+
+	AutoscalingPolicyKind := (&pb.AutoscalingPolicy{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, AutoscalingPolicyKind, storage.ListOptions{}, func(obj proto.Message) error {
+		autoScalingPolicy := obj.(*pb.AutoscalingPolicy)
+		if strings.HasPrefix(autoScalingPolicy.GetName(), name.String()) {
+			response.Policies = append(response.Policies, autoScalingPolicy)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *autoscalingPolicyServiceServer) populateDefaultsForAutoscalingPolicy(obj *pb.AutoscalingPolicy) {
+	if obj.GetBasicAlgorithm() == nil {
+		obj.Algorithm = &pb.AutoscalingPolicy_BasicAlgorithm{}
+	}
+	if obj.GetBasicAlgorithm().CooldownPeriod == nil {
+		obj.GetBasicAlgorithm().CooldownPeriod = durationpb.New(2 * time.Minute)
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig() == nil {
+		obj.GetBasicAlgorithm().Config = &pb.BasicAutoscalingAlgorithm_YarnConfig{}
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig().GracefulDecommissionTimeout == nil {
+		obj.GetBasicAlgorithm().GetYarnConfig().GracefulDecommissionTimeout = durationpb.New(24 * time.Hour)
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig().ScaleDownFactor == 0 {
+		obj.GetBasicAlgorithm().GetYarnConfig().ScaleDownFactor = 1
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig().ScaleDownMinWorkerFraction == 0 {
+		obj.GetBasicAlgorithm().GetYarnConfig().ScaleDownMinWorkerFraction = 1
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig().ScaleUpFactor == 0 {
+		obj.GetBasicAlgorithm().GetYarnConfig().ScaleUpFactor = 0.5
+	}
+	if obj.GetBasicAlgorithm().GetYarnConfig().ScaleUpMinWorkerFraction == 0 {
+		obj.GetBasicAlgorithm().GetYarnConfig().ScaleUpMinWorkerFraction = 0.5
+	}
+
+	if obj.WorkerConfig == nil {
+		obj.WorkerConfig = &pb.InstanceGroupAutoscalingPolicyConfig{}
+	}
+	if obj.WorkerConfig.MaxInstances == 0 {
+		obj.WorkerConfig.MaxInstances = 5
+	}
+
+	if obj.SecondaryWorkerConfig == nil {
+		obj.SecondaryWorkerConfig = &pb.InstanceGroupAutoscalingPolicyConfig{}
+	}
+	if obj.SecondaryWorkerConfig.MaxInstances == 0 {
+		obj.SecondaryWorkerConfig.MaxInstances = 1
+	}
+}
+
+type autoscalingPolicyName struct {
+	Project            *projects.ProjectData
+	Region             string
+	AutoscalingPolicy  string
+	AutoscalingPolicy2 string
+}
+
+func (n *autoscalingPolicyName) String() string {
+	return fmt.Sprintf("projects/%s/regions/%s/autoscalingPolicies/%s", n.Project.ID, n.Region, n.AutoscalingPolicy)
+}
+
+// parseAutoscalingPolicyName parses a string into an AutoscalingPolicyName.
+// The expected form is `projects/*/regions/*/autoscalingPolicies/*`.
+func (s *MockService) parseAutoscalingPolicyName(name string) (*autoscalingPolicyName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "autoscalingPolicies" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &autoscalingPolicyName{
+			Project:           project,
+			Region:            tokens[3],
+			AutoscalingPolicy: tokens[5],
+		}
+
+		return name, nil
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+}
+
+// buildAutoscalingPolicyName builds a AutoscalingPolicyName from the components.
+func (s *MockService) buildAutoscalingPolicyName(projectName, region, cluster string) (*autoscalingPolicyName, error) {
+	project, err := s.Projects.GetProjectByID(projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &autoscalingPolicyName{
+		Project:           project,
+		Region:            region,
+		AutoscalingPolicy: cluster,
+	}, nil
+}

--- a/mockgcp/mockdataproc/service.go
+++ b/mockgcp/mockdataproc/service.go
@@ -67,11 +67,13 @@ func (s *MockService) ExpectedHosts() []string {
 
 func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterClusterControllerServer(grpcServer, &clusterControllerServer{MockService: s})
+	pb.RegisterAutoscalingPolicyServiceServer(grpcServer, &autoscalingPolicyServiceServer{MockService: s})
 }
 
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{},
 		pbhttp.RegisterClusterControllerHandler,
+		pbhttp.RegisterAutoscalingPolicyServiceHandler,
 		s.operations.RegisterOperationsPath("/v1/{prefix=**}/operations/{name}"))
 	if err != nil {
 		return nil, err

--- a/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/_http.log
+++ b/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/_http.log
@@ -1,0 +1,102 @@
+GET https://dataproc.googleapis.com/v1/projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: com.google.cloud.hadoop.services.common.error.DataprocException: Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId} (NOT_FOUND) (CONFIG) [google.rpc.error_details_ext] { message: \"Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}\" }"
+      }
+    ],
+    "message": "Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+GET https://dataproc.googleapis.com/v1/projects/${projectId}/regions/us-central1/autoscalingPolicies?alt=json&pageSize=100
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "policies": [
+    {
+      "basicAlgorithm": {
+        "cooldownPeriod": "120s",
+        "yarnConfig": {
+          "gracefulDecommissionTimeout": "30s",
+          "scaleDownFactor": 0.5,
+          "scaleUpFactor": 0.5
+        }
+      },
+      "id": "dataprocautoscalingpolicy-1tzjbegzhqu4o",
+      "name": "projects/${projectId}/regions/us-central1/autoscalingPolicies/dataprocautoscalingpolicy-1tzjbegzhqu4o",
+      "secondaryWorkerConfig": {
+        "maxInstances": 2,
+        "weight": 1
+      },
+      "workerConfig": {
+        "maxInstances": 2,
+        "minInstances": 2,
+        "weight": 1
+      }
+    }
+  ]
+}
+
+---
+
+DELETE https://dataproc.googleapis.com/v1/projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: com.google.cloud.hadoop.services.common.error.DataprocException: Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId} (NOT_FOUND) (CONFIG) [google.rpc.error_details_ext] { message: \"Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}\" }"
+      }
+    ],
+    "message": "Not found: Autoscaling Policy projects/${projectId}/regions/us-central1/autoscalingPolicies/test-${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}

--- a/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/policy.yaml
+++ b/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/policy.yaml
@@ -1,0 +1,11 @@
+workerConfig:
+  minInstances: 10
+  maxInstances: 10
+secondaryWorkerConfig:
+  maxInstances: 50
+basicAlgorithm:
+  cooldownPeriod: 4m
+  yarnConfig:
+    scaleUpFactor: 0.05
+    scaleDownFactor: 1.0
+    gracefulDecommissionTimeout: 1h

--- a/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/script.yaml
+++ b/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/script.yaml
@@ -1,5 +1,5 @@
 
-- exec: gcloud dataproc autoscaling-policies import test-${uniqueId} --source=mockdataproc/testdata/autoscalingpolicy/crud/policy.yaml --region=us-central1
+- exec: gcloud dataproc autoscaling-policies import test-${uniqueId} --source=policy.yaml --region=us-central1
 - exec: gcloud dataproc autoscaling-policies describe test-${uniqueId} --region=us-central1
 - exec: gcloud dataproc autoscaling-policies list --region=us-central1
 - exec: gcloud dataproc autoscaling-policies delete test-${uniqueId} --region=us-central1

--- a/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/script.yaml
+++ b/mockgcp/mockdataproc/testdata/autoscalingpolicy/crud/script.yaml
@@ -1,0 +1,5 @@
+
+- exec: gcloud dataproc autoscaling-policies import test-${uniqueId} --source=mockdataproc/testdata/autoscalingpolicy/crud/policy.yaml --region=us-central1
+- exec: gcloud dataproc autoscaling-policies describe test-${uniqueId} --region=us-central1
+- exec: gcloud dataproc autoscaling-policies list --region=us-central1
+- exec: gcloud dataproc autoscaling-policies delete test-${uniqueId} --region=us-central1


### PR DESCRIPTION


- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
