### PR TITLE
conductor: dont retry runMockgcpTests

### DIFF
--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -795,6 +795,9 @@ func addProtoToMakefile(opts *RunnerOptions, branch Branch) {
 }
 
 func runMockgcpTests(opts *RunnerOptions, branch Branch) {
+    if opts.defaultRetries > 0 {
+        log.Printf("Command does not support retries")
+    }
 	ctx := context.TODO()
 
 	close := setLoggingWriter(opts, branch)
@@ -818,7 +821,7 @@ func runMockgcpTests(opts *RunnerOptions, branch Branch) {
 		},
 		WorkDir:    workDir,
 		Env:        map[string]string{"WRITE_GOLDEN_OUTPUT": "1", "E2E_GCP_TARGET": "mock"},
-		MaxRetries: 2,
+        MaxRetries: -1, // no retries, even if user defined
 	}
 	_, _, err := executeCommand(opts, cfg)
 	if err != nil {

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -347,9 +347,13 @@ func executeCommand(opts *RunnerOptions, cfg CommandConfig) (string, string, err
 	}
 
 	maxRetries := opts.defaultRetries
-	// If MaxRetries is set in config, cap it at that
-	if cfg.MaxRetries > 0 && cfg.MaxRetries < maxRetries {
-		maxRetries = cfg.MaxRetries
+	if cfg.MaxRetries == -1 { // cancel all retries for this command
+		maxRetries = 0
+	} else {
+		// If MaxRetries is set in config, cap it at that
+		if cfg.MaxRetries > 0 && cfg.MaxRetries < maxRetries {
+			maxRetries = cfg.MaxRetries
+		}
 	}
 
 	var lastErr error


### PR DESCRIPTION
I don't think we should retry the deterministic steps, like running the mockgcp tests since an error is terminal usually in that case.