### PR TITLE
controllerbuilder: gracefully handle missing mapper directory during enhancement

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/enhancewithmappers.go
@@ -58,7 +58,8 @@ func (x *EnhanceWithMappers) EnhanceDataPoint(ctx context.Context, p *DataPoint)
 	files, err := os.ReadDir(mapperDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("api.group %q might be incorrect", apiGroup)
+			klog.Warningf("skip enhancing with mappers for resource type %q because mapper directory does not exist. api.group %q might be incorrect", resourceType, apiGroup)
+			return nil
 		} else {
 			return fmt.Errorf("reading mapper directory: %w", err)
 		}


### PR DESCRIPTION
The fuzzer generation should not fail due to missing (mismatching) mapper functions.

Example error:
```
Error: walking directory tree: processing file "/usr/local/google/home/jingyih/kccai/work1/pkg/controller/direct/tasks/queue_fuzzer.go": api.group "cloudtasks.cnrm.cloud.google.com" might be incorrect
```

