### PR TITLE
tests: normalize folderID

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -690,6 +690,10 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 	return h
 }
 
+func (t *Harness) FolderID() string {
+	return testgcp.TestFolderID.Get()
+}
+
 func (h *Harness) RegisteredServices() mockgcpregistry.Normalizer {
 	return h.registeredServices
 }

--- a/pkg/test/resourcefixture/testdata/basic/kms/v1beta1/kmsautokeyconfig/_generated_object_kmsautokeyconfig.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/kms/v1beta1/kmsautokeyconfig/_generated_object_kmsautokeyconfig.golden.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   folderRef:
-    external: folders/123451001
+    external: folders/${folderID}
   keyProject:
     external: projects/diff-{uniqueId}
 status:
@@ -21,7 +21,7 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  externalRef: folders/123451001/autokeyConfig
+  externalRef: folders/${folderID}/autokeyConfig
   observedGeneration: 2
   observedState:
     state: ACTIVE

--- a/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementfullfolder/_generated_object_privilegedaccessmanagerentitlementfullfolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/privilegedaccessmanager/v1beta1/privilegedaccessmanagerentitlement/privilegedaccessmanagerentitlementfullfolder/_generated_object_privilegedaccessmanagerentitlementfullfolder.golden.yaml
@@ -30,7 +30,7 @@ spec:
   - principals:
     - serviceAccount:gsa-2-${uniqueId}@${projectId}.iam.gserviceaccount.com
   folderRef:
-    external: folders/123451001
+    external: folders/${folderID}
   location: global
   maxRequestDuration: 1h0m0s
   privilegedAccess:
@@ -47,7 +47,7 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  externalRef: //privilegedaccessmanager.googleapis.com/folders/123451001/locations/global/entitlements/privilegedaccessmanagerentitlement-${uniqueId}
+  externalRef: //privilegedaccessmanager.googleapis.com/folders/${folderID}/locations/global/entitlements/privilegedaccessmanagerentitlement-${uniqueId}
   observedGeneration: 2
   observedState:
     createTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/folder/folderinfolder/_generated_object_folderinfolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/folder/folderinfolder/_generated_object_folderinfolder.golden.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   displayName: KCC-2 ${uniqueId}
   folderRef:
-    external: "123451001"
+    external: ${folderID}
   resourceID: ${folderId}
 status:
   conditions:

--- a/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/resourcemanager/v1beta1/project/projectinfolder/_generated_object_projectinfolder.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   folderRef:
-    external: "123451001"
+    external: ${folderID}
   name: KCC-2 ${uniqueId}
   resourceID: project-${uniqueId}
 status:

--- a/pkg/test/resourcefixture/testdata/containerannotations/folderid/_generated_object_folderid.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/containerannotations/folderid/_generated_object_folderid.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
   annotations:
-    cnrm.cloud.google.com/folder-id: "123451001"
+    cnrm.cloud.google.com/folder-id: ${folderID}
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -15,7 +15,7 @@ metadata:
   namespace: ${uniqueId}
 spec:
   folderRef:
-    external: "123451001"
+    external: ${folderID}
   name: KCC-2 ${uniqueId}
   resourceID: project-${uniqueId}
 status:

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -35,9 +35,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project testgcp.GCPProject, uniqueID string) error {
+func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project testgcp.GCPProject, folderID string, uniqueID string) error {
 	replacements := NewReplacements()
 	findLinksInKRMObject(t, replacements, u)
+
+	if folderID != "" {
+		replacements.PathIDs[folderID] = "${folderID}"
+	}
 
 	annotations := u.GetAnnotations()
 	if annotations["cnrm.cloud.google.com/observed-secret-versions"] != "" {
@@ -47,6 +51,9 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 	if annotations["test.cnrm.cloud.google.com/reconcile-cookie"] != "" {
 		// Deliberately volatile, ignore
 		annotations["test.cnrm.cloud.google.com/reconcile-cookie"] = "(removed)"
+	}
+	for k, v := range annotations {
+		annotations[k] = replacements.ApplyReplacements(v)
 	}
 	u.SetAnnotations(annotations)
 
@@ -770,7 +777,7 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 	events.PrettifyJSON(func(requestURL string, obj map[string]any) {
 		u := &unstructured.Unstructured{}
 		u.Object = obj
-		if err := normalizeKRMObject(t, u, project, uniqueID); err != nil {
+		if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
 			t.Fatalf("error from normalizeObject: %v", err)
 		}
 	})

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -73,6 +73,7 @@ func TestE2EScript(t *testing.T) {
 
 			t.Run(scenarioPath, func(t *testing.T) {
 				uniqueID := testvariable.NewUniqueID()
+				folderID := ""
 
 				// Quickly load the sample with a dummy project, just to see if we should skip it
 				{
@@ -285,7 +286,7 @@ func TestE2EScript(t *testing.T) {
 							t.Logf("ignoring failure to export resource of gvk %v", exportResource.GroupVersionKind())
 							// t.Errorf("failed to export resource of gvk %v", exportResource.GroupVersionKind())
 						} else {
-							if err := normalizeKRMObject(t, u, project, uniqueID); err != nil {
+							if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
 								t.Fatalf("error from normalizeObject: %v", err)
 							}
 							got, err := yaml.Marshal(u)
@@ -308,7 +309,7 @@ func TestE2EScript(t *testing.T) {
 						if err := h.GetClient().Get(ctx, id, u); err != nil {
 							t.Errorf("failed to get kube object: %v", err)
 						} else {
-							if err := normalizeKRMObject(t, u, project, uniqueID); err != nil {
+							if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
 								t.Fatalf("error from normalizeObject: %v", err)
 							}
 							got, err := yaml.Marshal(u)

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -306,6 +306,8 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 				create.RunCreateDeleteTest(h, opt)
 
 				if os.Getenv("GOLDEN_OBJECT_CHECKS") != "" || os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
+					folderID := h.FolderID()
+
 					for _, obj := range exportResources {
 						// Get testName from t.Name()
 						// If t.Name() = TestAllInInSeries_fixtures_computenodetemplate
@@ -324,7 +326,7 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 							if err := yaml.Unmarshal([]byte(exportedYAML), exportedObj); err != nil {
 								t.Fatalf("FAIL: error from yaml.Unmarshal: %v", err)
 							}
-							if err := normalizeKRMObject(t, exportedObj, project, uniqueID); err != nil {
+							if err := normalizeKRMObject(t, exportedObj, project, folderID, uniqueID); err != nil {
 								t.Fatalf("FAIL: error from normalizeObject: %v", err)
 							}
 							got, err := yaml.Marshal(exportedObj)
@@ -342,7 +344,7 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 						if err := h.GetClient().Get(ctx, id, u); err != nil {
 							t.Fatalf("FAIL: failed to get KRM object: %v", err)
 						} else {
-							if err := normalizeKRMObject(t, u, project, uniqueID); err != nil {
+							if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
 								t.Fatalf("FAIL: error from normalizeObject: %v", err)
 							}
 							got, err := yaml.Marshal(u)


### PR DESCRIPTION
Actual folder values were appearing in the output,
which means we cannot have parity with realgcp.
