### PR TITLE
ci: no fuzz on experiments

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -21,12 +21,14 @@ on:
       - "**.md"
       - pkg/clients/generated
       - config/tests
+      - "experiments/**"
   pull_request:
     paths-ignore:
       - "third_party/**"
       - "**.md"
       - pkg/clients/generated
       - config/tests
+      - "experiments/**"
 permissions: read-all
 jobs:
   fuzzer:


### PR DESCRIPTION
I noticed we ran these under `experiments/` too. Probably can do without.