### PR TITLE
conductor: type/crd/mapper/fuzzer improvements

### DIFF
--- a/experiments/conductor/cmd/runner/fuzzer_commands.go
+++ b/experiments/conductor/cmd/runner/fuzzer_commands.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// runFuzzerTests runs the fuzzer tests for a branch
+func runFuzzerTests(ctx context.Context, opts *RunnerOptions, branch Branch, execResults *ExecResults) ([]string, *ExecResults, error) {
+	log.Printf("Running fuzzer tests for branch %s", branch.Name)
+
+	// Create the path to the fuzzer file
+	fuzzerPath := filepath.Join("pkg", "controller", "direct", branch.Group, branch.Resource+"_fuzzer.go")
+	fullFuzzerPath := filepath.Join(opts.branchRepoDir, fuzzerPath)
+
+	// Create the path to the mapper file
+	mapperPath := filepath.Join("pkg", "controller", "direct", branch.Group, "mapper.generated.go")
+	fullMapperPath := filepath.Join(opts.branchRepoDir, mapperPath)
+
+	// Check if fuzzer file exists
+	if _, err := os.Stat(fullFuzzerPath); err != nil {
+		log.Printf("Fuzzer file not found at %s, skipping fuzzer tests", fullFuzzerPath)
+		return []string{}, nil, fmt.Errorf("fuzzer file not found: %s", fullFuzzerPath)
+	}
+
+	// Check if mapper file exists
+	if _, err := os.Stat(fullMapperPath); err != nil {
+		log.Printf("Mapper file not found at %s, skipping fuzzer tests", fullMapperPath)
+		return []string{}, nil, fmt.Errorf("mapper file not found: %s", fullMapperPath)
+	}
+
+	// Run the fuzzer tests
+	cfg := CommandConfig{
+		Name: "Run Fuzzer Tests",
+		Cmd:  "go",
+		Args: []string{
+			"test", "-v",
+			"./pkg/fuzztesting/fuzztests/",
+			"-fuzz=FuzzAllMappers",
+			"-fuzztime", "60s",
+		},
+		WorkDir:     opts.branchRepoDir,
+		MaxAttempts: 1,
+	}
+
+	results, err := executeCommand(opts, cfg)
+	return []string{fuzzerPath}, &results, err
+}
+
+const FIX_FUZZER_FAILURES string = `Please fix the fuzzer file at: ${FUZZER_FILE}  and mapper file at: ${MAPPER_FILE} based on the failures seen in the fuzzer test run.
+
+The fuzzer test is failing with the error output shown below. Your task is to fix the issues in the fuzzer file
+to make the test pass.
+
+Start with the errors from the top of the output and work your way down.
+If you see a change that needs to be made, make the change and run the fuzzer test again.
+Fixing from top to bottom is important and will help you make progress.
+
+Once the changes are applied, use the RunShellCommand command to run the fuzzer test again to make sure the changes are valid.
+Use the output of the command to determine if the code changes are valid.
+
+RunShellCommand:
+go test -v ./pkg/fuzztesting/fuzztests/ -fuzz=FuzzAllMappers -fuzztime 10s
+
+Hints:
+
+* Use the ReadFile command to read the contents of the file.
+* Use the EditFile command to edit the file.
+* Look for issues with defaults, required fields, or field constraints in the fuzzer.
+* Pay attention to differences between fields in the mapper and the fuzzer.
+* Make sure the fuzzer handles all field types correctly.
+* Check any list, map, or pointer fields that might need special handling.
+
+The results of the fuzzer test run are:
+
+EXITCODE: ${TEST_OUTPUT_EXITCODE}
+
+STDERR:
+${TEST_OUTPUT_STDERR}
+
+STDOUT:
+${TEST_OUTPUT_STDOUT}
+`
+
+// fixFuzzerFailures attempts to fix issues in the fuzzer file based on test failures
+func fixFuzzerFailures(ctx context.Context, opts *RunnerOptions, branch Branch, execResults *ExecResults) ([]string, *ExecResults, error) {
+	log.Printf("Fixing fuzzer failures for branch %s", branch.Name)
+
+	// If tests passed, no need to fix anything
+	if execResults.ExitCode == 0 {
+		log.Printf("Fuzzer tests pass for branch %s, no fixes needed", branch.Name)
+		return []string{}, nil, nil
+	}
+
+	// Create the path to the fuzzer file
+	fuzzerPath := filepath.Join("pkg", "controller", "direct", branch.Group, branch.Resource+"_fuzzer.go")
+	fullFuzzerPath := filepath.Join(opts.branchRepoDir, fuzzerPath)
+
+	// Create the path to the mapper file
+	mapperPath := filepath.Join("pkg", "controller", "direct", branch.Group, "mapper.generated.go")
+	fullMapperPath := filepath.Join(opts.branchRepoDir, mapperPath)
+
+	// Check if fuzzer file exists
+	if _, err := os.Stat(fullFuzzerPath); err != nil {
+		log.Printf("Fuzzer file not found at %s, cannot fix", fullFuzzerPath)
+		return []string{}, nil, fmt.Errorf("fuzzer file not found: %s", fullFuzzerPath)
+	}
+
+	// Check if mapper file exists
+	if _, err := os.Stat(fullMapperPath); err != nil {
+		log.Printf("Mapper file not found at %s, cannot fix", fullMapperPath)
+		return []string{}, nil, fmt.Errorf("mapper file not found: %s", fullMapperPath)
+	}
+
+	// Create prompt with file contents and test output
+	prompt := strings.ReplaceAll(FIX_FUZZER_FAILURES, "${FUZZER_FILE}", fuzzerPath)
+	prompt = strings.ReplaceAll(prompt, "${MAPPER_FILE}", mapperPath)
+	prompt = strings.ReplaceAll(prompt, "${TEST_OUTPUT_EXITCODE}", fmt.Sprintf("%d", execResults.ExitCode))
+	prompt = strings.ReplaceAll(prompt, "${TEST_OUTPUT_STDERR}", execResults.Stderr)
+	prompt = strings.ReplaceAll(prompt, "${TEST_OUTPUT_STDOUT}", execResults.Stdout)
+
+	// Run codebot to fix the issues
+	cfg := CommandConfig{
+		Name:         "Fix Fuzzer Failures",
+		Cmd:          "codebot",
+		Args:         []string{"--prompt=/dev/stdin"},
+		Stdin:        strings.NewReader(prompt),
+		WorkDir:      opts.branchRepoDir,
+		RetryBackoff: GenerativeCommandRetryBackoff,
+	}
+
+	results, err := executeCommand(opts, cfg)
+	return []string{fuzzerPath}, &results, err
+}

