### PR TITLE
fix: fix permanent diff in SQLInstance backupConfiguration

### DIFF
--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -303,19 +303,21 @@ func BackupConfigurationsMatch(desired *api.BackupConfiguration, actual *api.Bac
 	if desired.PointInTimeRecoveryEnabled != actual.PointInTimeRecoveryEnabled {
 		return false
 	}
+	// Ignore StartTime if it is not set. empty string is not a valid start time.
+	if desired.StartTime != "" && desired.StartTime != actual.StartTime {
+		return false
+	}
+	// Ignore TransactionLogRetentionDays if it is not set. 0 is not a valid transaction log retention days.
+	if desired.TransactionLogRetentionDays != 0 && desired.TransactionLogRetentionDays != actual.TransactionLogRetentionDays {
+		return false
+	}
+
 	// Ignore ReplicationLogArchivingEnabled. It is not supported in KRM API.
-	if desired.StartTime != actual.StartTime {
-		return false
-	}
-	if desired.TransactionLogRetentionDays != actual.TransactionLogRetentionDays {
-		return false
-	}
 	// Ignore TransactionalLogStorageState. It is not supported in KRM API.
 	// Ignore ForceSendFields. Assume it is set correctly in desired.
 	// Ignore NullFields. Assume it is set correctly in desired.
 	return true
 }
-
 func BackupRetentionSettingsMatch(desired *api.BackupRetentionSettings, actual *api.BackupRetentionSettings) bool {
 	if desired == nil && actual == nil {
 		return true

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_generated_object_sqlinstance-backupconfiguration-diff.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_generated_object_sqlinstance-backupconfiguration-diff.golden.yaml
@@ -16,7 +16,7 @@ metadata:
   name: test-${uniqueId}
   namespace: ${uniqueId}
 spec:
-  databaseVersion: POSTGRES_13
+  databaseVersion: POSTGRES_9_6
   region: europe-west3
   resourceID: test-${uniqueId}
   settings:

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_generated_object_sqlinstance-backupconfiguration-diff.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_generated_object_sqlinstance-backupconfiguration-diff.golden.yaml
@@ -1,0 +1,61 @@
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLInstance
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 1
+  labels:
+    cnrm-test: "true"
+  name: test-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  databaseVersion: POSTGRES_13
+  region: europe-west3
+  resourceID: test-${uniqueId}
+  settings:
+    availabilityType: REGIONAL
+    backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: 30
+      enabled: true
+      pointInTimeRecoveryEnabled: true
+    databaseFlags:
+    - name: temp_file_limit
+      value: "3145728"
+    deletionProtectionEnabled: false
+    diskSize: 10
+    insightsConfig:
+      queryInsightsEnabled: true
+    ipConfiguration:
+      requireSsl: true
+    tier: db-g1-small
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  connectionName: ${projectId}:europe-west3:test-${uniqueId}
+  firstIpAddress: 10.1.2.3
+  instanceType: CLOUD_SQL_INSTANCE
+  ipAddress: 10.1.2.3
+  observedGeneration: 1
+  publicIpAddress: 10.1.2.3
+  selfLink: https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}
+  serverCaCert:
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    commonName: common-name
+    createTime: "1970-01-01T00:00:00Z"
+    expirationTime: "1970-01-01T00:00:00Z"
+    sha1Fingerprint: "12345678"
+  serviceAccountEmailAddress: p${projectNumber}-abcdef@gcp-sa-cloud-sql.iam.gserviceaccount.com

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_http.log
@@ -32,7 +32,7 @@ Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 {
-  "databaseVersion": "POSTGRES_13",
+  "databaseVersion": "POSTGRES_9_6",
   "instanceType": "CLOUD_SQL_INSTANCE",
   "kind": "sql#instance",
   "name": "test-${uniqueId}",
@@ -152,35 +152,32 @@ X-Xss-Protection: 0
   "backendType": "SECOND_GEN",
   "connectionName": "${projectId}:europe-west3:test-${uniqueId}",
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "databaseInstalledVersion": "POSTGRES_13_20",
-  "databaseVersion": "POSTGRES_13",
+  "databaseInstalledVersion": "POSTGRES_9_6",
+  "databaseVersion": "POSTGRES_9_6",
   "etag": "abcdef0123A=",
-  "failoverReplica": {
-    "available": true
-  },
   "gceZone": "us-central1-a",
   "geminiConfig": {
     "activeQueryEnabled": false,
     "entitled": false,
     "googleVacuumMgmtEnabled": false,
     "indexAdvisorEnabled": false,
-    "oomSessionCancelEnabled": true
+    "oomSessionCancelEnabled": false
   },
-  "includeReplicasForMajorVersionUpgrade": false,
   "instanceType": "CLOUD_SQL_INSTANCE",
   "ipAddresses": [
     {
       "ipAddress": "10.1.2.3",
       "type": "PRIMARY"
+    },
+    {
+      "ipAddress": "10.1.2.3",
+      "type": "OUTGOING"
     }
   ],
   "kind": "sql#instance",
-  "maintenanceVersion": "POSTGRES_13_20.R20250302.00_04",
   "name": "test-${uniqueId}",
   "project": "${projectId}",
   "region": "europe-west3",
-  "satisfiesPzi": true,
-  "secondaryGceZone": "europe-west3-a",
   "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
   "serverCaCert": {
     "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
@@ -205,10 +202,10 @@ X-Xss-Protection: 0
       "enabled": true,
       "kind": "sql#backupConfiguration",
       "pointInTimeRecoveryEnabled": true,
-      "replicationLogArchivingEnabled": true,
+      "replicationLogArchivingEnabled": false,
       "startTime": "12:00",
       "transactionLogRetentionDays": 7,
-      "transactionalLogStorageState": "CLOUD_STORAGE"
+      "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
     "dataDiskSizeGb": "10",
@@ -233,10 +230,9 @@ X-Xss-Protection: 0
     "kind": "sql#settings",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "zone": "europe-west3-b"
+      "zone": "europe-west3-a"
     },
     "pricingPlan": "PER_USE",
-    "replicationLagMaxSeconds": 31536000,
     "replicationType": "SYNCHRONOUS",
     "settingsVersion": "123",
     "storageAutoResize": true,
@@ -248,29 +244,7 @@ X-Xss-Protection: 0
     }
   },
   "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
