### PR TITLE
Remove log.Fatal from conductor cmds

### DIFF
--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -93,7 +93,9 @@ func createScriptYaml(opts *RunnerOptions, branch Branch) {
 	}
 	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("SCRIPT FILE GENERATE error: %q\n", err)
+		// Currently ignoring error and just basing on if the script.yaml was generated.
+		// log.Fatal(err)
 	}
 
 	// Check to see if the script file was created
@@ -370,7 +372,12 @@ func addServiceToRoundTrip(opts *RunnerOptions, branch Branch) {
 	}
 	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("addServiceToRoundTrip error: %q\n", err)
+		// Currently ignoring error and just basing on if the mock_http_roundtrip.go was diff.
+		// log.Fatal(err)
+	}
+	if !gitFileHasChange(workDir, "mock_http_roundtrip.go") {
+		return
 	}
 
 	// Add the new files to the current branch.
@@ -390,7 +397,7 @@ Hints:
 
 * The generate-grpc-for-google-protos command contains a long protoc command, split across multiple lines.  There should be a backslash character (\) on all lines but the last.  Make sure there is a space before the backslash.`
 
-func addProtoToMakfile(opts *RunnerOptions, branch Branch) {
+func addProtoToMakefile(opts *RunnerOptions, branch Branch) {
 	close := setLoggingWriter(opts, branch)
 	defer close()
 	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
@@ -421,9 +428,12 @@ func addProtoToMakfile(opts *RunnerOptions, branch Branch) {
 	}
 	_, _, err := executeCommand(opts, cfg)
 	if err != nil {
-		log.Fatal(err)
+		// log.Fatal(err)
+		log.Printf("updating proto Makefile error: %q\n", err)
 	}
-
+	if !gitFileHasChange(workDir, "Makefile") {
+		return
+	}
 	// Add the new files to the current branch.
 	gitAdd(workDir, &out, "Makefile")
 

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -234,7 +234,7 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 	case cmdAddProtoMakefile: // 14
 		for idx, branch := range branches.Branches {
 			log.Printf("Add proto to makefile: %d name: %s, branch: %s\r\n", idx, branch.Name, branch.Local)
-			addProtoToMakfile(opts, branch)
+			addProtoToMakefile(opts, branch)
 		}
 	case cmdRunMockTests: // 15
 		for idx, branch := range branches.Branches {

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -15,6 +15,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -189,6 +190,25 @@ func gitCommit(workDir string, out *strings.Builder, msg string) {
 	}
 	log.Printf("BRANCH COMMIT: %q\n", formatCommandOutput(out.String()))
 	out.Reset()
+}
+
+func gitFileHasChange(workDir string, filePath string) bool {
+	log.Printf("COMMAND: git diff -- %s", filePath)
+	args := []string{"diff", "--", filePath}
+	gitdiff := exec.Command("git", args...)
+	gitdiff.Dir = workDir
+	var out bytes.Buffer
+	gitdiff.Stdout = &out
+	if err := gitdiff.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			// Exit code 1 means no changes, not an error
+			return false
+		}
+		log.Printf("Git diff on file %s/%s error: %q\n", workDir, filePath, err)
+		return false
+	}
+	return len(strings.TrimSpace(out.String())) > 0
 }
 
 type closer func()


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Make a few conductor cmd to ignore error and move to the next branch

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
