### PR TITLE
conductor: fixes for cmd=12, mock service and resource gen

### DIFF
--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -511,38 +511,39 @@ const MOCK_RESOURCE_GO_GEN string = `// +tool:mockgcp-support
 func generateMockGo(opts *RunnerOptions, branch Branch) {
 	close := setLoggingWriter(opts, branch)
 	defer close()
-	workDir := filepath.Join(opts.branchRepoDir, "mockgcp")
+	workDir := opts.branchRepoDir
 
 	var out strings.Builder
 	var hasChange = false
 	checkoutBranch(branch, workDir, &out)
 
 	// Check to see if the http log file already exists
-	logFile := fmt.Sprintf("mock%s/testdata/%s/crud/_http.log", branch.Group, branch.Resource)
-	logFullPath := filepath.Join(workDir, logFile)
+	mockfolder := fmt.Sprintf("mock%s", branch.Group)
+
+	logFullPath := filepath.Join(workDir, "mockgcp", mockfolder, "testdata", branch.Resource, "crud", "_http.log")
 	if _, err := os.Stat(logFullPath); errors.Is(err, os.ErrNotExist) {
 		log.Printf("SKIPPING %s, missing %s", branch.Name, logFullPath)
 		return
 	}
 
 	// Delete then write the service go prompt file.
-	servicePromptPath := filepath.Join(opts.branchRepoDir, "mockgcp", "service_prompt.txt")
+	servicePromptPath := filepath.Join(workDir, "service_prompt.txt")
 	writeTemplateToFile(branch, servicePromptPath, MOCK_SERVICE_GO_GEN)
 
 	// Delete then write the resource go prompt file.
-	resourcePromptPath := filepath.Join(opts.branchRepoDir, "mockgcp", "resource_prompt.txt")
+	resourcePromptPath := filepath.Join(workDir, "resource_prompt.txt")
 	writeTemplateToFile(branch, resourcePromptPath, MOCK_RESOURCE_GO_GEN)
 
 	// Run the controller builder to generate the service go file.
-	serviceFile := filepath.Join(workDir, fmt.Sprintf("mock%s", branch.Group), "service.go")
+	serviceFile := filepath.Join(workDir, "mockgcp", mockfolder, "service.go")
 	if _, err := os.Stat(serviceFile); errors.Is(err, os.ErrNotExist) || opts.force {
 		cfg := CommandConfig{
 			Name: "Generate service mock",
 			Cmd:  "controllerbuilder",
 			Args: []string{
 				"prompt",
-				"--src-dir", opts.branchRepoDir,
-				"--proto-dir", fmt.Sprintf("%s/.build/third_party/googleapis/", opts.branchRepoDir),
+				"--src-dir", "./mockgcp",
+				"--proto-dir", fmt.Sprintf(".build/third_party/googleapis/"),
 				"--input-file", "service_prompt.txt",
 			},
 			WorkDir:      workDir,
@@ -574,15 +575,15 @@ func generateMockGo(opts *RunnerOptions, branch Branch) {
 	}
 
 	// Run the controller builder to generate the resource go file.
-	resourceFile := filepath.Join(workDir, fmt.Sprintf("mock%s", branch.Group), fmt.Sprintf("%s.go", strings.ToLower(branch.Resource)))
+	resourceFile := filepath.Join(workDir, "mockgcp", mockfolder, fmt.Sprintf("%s.go", strings.ToLower(branch.Resource)))
 	if _, err := os.Stat(resourceFile); errors.Is(err, os.ErrNotExist) || opts.force {
 		cfg := CommandConfig{
 			Name: "Generate resource mock",
 			Cmd:  "controllerbuilder",
 			Args: []string{
 				"prompt",
-				"--src-dir", opts.branchRepoDir,
-				"--proto-dir", fmt.Sprintf("%s/.build/third_party/googleapis/", opts.branchRepoDir),
+				"--src-dir", "./mockgcp",
+				"--proto-dir", ".build/third_party/googleapis/",
 				"--input-file", "resource_prompt.txt",
 			},
 			WorkDir:      workDir,


### PR DESCRIPTION
Verified:

```
❯ time ./bin/conductor runner --branch-repo=/usr/local/google/home/barni/workspace/src/github.com/barney-s/vertex-notebook/k8s-config-connector  --branch-conf=branches-barni.yaml --logging-dir=logs  --command=12
2025/03/08 20:39:50 Running conductor runner with branch config: branches-barni.yaml
2025/03/08 20:39:50 Starting Runner
2025/03/08 20:39:50 Generate mock Service and Resource go files: 0 name: api-quotapreference, branch: resource-api-quotapreference
2025/03/08 20:39:50 Logging dir: logs/api-quotapreference
2025/03/08 20:39:50 Generate mock Service and Resource go files: 1 name: api-quotaadjustersettings, branch: resource-api-quotaadjustersettings
2025/03/08 20:39:50 Logging dir: logs/api-quotaadjustersettings
2025/03/08 20:40:29 Generate mock Service and Resource go files: 2 name: asset-feed, branch: resource-asset-feed
2025/03/08 20:40:29 Logging dir: logs/asset-feed
2025/03/08 20:40:55 Generate mock Service and Resource go files: 3 name: asset-savedquery, branch: resource-asset-savedquery
2025/03/08 20:40:55 Logging dir: logs/asset-savedquery
2025/03/08 20:41:28 Generate mock Service and Resource go files: 4 name: datacatalog-entry, branch: resource-datacatalog-entry
2025/03/08 20:41:28 Logging dir: logs/datacatalog-entry
2025/03/08 20:41:57 Generate mock Service and Resource go files: 5 name: datacatalog-entrygroup, branch: resource-datacatalog-entrygroup
2025/03/08 20:41:57 Logging dir: logs/datacatalog-entrygroup
2025/03/08 20:42:40 Generate mock Service and Resource go files: 6 name: datacatalog-tag, branch: resource-datacatalog-tag
2025/03/08 20:42:40 Logging dir: logs/datacatalog-tag
2025/03/08 20:43:09 Generate mock Service and Resource go files: 7 name: datacatalog-tagtemplate, branch: resource-datacatalog-tagtemplate
2025/03/08 20:43:09 Logging dir: logs/datacatalog-tagtemplate
2025/03/08 20:43:37 Generate mock Service and Resource go files: 8 name: essentialcontacts-contact, branch: resource-essentialcontacts-contact
2025/03/08 20:43:37 Logging dir: logs/essentialcontacts-contact
2025/03/08 20:44:05 Generate mock Service and Resource go files: 9 name: eventarc-channel, branch: resource-eventarc-channel
2025/03/08 20:44:05 Logging dir: logs/eventarc-channel
2025/03/08 20:45:02 Generate mock Service and Resource go files: 10 name: eventarc-googlechannelconfig, branch: resource-eventarc-googlechannelconfig
2025/03/08 20:45:02 Logging dir: logs/eventarc-googlechannelconfig
2025/03/08 20:45:31 Generate mock Service and Resource go files: 11 name: metastore-service, branch: resource-metastore-service
2025/03/08 20:45:31 Logging dir: logs/metastore-service
2025/03/08 20:45:56 Generate mock Service and Resource go files: 12 name: metastore-backup, branch: resource-metastore-backup
2025/03/08 20:45:56 Logging dir: logs/metastore-backup
2025/03/08 20:46:24 Generate mock Service and Resource go files: 13 name: metastore-federation, branch: resource-metastore-federation
2025/03/08 20:46:24 Logging dir: logs/metastore-federation
./bin/conductor runner  --branch-conf=branches-barni.yaml --logging-dir=logs   62.96s user 40.32s system 24% cpu 7:07.19 total
```