### PR TITLE
tool: Filter out resources without proper gcloud support

### DIFF
--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -50,7 +50,6 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdCreateGitBranch     = 2
 	cmdDeleteGitBranch     = 3
 	cmdEnableGCPAPIs       = 4
-	cmdSetSkipOnBranch     = 5
 	cmdCreateScriptYaml    = 10
 	cmdCaptureHttpLog      = 11
 	cmdGenerateMockGo      = 12
@@ -707,6 +706,14 @@ func splitMetadata(opts *RunnerOptions, branches Branches) {
 }
 
 func setSkipOnBranchModifier(opts *RunnerOptions, branch Branch, workDir string) Branch {
+	close := setLoggingWriter(opts, branch)
+	defer close()
+
+	if branch.Command == "" {
+		branch.Skip = true
+		branch.Notes = append(branch.Notes, "no gcloud command")
+	}
+
 	// Run gcloud xxx --help to see if it implements CRUD methods
 	gcloudCommand := branch.Command
 	gcloudCommand = strings.TrimPrefix(gcloudCommand, "gcloud")

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -15,6 +15,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -48,6 +50,7 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdCreateGitBranch     = 2
 	cmdDeleteGitBranch     = 3
 	cmdEnableGCPAPIs       = 4
+	cmdSetSkipOnBranch     = 5
 	cmdCreateScriptYaml    = 10
 	cmdCaptureHttpLog      = 11
 	cmdGenerateMockGo      = 12
@@ -180,6 +183,8 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 	branches.Branches = filteredBranches
 
 	switch opts.command {
+	case -4:
+		fixMetadata(opts, branches, setSkipOnBranchModifier)
 	case -3:
 		fixMetadata(opts, branches, addEnableAPIsModifier)
 	case -2:
@@ -699,4 +704,36 @@ func splitMetadata(opts *RunnerOptions, branches Branches) {
 			log.Fatal(err)
 		}
 	}
+}
+
+func setSkipOnBranchModifier(opts *RunnerOptions, branch Branch, workDir string) Branch {
+	// Run gcloud xxx --help to see if it implements CRUD methods
+	gcloudCommand := branch.Command
+	gcloudCommand = strings.TrimPrefix(gcloudCommand, "gcloud")
+	args := strings.Fields(gcloudCommand)
+
+	// Skip if gcloud command has no args
+	if len(args) == 0 {
+		branch.Skip = true
+		branch.Notes = append(branch.Notes, "invalid gcloud command")
+	}
+
+	// Keep if any of CRUD is supported
+	args = append(args, "--help")
+	cmd := exec.Command("gcloud", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	// todo: shall we keep when gcloud xxx --help returns error?
+	// Just keep everything for now
+	if err == nil {
+		output := stdout.String()
+		// todo: Do we need to include 'patch'? I thought 'gcloud' primarily uses 'update' for these operations.
+		var operationRegex = regexp.MustCompile(`(create|update|delete)`)
+		if !operationRegex.MatchString(output) {
+			branch.Skip = true
+			branch.Notes = append(branch.Notes, "gcloud command does not contain any of create/update/delete")
+		}
+	}
+	return branch
 }


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Also filter out resources without CRUD in gcloud. 
We can add more filter rules in `setSkipOnBranchModifier` as well.
 
### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
