### PR TITLE
Broken Head: make gen-proto on latest, uploading diff

### DIFF
--- a/mockgcp/generated/google/bigtable/admin/v2/bigtable_instance_admin.pb.gw.go
+++ b/mockgcp/generated/google/bigtable/admin/v2/bigtable_instance_admin.pb.gw.go
@@ -13,10 +13,10 @@ import (
 	"io"
 	"net/http"
 
-	extAdminpb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
 	extIampb "cloud.google.com/go/iam/apiv1/iampb"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
+	extAdminpb "google.golang.org/genproto/googleapis/bigtable/admin/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"

--- a/mockgcp/generated/google/bigtable/admin/v2/bigtable_table_admin.pb.gw.go
+++ b/mockgcp/generated/google/bigtable/admin/v2/bigtable_table_admin.pb.gw.go
@@ -13,10 +13,10 @@ import (
 	"io"
 	"net/http"
 
-	extAdminpb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
 	extIampb "cloud.google.com/go/iam/apiv1/iampb"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
+	extAdminpb "google.golang.org/genproto/googleapis/bigtable/admin/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"


### PR DESCRIPTION
On head, we are seeing bq diff when running `make gen-proto`.

Caused presubmit failure for one of my PRs: 
https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/13759284116/job/38471846394?pr=3939