-  "state": "RUNNABLE",
-  "upgradableDatabaseVersions": [
-    {
-      "displayName": "PostgreSQL 14",
-      "majorVersion": "POSTGRES_14",
-      "name": "POSTGRES_14"
-    },
-    {
-      "displayName": "PostgreSQL 15",
-      "majorVersion": "POSTGRES_15",
-      "name": "POSTGRES_15"
-    },
-    {
-      "displayName": "PostgreSQL 16",
-      "majorVersion": "POSTGRES_16",
-      "name": "POSTGRES_16"
-    },
-    {
-      "displayName": "PostgreSQL 17",
-      "majorVersion": "POSTGRES_17",
-      "name": "POSTGRES_17"
-    }
-  ]
+  "state": "RUNNABLE"
 }
 
 ---
@@ -321,35 +295,32 @@ X-Xss-Protection: 0
   "backendType": "SECOND_GEN",
   "connectionName": "${projectId}:europe-west3:test-${uniqueId}",
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "databaseInstalledVersion": "POSTGRES_13_20",
-  "databaseVersion": "POSTGRES_13",
+  "databaseInstalledVersion": "POSTGRES_9_6",
+  "databaseVersion": "POSTGRES_9_6",
   "etag": "abcdef0123A=",
-  "failoverReplica": {
-    "available": true
-  },
   "gceZone": "us-central1-a",
   "geminiConfig": {
     "activeQueryEnabled": false,
     "entitled": false,
     "googleVacuumMgmtEnabled": false,
     "indexAdvisorEnabled": false,
-    "oomSessionCancelEnabled": true
+    "oomSessionCancelEnabled": false
   },
