### PR TITLE
Revert "chore: remove duplicated resource"

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudtasksqueues.cloudtasks.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_cloudtasksqueues.cloudtasks.cnrm.cloud.google.com.yaml
@@ -1,0 +1,270 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 0.0.0-dev
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/managed-by-kcc: "true"
+    cnrm.cloud.google.com/stability-level: alpha
+    cnrm.cloud.google.com/system: "true"
+    cnrm.cloud.google.com/tf2crd: "true"
+  name: cloudtasksqueues.cloudtasks.cnrm.cloud.google.com
+spec:
+  group: cloudtasks.cnrm.cloud.google.com
+  names:
+    categories:
+    - gcp
+    kind: CloudTasksQueue
+    plural: cloudtasksqueues
+    shortNames:
+    - gcpcloudtasksqueue
+    - gcpcloudtasksqueues
+    singular: cloudtasksqueue
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'True', the most recent reconcile of the resource succeeded
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The reason for the value in 'Ready'
+      jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Status
+      type: string
+    - description: The last transition time for the value in 'Status'
+      jsonPath: .status.conditions[?(@.type=='Ready')].lastTransitionTime
+      name: Status Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'apiVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              appEngineRoutingOverride:
+                description: |-
+                  Overrides for task-level appEngineRouting. These settings apply only
+                  to App Engine tasks in this queue.
+                properties:
+                  host:
+                    description: The host that the task is sent to.
+                    type: string
+                  instance:
+                    description: |-
+                      App instance.
+
+                      By default, the task is sent to an instance which is available when the task is attempted.
+                    type: string
+                  service:
+                    description: |-
+                      App service.
+
+                      By default, the task is sent to the service which is the default service when the task is attempted.
+                    type: string
+                  version:
+                    description: |-
+                      App version.
+
+                      By default, the task is sent to the version which is the default version when the task is attempted.
+                    type: string
+                type: object
+              location:
+                description: Immutable. The location of the queue.
+                type: string
+              projectRef:
+                description: The project that this resource belongs to.
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    description: 'Allowed value: The `name` field of a `Project` resource.'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                type: object
+              rateLimits:
+                description: |-
+                  Rate limits for task dispatches.
+
+                  The queue's actual dispatch rate is the result of:
+
+                  * Number of tasks in the queue
+                  * User-specified throttling: rateLimits, retryConfig, and the queue's state.
+                  * System throttling due to 429 (Too Many Requests) or 503 (Service
+                    Unavailable) responses from the worker, high error rates, or to
+                    smooth sudden large traffic spikes.
+                properties:
+                  maxBurstSize:
+                    description: |-
+                      The max burst size.
+
+                      Max burst size limits how fast tasks in queue are processed when many tasks are
+                      in the queue and the rate is high. This field allows the queue to have a high
+                      rate so processing starts shortly after a task is enqueued, but still limits
+                      resource usage when many tasks are enqueued in a short period of time.
+                    type: integer
+                  maxConcurrentDispatches:
+                    description: |-
+                      The maximum number of concurrent tasks that Cloud Tasks allows to
+                      be dispatched for this queue. After this threshold has been
+                      reached, Cloud Tasks stops dispatching tasks until the number of
+                      concurrent requests decreases.
+                    type: integer
+                  maxDispatchesPerSecond:
+                    description: |-
+                      The maximum rate at which tasks are dispatched from this queue.
+
+                      If unspecified when the queue is created, Cloud Tasks will pick the default.
+                    type: number
+                type: object
+              resourceID:
+                description: Immutable. Optional. The name of the resource. Used for
+                  creation and acquisition. When unset, the value of `metadata.name`
+                  is used as the default.
+                type: string
+              retryConfig:
+                description: Settings that determine the retry behavior.
+                properties:
+                  maxAttempts:
+                    description: |-
+                      Number of attempts per task.
+
+                      Cloud Tasks will attempt the task maxAttempts times (that is, if
+                      the first attempt fails, then there will be maxAttempts - 1
+                      retries). Must be >= -1.
+
+                      If unspecified when the queue is created, Cloud Tasks will pick
+                      the default.
+
+                      -1 indicates unlimited attempts.
+                    type: integer
+                  maxBackoff:
+                    description: |-
+                      A task will be scheduled for retry between minBackoff and
+                      maxBackoff duration after it fails, if the queue's RetryConfig
+                      specifies that the task should be retried.
+                    type: string
+                  maxDoublings:
+                    description: |-
+                      The time between retries will double maxDoublings times.
+
+                      A task's retry interval starts at minBackoff, then doubles maxDoublings times,
+                      then increases linearly, and finally retries retries at intervals of maxBackoff
+                      up to maxAttempts times.
+                    type: integer
+                  maxRetryDuration:
+                    description: |-
+                      If positive, maxRetryDuration specifies the time limit for
+                      retrying a failed task, measured from when the task was first
+                      attempted. Once maxRetryDuration time has passed and the task has
+                      been attempted maxAttempts times, no further attempts will be
+                      made and the task will be deleted.
+
+                      If zero, then the task age is unlimited.
+                    type: string
+                  minBackoff:
+                    description: |-
+                      A task will be scheduled for retry between minBackoff and
+                      maxBackoff duration after it fails, if the queue's RetryConfig
+                      specifies that the task should be retried.
+                    type: string
+                type: object
+              stackdriverLoggingConfig:
+                description: Configuration options for writing logs to Stackdriver
+                  Logging.
+                properties:
+                  samplingRatio:
+                    description: |-
+                      Specifies the fraction of operations to write to Stackdriver Logging.
+                      This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the
+                      default and means that no operations are logged.
+                    type: number
+                required:
+                - samplingRatio
+                type: object
+            required:
+            - location
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions represent the latest available observation
+                  of the resource's current state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the generation of the resource
+                  that was most recently observed by the Config Connector controller.
+                  If this is equal to metadata.generation, then that means that the
+                  current reported status reflects the most recent desired state of
+                  the resource.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/installbundle/components/clusterroles/cnrm_admin.yaml
+++ b/config/installbundle/components/clusterroles/cnrm_admin.yaml
@@ -380,6 +380,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - cloudtasks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - colab.cnrm.cloud.google.com
   resources:
   - '*'

