### PR TITLE
mockgcp: support for compute-computeresourcepolicies

### DIFF
--- a/mockgcp/mockcompute/computeresourcepolicies.go
+++ b/mockgcp/mockcompute/computeresourcepolicies.go
@@ -1,0 +1,198 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.compute.v1.ResourcePolicies
+// proto.message: google.cloud.compute.v1.ResourcePolicy
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+)
+
+type resourcePolicies struct {
+	*MockService
+	pb.UnimplementedResourcePoliciesServer
+}
+
+func (s *resourcePolicies) Get(ctx context.Context, req *pb.GetResourcePolicyRequest) (*pb.ResourcePolicy, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.ResourcePolicy{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "ResourcePolicy %q not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *resourcePolicies) Insert(ctx context.Context, req *pb.InsertResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicyResource().GetName())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	obj := proto.Clone(req.GetResourcePolicyResource()).(*pb.ResourcePolicy)
+	obj.Id = proto.Uint64(s.generateID())
+	obj.SelfLink = PtrTo(buildComputeSelfLink(ctx, fqn))
+	obj.Kind = PtrTo("compute#resourcePolicy")
+	obj.CreationTimestamp = PtrTo(s.nowString())
+	obj.Status = PtrTo("READY")
+
+	obj.Region = PtrTo(makeFullyQualifiedRegion(ctx, name.Project.ID, name.Region))
+
+	s.populateDefaultsForResourcePolicy(obj)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("insert"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *resourcePolicies) populateDefaultsForResourcePolicy(obj *pb.ResourcePolicy) {
+	if snapshotSchedulePolicy := obj.GetSnapshotSchedulePolicy(); snapshotSchedulePolicy != nil {
+		if retentionPolicy := snapshotSchedulePolicy.GetRetentionPolicy(); retentionPolicy != nil {
+			if retentionPolicy.OnSourceDiskDelete == nil {
+				retentionPolicy.OnSourceDiskDelete = PtrTo("KEEP_AUTO_SNAPSHOTS")
+			}
+		}
+		if schedule := snapshotSchedulePolicy.GetSchedule(); schedule != nil {
+			if dailySchedule := schedule.GetDailySchedule(); dailySchedule != nil {
+				if dailySchedule.Duration == nil {
+					dailySchedule.Duration = PtrTo("PT14400S")
+				}
+			}
+
+		}
+	}
+}
+
+func (s *resourcePolicies) Delete(ctx context.Context, req *pb.DeleteResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.ResourcePolicy{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("delete"),
+		TargetId:      deleted.Id,
+		TargetLink:    deleted.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return &emptypb.Empty{}, nil
+	})
+}
+
+func (s *resourcePolicies) Update(ctx context.Context, req *pb.PatchResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.ResourcePolicy{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	proto.Merge(obj, req.GetResourcePolicyResource())
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("update"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+type resourcePolicyName struct {
+	Project *projects.ProjectData
+	Region  string
+	Name    string
+}
+
+func (n *resourcePolicyName) String() string {
+	return "projects/" + n.Project.ID + "/regions/" + n.Region + "/resourcePolicies/" + n.Name
+}
+
+// parseResourcePolicyName parses a string into a resourcePolicyName.
+// The expected form is `locations/global/firewallPolicies/*`.
+func (s *MockService) parseResourcePolicyName(name string) (*resourcePolicyName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "resourcePolicies" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &resourcePolicyName{
+			Project: project,
+			Region:  tokens[3],
+			Name:    tokens[5],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -62,8 +62,13 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterExternalVpnGatewaysServer(grpcServer, &externalVPNGateways{MockService: s})
 
 	pb.RegisterNetworksServer(grpcServer, &NetworksV1{MockService: s})
+
+	pb.RegisterResourcePoliciesServer(grpcServer, &resourcePolicies{MockService: s})
+
 	pb.RegisterSubnetworksServer(grpcServer, &SubnetsV1{MockService: s})
+
 	pb.RegisterVpnGatewaysServer(grpcServer, &VPNGatewaysV1{MockService: s})
+
 	pb.RegisterTargetVpnGatewaysServer(grpcServer, &TargetVpnGatewaysV1{MockService: s})
 	pb.RegisterTargetGrpcProxiesServer(grpcServer, &TargetGrpcProxyV1{MockService: s})
 
@@ -136,6 +141,10 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 	}
 
 	if err := pb.RegisterNetworksHandler(ctx, mux.ServeMux, conn); err != nil {
+		return nil, err
+	}
+
+	if err := pb.RegisterResourcePoliciesHandler(ctx, mux.ServeMux, conn); err != nil {
 		return nil, err
 	}
 

--- a/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/_http.log
@@ -1,0 +1,228 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "name": "${resourcePolicyID}",
+  "region": "us-central1",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "startTime": "13:00"
+      }
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#resourcePolicy",
+  "name": "${resourcePolicyID}",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1,
+      "onSourceDiskDelete": "KEEP_AUTO_SNAPSHOTS"
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "duration": "PT14400S",
+        "startTime": "13:00"
+      }
+    }
+  },
+  "status": "READY"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#resourcePolicy",
+  "name": "${resourcePolicyID}",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1,
+      "onSourceDiskDelete": "KEEP_AUTO_SNAPSHOTS"
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "duration": "PT14400S",
+        "startTime": "13:00"
+      }
+    }
+  },
+  "status": "READY"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/script.yaml
@@ -1,0 +1,4 @@
+
+- exec: gcloud compute resource-policies create snapshot-schedule test-policy-${uniqueId} --region=us-central1 --max-retention-days=1 --start-time=13:00 --daily-schedule --project=${projectId}
+- exec: gcloud compute resource-policies describe test-policy-${uniqueId} --region=us-central1 --project=${projectId}
+- exec: gcloud compute resource-policies delete test-policy-${uniqueId} --region=us-central1 --project=${projectId} --quiet

