### PR TITLE
mockgcp: fill in monitoring notificationchannel

### DIFF
--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -96,7 +96,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetworkmanagement"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetworkservices"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknotebooks"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivateca"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivateca"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivilegedaccessmanager"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockpubsub"

--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -223,12 +223,10 @@ func NewMockRoundTripper(ctx context.Context, k8sClient client.Client, storage s
 	services = append(services, mockclouddeploy.New(env, storage))
 	services = append(services, mocksecretmanager.New(env, storage))
 	services = append(services, mockspanner.New(env, storage))
-	services = append(services, mockprivateca.New(env, storage))
 	services = append(services, mockpubsublite.New(env, storage))
 	services = append(services, mocknetworkconnectivity.New(env, storage))
 	services = append(services, mocknotebooks.New(env, storage))
 	services = append(services, mockprivilegedaccessmanager.New(env, storage))
-
 	services = append(services, mockredis.New(env, storage))
 	services = append(services, mocksecuresourcemanager.New(env, storage))
 	services = append(services, mockservicenetworking.New(env, storage))

--- a/mockgcp/mock_http_roundtrip.go
+++ b/mockgcp/mock_http_roundtrip.go
@@ -90,12 +90,13 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmanagedkafka"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmetastore"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmodelarmor"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmonitoring"
+	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockmonitoring"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetapp"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetworkconnectivity"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetworkmanagement"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknetworkservices"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocknotebooks"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivateca"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivateca"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockprivilegedaccessmanager"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockpubsub"
@@ -223,7 +224,7 @@ func NewMockRoundTripper(ctx context.Context, k8sClient client.Client, storage s
 	services = append(services, mockclouddeploy.New(env, storage))
 	services = append(services, mocksecretmanager.New(env, storage))
 	services = append(services, mockspanner.New(env, storage))
-	services = append(services, mockmonitoring.New(env, storage))
+	services = append(services, mockprivateca.New(env, storage))
 	services = append(services, mockpubsublite.New(env, storage))
 	services = append(services, mocknetworkconnectivity.New(env, storage))
 	services = append(services, mocknotebooks.New(env, storage))

--- a/mockgcp/mockmonitoring/normalize.go
+++ b/mockgcp/mockmonitoring/normalize.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockmonitoring
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockgcpregistry"
+)
+
+var _ mockgcpregistry.SupportsNormalization = &MockService{}
+
+const (
+	emailPlaceholder = "user@example.com"
+	timePlaceholder  = "2024-04-01T12:34:56.123456Z"
+)
+
+func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.NormalizingVisitor) {
+	replacements.ReplacePath(".creationRecord.mutateTime", timePlaceholder)
+	replacements.ReplacePath(".notificationChannels[].creationRecord.mutateTime", timePlaceholder)
+
+	replacements.ReplacePath(".mutationRecord.mutateTime", timePlaceholder)
+	replacements.ReplacePath(".notificationChannels[].mutationRecord.mutateTime", timePlaceholder)
+
+	replacements.ReplacePath(".mutationRecords[].mutateTime", timePlaceholder)
+	replacements.ReplacePath(".notificationChannels[].mutationRecords[].mutateTime", timePlaceholder)
+
+	replacements.ReplacePath(".creationRecord.mutatedBy", emailPlaceholder)
+	replacements.ReplacePath(".mutationRecord.mutatedBy", emailPlaceholder)
+	replacements.ReplacePath(".mutationRecords[].mutatedBy", emailPlaceholder)
+
+}
+
+func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {
+}

--- a/mockgcp/mockmonitoring/service.go
+++ b/mockgcp/mockmonitoring/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockgcpregistry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"google.golang.org/grpc"
 
@@ -28,6 +29,10 @@ import (
 	metricsscopepb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/monitoring/metricsscope/v1"
 	monitoringpb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/monitoring/v3"
 )
