### PR TITLE
Master broken: One of the earlier commits broke script a test

### DIFF
--- a/mockgcp/mockasset/testdata/savedquery/crud/script.yaml
+++ b/mockgcp/mockasset/testdata/savedquery/crud/script.yaml
@@ -1,4 +1,4 @@
-- pre: |
+- exec: |
     rm -f /tmp/assetsavedquery.yaml
     echo "IamPolicyAnalysisQuery:" > /tmp/assetsavedquery.yaml
     echo "  scope: projects/${projectId}" >> /tmp/assetsavedquery.yaml
@@ -7,7 +7,7 @@
     echo "      - roles/viewer" >> /tmp/assetsavedquery.yaml
 - exec: gcloud asset saved-queries create test-${uniqueId} --project=${projectId} --query-file-path=/tmp/assetsavedquery.yaml --description="Test query" --labels=test=test
 - exec: gcloud asset saved-queries describe test-${uniqueId} --project=${projectId}
-- pre: echo "      - roles/iam.serviceAccountUser" >> /tmp/assetsavedquery.yaml
+- exec: echo "      - roles/iam.serviceAccountUser" >> /tmp/assetsavedquery.yaml
 - exec: gcloud asset saved-queries update test-${uniqueId} --project=${projectId} --query-file-path=/tmp/assetsavedquery.yaml --description="Test query updated"
 - exec: gcloud asset saved-queries delete test-${uniqueId} --project=${projectId}
 - post: rm -f /tmp/assetsavedquery.yaml


### PR DESCRIPTION
One of the earlier commits broke script execution by removing execution by removing pre/post for mocks.

* marking the pre/post in this case as exec. it is safe to do so since there are no gcloud commands.
* commit that broke this: 'https://github.com/GoogleCloudPlatform/k8s-config-connector/commit/0c90028af4c52ab35a602714ca827f6cdfcf7ce3#diff-be525b45d767496986e663eb33d460ae34834d69f780e874dd000ea2fcd9f0f8'
* we need to discuss if skipping is required for mocks and why so ?
