### PR TITLE
mockgcp tests: ignore x-goog-user-project header

### DIFF
--- a/mockgcp/mockgcptests/e2e_test.go
+++ b/mockgcp/mockgcptests/e2e_test.go
@@ -136,6 +136,10 @@ func TestScripts(t *testing.T) {
 					// Just remove it from the golden output.
 					httpEvent.Request.RemoveHeader("user-agent")
 
+					// The X-Goog-User-Project header is (always) set by gcloud if a quota project is set,
+					// so this header reflects configuration not the actual protocol.
+					httpEvent.Request.RemoveHeader("X-Goog-User-Project")
+
 					// Remove the Content-Length header, as it changes with dynamic values
 					httpEvent.Request.RemoveHeader("Content-Length")
 					httpEvent.Response.RemoveHeader("Content-Length")


### PR DESCRIPTION
This header is (always) sent by gcloud if a quota project is set,
so this header reflects configuration, not the actual protocol.
