### PR TITLE
controllerbuilder: remove empty lines in response decorations

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -383,6 +383,11 @@ func (x *CSVExporter) InferOutput_WithCompletion(ctx context.Context, model stri
 			continue
 		}
 
+		if lines[len(lines)-1] == "" { // empty line
+			lines = lines[:len(lines)-1]
+			continue
+		}
+
 		break
 	}
 


### PR DESCRIPTION
I noticed that the files generated by `controllerbuilder prompt` sometimes still contain the following at the end. I suspect this might be due to empty lines between the decoration markers.

```
</out>



```