### PR TITLE
Improve error message in mapper enhancer and fix api.group

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
@@ -16,6 +16,7 @@ package toolbot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -56,7 +57,11 @@ func (x *EnhanceWithMappers) EnhanceDataPoint(ctx context.Context, p *DataPoint)
 	mapperDir := filepath.Join(x.srcDirectory, resourceType)
 	files, err := os.ReadDir(mapperDir)
 	if err != nil {
-		return fmt.Errorf("reading mapper directory: %w", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("api.group %q might be incorrect", apiGroup)
+		} else {
+			return fmt.Errorf("reading mapper directory: %w", err)
+		}
 	}
 
 	var mappers []string

--- a/pkg/controller/direct/vertexai/featurestore_fuzzer.go
+++ b/pkg/controller/direct/vertexai/featurestore_fuzzer.go
@@ -14,7 +14,7 @@
 
 // +tool:fuzz-gen
 // proto.message: google.cloud.aiplatform.v1beta1.Featurestore
-// api.group: aiplatform.cnrm.cloud.google.com
+// api.group: vertexai.cnrm.cloud.google.com
 
 package vertexai
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
With `// api.group: aiplatform.cnrm.cloud.google.com`, the prompt gives the following error and it is kinda confusing.

```
walking directory tree: processing file "/usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/5-k8s-config-connector/pkg/controller/direct/vertexai/featurestore_fuzzer.go": reading mapper directory: open /usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/5-k8s-config-connector/pkg/controller/direct/aiplatform: no such file or directory
```

The root cause is `api.group` data point in featurestore_fuzzer.go contained incorrect value.

Fixed `api.group` and also improved the error message in mapper enhancer.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