+
+func init() {
+	mockgcpregistry.Register(New)
+}
 
 // MockService represents a mocked apikeys service.
 type MockService struct {
@@ -37,7 +42,7 @@ type MockService struct {
 }
 
 // New creates a MockService.
-func New(env *common.MockEnvironment, storage storage.Storage) *MockService {
+func New(env *common.MockEnvironment, storage storage.Storage) mockgcpregistry.MockService {
 	s := &MockService{
 		MockEnvironment: env,
 		storage:         storage,

--- a/mockgcp/mockmonitoring/testdata/monitoringnotificationchannel/crud/_http.log
+++ b/mockgcp/mockmonitoring/testdata/monitoringnotificationchannel/crud/_http.log
@@ -1,0 +1,221 @@
+POST https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "description": "Test Channel Description",
+  "displayName": "Test Channel ${uniqueId}",
+  "labels": {
+    "email_address": "test-${uniqueId}@example.com"
+  },
+  "type": "email"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationRecord": {
+    "mutateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "description": "Test Channel Description",
+  "displayName": "Test Channel ${uniqueId}",
+  "enabled": true,
+  "labels": {
+    "email_address": "test-${uniqueId}@example.com"
+  },
+  "mutationRecords": [
+    {
+      "mutateTime": "2024-04-01T12:34:56.123456Z"
+    }
+  ],
+  "name": "projects/${projectId}/notificationChannels/${notificationChannelID}",
+  "type": "email"
+}
+
+---
+
+GET https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "notificationChannels": [
+    {
+      "creationRecord": {
+        "mutateTime": "2024-04-01T12:34:56.123456Z"
+      },
+      "description": "Test Channel Description",
+      "displayName": "Test Channel ${uniqueId}",
+      "enabled": true,
+      "labels": {
+        "email_address": "test-${uniqueId}@example.com"
+      },
+      "mutationRecords": [
+        {
+          "mutateTime": "2024-04-01T12:34:56.123456Z"
+        }
+      ],
+      "name": "projects/${projectId}/notificationChannels/${notificationChannelID}",
+      "type": "email"
+    }
+  ],
+  "totalSize": 1
+}
+
+---
+
+GET https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels?alt=json&filter=labels.email_address%3D%22test-${uniqueId}%40example.com%22
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "notificationChannels": [
+    {
+      "creationRecord": {
+        "mutateTime": "2024-04-01T12:34:56.123456Z"
+      },
+      "description": "Test Channel Description",
+      "displayName": "Test Channel ${uniqueId}",
+      "enabled": true,
+      "labels": {
+        "email_address": "test-${uniqueId}@example.com"
+      },
+      "mutationRecords": [
+        {
+          "mutateTime": "2024-04-01T12:34:56.123456Z"
+        }
+      ],
+      "name": "projects/${projectId}/notificationChannels/${notificationChannelID}",
+      "type": "email"
+    }
+  ],
+  "totalSize": 1
+}
+
+---
+
+GET https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels/${notificationChannelID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationRecord": {
+    "mutateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "description": "Test Channel Description",
+  "displayName": "Test Channel ${uniqueId}",
+  "enabled": true,
+  "labels": {
+    "email_address": "test-${uniqueId}@example.com"
+  },
+  "mutationRecords": [
+    {
+      "mutateTime": "2024-04-01T12:34:56.123456Z"
+    }
+  ],
+  "name": "projects/${projectId}/notificationChannels/${notificationChannelID}",
+  "type": "email"
+}
+
+---
+
+GET https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels?alt=json&filter=labels.email_address%3D%22test-${uniqueId}%40example.com%22
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "notificationChannels": [
+    {
+      "creationRecord": {
+        "mutateTime": "2024-04-01T12:34:56.123456Z"
+      },
+      "description": "Test Channel Description",
+      "displayName": "Test Channel ${uniqueId}",
+      "enabled": true,
+      "labels": {
+        "email_address": "test-${uniqueId}@example.com"
+      },
+      "mutationRecords": [
+        {
+          "mutateTime": "2024-04-01T12:34:56.123456Z"
+        }
+      ],
+      "name": "projects/${projectId}/notificationChannels/${notificationChannelID}",
+      "type": "email"
+    }
+  ],
+  "totalSize": 1
+}
+
+---
+
+DELETE https://monitoring.googleapis.com/v3/projects/${projectId}/notificationChannels/${notificationChannelID}?alt=json&force=False
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/mockgcp/mockmonitoring/testdata/monitoringnotificationchannel/crud/script.yaml
+++ b/mockgcp/mockmonitoring/testdata/monitoringnotificationchannel/crud/script.yaml
@@ -1,0 +1,4 @@
+- exec: gcloud beta monitoring channels create --type=email --channel-labels=email_address=test-${uniqueId}@example.com --display-name="Test Channel ${uniqueId}" --description="Test Channel Description" --project=${projectId}
+- exec: gcloud beta monitoring channels list --project=${projectId}
+- exec: gcloud beta monitoring channels describe $(gcloud beta monitoring channels list --filter='labels.email_address="test-${uniqueId}@example.com"'  --format='value(name)') --project=${projectId}
+- exec: gcloud beta monitoring channels delete $(gcloud beta monitoring channels list --filter='labels.email_address="test-${uniqueId}@example.com"'  --format='value(name)') --project=${projectId} --quiet

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -752,14 +752,6 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					addReplacement("revisionCreateTime", "2024-04-01T12:34:56.123456Z")
 					addReplacement("revisionId", "revision-id-placeholder")
 
-					// Specific to monitoring
-					addSetStringReplacement(".creationRecord.mutateTime", "2024-04-01T12:34:56.123456Z")
-					addSetStringReplacement(".creationRecord.mutatedBy", "user@example.com")
-					addSetStringReplacement(".mutationRecord.mutateTime", "2024-04-01T12:34:56.123456Z")
-					addSetStringReplacement(".mutationRecord.mutatedBy", "user@example.com")
-					addSetStringReplacement(".mutationRecords[].mutateTime", "2024-04-01T12:34:56.123456Z")
-					addSetStringReplacement(".mutationRecords[].mutatedBy", "user@example.com")
-
 					// Specific to CertificateManager
 					addReplacement("response.dnsResourceRecord.data", uniqueID)
 					jsonMutators = append(jsonMutators, func(requestURL string, obj map[string]any) {


### PR DESCRIPTION
- **conductor: "Create gcloud script.yaml. WARN: go cmds failed."**
- **conductor: "Capture HTTP Log for mocks"**
- **mockgcp: more fidelity for monitoring notificationchannel**
