### PR TITLE
fix: Fix ApigeeInstance update mask

### DIFF
--- a/mockgcp/mockapigee/instance.go
+++ b/mockgcp/mockapigee/instance.go
@@ -133,8 +133,16 @@ func (s *instancesServer) PatchOrganizationsInstance(ctx context.Context, req *p
 
 	for _, path := range fieldMask.GetPaths() {
 		switch path {
-		case "access_logging_config":
-			obj.AccessLoggingConfig = req.OrganizationsInstance.AccessLoggingConfig
+		case "access_logging_config.enabled":
+			if obj.AccessLoggingConfig == nil {
+				obj.AccessLoggingConfig = &pb.GoogleCloudApigeeV1AccessLoggingConfig{}
+			}
+			obj.AccessLoggingConfig.Enabled = req.OrganizationsInstance.AccessLoggingConfig.Enabled
+		case "access_logging_config.filter":
+			if obj.AccessLoggingConfig == nil {
+				obj.AccessLoggingConfig = &pb.GoogleCloudApigeeV1AccessLoggingConfig{}
+			}
+			obj.AccessLoggingConfig.Filter = req.OrganizationsInstance.AccessLoggingConfig.Filter
 		case "consumer_accept_list":
 			obj.ConsumerAcceptList = req.OrganizationsInstance.ConsumerAcceptList
 		default:

--- a/pkg/controller/direct/apigee/instance_controller.go
+++ b/pkg/controller/direct/apigee/instance_controller.go
@@ -173,37 +173,19 @@ func (a *ApigeeInstanceAdapter) Update(ctx context.Context, updateOp *directbase
 		return mapCtx.Err()
 	}
 
-	if resource.AccessLoggingConfig != nil && !reflect.DeepEqual(resource.AccessLoggingConfig, a.actual.AccessLoggingConfig) {
-		log.V(2).Info("change detected: accessLoggingConfig")
-		updateMask.Paths = append(updateMask.Paths, "access_logging_config")
+	if resource.AccessLoggingConfig != nil {
+		if resource.AccessLoggingConfig.Enabled != a.actual.AccessLoggingConfig.Enabled {
+			log.V(2).Info("change detected: accessLoggingConfig.enabled")
+			updateMask.Paths = append(updateMask.Paths, "access_logging_config.enabled")
+		}
+		if resource.AccessLoggingConfig.Filter != a.actual.AccessLoggingConfig.Filter {
+			log.V(2).Info("change detected: accessLoggingConfig.filter")
+			updateMask.Paths = append(updateMask.Paths, "access_logging_config.filter")
+		}
 	}
 	if resource.ConsumerAcceptList != nil && !reflect.DeepEqual(asSortedCopy(resource.ConsumerAcceptList), asSortedCopy(a.actual.ConsumerAcceptList)) {
 		log.V(2).Info("change detected: consumerAcceptList")
 		updateMask.Paths = append(updateMask.Paths, "consumer_accept_list")
-	}
-	if !reflect.DeepEqual(resource.Description, a.actual.Description) {
-		log.V(2).Info("change detected: description")
-		updateMask.Paths = append(updateMask.Paths, "description")
-	}
-	if !reflect.DeepEqual(resource.DiskEncryptionKeyName, a.actual.DiskEncryptionKeyName) {
-		log.V(2).Info("change detected: diskEncryptionKeyName")
-		updateMask.Paths = append(updateMask.Paths, "disk_encryption_key_name")
-	}
-	if !reflect.DeepEqual(resource.DisplayName, a.actual.DisplayName) {
-		log.V(2).Info("change detected: displayName")
-		updateMask.Paths = append(updateMask.Paths, "display_name")
-	}
-	if !reflect.DeepEqual(resource.IpRange, a.actual.IpRange) {
-		log.V(2).Info("change detected: ipRange")
-		updateMask.Paths = append(updateMask.Paths, "ip_range")
-	}
-	if !reflect.DeepEqual(resource.Location, a.actual.Location) {
-		log.V(2).Info("change detected: location")
-		updateMask.Paths = append(updateMask.Paths, "location")
-	}
-	if !reflect.DeepEqual(resource.PeeringCidrRange, a.actual.PeeringCidrRange) {
-		log.V(2).Info("change detected: peeringCIDRRange")
-		updateMask.Paths = append(updateMask.Paths, "peering_cidr_range")
 	}
 
 	if len(updateMask.Paths) == 0 {

--- a/pkg/test/resourcefixture/testdata/basic/apigee/apigeeinstance/apigeeinstance-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/apigee/apigeeinstance/apigeeinstance-full/_http.log
@@ -635,7 +635,7 @@ X-Xss-Protection: 0
 
 ---
 
-PATCH https://apigee.googleapis.com/v1/organizations/${projectId}/instances/apigeeinstance-${uniqueId}?alt=json&prettyPrint=false&updateMask=access_logging_config%2Cconsumer_accept_list
+PATCH https://apigee.googleapis.com/v1/organizations/${projectId}/instances/apigeeinstance-${uniqueId}?alt=json&prettyPrint=false&updateMask=access_logging_config.enabled%2Caccess_logging_config.filter%2Cconsumer_accept_list
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 


### PR DESCRIPTION
Only allow mutations to the mutable fields. This fixes the error observed when running in real GCP:

> {"severity":"error","timestamp":"2025-03-05T18:21:51.323Z","msg":"Reconciler error","controller":"apigeeinstance-controller","controllerGroup":"apigee.cnrm.cloud.google.com","controllerKind"
:"ApigeeInstance","ApigeeInstance":{"name":"apigeeinstance-sample","namespace":"default"},"namespace":"default","name":"apigeeinstance-sample","reconcileID":"cebb8672-4452-4657-829a-7a8ed673
b1e3","error":"Update call failed: error updating: updating ApigeeInstance organizations/xyz/instances/apigeeinstance-sample: googleapi: Error 400: Request contains a
n invalid argument.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.RequestInfo\",\n    \"requestId\": \"4518562949576557033\"\n  },\n  {\n    \"@type\": \"type.googleapis
.com/google.rpc.DebugInfo\",\n    \"detail\": \"[ORIGINAL ERROR] generic::invalid_argument: unsupported update mask provided, updateInstance mask supports [access_logging_config.enabled, acc
ess_logging_config.filter, consumer_accept_list, maintenance_update_policy.maintenance_windows] only or update to environments [google.rpc.error_details_ext] { details { [type.googleapis.com
/google.rpc.RequestInfo] { request_id: \\\"4518562949576557033\\\" } } }\"\n  }\n]"}

Seems the `access_logging_config` fields must be specified individually; it is impossible to update the entire struct in-place. Also, we really only support updates to three fields:
* access_logging_config.enabled
* access_logging_config.filter
* consumer_accept_list

The maintenance_update_policy field is not specified in the API / proto, assuming it is somehow hidden. We do not support updating this field or setting it in the first place in KCC.