### PR TITLE
e2e: enable sourcerepo.googleapis.com

### DIFF
--- a/dev/tasks/create-test-project
+++ b/dev/tasks/create-test-project
@@ -68,6 +68,7 @@ gcloud services enable \
   secretmanager.googleapis.com \
   servicenetworking.googleapis.com \
   serviceusage.googleapis.com \
+  sourcerepo.googleapis.com \
   sqladmin.googleapis.com \
   workstations.googleapis.com
 


### PR DESCRIPTION
Used by cloudbuild tests