--- a/config/installbundle/components/clusterroles/cnrm_viewer.yaml
+++ b/config/installbundle/components/clusterroles/cnrm_viewer.yaml
@@ -255,6 +255,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - cloudtasks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - colab.cnrm.cloud.google.com
   resources:
   - '*'

--- a/pkg/gvks/supportedgvks/gvks_generated.go
+++ b/pkg/gvks/supportedgvks/gvks_generated.go
@@ -1125,6 +1125,18 @@ var SupportedGVKs = map[schema.GroupVersionKind]GVKMetadata{
 		},
 	},
 	{
+		Group:   "cloudtasks.cnrm.cloud.google.com",
+		Version: "v1alpha1",
+		Kind:    "CloudTasksQueue",
+	}: {
+		Labels: map[string]string{
+			"cnrm.cloud.google.com/managed-by-kcc":  "true",
+			"cnrm.cloud.google.com/stability-level": "alpha",
+			"cnrm.cloud.google.com/system":          "true",
+			"cnrm.cloud.google.com/tf2crd":          "true",
+		},
+	},
+	{
 		Group:   "colab.cnrm.cloud.google.com",
 		Version: "v1alpha1",
 		Kind:    "ColabRuntimeTemplate",

--- a/scripts/resource-autogen/allowlist/allowlist.go
+++ b/scripts/resource-autogen/allowlist/allowlist.go
@@ -61,6 +61,7 @@ var (
 		"cloud_asset/google_cloud_asset_organization_feed",
 		"cloud_asset/google_cloud_asset_project_feed",
 		"cloud_ids/google_cloud_ids_endpoint",
+		"cloud_tasks/google_cloud_tasks_queue",
 		"cloudfunctions2/google_cloudfunctions2_function",
 		"cloudiot/google_cloudiot_device",
 		"cloudiot/google_cloudiot_registry",


### PR DESCRIPTION
This PR reverts #4019
We probably want to keep the old CRD and permission, just to be safe.

Alternatively, we can simply remove this CRD. If users notice permission issues with the ConfigConnector operator, we can ask them to manually delete the CRD from their clusters.