### PR TITLE
Improve mockgcp TestScripts to support setup/teardown and more placeholders

### DIFF
--- a/mockgcp/mockgcptests/account.go
+++ b/mockgcp/mockgcptests/account.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockgcptests
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func GetDefaultAccount(t *testing.T) string {
+	t.Helper()
+
+	account, err := getGCloudDefaultAccount()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return account
+}
+
+func getGCloudDefaultAccount() (string, error) {
+	cmd := exec.Command("gcloud", "config", "get-value", "account")
+	bytes, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("error executing command '%v': %w'", cmd, err)
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}

--- a/mockgcp/mockgcptests/e2e_test.go
+++ b/mockgcp/mockgcptests/e2e_test.go
@@ -34,10 +34,13 @@ import (
 )
 
 type Placeholders struct {
-	ProjectID        string
-	ProjectNumber    int64
-	UniqueID         string
-	BillingAccountID string
+	ProjectID               string
+	ProjectNumber           int64
+	UniqueID                string
+	BillingAccountID        string
+	IAMTestOrganizationID   string
+	IAMTestBillingAccountID string
+	User                    string
 }
 
 func TestScripts(t *testing.T) {
@@ -45,7 +48,6 @@ func TestScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot find base dir for mockgcp: %v", err)
 	}
-
 	scriptPaths := findScripts(t, baseDir)
 
 	for _, scriptPath := range scriptPaths {
@@ -64,12 +66,41 @@ func TestScripts(t *testing.T) {
 			project := h.Project
 			testDir := filepath.Join(baseDir, scriptPath)
 			placeholders := Placeholders{
-				ProjectID:        project.ProjectID,
-				ProjectNumber:    project.ProjectNumber,
-				UniqueID:         uniqueID,
-				BillingAccountID: testgcp.TestBillingAccountID.Get(),
+				ProjectID:               project.ProjectID,
+				ProjectNumber:           project.ProjectNumber,
+				UniqueID:                uniqueID,
+				BillingAccountID:        testgcp.TestBillingAccountID.Get(),
+				IAMTestBillingAccountID: testgcp.IAMIntegrationTestsBillingAccountID.Get(),
+				IAMTestOrganizationID:   testgcp.IAMIntegrationTestsOrganizationID.Get(),
+				User:                    GetDefaultAccount(t),
 			}
 			script := loadScript(t, testDir, placeholders)
+
+			for _, step := range script.SetupSteps {
+				if step.Exec != "" {
+					cmd := exec.CommandContext(ctx, "bash", "-c", step.Exec)
+					var stdout bytes.Buffer
+					cmd.Stdout = &stdout
+					var stderr bytes.Buffer
+					cmd.Stderr = &stderr
+
+					cmd.Env = append(cmd.Env, os.Environ()...)
+
+					if h.gcpAccessToken != "" {
+						cmd.Env = append(cmd.Env, fmt.Sprintf("CLOUDSDK_AUTH_ACCESS_TOKEN=%v", h.gcpAccessToken))
+					}
+					cmd.Env = append(cmd.Env, "CLOUDSDK_CORE_PROJECT="+h.Project.ProjectID)
+					cmd.Dir = testDir
+
+					t.Logf("executing setup step command %q", step.Exec)
+					if err := cmd.Run(); err != nil {
+						t.Logf("stdout: %v", stdout.String())
+						t.Logf("stderr: %v", stderr.String())
+
+						t.Errorf("error running command %q: %v", step.Exec, err)
+					}
+				}
+			}
 
 			h.StartProxy(ctx)
 
@@ -128,6 +159,31 @@ func TestScripts(t *testing.T) {
 				h.CompareGoldenFile(expectedPath, got)
 			}
 
+			for _, step := range script.TeardownSteps {
+				if step.Exec != "" {
+					cmd := exec.CommandContext(ctx, "bash", "-c", step.Exec)
+					var stdout bytes.Buffer
+					cmd.Stdout = &stdout
+					var stderr bytes.Buffer
+					cmd.Stderr = &stderr
+
+					cmd.Env = append(cmd.Env, os.Environ()...)
+
+					if h.gcpAccessToken != "" {
+						cmd.Env = append(cmd.Env, fmt.Sprintf("CLOUDSDK_AUTH_ACCESS_TOKEN=%v", h.gcpAccessToken))
+					}
+					cmd.Env = append(cmd.Env, "CLOUDSDK_CORE_PROJECT="+h.Project.ProjectID)
+					cmd.Dir = testDir
+
+					t.Logf("executing teardown step command %q", step.Exec)
+					if err := cmd.Run(); err != nil {
+						t.Logf("stdout: %v", stdout.String())
+						t.Logf("stderr: %v", stderr.String())
+
+						t.Errorf("error running command %q: %v", step.Exec, err)
+					}
+				}
+			}
 		})
 	}
 }