-  "includeReplicasForMajorVersionUpgrade": false,
   "instanceType": "CLOUD_SQL_INSTANCE",
   "ipAddresses": [
     {
       "ipAddress": "10.1.2.3",
       "type": "PRIMARY"
+    },
+    {
+      "ipAddress": "10.1.2.3",
+      "type": "OUTGOING"
     }
   ],
   "kind": "sql#instance",
-  "maintenanceVersion": "POSTGRES_13_20.R20250302.00_04",
   "name": "test-${uniqueId}",
   "project": "${projectId}",
   "region": "europe-west3",
-  "satisfiesPzi": true,
-  "secondaryGceZone": "europe-west3-a",
   "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
   "serverCaCert": {
     "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
@@ -374,10 +345,10 @@ X-Xss-Protection: 0
       "enabled": true,
       "kind": "sql#backupConfiguration",
       "pointInTimeRecoveryEnabled": true,
-      "replicationLogArchivingEnabled": true,
+      "replicationLogArchivingEnabled": false,
       "startTime": "12:00",
       "transactionLogRetentionDays": 7,
-      "transactionalLogStorageState": "CLOUD_STORAGE"
+      "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
     "dataDiskSizeGb": "10",
@@ -402,10 +373,9 @@ X-Xss-Protection: 0
     "kind": "sql#settings",
     "locationPreference": {
       "kind": "sql#locationPreference",
-      "zone": "europe-west3-b"
+      "zone": "europe-west3-a"
     },
     "pricingPlan": "PER_USE",
-    "replicationLagMaxSeconds": 31536000,
     "replicationType": "SYNCHRONOUS",
     "settingsVersion": "123",
     "storageAutoResize": true,
@@ -417,29 +387,7 @@ X-Xss-Protection: 0
     }
   },
   "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
