### PR TITLE
chore: fix mockgcp Makefile

### DIFF
--- a/mockgcp/Makefile
+++ b/mockgcp/Makefile
@@ -171,9 +171,7 @@ gen-proto-no-fixup:
 		./third_party/googleapis/mockgcp/cloud/backupdr/v1/*.proto \
 		./third_party/googleapis/mockgcp/cloud/essentialcontacts/v1/*.proto \
 		./third_party/googleapis/mockgcp/cloud/networkmanagement/v1/*.proto \
-		./third_party/googleapis/mockgcp/cloud/asset/v1/*.proto \
-		./third_party/googleapis/mockgcp/cloud/netapp/v1/*.proto
-		./third_party/googleapis/mockgcp/cloud/networkmanagement/v1/*.proto
+		./third_party/googleapis/mockgcp/cloud/netapp/v1/*.proto \
 		./third_party/googleapis/mockgcp/cloud/dataplex/v1/*.proto
 
 .PHONY: generate-grpc-for-google-protos


### PR DESCRIPTION
Currently the mockgcp Makefile is broken due to duplicated entries.

```
$ make gen-proto
...
...
...
--grpc-gateway_out: duplicate annotation: method=POST, template=/v1/{parent=*/*}:exportAssets
make[1]: *** [Makefile:37: gen-proto-no-fixup] Error 1
make: *** [Makefile:31: gen-proto] Error 2
```