### PR TITLE
controllerbuilder: support filters on extraction

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -125,12 +125,6 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 		x.StrictInputColumnKeys = sets.New(o.StrictInputColumnKeys...)
 	}
 
-	if o.SrcDir != "" {
-		if err := x.VisitCodeDir(ctx, o.SrcDir); err != nil {
-			return err
-		}
-	}
-
 	var b []byte
 	if o.InputFile == "" {
 		if b, err = io.ReadAll(os.Stdin); err != nil {
@@ -155,6 +149,15 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 	dataPoint.Output = ""
 
 	log.Info("built data point", "dataPoint", dataPoint)
+
+	if o.SrcDir != "" {
+		filterByType := func(p *toolbot.DataPoint) bool {
+			return p.Type == dataPoint.Type
+		}
+		if err := x.VisitCodeDir(ctx, o.SrcDir, filterByType); err != nil {
+			return err
+		}
+	}
 
 	model := os.Getenv("LLM_MODEL")
 	if model == "" {

--- a/dev/tools/controllerbuilder/pkg/toolbot/extracttoolmarkers.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/extracttoolmarkers.go
@@ -32,7 +32,7 @@ type ExtractToolMarkers struct {
 var _ Extractor = &ExtractToolMarkers{}
 
 // Extract extracts tool markers from source code.
-func (x *ExtractToolMarkers) Extract(ctx context.Context, description string, src []byte) ([]*DataPoint, error) {
+func (x *ExtractToolMarkers) Extract(ctx context.Context, description string, src []byte, filters ...Filter) ([]*DataPoint, error) {
 	var dataPoints []*DataPoint
 
 	r := bytes.NewReader(src)
@@ -81,7 +81,16 @@ func (x *ExtractToolMarkers) Extract(ctx context.Context, description string, sr
 						return nil, fmt.Errorf("cannot parse tool line %q", toolLine)
 					}
 				}
-				dataPoints = append(dataPoints, dataPoint)
+
+				shouldAdd := true
+				for _, filter := range filters {
+					if !filter(dataPoint) {
+						shouldAdd = false
+					}
+				}
+				if shouldAdd {
+					dataPoints = append(dataPoints, dataPoint)
+				}
 			}
 
 			if strings.HasPrefix(comment, "+kcc:proto=") {
@@ -113,7 +122,16 @@ func (x *ExtractToolMarkers) Extract(ctx context.Context, description string, sr
 					}
 				}
 				dataPoint.Output = bb.String()
-				dataPoints = append(dataPoints, dataPoint)
+
+				shouldAdd := true
+				for _, filter := range filters {
+					if !filter(dataPoint) {
+						shouldAdd = false
+					}
+				}
+				if shouldAdd {
+					dataPoints = append(dataPoints, dataPoint)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is more efficient and reduces the blast radius of bad input data.