@@ -156,6 +212,9 @@ type Script struct {
 	Name      string
 	SourceDir string
 	Steps     []*Step
+
+	SetupSteps    []*Step
+	TeardownSteps []*Step
 }
 
 type Step struct {
@@ -167,18 +226,34 @@ func loadScript(t *testing.T, dir string, placeholders Placeholders) *Script {
 		Name:      dir,
 		SourceDir: dir,
 	}
-	b := test.MustReadFile(t, filepath.Join(dir, "script.yaml"))
+	s.Steps = loadFile(t, dir, "script.yaml", placeholders, true)
+	s.SetupSteps = loadFile(t, dir, "setup.yaml", placeholders, false)
+	s.TeardownSteps = loadFile(t, dir, "teardown.yaml", placeholders, false)
+	return s
+}
+
+func loadFile(t *testing.T, dir, fileName string, placeholders Placeholders, mustRead bool) []*Step {
+	var b []byte
+	var err error
+	if mustRead {
+		b = test.MustReadFile(t, filepath.Join(dir, fileName))
+	} else {
+		b, err = os.ReadFile(filepath.Join(dir, fileName))
+		if err != nil {
+			return nil
+		}
+	}
+	if len(b) == 0 {
+		return nil
+	}
 
 	b = ReplaceTestVars(t, b, placeholders)
 
 	var steps []*Step
 	if err := yaml.Unmarshal(b, &steps); err != nil {
-		t.Fatalf("error unmarshalling steps: %v", err)
+		t.Fatalf("error unmarshalling steps in %s: %v", fileName, err)
 	}
-
-	s.Steps = steps
-
-	return s
+	return steps
 }
 
 // ReplaceTestVars replaces all occurrences of placeholder strings e.g. ${uniqueId} in a given byte slice.
@@ -188,5 +263,8 @@ func ReplaceTestVars(t *testing.T, b []byte, placeholders Placeholders) []byte {
 	s = strings.Replace(s, "${projectId}", placeholders.ProjectID, -1)
 	s = strings.Replace(s, "${projectNumber}", strconv.FormatInt(placeholders.ProjectNumber, 10), -1)
 	s = strings.Replace(s, "${BILLING_ACCOUNT_ID}", placeholders.BillingAccountID, -1)
+	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.IAMIntegrationTestsOrganizationID.Key), placeholders.IAMTestOrganizationID, -1)
+	s = strings.Replace(s, fmt.Sprintf("${%s}", testgcp.IAMIntegrationTestsBillingAccountID.Key), placeholders.IAMTestBillingAccountID, -1)
+	s = strings.Replace(s, "${user}", placeholders.User, -1)
 	return []byte(s)
 }

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -395,8 +395,25 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 	}
 
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
-		return strings.ReplaceAll(s, "organizations/"+testgcp.TestOrgID.Get(), "organizations/${organizationID}")
-
+		if testgcp.TestOrgID.Get() != "" {
+			return strings.ReplaceAll(s, "organizations/"+testgcp.TestOrgID.Get(), "organizations/${organizationID}")
+		}
+		if testgcp.IAMIntegrationTestsOrganizationID.Get() != "" {
+			return strings.ReplaceAll(s, "organizations/"+testgcp.IAMIntegrationTestsOrganizationID.Get(), "organizations/${organizationID}")
+		}
+		return ""
+	})
+	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+		if testgcp.TestBillingAccountID.Get() != "" {
+			return strings.ReplaceAll(s, "billingAccounts/"+testgcp.TestBillingAccountID.Get(), "billingAccounts/${billingAccountID}")
+		}
+		if testgcp.IAMIntegrationTestsBillingAccountID.Get() != "" {
+			return strings.ReplaceAll(s, "billingAccounts/"+testgcp.IAMIntegrationTestsBillingAccountID.Get(), "billingAccounts/${billingAccountID}")
+		}
+		if testgcp.TestBillingAccountIDForBillingResources.Get() != "" {
+			return strings.ReplaceAll(s, "billingAccounts/"+testgcp.TestBillingAccountIDForBillingResources.Get(), "billingAccounts/${billingAccountID}")
+		}
+		return ""
 	})
 
 	return visitor.VisitUnstructured(u)
@@ -925,6 +942,12 @@ func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer,
 	{
 		visitor.ReplacePath(".metadata.commonMetadata.createTime", "2025-01-01T12:34:56.123456Z")
 		visitor.ReplacePath(".metadata.commonMetadata.updateTime", "2025-01-02T12:34:56.123456Z")
+	}
+
+	// AssuredWorkloads
+	{
+		visitor.ReplacePath(".workloads[].etag", "abcdef0123A=")
+		visitor.ReplacePath(".workloads[].createTime", "1970-01-01T00:00:00Z")
 	}
 
 	// Run visitors

--- a/tests/e2e/replacements.go
+++ b/tests/e2e/replacements.go
@@ -154,6 +154,10 @@ func (r *Replacements) placeholderForGCPResource(resource string) string {
 		return "${processorID}"
 	case "processorVersions":
 		return "${processorVersionID}"
+	case "workloads":
+		return "${workloadID}"
+	case "organizations":
+		return "${organizationID}"
 	default:
 		return ""
 	}
@@ -165,7 +169,11 @@ func (r *Replacements) ExtractIDsFromLinks(link string) {
 	if u != nil {
 		for _, item := range u.PathItems {
 			placeholder := r.placeholderForGCPResource(item.Resource)
-			if placeholder != "" {
+			// Apigee organization maps to GCP project but not GCP organization,
+			// so when we have "organizations/mock-project", it's likely an
+			// Apigee organization, and we don't replace the value with
+			// ${organizationID} placeholder.
+			if placeholder != "" && !(item.Resource == "organizations" && item.Name == "mock-project") {
 				r.PathIDs[item.Name] = placeholder
 			}
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
* Support setup.yaml and teardown.yaml in addition to script.yaml so that setup or teardown commands can be executed separately without being logged or causing confusion.
* Support new placeholders.
* Ensure organization ID, billing account ID are not exposed.
* Normalize assured workloads workload fields.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