-  "state": "RUNNABLE",
-  "upgradableDatabaseVersions": [
-    {
-      "displayName": "PostgreSQL 14",
-      "majorVersion": "POSTGRES_14",
-      "name": "POSTGRES_14"
-    },
-    {
-      "displayName": "PostgreSQL 15",
-      "majorVersion": "POSTGRES_15",
-      "name": "POSTGRES_15"
-    },
-    {
-      "displayName": "PostgreSQL 16",
-      "majorVersion": "POSTGRES_16",
-      "name": "POSTGRES_16"
-    },
-    {
-      "displayName": "PostgreSQL 17",
-      "majorVersion": "POSTGRES_17",
-      "name": "POSTGRES_17"
-    }
-  ]
+  "state": "RUNNABLE"
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/_http.log
@@ -1,0 +1,501 @@
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The Cloud SQL instance does not exist.",
+        "reason": "instanceDoesNotExist"
+      }
+    ],
+    "message": "The Cloud SQL instance does not exist."
+  }
+}
+
+---
+
+POST https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "databaseVersion": "POSTGRES_13",
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "kind": "sql#instance",
+  "name": "test-${uniqueId}",
+  "region": "europe-west3",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "availabilityType": "REGIONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 30,
+        "retentionUnit": "COUNT"
+      },
+      "enabled": true,
+      "kind": "sql#backupConfiguration",
+      "pointInTimeRecoveryEnabled": true
+    },
+    "connectorEnforcement": "NOT_REQUIRED",
+    "dataDiskSizeGb": "10",
+    "dataDiskType": "PD_SSD",
+    "databaseFlags": [
+      {
+        "name": "temp_file_limit",
+        "value": "3145728"
+      }
+    ],
+    "deletionProtectionEnabled": false,
+    "edition": "ENTERPRISE",
+    "insightsConfig": {
+      "queryInsightsEnabled": true
+    },
+    "ipConfiguration": {
+      "ipv4Enabled": true,
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+    },
+    "kind": "sql#settings",
+    "pricingPlan": "PER_USE",
+    "replicationType": "SYNCHRONOUS",
+    "storageAutoResize": true,
+    "tier": "db-g1-small",
+    "userLabels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "CREATE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "status": "PENDING",
+  "targetId": "test-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "CREATE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "test-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "backendType": "SECOND_GEN",
+  "connectionName": "${projectId}:europe-west3:test-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "databaseInstalledVersion": "POSTGRES_13_20",
+  "databaseVersion": "POSTGRES_13",
+  "etag": "abcdef0123A=",
+  "failoverReplica": {
+    "available": true
+  },
+  "gceZone": "us-central1-a",
+  "geminiConfig": {
+    "activeQueryEnabled": false,
+    "entitled": false,
+    "googleVacuumMgmtEnabled": false,
+    "indexAdvisorEnabled": false,
+    "oomSessionCancelEnabled": true
+  },
+  "includeReplicasForMajorVersionUpgrade": false,
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "ipAddresses": [
+    {
+      "ipAddress": "10.1.2.3",
+      "type": "PRIMARY"
+    }
+  ],
+  "kind": "sql#instance",
+  "maintenanceVersion": "POSTGRES_13_20.R20250302.00_04",
+  "name": "test-${uniqueId}",
+  "project": "${projectId}",
+  "region": "europe-west3",
+  "satisfiesPzi": true,
+  "secondaryGceZone": "europe-west3-a",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "serverCaCert": {
+    "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+    "certSerialNumber": "0",
+    "commonName": "common-name",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "expirationTime": "2024-04-01T12:34:56.123456Z",
+    "instance": "test-${uniqueId}",
+    "kind": "sql#sslCert",
+    "sha1Fingerprint": "12345678"
+  },
+  "serviceAccountEmailAddress": "p${projectNumber}-abcdef@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "authorizedGaeApplications": [],
+    "availabilityType": "REGIONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 30,
+        "retentionUnit": "COUNT"
+      },
+      "enabled": true,
+      "kind": "sql#backupConfiguration",
+      "pointInTimeRecoveryEnabled": true,
+      "replicationLogArchivingEnabled": true,
+      "startTime": "12:00",
+      "transactionLogRetentionDays": 7,
+      "transactionalLogStorageState": "CLOUD_STORAGE"
+    },
+    "connectorEnforcement": "NOT_REQUIRED",
+    "dataDiskSizeGb": "10",
+    "dataDiskType": "PD_SSD",
+    "databaseFlags": [
+      {
+        "name": "temp_file_limit",
+        "value": "3145728"
+      }
+    ],
+    "deletionProtectionEnabled": false,
+    "edition": "ENTERPRISE",
+    "insightsConfig": {
+      "queryInsightsEnabled": true
+    },
+    "ipConfiguration": {
+      "authorizedNetworks": [],
+      "ipv4Enabled": true,
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+    },
+    "kind": "sql#settings",
+    "locationPreference": {
+      "kind": "sql#locationPreference",
+      "zone": "europe-west3-b"
+    },
+    "pricingPlan": "PER_USE",
+    "replicationLagMaxSeconds": 31536000,
+    "replicationType": "SYNCHRONOUS",
+    "settingsVersion": "123",
+    "storageAutoResize": true,
+    "storageAutoResizeLimit": "0",
+    "tier": "db-g1-small",
+    "userLabels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    }
+  },
+  "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
+  "state": "RUNNABLE",
+  "upgradableDatabaseVersions": [
+    {
+      "displayName": "PostgreSQL 14",
+      "majorVersion": "POSTGRES_14",
+      "name": "POSTGRES_14"
+    },
+    {
+      "displayName": "PostgreSQL 15",
+      "majorVersion": "POSTGRES_15",
+      "name": "POSTGRES_15"
+    },
+    {
+      "displayName": "PostgreSQL 16",
+      "majorVersion": "POSTGRES_16",
+      "name": "POSTGRES_16"
+    },
+    {
+      "displayName": "PostgreSQL 17",
+      "majorVersion": "POSTGRES_17",
+      "name": "POSTGRES_17"
+    }
+  ]
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}/users?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "items": [
+    {
+      "etag": "abcdef0123A=",
+      "host": "",
+      "instance": "test-${uniqueId}",
+      "kind": "sql#user",
+      "name": "postgres",
+      "project": "${projectId}"
+    }
+  ],
+  "kind": "sql#usersList"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "backendType": "SECOND_GEN",
+  "connectionName": "${projectId}:europe-west3:test-${uniqueId}",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "databaseInstalledVersion": "POSTGRES_13_20",
+  "databaseVersion": "POSTGRES_13",
+  "etag": "abcdef0123A=",
+  "failoverReplica": {
+    "available": true
+  },
+  "gceZone": "us-central1-a",
+  "geminiConfig": {
+    "activeQueryEnabled": false,
+    "entitled": false,
+    "googleVacuumMgmtEnabled": false,
+    "indexAdvisorEnabled": false,
+    "oomSessionCancelEnabled": true
+  },
+  "includeReplicasForMajorVersionUpgrade": false,
+  "instanceType": "CLOUD_SQL_INSTANCE",
+  "ipAddresses": [
+    {
+      "ipAddress": "10.1.2.3",
+      "type": "PRIMARY"
+    }
+  ],
+  "kind": "sql#instance",
+  "maintenanceVersion": "POSTGRES_13_20.R20250302.00_04",
+  "name": "test-${uniqueId}",
+  "project": "${projectId}",
+  "region": "europe-west3",
+  "satisfiesPzi": true,
+  "secondaryGceZone": "europe-west3-a",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "serverCaCert": {
+    "cert": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+    "certSerialNumber": "0",
+    "commonName": "common-name",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "expirationTime": "2024-04-01T12:34:56.123456Z",
+    "instance": "test-${uniqueId}",
+    "kind": "sql#sslCert",
+    "sha1Fingerprint": "12345678"
+  },
+  "serviceAccountEmailAddress": "p${projectNumber}-abcdef@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+  "settings": {
+    "activationPolicy": "ALWAYS",
+    "authorizedGaeApplications": [],
+    "availabilityType": "REGIONAL",
+    "backupConfiguration": {
+      "backupRetentionSettings": {
+        "retainedBackups": 30,
+        "retentionUnit": "COUNT"
+      },
+      "enabled": true,
+      "kind": "sql#backupConfiguration",
+      "pointInTimeRecoveryEnabled": true,
+      "replicationLogArchivingEnabled": true,
+      "startTime": "12:00",
+      "transactionLogRetentionDays": 7,
+      "transactionalLogStorageState": "CLOUD_STORAGE"
+    },
+    "connectorEnforcement": "NOT_REQUIRED",
+    "dataDiskSizeGb": "10",
+    "dataDiskType": "PD_SSD",
+    "databaseFlags": [
+      {
+        "name": "temp_file_limit",
+        "value": "3145728"
+      }
+    ],
+    "deletionProtectionEnabled": false,
+    "edition": "ENTERPRISE",
+    "insightsConfig": {
+      "queryInsightsEnabled": true
+    },
+    "ipConfiguration": {
+      "authorizedNetworks": [],
+      "ipv4Enabled": true,
+      "requireSsl": true,
+      "sslMode": "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+    },
+    "kind": "sql#settings",
+    "locationPreference": {
+      "kind": "sql#locationPreference",
+      "zone": "europe-west3-b"
+    },
+    "pricingPlan": "PER_USE",
+    "replicationLagMaxSeconds": 31536000,
+    "replicationType": "SYNCHRONOUS",
+    "settingsVersion": "123",
+    "storageAutoResize": true,
+    "storageAutoResizeLimit": "0",
+    "tier": "db-g1-small",
+    "userLabels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    }
+  },
+  "sqlNetworkArchitecture": "NEW_NETWORK_ARCHITECTURE",
+  "state": "RUNNABLE",
+  "upgradableDatabaseVersions": [
+    {
+      "displayName": "PostgreSQL 14",
+      "majorVersion": "POSTGRES_14",
+      "name": "POSTGRES_14"
+    },
+    {
+      "displayName": "PostgreSQL 15",
+      "majorVersion": "POSTGRES_15",
+      "name": "POSTGRES_15"
+    },
+    {
+      "displayName": "PostgreSQL 16",
+      "majorVersion": "POSTGRES_16",
+      "name": "POSTGRES_16"
+    },
+    {
+      "displayName": "PostgreSQL 17",
+      "majorVersion": "POSTGRES_17",
+      "name": "POSTGRES_17"
+    }
+  ]
+}
+
+---
+
+DELETE https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "DELETE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "status": "PENDING",
+  "targetId": "test-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "sql#operation",
+  "name": "${operationID}",
+  "operationType": "DELETE",
+  "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "test-${uniqueId}",
+  "targetLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/${projectId}/instances/test-${uniqueId}",
+  "targetProject": "${projectId}",
+  "user": "user@example.com"
+}

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/create.yaml
@@ -1,0 +1,35 @@
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLInstance
+metadata:
+  annotations:
+    # cnrm.cloud.google.com/deletion-policy: abandon # so that the instance can be deleted
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+    cnrm.cloud.google.com/observed-secret-versions: '{}'
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  name: test-${uniqueId}
+spec:
+  databaseVersion: POSTGRES_13
+  region: europe-west3
+  resourceID: test-${uniqueId}
+  settings:
+    availabilityType: REGIONAL
+    backupConfiguration:
+      backupRetentionSettings:
+        retainedBackups: 30
+      enabled: true
+      pointInTimeRecoveryEnabled: true
+    databaseFlags:
+    - name: temp_file_limit
+      value: "3145728"
+    deletionProtectionEnabled: false # so that the instance can be deleted
+    diskSize: 10
+    insightsConfig:
+      queryInsightsEnabled: true
+    ipConfiguration:
+      requireSsl: true
+    tier: db-g1-small

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-backupconfiguration-diff/create.yaml
@@ -13,7 +13,7 @@ metadata:
   - cnrm.cloud.google.com/deletion-defender
   name: test-${uniqueId}
 spec:
