### PR TITLE
conductor: minor adjustment to test generation

### DIFF
--- a/experiments/conductor/cmd/runner/controller_commands.go
+++ b/experiments/conductor/cmd/runner/controller_commands.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // generateControllerClient creates a controller client for the branch
@@ -310,17 +311,34 @@ func createControllerTest(ctx context.Context, opts *RunnerOptions, branch Branc
 		return nil, nil, fmt.Errorf("failed to create test directory %s: %w", fullTestDir, err)
 	}
 
+	currentYear := time.Now().Year()
+	yamlCopyright := fmt.Sprintf(`# Copyright %d Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+`, currentYear)
+
 	// Create create.yaml
-	createYaml := fmt.Sprintf(`apiVersion: %s/%s
+	createYaml := fmt.Sprintf(`%s
+apiVersion: %s/%s
 kind: %s
 metadata:
   name: %s-minimal-${uniqueId}
 spec:
   projectRef:
     external: ${projectId}
-  locationID: us-west2
+  location: us-central1
   description: "Initial description"
-`, crdGroup, crdVersion, branch.Kind, strings.ToLower(branch.Kind))
+`, yamlCopyright, crdGroup, crdVersion, branch.Kind, strings.ToLower(branch.Kind))
 
 	createYamlPath := filepath.Join(fullTestDir, "create.yaml")
 	if err := os.WriteFile(createYamlPath, []byte(createYaml), 0644); err != nil {
@@ -328,16 +346,17 @@ spec:
 	}
 
 	// Create update.yaml
-	updateYaml := fmt.Sprintf(`apiVersion: %s/%s
+	updateYaml := fmt.Sprintf(`%s
+apiVersion: %s/%s
 kind: %s
 metadata:
   name: %s-minimal-${uniqueId}
 spec:
   projectRef:
     external: ${projectId}
-  locationID: us-west2
+  location: us-central1
   description: "Updated description"
-`, crdGroup, crdVersion, branch.Kind, strings.ToLower(branch.Kind))
+`, yamlCopyright, crdGroup, crdVersion, branch.Kind, strings.ToLower(branch.Kind))
 
 	updateYamlPath := filepath.Join(fullTestDir, "update.yaml")
 	if err := os.WriteFile(updateYamlPath, []byte(updateYaml), 0644); err != nil {

--- a/experiments/conductor/cmd/runner/scripts/controller/04-create-test.sh
+++ b/experiments/conductor/cmd/runner/scripts/controller/04-create-test.sh
@@ -43,6 +43,20 @@ TESTDIR=pkg/test/resourcefixture/testdata/basic/${SERVICE}/v1alpha1/${CRD_KIND,,
 mkdir -p ${TESTDIR}
 
 cat <<EOF > ${TESTDIR}/create.yaml
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: ${CRD_GROUP}/${CRD_VERSION}
 kind: ${CRD_KIND}
 metadata:
@@ -50,11 +64,25 @@ metadata:
 spec:
   projectRef:
     external: \${projectId}
-  locationID: us-west2
+  location: us-central1
   description: "Initial description"
 EOF
 
 cat <<EOF > ${TESTDIR}/update.yaml
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License a
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: ${CRD_GROUP}/${CRD_VERSION}
 kind: ${CRD_KIND}
 metadata:
@@ -62,7 +90,7 @@ metadata:
 spec:
   projectRef:
     external: \${projectId}
-  locationID: us-west2
+  location: us-central1
   description: "Updated description"
 EOF
 


### PR DESCRIPTION
Add license header. Rename `locationID` to `location` which is more commonly used by resources.