--- a/experiments/conductor/cmd/runner/github_commands.go
+++ b/experiments/conductor/cmd/runner/github_commands.go
@@ -201,6 +201,11 @@ func pushBranch(ctx context.Context, opts *RunnerOptions, branch Branch, execRes
 
 func makeReadyPR(ctx context.Context, opts *RunnerOptions, branch Branch, execResults *ExecResults) ([]string, *ExecResults, error) {
 	// Run git push command with force flag
+	if opts.skipMakeReadyPR {
+		log.Printf("Skipping make ready-pr for branch %s (--skip-makereadypr flag is set)", branch.Name)
+		return nil, nil, nil
+	}
+
 	cfg := CommandConfig{
 		Name: "Make ready PR",
 		Cmd:  "make",

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -66,6 +66,8 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdGenerateCRD             = 22
 	cmdGenerateMapper          = 23
 	cmdGenerateFuzzer          = 24
+	cmdRunAndFixFuzzTests      = 25
+	cmdRunAndFixAPIChecks      = 26
 	cmdControllerClient        = 40
 	cmdGenerateController      = 41
 	cmdCreateIdentity          = 43
@@ -116,27 +118,27 @@ func BuildRunnerCmd() *cobra.Command {
 		"v", false, "Enable verbose output logging")
 	cmd.Flags().StringVarP(&opts.branchSuffix, "branch-suffix",
 		"", "", "Suffix to append to remote branch names when pushing")
+	cmd.Flags().BoolVarP(&opts.skipMakeReadyPR, "skip-makereadypr",
+		"", false, "Skip the make ready-pr step when pushing branches")
 
 	return cmd
 }
 
 type RunnerOptions struct {
-	branchConfFile string
-	branchRepoDir  string
-	command        int64
-	loggingDir     string
-	timeout        time.Duration
-	readFileType   string
-	defaultRetries int    // Default number of retries for commands
-	forResources   string // Comma-separated list of branch names to filter on
-
-	// forResourcesRegex filters branches, only branches that match the regex are processed
-	forResourcesRegex string
-
-	force        bool   // Force flag to override file existence checks
-	numCommits   int    // Number of commits to diff (default: 1)
-	verbose      bool   // Verbose output flag
-	branchSuffix string // Suffix to append to remote branch names when pushing
+	branchConfFile    string
+	branchRepoDir     string
+	command           int64
+	loggingDir        string
+	timeout           time.Duration
+	readFileType      string
+	defaultRetries    int    // Default number of retries for commands
+	forResources      string // Comma-separated list of branch names to filter on
+	forResourcesRegex string // Regex to filter branches, only branches that match the regex are processed
+	force             bool   // Force flag to override file existence checks
+	numCommits        int    // Number of commits to diff (default: 1)
+	verbose           bool   // Verbose output flag
+	branchSuffix      string // Suffix to append to remote branch names when pushing
+	skipMakeReadyPR   bool   // Skip make ready-pr step when pushing branches
 }
 
 func (opts *RunnerOptions) validateFlags() error {
@@ -341,10 +343,11 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		}
 	case cmdPushBranch: // 9
 		processors := []BranchProcessor{
-			{Fn: makeReadyPR, CommitMsgTemplate: "make ready-pr"},
+			{Fn: runAPIChecks, CommitMsgTemplate: "{{kind}}: Normalize api checks"},
+			{Fn: makeReadyPR, CommitMsgTemplate: "make ready-pr", AttemptsOnChanges: 5},
 			{Fn: pushBranch, CommitMsgTemplate: "push branch"},
 		}
-		processBranches(ctx, opts, branches.Branches, "Pushing Branch", processors)
+		processBranches(ctx, opts, branches.Branches, "Prep and Push Branch", processors)
 	case cmdCreateScriptYaml: // 10
 		processBranches(ctx, opts, branches.Branches, "Script YAML", []BranchProcessor{{Fn: createScriptYaml, CommitMsgTemplate: "mockgcp: create test script for {{command}}"}})
 	case cmdCaptureHttpLog: // 11
@@ -358,7 +361,7 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 	case cmdBuildProto: // 15
 		processBranches(ctx, opts, branches.Branches, "Build Proto", []BranchProcessor{{Fn: buildProtoFiles, CommitMsgTemplate: "chore: Build and add generated proto files"}})
 	case cmdRunMockTests: // 16
-		processBranches(ctx, opts, branches.Branches, "Mock Tests", []BranchProcessor{{Fn: fixMockgcpFailures, CommitMsgTemplate: "Verify and Fix mock tests", VerifyFn: runMockgcpTests, VerifyAttempts: 5, AttemptsOnNoChange: 2}})
+		processBranches(ctx, opts, branches.Branches, "Mock Tests", []BranchProcessor{{Fn: fixMockgcpFailures, CommitMsgTemplate: "Verify and Fix mock tests", VerifyFn: runMockgcpTests, VerifyAttempts: 10, AttemptsOnNoChange: 2}})
 	case cmdGenerateTypes: // 20
 		processBranches(ctx, opts, branches.Branches, "Types", []BranchProcessor{{Fn: generateTypes, CommitMsgTemplate: "{{kind}}: Add generated types"}})
 	case cmdAdjustTypes: // 21
@@ -366,21 +369,25 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 			{Fn: setTypeSpecStatus, CommitMsgTemplate: "{{kind}}: Add spec and status to generated type"},
 			{Fn: setTypeParent, CommitMsgTemplate: "{{kind}}: Add parent to generated type"},
 			{Fn: adjustIdentityParent, CommitMsgTemplate: "{{kind}}: Adjust identity parent"},
-			//{Fn: adjustIdentityParentNewFunction, CommitMsg: "Adjust identity parent NewIdentity method"},
 			{Fn: regenerateTypes, CommitMsgTemplate: "{{kind}}: Regenerate types"},
-			// preferred manual: Add something for Capitalization of Abbreviations: any acronyms that are not all caps should be all caps
-			// manual: Add something to handle references to other resources: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4010/commits/1651a0a7af5bca37b5c2e134dd3f600ebac6a172
+			{Fn: removeNameField, CommitMsgTemplate: "{{kind}}: Remove Name Field"},
+			{Fn: moveEtagField, CommitMsgTemplate: "{{kind}}: Move Etag Field", AttemptsOnNoChange: 1},
+			// add a kubebuilder required field label to the fields that are marked required in proto
+			{Fn: addRequiredFieldTags, CommitMsgTemplate: "{{kind}}: Add Required Field Tags"},
+			// TODO? manual: Add something to handle references to other resources: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4010/commits/1651a0a7af5bca37b5c2e134dd3f600ebac6a172
 			// * https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4017/commits/cc726106aff55d41e6bc94272acc3612f2636397
-			// Manually add a kubebuilder required field label to the fields that are marked required in proto
 		}
 		processBranches(ctx, opts, branches.Branches, "Adjusting types", processors)
 	case cmdGenerateCRD: // 22
 		processBranches(ctx, opts, branches.Branches, "CRD", []BranchProcessor{{Fn: generateCRD, CommitMsgTemplate: "{{kind}}: Add generated CRD"}})
 	case cmdGenerateMapper: // 23
 		processBranches(ctx, opts, branches.Branches, "Mapper", []BranchProcessor{{Fn: generateMapper, CommitMsgTemplate: "{{kind}}: Add generated mapper"}})
-		// handle references to other resources: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4010/commits/1651a0a7af5bca37b5c2e134dd3f600ebac6a172
 	case cmdGenerateFuzzer: // 24
 		processBranches(ctx, opts, branches.Branches, "Fuzzer", []BranchProcessor{{Fn: generateFuzzer, CommitMsgTemplate: "{{kind}}: Add generated fuzzer"}})
+	case cmdRunAndFixFuzzTests: // 25
+		processBranches(ctx, opts, branches.Branches, "Fuzzer Tests", []BranchProcessor{{Fn: fixFuzzerFailures, CommitMsgTemplate: "{{kind}}: Verify and Fix fuzzer tests", VerifyFn: runFuzzerTests, VerifyAttempts: 5, AttemptsOnNoChange: 2}})
+	case cmdRunAndFixAPIChecks: // 26
+		processBranches(ctx, opts, branches.Branches, "API Checks", []BranchProcessor{{Fn: fixAPICheckFailures, CommitMsgTemplate: "{{kind}}: Verify and Fix API checks", VerifyFn: runAPIChecks, VerifyAttempts: 5}})
 	case cmdControllerClient: // 40
 		processBranches(ctx, opts, branches.Branches, "Controller Client", []BranchProcessor{{Fn: generateControllerClient, CommitMsgTemplate: "{{kind}}: Add controller client"}})
 	case cmdGenerateController: // 41
@@ -428,6 +435,8 @@ func printHelp() {
 	log.Println("\t22 - [CRD] Generate CRD for each branch")
 	log.Println("\t23 - [CRD] Generate Mapper for each branch")
 	log.Println("\t24 - [CRD] Generate Fuzzer for each branch")
+	log.Println("\t25 - [CRD] Run and Fix fuzzer tests for each branch")
+	log.Println("\t26 - [CRD] Run and Fix API checks for each branch")
 	log.Println("\t40 - [Controller] Generate controller client for each branch")
 	log.Println("\t41 - [Controller] Generate controller for each branch")
 	log.Println("\t43 - [Controller] [optional, simialr to 20, 21] Create identity and reference files for each branch")


### PR DESCRIPTION
conductor: type/crd/mapper/fuzzer improvements
* Add more llm based fixes for types:
  * removeNameField - Remove Name field in Spec (ResourceID instead) and Status (ExternalRef instead)
  * moveEtagField - Belongs to Status
  * addRequiredFieldTags - add KRM +reuired tag
* Improve existing prompts for:
  * fixing mockgcp failures
* Autofix: Add fuzz testing and fix loop
* Autofix: Add apichecks and fix loop
* Add crunAPIChecks to run apichecks as part of cmd=9
* Add --skip-makereadypr when pushing changes (cmd=9)
* Add ability to run make ready-pr until no changes are detected.
  Sometime make ready-pr makes a change once and we need to rerun make
  ready-pr again. So add AttemptsOnChanges to handle this case.