### PR TITLE
fix: Fix SQLInstance replica periodic

### DIFF
--- a/pkg/test/resourcefixture/contexts/sql_context.go
+++ b/pkg/test/resourcefixture/contexts/sql_context.go
@@ -40,6 +40,12 @@ func init() {
 		ResourceKind: "SQLInstance",
 	}
 
+	resourceContextMap["sqlinstance-replica-direct"] = ResourceContext{
+		// Defaulting behavior of backup configuration requires multiple updates.
+		SkipNoChange: true,
+		ResourceKind: "SQLInstance",
+	}
+
 	resourceContextMap["sqldatabase"] = ResourceContext{
 		ResourceKind: "SQLDatabase",
 	}


### PR DESCRIPTION
This test has the same issue as the other SQLInstance backup tests, because backup configuration is required to configure a replica.