### PR TITLE
conductor: use proto name for controller filename

### DIFF
--- a/experiments/conductor/cmd/runner/controller_commands.go
+++ b/experiments/conductor/cmd/runner/controller_commands.go
@@ -105,7 +105,7 @@ func generateController(ctx context.Context, opts *RunnerOptions, branch Branch,
 	}
 
 	// Create the controller
-	controllerFileName := strings.ToLower(branch.Kind) + "_controller.go"
+	controllerFileName := strings.ToLower(branch.Proto) + "_controller.go"
 	outputPath := filepath.Join("pkg", "controller", "direct", branch.Group, controllerFileName)
 
 	// Create the prompt for controllerbuilder


### PR DESCRIPTION
Let's keep the filename consistent. In the `xxx_types.go` file, we use the "proto name" as the prefix.

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/5ba0bc4e29a8dfae187b00dc49e31483fc9bb549/dev/tools/controllerbuilder/scaffold/apis.go#L144

I also noticed that the conductor used "branch.Resource" for the fuzzer file. I'm not sure what the difference is between "resource" and the proto name. Is "resource" the GCP resource name?

https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/5ba0bc4e29a8dfae187b00dc49e31483fc9bb549/experiments/conductor/cmd/runner/crd_generator_commands.go#L294