--- a/mockgcp/mockcompute/utils.go
+++ b/mockgcp/mockcompute/utils.go
@@ -77,3 +77,13 @@ func buildComputeSelfLink(ctx context.Context, fqn string) string {
 	version := getAPIVersion(ctx)
 	return "https://www.googleapis.com/compute/" + version + "/" + fqn
 }
+
+// makeFullyQualifiedRegion will convert a short-form region name to a fully-qualified name
+func makeFullyQualifiedRegion(ctx context.Context, projectID string, region string) string {
+	s := region
+	tokens := strings.Split(s, "/")
+	if len(tokens) == 1 {
+		s = buildComputeSelfLink(ctx, "projects/"+projectID+"/regions/"+region)
+	}
+	return s
+}

--- a/mockgcp/mockgcptests/e2e_test.go
+++ b/mockgcp/mockgcptests/e2e_test.go
@@ -150,7 +150,7 @@ func TestScripts(t *testing.T) {
 
 				e2e.NormalizeHTTPLog(t, httpEvents, h.RegisteredServices(), testgcp.GCPProject{ProjectID: h.Project.ProjectID, ProjectNumber: h.Project.ProjectNumber}, uniqueID, folderID, organizationID)
 
-				x := e2e.NewNormalizer(uniqueID, testgcp.GCPProject{ProjectID: h.Project.ProjectID, ProjectNumber: h.Project.ProjectNumber})
+				x := e2e.NewNormalizer(testgcp.GCPProject{ProjectID: h.Project.ProjectID, ProjectNumber: h.Project.ProjectNumber})
 
 				x.Preprocess(httpEvents)
 

--- a/tests/e2e/httplog.go
+++ b/tests/e2e/httplog.go
@@ -26,15 +26,13 @@ import (
 )
 
 type Normalizer struct {
-	uniqueID string
-	project  testgcp.GCPProject
+	project testgcp.GCPProject
 
 	*Replacements
 }
 
-func NewNormalizer(uniqueID string, project testgcp.GCPProject) *Normalizer {
+func NewNormalizer(project testgcp.GCPProject) *Normalizer {
 	return &Normalizer{
-		uniqueID:     uniqueID,
 		project:      project,
 		Replacements: NewReplacements(),
 	}
@@ -229,7 +227,6 @@ func (x *Normalizer) Render(events test.LogEntries) string {
 
 	got := events.FormatHTTP()
 	normalizers := []func(string) string{}
-	normalizers = append(normalizers, ReplaceString(x.uniqueID, "${uniqueId}"))
 	normalizers = append(normalizers, ReplaceString(x.project.ProjectID, "${projectId}"))
 	normalizers = append(normalizers, ReplaceString(fmt.Sprintf("%d", x.project.ProjectNumber), "${projectNumber}"))
 	for k, v := range x.PathIDs {

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -258,9 +258,11 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 		return strings.ReplaceAll(s, fmt.Sprintf("%d", project.ProjectNumber), "${projectNumber}")
 	})
 
-	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
-		return strings.ReplaceAll(s, uniqueID, "${uniqueId}")
-	})
+	if uniqueID != "" {
+		visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
+			return strings.ReplaceAll(s, uniqueID, "${uniqueId}")
+		})
+	}
 
 	// TODO: Only for some objects?
 	visitor.stringTransforms = append(visitor.stringTransforms, func(path string, s string) string {
@@ -497,7 +499,8 @@ func (o *objectWalker) visitAny(v any, path string) (any, error) {
 	case int64, float64, bool:
 		return o.visitPrimitive(v, path)
 	case string:
-		return o.visitString(v, path)
+		s := o.VisitString(v, path)
+		return s, nil
 	default:
 		return nil, fmt.Errorf("unhandled type at path %q: %T", path, v)
 	}
@@ -600,14 +603,14 @@ func (o *objectWalker) visitPrimitive(v any, _ string) (any, error) {
 	return v, nil
 }
 
-func (o *objectWalker) visitString(s string, path string) (string, error) {
+func (o *objectWalker) VisitString(s string, path string) string {
 	for _, stringReplacement := range o.stringReplacements {
 		s = strings.ReplaceAll(s, stringReplacement.Find, stringReplacement.Replace)
 	}
 	for _, fn := range o.stringTransforms {
 		s = fn(path, s)
 	}
-	return s, nil
+	return s
 }
 
 func (o *objectWalker) VisitUnstructured(v *unstructured.Unstructured) error {
@@ -702,7 +705,7 @@ func findLinksInKRMObject(t *testing.T, replacement *Replacements, u *unstructur
 }
 
 func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregistry.Normalizer, project testgcp.GCPProject, uniqueID string, folderID string, organizationID string) {
-	normalizer := NewNormalizer(uniqueID, project)
+	normalizer := NewNormalizer(project)
 
 	normalizer.Preprocess(events)
 
@@ -711,9 +714,6 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 	}
 	if folderID != "" {
 		normalizer.Replacements.PathIDs[folderID] = "${folderID}"
-	}
-	if uniqueID != "" {
-		normalizer.Replacements.PathIDs[uniqueID] = "${uniqueId}"
 	}
 
 	// Find any URLs
@@ -764,7 +764,34 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 		}
 	}
 
-	normalizeHTTPResponses(t, services, events)
+	// Run per-service replacers
+	{
+		replacements := newObjectWalker()
+
+		if uniqueID != "" {
+			replacements.ReplaceStringValue(uniqueID, "${uniqueId}")
+		}
+
+		for _, entry := range events {
+			services.ConfigureVisitor(entry.Request.URL, replacements)
+		}
+
+		for _, entry := range events {
+			services.Previsit(entry, replacements)
+		}
+
+		events.PrettifyJSON(func(requestURL string, obj map[string]any) {
+			if err := replacements.visitMap(obj, ""); err != nil {
+				t.Fatalf("error normalizing response: %v", err)
+			}
+		})
+
+		for _, event := range events {
+			event.Request.URL = replacements.VisitString(event.Request.URL, "<url>")
+		}
+	}
+
+	normalizeHTTPResponses(t, events)
 
 	// Normalize using the KRM normalization function
 	events.PrettifyJSON(func(requestURL string, obj map[string]any) {
@@ -779,7 +806,7 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 	normalizer.Replacements.ApplyReplacementsToHTTPEvents(events)
 }
 
-func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer, events test.LogEntries) {
+func normalizeHTTPResponses(t *testing.T, events test.LogEntries) {
 	visitor := newObjectWalker()
 
 	// If we get detailed info, don't record it - it's not part of the API contract
@@ -962,24 +989,6 @@ func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer,
 		}
 	})
 
-	// Run per-service replaceres
-	{
-		replacements := newObjectWalker()
-
-		for _, entry := range events {
-			normalizer.ConfigureVisitor(entry.Request.URL, replacements)
-		}
-
-		for _, entry := range events {
-			normalizer.Previsit(entry, replacements)
-		}
-
-		events.PrettifyJSON(func(requestURL string, obj map[string]any) {
-			if err := replacements.visitMap(obj, ""); err != nil {
-				t.Fatalf("error normalizing response: %v", err)
-			}
-		})
-	}
 }
 
 // Compute URLs: Replace any compute beta URLs with v1 URLs

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -354,7 +354,7 @@ func TestE2EScript(t *testing.T) {
 
 				if os.Getenv("GOLDEN_REQUEST_CHECKS") != "" || os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
 					{
-						x := NewNormalizer(uniqueID, project)
+						x := NewNormalizer(project)
 
 						for _, stepEvents := range eventsByStep {
 							x.Preprocess(stepEvents)


### PR DESCRIPTION
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computeresourcepolicies"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computeresourcepolicies"**
- **conductor: "Adding mock service and resource for compute-computeresourcepolicies"**
