### PR TITLE
chore: mark mockgcptests as parallel-safe

### DIFF
--- a/mockgcp/mockgcptests/e2e_test.go
+++ b/mockgcp/mockgcptests/e2e_test.go
@@ -50,6 +50,8 @@ func TestScripts(t *testing.T) {
 
 	for _, scriptPath := range scriptPaths {
 		t.Run(scriptPath, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := context.TODO()
 			ctx, closeContext := context.WithCancel(ctx)
 			t.Cleanup(closeContext)


### PR DESCRIPTION
We use env vars and proxies on unique ports
