### PR TITLE
mockgcp: stop using api overrides, rely on CONNECT proxy

### DIFF
--- a/mockgcp/mockgcptests/proxy.go
+++ b/mockgcp/mockgcptests/proxy.go
@@ -217,15 +217,6 @@ func (p *Proxy) runRequest(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("reading request body: %v", err)
 	}
 
-	// HACK: fix malformed network URLs in the request body
-	if strings.Contains(string(body), "\"network\": \"http://compute.googleapis.com/") {
-		bodyStr := string(body)
-		bodyStr = strings.Replace(bodyStr,
-			"\"network\": \"http://compute.googleapis.com/",
-			"\"network\": \"", -1)
-		body = []byte(bodyStr)
-	}
-
 	u := req.URL
 	u.Scheme = "https"
 	if u.Host == "" {
@@ -276,126 +267,8 @@ func (p *Proxy) BuildGcloudConfig(proxyEndpoint *net.TCPAddr, mockgcp mockgcp.In
 	config.AddConfig("proxy/port", strconv.Itoa(proxyEndpoint.Port))
 	config.AddConfig("auth/disable_ssl_validation", "True")
 
-	// We need to register services to use http, to stop gcloud trying to use TUNNEL with our proxy
-
-	// We need a hard-coded list, because we don't always mockgcp available
-
-	// This list should be kept in sync with the output from `gcloud config  list api_endpoint_overrides/ --all --format json | jq -r '.api_endpoint_overrides | keys[]'`
-	apiEndpointOverrides := []string{
-		"accessapproval",
-		"accesscontextmanager",
-		"ai",
-		"aiplatform",
-		"anthosevents",
-		"anthospolicycontrollerstatus_pa",
-		"apigateway",
-		"apigee",
-		"appengine",
-		"apphub",
-		"artifactregistry",
-		"assuredworkloads",
-		"auditmanager",
-		"baremetalsolution",
-		"bigtableadmin",
-		"certificatemanager",
-		"cloudasset",
-		"cloudbilling",
-		"cloudbuild",
-		"cloudcommerceconsumerprocurement",
-		"clouddebugger",
-		"clouddeploy",
-		"clouderrorreporting",
-		"cloudfunctions",
-		"cloudidentity",
-		"cloudkms",
-		"cloudresourcemanager",
-		"cloudscheduler",
-		"cloudtasks",
-		"cloudtrace",
-		"composer",
-		"compute",
-		"config",
-		"container",
-		"datacatalog",
-		"dataflow",
-		"datafusion",
-		"datamigration",
-		"datapipelines",
-		"dataplex",
-		"dataproc",
-		"datastore",
-		"datastream",
-		"deploymentmanager",
-		"developerconnect",
-		"dns",
-		"domains",
-		"edgecontainer",
-		"eventarc",
-		"eventarcpublishing",
-		"faultinjectiontesting",
-		"file",
-		"firebasedataconnect",
-		"firestore",
-		"genomics",
-		"gkemulticloud",
-		"healthcare",
-		"iam",
-		"iamcredentials",
-		"iap",
-		"ids",
-		"krmapihosting",
-		"language",
-		"lifesciences",
-		"logging",
-		"looker",
-		"managedidentities",
-		"marketplacesolutions",
-		"mediaasset",
-		"memcache",
-		"metastore",
-		"monitoring",
-		"netapp",
-		"networkconnectivity",
-		"networkmanagement",
-		"networksecurity",
-		"networkservices",
-		"notebooks",
-		"orgpolicy",
-		"pam",
-		"policyanalyzer",
-		"privateca",
-		"publicca",
-		"pubsub",
-		"recaptchaenterprise",
-		"recommender",
-		"redis",
-		"resourcesettings",
-		"run",
-		"runtimeconfig",
-		"sddc",
-		"secretmanager",
-		"securitycenter",
-		"servicedirectory",
-		"servicemanagement",
-		"sourcerepo",
-		"spanner",
-		"speech",
-		"sql",
-		"storage",
-		"testing",
-		"transfer",
-		"transferappliance",
-		"vision",
-		"vmmigration",
-		"vmwareengine",
-		"workflowexecutions",
-		"workflows",
-		"workstations",
-	}
-
-	for _, apiEndpointOverride := range apiEndpointOverrides {
-		config.AddConfig(fmt.Sprintf("api_endpoint_overrides/%v", apiEndpointOverride), fmt.Sprintf("http://%s.googleapis.com/", apiEndpointOverride))
-	}
+	// Note: we used to use api_endpoint_overrides here; however that seems to change the behaviour of gcloud,
+	// particularly when normalizing compute urls?
 
 	return config
 }


### PR DESCRIPTION
The API overrides are not implemented everywhere.

Also we have observed some oddities with gcloud behaving differently
with api_endpoint_overrides, such as the URLs in the compute APIS.

(For example, gcloud compute instance-templates create foo)
