### PR TITLE
mockgcp: better support for compute networks

### DIFF
--- a/mockgcp/common/regions/regions.go
+++ b/mockgcp/common/regions/regions.go
@@ -33,6 +33,7 @@ func GetAllRegions(ctx context.Context) []string {
 		"australia-southeast2",
 		"europe-central2",
 		"europe-north1",
+		"europe-north2",
 		"europe-southwest1",
 		"europe-west1",
 		"europe-west10",

--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -54,7 +54,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcloudidentity"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcloudids"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcomposer"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcompute"
+	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcompute"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcontainer"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockcontaineranalysis"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockdataflow"
@@ -190,7 +190,6 @@ func NewMockRoundTripper(ctx context.Context, k8sClient client.Client, storage s
 	services = append(services, mockcloudidentity.New(env, storage))
 	services = append(services, mockcontainer.New(env, storage))
 	services = append(services, mockcertificatemanager.New(env, storage))
-	services = append(services, mockcompute.New(env, storage))
 	services = append(services, mockdataflow.New(env, storage))
 	services = append(services, mockdiscoveryengine.New(env, storage))
 	services = append(services, mockfirestore.New(env, storage))

--- a/mockgcp/mockcompute/computebackendbuckets.go
+++ b/mockgcp/mockcompute/computebackendbuckets.go
@@ -1,0 +1,207 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.compute.v1.BackendBuckets
+// proto.message: google.cloud.compute.v1.BackendBucket
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+)
+
+type backendBuckets struct {
+	*MockService
+	pb.UnimplementedBackendBucketsServer
+}
+
+func (s *backendBuckets) Get(ctx context.Context, req *pb.GetBackendBucketRequest) (*pb.BackendBucket, error) {
+	reqName := fmt.Sprintf("projects/%s/global/backendBuckets/%s", req.GetProject(), req.GetBackendBucket())
+	name, err := s.parseBackendBucketName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.BackendBucket{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "BackendBucket %q not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *backendBuckets) Insert(ctx context.Context, req *pb.InsertBackendBucketRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/backendBuckets/%s", req.GetProject(), req.GetBackendBucketResource().GetName())
+	name, err := s.parseBackendBucketName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := proto.Clone(req.GetBackendBucketResource()).(*pb.BackendBucket)
+	obj.Id = proto.Uint64(s.generateID())
+	obj.SelfLink = PtrTo(buildComputeSelfLink(ctx, fqn))
+	obj.Kind = PtrTo("compute#backendBucket")
+	obj.CreationTimestamp = PtrTo(s.nowString())
+
+	if obj.Description == nil {
+		obj.Description = PtrTo("")
+	}
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("insert"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *backendBuckets) Delete(ctx context.Context, req *pb.DeleteBackendBucketRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/backendBuckets/%s", req.GetProject(), req.GetBackendBucket())
+	name, err := s.parseBackendBucketName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	deleted := &pb.BackendBucket{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("delete"),
+		TargetId:      deleted.Id,
+		TargetLink:    deleted.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return &emptypb.Empty{}, nil
+	})
+}
+
+func (s *backendBuckets) Update(ctx context.Context, req *pb.UpdateBackendBucketRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/backendBuckets/%s", req.GetProject(), req.GetBackendBucket())
+	name, err := s.parseBackendBucketName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.BackendBucket{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	// TODO: Apply field mask.
+	proto.Merge(obj, req.GetBackendBucketResource())
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("update"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *backendBuckets) Patch(ctx context.Context, req *pb.PatchBackendBucketRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/backendBuckets/%s", req.GetProject(), req.GetBackendBucket())
+	name, err := s.parseBackendBucketName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.BackendBucket{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	// TODO: Apply field mask.
+	proto.Merge(obj, req.GetBackendBucketResource())
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("patch"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+type backendBucketName struct {
+	Project *projects.ProjectData
+	Name    string
+}
+
+func (n *backendBucketName) String() string {
+	return "projects/" + n.Project.ID + "/global/backendBuckets/" + n.Name
+}
+
+// parseBackendBucketName parses a string into a backendBucketName.
+// The expected form is `locations/global/firewallPolicies/*`.
+func (s *MockService) parseBackendBucketName(name string) (*backendBucketName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 5 && tokens[0] == "projects" && tokens[2] == "global" && tokens[3] == "backendBuckets" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &backendBucketName{
+			Project: project,
+			Name:    tokens[4],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockcompute/computeexternalvpngateways.go
+++ b/mockgcp/mockcompute/computeexternalvpngateways.go
@@ -1,0 +1,176 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.compute.v1.ExternalVpnGateways
+// proto.message: google.cloud.compute.v1.ExternalVpnGateway
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+)
+
+type externalVPNGateways struct {
+	*MockService
+	pb.UnimplementedExternalVpnGatewaysServer
+}
+
+func (s *externalVPNGateways) Get(ctx context.Context, req *pb.GetExternalVpnGatewayRequest) (*pb.ExternalVpnGateway, error) {
+	reqName := fmt.Sprintf("projects/%s/global/externalVpnGateways/%s", req.GetProject(), req.GetExternalVpnGateway())
+	name, err := s.parseExternalVpnGatewayName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.ExternalVpnGateway{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "ExternalVpnGateway %q not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *externalVPNGateways) Insert(ctx context.Context, req *pb.InsertExternalVpnGatewayRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/externalVpnGateways/%s", req.GetProject(), req.GetExternalVpnGatewayResource().GetName())
+	name, err := s.parseExternalVpnGatewayName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := proto.Clone(req.GetExternalVpnGatewayResource()).(*pb.ExternalVpnGateway)
+	obj.Id = proto.Uint64(s.generateID())
+	obj.SelfLink = PtrTo(buildComputeSelfLink(ctx, fqn))
+	obj.Kind = PtrTo("compute#externalVpnGateway")
+	obj.CreationTimestamp = PtrTo(s.nowString())
+
+	obj.LabelFingerprint = PtrTo(labelsFingerprint(obj.GetLabels()))
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("compute.externalVpnGateways.insert"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *externalVPNGateways) Delete(ctx context.Context, req *pb.DeleteExternalVpnGatewayRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/externalVpnGateways/%s", req.GetProject(), req.GetExternalVpnGateway())
+	name, err := s.parseExternalVpnGatewayName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	deleted := &pb.ExternalVpnGateway{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("compute.externalVpnGateways.delete"),
+		TargetId:      deleted.Id,
+		TargetLink:    deleted.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return &emptypb.Empty{}, nil
+	})
+}
+
+func (s *externalVPNGateways) SetLabels(ctx context.Context, req *pb.SetLabelsExternalVpnGatewayRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/global/externalVpnGateways/%s", req.GetProject(), req.GetResource())
+	name, err := s.parseExternalVpnGatewayName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.ExternalVpnGateway{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	if obj.GetLabelFingerprint() != req.GetGlobalSetLabelsRequestResource().GetLabelFingerprint() {
+		return nil, status.Errorf(codes.FailedPrecondition, "LabelFingerprint mismatch")
+	}
+	obj.Labels = req.GetGlobalSetLabelsRequestResource().GetLabels()
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("update"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startGlobalLRO(ctx, name.Project.ID, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+type externalVpnGatewayName struct {
+	Project *projects.ProjectData
+	Name    string
+}
+
+func (n *externalVpnGatewayName) String() string {
+	return "projects/" + n.Project.ID + "/global/externalVpnGateways/" + n.Name
+}
+
+// parseExternalVpnGatewayName parses a string into a externalVpnGatewayName.
+// The expected form is `locations/global/firewallPolicies/*`.
+func (s *MockService) parseExternalVpnGatewayName(name string) (*externalVpnGatewayName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 5 && tokens[0] == "projects" && tokens[2] == "global" && tokens[3] == "externalVpnGateways" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &externalVpnGatewayName{
+			Project: project,
+			Name:    tokens[4],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockcompute/computeresourcepolicies.go
+++ b/mockgcp/mockcompute/computeresourcepolicies.go
@@ -1,0 +1,198 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.compute.v1.ResourcePolicies
+// proto.message: google.cloud.compute.v1.ResourcePolicy
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/compute/v1"
+)
+
+type resourcePolicies struct {
+	*MockService
+	pb.UnimplementedResourcePoliciesServer
+}
+
+func (s *resourcePolicies) Get(ctx context.Context, req *pb.GetResourcePolicyRequest) (*pb.ResourcePolicy, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.ResourcePolicy{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "ResourcePolicy %q not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *resourcePolicies) Insert(ctx context.Context, req *pb.InsertResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicyResource().GetName())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	obj := proto.Clone(req.GetResourcePolicyResource()).(*pb.ResourcePolicy)
+	obj.Id = proto.Uint64(s.generateID())
+	obj.SelfLink = PtrTo(buildComputeSelfLink(ctx, fqn))
+	obj.Kind = PtrTo("compute#resourcePolicy")
+	obj.CreationTimestamp = PtrTo(s.nowString())
+	obj.Status = PtrTo("READY")
+
+	obj.Region = PtrTo(makeFullyQualifiedRegion(ctx, name.Project.ID, name.Region))
+
+	s.populateDefaultsForResourcePolicy(obj)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("insert"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+func (s *resourcePolicies) populateDefaultsForResourcePolicy(obj *pb.ResourcePolicy) {
+	if snapshotSchedulePolicy := obj.GetSnapshotSchedulePolicy(); snapshotSchedulePolicy != nil {
+		if retentionPolicy := snapshotSchedulePolicy.GetRetentionPolicy(); retentionPolicy != nil {
+			if retentionPolicy.OnSourceDiskDelete == nil {
+				retentionPolicy.OnSourceDiskDelete = PtrTo("KEEP_AUTO_SNAPSHOTS")
+			}
+		}
+		if schedule := snapshotSchedulePolicy.GetSchedule(); schedule != nil {
+			if dailySchedule := schedule.GetDailySchedule(); dailySchedule != nil {
+				if dailySchedule.Duration == nil {
+					dailySchedule.Duration = PtrTo("PT14400S")
+				}
+			}
+
+		}
+	}
+}
+
+func (s *resourcePolicies) Delete(ctx context.Context, req *pb.DeleteResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.ResourcePolicy{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("delete"),
+		TargetId:      deleted.Id,
+		TargetLink:    deleted.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return &emptypb.Empty{}, nil
+	})
+}
+
+func (s *resourcePolicies) Update(ctx context.Context, req *pb.PatchResourcePolicyRequest) (*pb.Operation, error) {
+	reqName := fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", req.GetProject(), req.GetRegion(), req.GetResourcePolicy())
+	name, err := s.parseResourcePolicyName(reqName)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.ResourcePolicy{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	proto.Merge(obj, req.GetResourcePolicyResource())
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	op := &pb.Operation{
+		OperationType: PtrTo("update"),
+		TargetId:      obj.Id,
+		TargetLink:    obj.SelfLink,
+		User:          PtrTo("user@example.com"),
+	}
+	return s.computeOperations.startRegionalLRO(ctx, name.Project.ID, name.Region, op, func() (proto.Message, error) {
+		return obj, nil
+	})
+}
+
+type resourcePolicyName struct {
+	Project *projects.ProjectData
+	Region  string
+	Name    string
+}
+
+func (n *resourcePolicyName) String() string {
+	return "projects/" + n.Project.ID + "/regions/" + n.Region + "/resourcePolicies/" + n.Name
+}
+
+// parseResourcePolicyName parses a string into a resourcePolicyName.
+// The expected form is `locations/global/firewallPolicies/*`.
+func (s *MockService) parseResourcePolicyName(name string) (*resourcePolicyName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "regions" && tokens[4] == "resourcePolicies" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &resourcePolicyName{
+			Project: project,
+			Region:  tokens[3],
+			Name:    tokens[5],
+		}
+
+		return name, nil
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+	}
+}

--- a/mockgcp/mockcompute/networksv1.go
+++ b/mockgcp/mockcompute/networksv1.go
@@ -69,6 +69,7 @@ func (s *NetworksV1) Insert(ctx context.Context, req *pb.InsertNetworkRequest) (
 	obj.SelfLinkWithId = PtrTo(buildComputeSelfLink(ctx, fmt.Sprintf("projects/%s/global/networks/%d", name.Project.ID, id)))
 	obj.Kind = PtrTo("compute#network")
 
+	s.populateDefaultsForNetwork(obj)
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
@@ -88,6 +89,17 @@ func (s *NetworksV1) Insert(ctx context.Context, req *pb.InsertNetworkRequest) (
 		}
 		return obj, nil
 	})
+}
+
+func (s *NetworksV1) populateDefaultsForNetwork(obj *pb.Network) {
+	if obj.NetworkFirewallPolicyEnforcementOrder == nil {
+		obj.NetworkFirewallPolicyEnforcementOrder = PtrTo("AFTER_CLASSIC_FIREWALL")
+	}
+	if obj.RoutingConfig != nil {
+		if obj.RoutingConfig.BgpBestPathSelectionMode == nil {
+			obj.RoutingConfig.BgpBestPathSelectionMode = PtrTo("LEGACY")
+		}
+	}
 }
 
 // Patches the specified network with the data included in the request.

--- a/mockgcp/mockcompute/normalize.go
+++ b/mockgcp/mockcompute/normalize.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockcompute
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockgcpregistry"
+)
+
+const PlaceholderTimestamp = "2024-04-01T12:34:56.123456Z"
+
+var _ mockgcpregistry.SupportsNormalization = &MockService{}
+
+func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.NormalizingVisitor) {
+	// General
+	replacements.ReplacePath(".creationTimestamp", PlaceholderTimestamp)
+	replacements.ReplacePath(".items[].creationTimestamp", PlaceholderTimestamp)
+
+	// Addresses
+	replacements.ReplacePath(".labelFingerprint", "abcdef0123A=")
+	replacements.ReplacePath(".items[].labelFingerprint", "abcdef0123A=")
+
+	replacements.ReplacePath(".address", "8.8.8.8")
+	replacements.ReplacePath(".items[].address", "8.8.8.8")
+
+	replacements.SortSlice(".subnetworks")
+}
+
+func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {
+
+}

--- a/mockgcp/mockcompute/normalize.go
+++ b/mockgcp/mockcompute/normalize.go
@@ -62,7 +62,7 @@ func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcp
 			if n >= 2 {
 				kind := tokens[n-2]
 
-				placeholder := "${" + strings.TrimSuffix(kind, "s") + "Id}"
+				placeholder := "${" + replacements.PlaceholderForGCPResource(kind) + "Id}"
 				// We _should_ differentiate between ID and number.
 				// But this causes too many diffs right now.
 				replacements.ReplaceStringValue(targetId, placeholder)

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -57,6 +57,8 @@ func (s *MockService) ExpectedHosts() []string {
 }
 
 func (s *MockService) Register(grpcServer *grpc.Server) {
+	pb.RegisterBackendBucketsServer(grpcServer, &backendBuckets{MockService: s})
+
 	pb.RegisterNetworksServer(grpcServer, &NetworksV1{MockService: s})
 	pb.RegisterSubnetworksServer(grpcServer, &SubnetsV1{MockService: s})
 	pb.RegisterVpnGatewaysServer(grpcServer, &VPNGatewaysV1{MockService: s})
@@ -113,6 +115,10 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (http.Handler, error) {
 	mux, err := httpmux.NewServeMux(ctx, conn, httpmux.Options{})
 	if err != nil {
+		return nil, err
+	}
+
+	if err := pb.RegisterBackendBucketsHandler(ctx, mux.ServeMux, conn); err != nil {
 		return nil, err
 	}
 

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -59,6 +59,8 @@ func (s *MockService) ExpectedHosts() []string {
 func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterBackendBucketsServer(grpcServer, &backendBuckets{MockService: s})
 
+	pb.RegisterExternalVpnGatewaysServer(grpcServer, &externalVPNGateways{MockService: s})
+
 	pb.RegisterNetworksServer(grpcServer, &NetworksV1{MockService: s})
 	pb.RegisterSubnetworksServer(grpcServer, &SubnetsV1{MockService: s})
 	pb.RegisterVpnGatewaysServer(grpcServer, &VPNGatewaysV1{MockService: s})
@@ -126,6 +128,10 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 		return nil, err
 	}
 	if err := pb.RegisterRegionBackendServicesHandler(ctx, mux.ServeMux, conn); err != nil {
+		return nil, err
+	}
+
+	if err := pb.RegisterExternalVpnGatewaysHandler(ctx, mux.ServeMux, conn); err != nil {
 		return nil, err
 	}
 

--- a/mockgcp/mockcompute/service.go
+++ b/mockgcp/mockcompute/service.go
@@ -62,8 +62,13 @@ func (s *MockService) Register(grpcServer *grpc.Server) {
 	pb.RegisterExternalVpnGatewaysServer(grpcServer, &externalVPNGateways{MockService: s})
 
 	pb.RegisterNetworksServer(grpcServer, &NetworksV1{MockService: s})
+
+	pb.RegisterResourcePoliciesServer(grpcServer, &resourcePolicies{MockService: s})
+
 	pb.RegisterSubnetworksServer(grpcServer, &SubnetsV1{MockService: s})
+
 	pb.RegisterVpnGatewaysServer(grpcServer, &VPNGatewaysV1{MockService: s})
+
 	pb.RegisterTargetVpnGatewaysServer(grpcServer, &TargetVpnGatewaysV1{MockService: s})
 	pb.RegisterTargetGrpcProxiesServer(grpcServer, &TargetGrpcProxyV1{MockService: s})
 
@@ -136,6 +141,10 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 	}
 
 	if err := pb.RegisterNetworksHandler(ctx, mux.ServeMux, conn); err != nil {
+		return nil, err
+	}
+
+	if err := pb.RegisterResourcePoliciesHandler(ctx, mux.ServeMux, conn); err != nil {
 		return nil, err
 	}
 

--- a/mockgcp/mockcompute/testdata/computeaddresses/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computeaddresses/crud/_http.log
@@ -1,0 +1,239 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "name": "test-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${addressID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${addressID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/${addressID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "address": "8.8.8.8",
+  "addressType": "EXTERNAL",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#address",
+  "labelFingerprint": "abcdef0123A=",
+  "name": "test-${uniqueId}",
+  "networkTier": "PREMIUM",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "status": "RESERVED"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/${addressID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "address": "8.8.8.8",
+  "addressType": "EXTERNAL",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#address",
+  "labelFingerprint": "abcdef0123A=",
+  "name": "test-${uniqueId}",
+  "networkTier": "PREMIUM",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "status": "RESERVED"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses?alt=json&maxResults=500
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "items": [
+    {
+      "address": "8.8.8.8",
+      "addressType": "EXTERNAL",
+      "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+      "description": "",
+      "id": "${addressID}",
+      "kind": "compute#address",
+      "labelFingerprint": "abcdef0123A=",
+      "name": "test-${uniqueId}",
+      "networkTier": "PREMIUM",
+      "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+      "status": "RESERVED"
+    }
+  ],
+  "kind": "compute#addressList",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/${addressID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${addressID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${addressID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/addresses/test-${uniqueId}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computeaddresses/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computeaddresses/crud/script.yaml
@@ -1,0 +1,5 @@
+
+- exec: gcloud compute addresses create test-${uniqueId} --region=us-central1 --project=${projectId}
+- exec: gcloud compute addresses describe test-${uniqueId} --region=us-central1 --project=${projectId}
+- exec: gcloud compute addresses list --regions=us-central1 --project=${projectId}
+- exec: gcloud compute addresses delete test-${uniqueId} --region=us-central1 --project=${projectId} --quiet

--- a/mockgcp/mockcompute/testdata/computebackendbuckets/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computebackendbuckets/crud/_http.log
@@ -1,0 +1,324 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "enableCdn": false,
+  "name": "${backendBucketId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "enableCdn": false,
+  "id": "000000000000000000000",
+  "kind": "compute#backendBucket",
+  "name": "${backendBucketId}",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "enableCdn": false,
+  "id": "000000000000000000000",
+  "kind": "compute#backendBucket",
+  "name": "${backendBucketId}",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "enableCdn": false,
+  "id": "000000000000000000000",
+  "kind": "compute#backendBucket",
+  "name": "${backendBucketId}",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "customResponseHeaders": [],
+  "description": "test updated",
+  "enableCdn": false,
+  "id": "000000000000000000000",
+  "kind": "compute#backendBucket",
+  "name": "${backendBucketId}",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "patch",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "patch",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketName": "testbucket-${uniqueId}",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "test updated",
+  "enableCdn": false,
+  "id": "000000000000000000000",
+  "kind": "compute#backendBucket",
+  "name": "${backendBucketId}",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${backendBucketId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/backendBuckets/${backendBucketId}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computebackendbuckets/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computebackendbuckets/crud/script.yaml
@@ -1,0 +1,7 @@
+
+- pre: gcloud storage buckets create gs://testbucket-${uniqueId}
+- exec: gcloud compute backend-buckets create test-${uniqueId} --gcs-bucket-name=testbucket-${uniqueId} --project=${projectId}
+- exec: gcloud compute backend-buckets describe test-${uniqueId} --project=${projectId}
+- exec: gcloud compute backend-buckets update test-${uniqueId} --description="test updated" --project=${projectId}
+- exec: gcloud compute backend-buckets delete test-${uniqueId} --project=${projectId}
+- post: gcloud storage buckets delete gs://testbucket-${uniqueId}

--- a/mockgcp/mockcompute/testdata/computeexternalvpngateways/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computeexternalvpngateways/crud/_http.log
@@ -1,0 +1,205 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "interfaces": [
+    {
+      "id": 0,
+      "ipAddress": "192.0.2.0"
+    }
+  ],
+  "name": "${externalVpnGatewayId}",
+  "redundancyType": "SINGLE_IP_INTERNALLY_REDUNDANT"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "compute.externalVpnGateways.insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${externalVpnGatewayId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "compute.externalVpnGateways.insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${externalVpnGatewayId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "interfaces": [
+    {
+      "id": 0,
+      "ipAddress": "192.0.2.0"
+    }
+  ],
+  "kind": "compute#externalVpnGateway",
+  "labelFingerprint": "abcdef0123A=",
+  "name": "${externalVpnGatewayId}",
+  "redundancyType": "SINGLE_IP_INTERNALLY_REDUNDANT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "interfaces": [
+    {
+      "id": 0,
+      "ipAddress": "192.0.2.0"
+    }
+  ],
+  "kind": "compute#externalVpnGateway",
+  "labelFingerprint": "abcdef0123A=",
+  "name": "${externalVpnGatewayId}",
+  "redundancyType": "SINGLE_IP_INTERNALLY_REDUNDANT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/test-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "compute.externalVpnGateways.delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${externalVpnGatewayId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "compute.externalVpnGateways.delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${externalVpnGatewayId}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/externalVpnGateways/${externalVpnGatewayId}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computeexternalvpngateways/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computeexternalvpngateways/crud/script.yaml
@@ -1,0 +1,4 @@
+
+- exec: gcloud compute external-vpn-gateways create test-${uniqueId} --interfaces 0=192.0.2.0 --project=${projectId}
+- exec: gcloud compute external-vpn-gateways describe test-${uniqueId} --project=${projectId}
+- exec: gcloud compute external-vpn-gateways delete test-${uniqueId} --project=${projectId} --quiet

--- a/mockgcp/mockcompute/testdata/computenetworks/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computenetworks/crud/_http.log
@@ -1,0 +1,286 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "autoCreateSubnetworks": true,
+  "name": "${networkID}",
+  "routingConfig": {
+    "routingMode": "REGIONAL"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": true,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "subnetworks": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/africa-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-east2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-south2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-southeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-southeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/australia-southeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/australia-southeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-central2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-north1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-north2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-southwest1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west10/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west12/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west4/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west6/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west8/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west9/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/me-central1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/me-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-northeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-northeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/southamerica-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/southamerica-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east4/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east5/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west4/subnetworks/${networkID}"
+  ]
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": true,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "subnetworks": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/africa-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-east2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-northeast3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-south2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-southeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/asia-southeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/australia-southeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/australia-southeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-central2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-north1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-north2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-southwest1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west10/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west12/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west4/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west6/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west8/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/europe-west9/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/me-central1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/me-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-northeast1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-northeast2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/northamerica-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/southamerica-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/southamerica-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east4/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-east5/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-south1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west1/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west2/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west3/subnetworks/${networkID}",
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-west4/subnetworks/${networkID}"
+  ]
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computenetworks/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computenetworks/crud/script.yaml
@@ -1,0 +1,3 @@
+- exec: gcloud compute networks create test-${uniqueId} --project=${projectId}
+- exec: gcloud compute networks describe test-${uniqueId} --project=${projectId}
+- exec: gcloud compute networks delete test-${uniqueId} --project=${projectId}

--- a/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/_http.log
+++ b/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/_http.log
@@ -1,0 +1,228 @@
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "name": "${resourcePolicyID}",
+  "region": "us-central1",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "startTime": "13:00"
+      }
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#resourcePolicy",
+  "name": "${resourcePolicyID}",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1,
+      "onSourceDiskDelete": "KEEP_AUTO_SNAPSHOTS"
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "duration": "PT14400S",
+        "startTime": "13:00"
+      }
+    }
+  },
+  "status": "READY"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#resourcePolicy",
+  "name": "${resourcePolicyID}",
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "snapshotSchedulePolicy": {
+    "retentionPolicy": {
+      "maxRetentionDays": 1,
+      "onSourceDiskDelete": "KEEP_AUTO_SNAPSHOTS"
+    },
+    "schedule": {
+      "dailySchedule": {
+        "daysInCycle": 1,
+        "duration": "PT14400S",
+        "startTime": "13:00"
+      }
+    }
+  },
+  "status": "READY"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}/wait?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${resourcePolicyID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/resourcePolicies/${resourcePolicyID}",
+  "user": "user@example.com"
+}

--- a/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/script.yaml
+++ b/mockgcp/mockcompute/testdata/computeresourcepolicies/crud/script.yaml
@@ -1,0 +1,4 @@
+
+- exec: gcloud compute resource-policies create snapshot-schedule test-policy-${uniqueId} --region=us-central1 --max-retention-days=1 --start-time=13:00 --daily-schedule --project=${projectId}
+- exec: gcloud compute resource-policies describe test-policy-${uniqueId} --region=us-central1 --project=${projectId}
+- exec: gcloud compute resource-policies delete test-policy-${uniqueId} --region=us-central1 --project=${projectId} --quiet

--- a/mockgcp/mockcompute/utils.go
+++ b/mockgcp/mockcompute/utils.go
@@ -77,3 +77,13 @@ func buildComputeSelfLink(ctx context.Context, fqn string) string {
 	version := getAPIVersion(ctx)
 	return "https://www.googleapis.com/compute/" + version + "/" + fqn
 }
+
+// makeFullyQualifiedRegion will convert a short-form region name to a fully-qualified name
+func makeFullyQualifiedRegion(ctx context.Context, projectID string, region string) string {
+	s := region
+	tokens := strings.Split(s, "/")
+	if len(tokens) == 1 {
+		s = buildComputeSelfLink(ctx, "projects/"+projectID+"/regions/"+region)
+	}
+	return s
+}

--- a/mockgcp/mockgcpregistry/interfaces.go
+++ b/mockgcp/mockgcpregistry/interfaces.go
@@ -55,6 +55,9 @@ type NormalizingVisitor interface {
 
 	// SortSlice will sort the slice at the given path
 	SortSlice(path string)
+
+	// PlaceholderForGCPResource returns the placeholder we use for the value, if we recognize the GCP resource type
+	PlaceholderForGCPResource(resource string) string
 }
 
 type Normalizer interface {

--- a/mockgcp/mockgcpregistry/interfaces.go
+++ b/mockgcp/mockgcpregistry/interfaces.go
@@ -52,6 +52,9 @@ type NormalizingVisitor interface {
 
 	// ReplaceStringValue replaces the given string value with the provided string value
 	ReplaceStringValue(oldValue string, newValue string)
+
+	// SortSlice will sort the slice at the given path
+	SortSlice(path string)
 }
 
 type Normalizer interface {

--- a/mockgcp/mockgcpregistry/interfaces.go
+++ b/mockgcp/mockgcpregistry/interfaces.go
@@ -68,6 +68,9 @@ type Event interface {
 	// URL returns the URL of the request
 	URL() string
 
+	// Method returns the HTTP Method of the request
+	Method() string
+
 	// VisitRequestStringValues calls the callback for each string-typed value found in the request object (if any)
 	VisitRequestStringValues(callback func(path string, value string))
 

--- a/pkg/test/http_recorder.go
+++ b/pkg/test/http_recorder.go
@@ -39,6 +39,10 @@ func (e *LogEntry) URL() string {
 	return e.Request.URL
 }
 
+func (e *LogEntry) Method() string {
+	return e.Request.Method
+}
+
 // VisitRequestStringValues calls callback for any string values in the request body
 func (e *LogEntry) VisitRequestStringValues(callback func(path, value string)) {
 	body := e.Request.Body

--- a/tests/e2e/httplog.go
+++ b/tests/e2e/httplog.go
@@ -306,7 +306,7 @@ func (x *Normalizer) Preprocess(events []*test.LogEntry) {
 			if u != nil {
 				kind := u.PathItems[len(u.PathItems)-1].Resource
 
-				placeholder := x.placeholderForGCPResource(kind)
+				placeholder := PlaceholderForGCPResource(kind)
 				if placeholder != "" {
 					// We _should_ differentiate between ID and number.
 					// But this causes too many diffs right now.

--- a/tests/e2e/httplog.go
+++ b/tests/e2e/httplog.go
@@ -291,6 +291,7 @@ func (x *Normalizer) Preprocess(events []*test.LogEntry) {
 		}
 	}
 
+	// TODO: Remove this, it should now be done in normalize in mockcompute
 	// Extract resource IDs / numbers from compute operations.
 	// The number / id is in the targetID field, we infer the type from the targetLink field.
 	for _, event := range events {

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -464,6 +464,10 @@ func (o *objectWalker) SortSlice(path string) {
 	o.sortSlices.Insert(path)
 }
 
+func (o *objectWalker) PlaceholderForGCPResource(kind string) string {
+	return PlaceholderForGCPResource(kind)
+}
+
 func (o *objectWalker) visitAny(v any, path string) (any, error) {
 	if v == nil {
 		return v, nil

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -781,7 +781,6 @@ func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer,
 	visitor.replacePaths[".fingerprint"] = "abcdef0123A="
 	visitor.replacePaths[".startTime"] = "2024-04-01T12:34:56.123456Z"
 
-
 	// Specific to Apigee
 	visitor.replacePaths[".response.createdAt"] = strconv.FormatInt(time.Date(2024, 4, 1, 12, 34, 56, 123456, time.UTC).Unix(), 10)
 	visitor.replacePaths[".response.lastModifiedAt"] = strconv.FormatInt(time.Date(2024, 4, 1, 12, 34, 56, 123456, time.UTC).Unix(), 10)

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -781,8 +781,6 @@ func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer,
 	visitor.replacePaths[".fingerprint"] = "abcdef0123A="
 	visitor.replacePaths[".startTime"] = "2024-04-01T12:34:56.123456Z"
 
-	// Compute resources
-	visitor.sortSlices.Insert(".subnetworks")
 
 	// Specific to Apigee
 	visitor.replacePaths[".response.createdAt"] = strconv.FormatInt(time.Date(2024, 4, 1, 12, 34, 56, 123456, time.UTC).Unix(), 10)
@@ -911,14 +909,6 @@ func normalizeHTTPResponses(t *testing.T, normalizer mockgcpregistry.Normalizer,
 		visitor.ReplacePath(".response.revisionCreateTime", "2024-04-01T12:34:56.123456Z")
 		visitor.ReplacePath(".revisionId", "revision-id-placeholder")
 		visitor.ReplacePath(".response.revisionId", "revision-id-placeholder")
-	}
-
-	// Compute
-	{
-		visitor.sortSlices.Insert(".subnetworks")
-
-		visitor.replacePaths[".labelFingerprint"] = "abcdef0123A="
-		visitor.replacePaths[".address"] = "8.8.8.8"
 	}
 
 	// DocumentAI

--- a/tests/e2e/replacements.go
+++ b/tests/e2e/replacements.go
@@ -91,8 +91,8 @@ func (r *Replacements) ApplyReplacements(s string) string {
 	return s
 }
 
-// placeholderForGCPResource returns the placeholder we use for the value, if we recognize the GCP resource type
-func (r *Replacements) placeholderForGCPResource(resource string) string {
+// PlaceholderForGCPResource returns the placeholder we use for the value, if we recognize the GCP resource type
+func PlaceholderForGCPResource(resource string) string {
 	switch resource {
 	case "addresses":
 		return "${addressID}"
@@ -154,9 +154,22 @@ func (r *Replacements) placeholderForGCPResource(resource string) string {
 		return "${processorID}"
 	case "processorVersions":
 		return "${processorVersionID}"
-	default:
+	case "projects":
+		// Handled specially
+		return ""
+	case "regions":
+		// Not normally volatile, don't use placeholder
 		return ""
 	}
+
+	if strings.HasSuffix(resource, "ies") {
+		return "${" + strings.TrimSuffix(resource, "ies") + "yID}"
+	}
+	if strings.HasSuffix(resource, "s") {
+		return "${" + strings.TrimSuffix(resource, "s") + "ID}"
+	}
+
+	return ""
 }
 
 // ExtractIDsFromLinks parses the URL or partial URL, and extracts generated IDs from it.
@@ -164,7 +177,7 @@ func (r *Replacements) ExtractIDsFromLinks(link string) {
 	u, _ := ParseGCPLink(link)
 	if u != nil {
 		for _, item := range u.PathItems {
-			placeholder := r.placeholderForGCPResource(item.Resource)
+			placeholder := PlaceholderForGCPResource(item.Resource)
 			if placeholder != "" {
 				r.PathIDs[item.Name] = placeholder
 			}

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -568,7 +568,6 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 
 					// Specific to Compute
 					addReplacement("natIP", "192.0.0.10")
-					addReplacement("labelFingerprint", "abcdef0123A=")
 					addReplacement("fingerprint", "abcdef0123A=")
 					// Matches the mock ip address of Compute forwarding rule
 					addReplacement("IPAddress", "8.8.8.8")


### PR DESCRIPTION
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computeaddresses"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computeaddresses"**
- **mockgcp: more parity for compute addresses**
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computebackendbuckets"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computebackendbuckets"**
- **conductor: "Adding mock service and resource for compute-computebackendbuckets"**
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computeexternalvpngateways"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computeexternalvpngateways"**
- **conductor: "Adding mock service and resource for compute-computeexternalvpngateways"**
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computeresourcepolicies"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computeresourcepolicies"**
- **conductor: "Adding mock service and resource for compute-computeresourcepolicies"**
- **conductor: "Adding LLM/gcloud generated test script.yaml for compute-computenetworks"**
- **conductor: "Adding mockgcptests generated _http.log for compute-computenetworks"**
- **mockgcp: more fidelity for compute networks**
