### PR TITLE
Skip recording auth token exchanges

### DIFF
--- a/pkg/test/eventsink.go
+++ b/pkg/test/eventsink.go
@@ -71,6 +71,10 @@ func (s *MemoryEventSink) AddHTTPEvent(ctx context.Context, entry *LogEntry) { /
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	// HACK: Filter oauth events
+	if strings.Contains(entry.Request.URL, "oauth2.googleapis.com") {
+		return
+	}
 	s.HTTPEvents = append(s.HTTPEvents, entry)
 }
 


### PR DESCRIPTION
* Was causing json parse failures when recording the request.
* also recording tokens is not a good idea

```
2025/03/08 03:47:42   > F0308 03:47:42.302034  337173 http_recorder.go:285] error from json.Unmarshal("grant_type=refresh_token&client_id=32555940559.apps.googleusercontent.com&client_secret=****&scope=openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fappengine.admin+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fsqlservice.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcompute+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Faccounts.reauth"): invalid character 'g' looking for beginning of value

```


```
request:
  body: grant_type=refresh_token&client_id=32555940559.apps.googleusercontent.com&client_secret=**redacted***&scope=openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fappengine.admin+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fsqlservice.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcompute+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Faccounts.reauth
  header:
    Accept:
    - '*/*'
    Connection:
    - keep-alive
    Content-Length:
    - "586"
    Content-Type:
    - application/x-www-form-urlencoded
    User-Agent:
    - google-cloud-sdk gcloud/512.0.0 command/gcloud.metastore.services.create invocation-id/7feaee37a45549208e6e0de756f4f2ec
      environment/GCE environment-version/None client-os/LINUX client-os-ver/6.10.11
      client-pltf-arch/x86_64 interactive/False from-script/False python/3.12.8 term/xterm-256color
      (Linux 6.10.11-1rodete2-amd64)
  method: POST
  url: https://oauth2.googleapis.com/token
```