### PR TITLE
conductor: ensure mock directory exists before writing files

### DIFF
--- a/experiments/conductor/cmd/runner/mock_commands.go
+++ b/experiments/conductor/cmd/runner/mock_commands.go
@@ -482,6 +482,12 @@ func generateMockGo(ctx context.Context, opts *RunnerOptions, branch Branch, exe
 	// Check to see if the http log file already exists
 	mockfolder := fmt.Sprintf("mock%s", branch.Group)
 
+	// Create the directory if it doesn't exist
+	mockfolderPath := filepath.Join(opts.branchRepoDir, "mockgcp", mockfolder)
+	if err := os.MkdirAll(mockfolderPath, 0755); err != nil {
+		return affectedPaths, nil, fmt.Errorf("failed to create directory %s: %w", mockfolderPath, err)
+	}
+
 	// Run the controller builder to generate the service go file.
 	serviceFileRelativePath := filepath.Join("mockgcp", mockfolder, "service.go")
 	serviceFile := filepath.Join(opts.branchRepoDir, serviceFileRelativePath)


### PR DESCRIPTION
This update ensures conductor runner checks and creates the mock directory before writing service and resource files, preventing file write errors when the directory doesn't exist.


```
2025/03/23 00:10:09 failed to process branch gkebackup-backupplan on attempt 1: WRITE MOCK SERVICE xxx/mockgcp/mockgkebackup/service.go error: open xxx/mockgcp/mockgkebackup/service.go: no such file or directory
```