### PR TITLE
mockgcp: don't ignore unknown fields/enum values by default

### DIFF
--- a/mockgcp/common/httpmux/mux.go
+++ b/mockgcp/common/httpmux/mux.go
@@ -32,6 +32,9 @@ type Options struct {
 	// Some older APIs do this (e.g. cloudbilling)
 	// While it likely doesn't matter, it makes golden testing easier to match.
 	EmitUnpopulated bool
+
+	// DiscardUnknownFields controls whether we ignore unknown fields while parsing
+	DiscardUnknownFields bool
 }
 
 type ServeMux struct {
@@ -56,7 +59,7 @@ func NewServeMux(ctx context.Context, conn *grpc.ClientConn, opt Options, handle
 				Resolver:        resolver,
 			},
 			UnmarshalOptions: protojson.UnmarshalOptions{
-				DiscardUnknown: true,
+				DiscardUnknown: opt.DiscardUnknownFields,
 				Resolver:       resolver,
 			},
 		},


### PR DESCRIPTION
We introduced this so that when the API client had newer fields
than we have in our protos, we would not treat that as an error.

However, this also means that we ignore unknown enum values,
which seems much more problematic.

Let's switch the default to strict mode, we should be OK for
most services!