-  databaseVersion: POSTGRES_13
+  databaseVersion: POSTGRES_9_6 # POSTGRES_13 is not supported by mock
   region: europe-west3
   resourceID: test-${uniqueId}
   settings:


### PR DESCRIPTION
This PR
 - Add a test case to reproduce #4207
 - Fix the permanent diff in `backupConfiguration` for `SQLInstance`. This is a behavior change introduced when migrating the resource from the TF controller to the direct controller. The fix effectively reverts the behavior change.

Fixes: #4207

Without the change:
```
$ go test -v -tags=integration ./pkg/controller/dynamic/ -run TestCreateNoChangeUpdateDelete/sql/basic-sqlinstance-backupconfiguration-diff 
...
k8s.go:84: expected event with reason 'Updating' to not be recorded for SQLInstance pxx4um5zs4ihvqa/test-pxx4um5zs4ihvqa, but it was
...
--- FAIL: TestCreateNoChangeUpdateDelete (0.17s)
    --- FAIL: TestCreateNoChangeUpdateDelete/sql (0.00s)
        --- FAIL: TestCreateNoChangeUpdateDelete/sql/basic-sqlinstance-backupconfiguration-diff  (310.95s)
FAIL
```

With the change
```
$ go test -v -tags=integration ./pkg/controller/dynamic/ -run TestCreateNoChangeUpdateDelete/sql/basic-sqlinstance-backupconfiguration-diff 
...
--- PASS: TestCreateNoChangeUpdateDelete (0.22s)
    --- PASS: TestCreateNoChangeUpdateDelete/sql (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/sql/basic-sqlinstance-backupconfiguration-diff (1037.23s)
PASS
```