### PR TITLE
test: split out vmwareengine and backupdr into individual tests

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -134,6 +134,26 @@ jobs:
           path: /tmp/artifacts/
 
 
+  tests-e2e-fixtures-backupdr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-backupdr"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-backupdr
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-backupdr
+          path: /tmp/artifacts/
+
+
   tests-e2e-fixtures-bigquery:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -271,6 +291,26 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-tests-e2e-fixtures-vertexai
+          path: /tmp/artifacts/
+
+
+  tests-e2e-fixtures-vmwareengine:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-vmwareengine"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-vmwareengine
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-vmwareengine
           path: /tmp/artifacts/
 
 

--- a/scripts/github-actions/tests-e2e-fixtures
+++ b/scripts/github-actions/tests-e2e-fixtures
@@ -23,6 +23,10 @@ cd ${REPO_ROOT}/
 SKIP_TEST_APIGROUPS=(
     "apigee.cnrm.cloud.google.com"
     "bigquery.cnrm.cloud.google.com"
+    "bigqueryanalyticshub.cnrm.cloud.google.com"
+    "bigqueryconnection.cnrm.cloud.google.com"
+    "bigquerydatatransfer.cnrm.cloud.google.com"
+    "bigqueryreservation.cnrm.cloud.google.com"
     "compute.cnrm.cloud.google.com"
     "gkehub.cnrm.cloud.google.com"
     "monitoring.cnrm.cloud.google.com"

--- a/scripts/github-actions/tests-e2e-fixtures-backupdr
+++ b/scripts/github-actions/tests-e2e-fixtures-backupdr
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,22 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-SKIP_TEST_APIGROUPS=(
-    "apigee.cnrm.cloud.google.com"
-    "backupdr.cnrm.cloud.google.com"
-    "bigquery.cnrm.cloud.google.com"
-    "bigqueryanalyticshub.cnrm.cloud.google.com"
-    "bigqueryconnection.cnrm.cloud.google.com"
-    "bigquerydatatransfer.cnrm.cloud.google.com"
-    "bigqueryreservation.cnrm.cloud.google.com"
-    "compute.cnrm.cloud.google.com"
-    "gkehub.cnrm.cloud.google.com"
-    "monitoring.cnrm.cloud.google.com"
-    "secretmanager.cnrm.cloud.google.com"
-    "sql.cnrm.cloud.google.com"
-    "vertexai.cnrm.cloud.google.com"
-    "vmwareengine.cnrm.cloud.google.com"
-)
+export ONLY_TEST_APIGROUPS="backupdr.cnrm.cloud.google.com"
 
-export SKIP_TEST_APIGROUP=$(IFS=, ; echo "${SKIP_TEST_APIGROUPS[*]}")
 ${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-bigquery
+++ b/scripts/github-actions/tests-e2e-fixtures-bigquery
@@ -20,6 +20,13 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-export ONLY_TEST_APIGROUPS="bigquery.cnrm.cloud.google.com"
+APIGROUPS=(
+    "bigquery.cnrm.cloud.google.com"
+    "bigqueryanalyticshub.cnrm.cloud.google.com"
+    "bigqueryconnection.cnrm.cloud.google.com"
+    "bigquerydatatransfer.cnrm.cloud.google.com"
+    "bigqueryreservation.cnrm.cloud.google.com"
+)
 
+export ONLY_TEST_APIGROUPS=$(IFS=,; echo "${APIGROUPS[*]}")
 ${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-vmwareengine
+++ b/scripts/github-actions/tests-e2e-fixtures-vmwareengine
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,22 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
-SKIP_TEST_APIGROUPS=(
-    "apigee.cnrm.cloud.google.com"
-    "backupdr.cnrm.cloud.google.com"
-    "bigquery.cnrm.cloud.google.com"
-    "bigqueryanalyticshub.cnrm.cloud.google.com"
-    "bigqueryconnection.cnrm.cloud.google.com"
-    "bigquerydatatransfer.cnrm.cloud.google.com"
-    "bigqueryreservation.cnrm.cloud.google.com"
-    "compute.cnrm.cloud.google.com"
-    "gkehub.cnrm.cloud.google.com"
-    "monitoring.cnrm.cloud.google.com"
-    "secretmanager.cnrm.cloud.google.com"
-    "sql.cnrm.cloud.google.com"
-    "vertexai.cnrm.cloud.google.com"
-    "vmwareengine.cnrm.cloud.google.com"
-)
+export ONLY_TEST_APIGROUPS="vmwareengine.cnrm.cloud.google.com"
 
-export SKIP_TEST_APIGROUP=$(IFS=, ; echo "${SKIP_TEST_APIGROUPS[*]}")
 ${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
The `tests-e2e-fixtures` is timing out again.