### PR TITLE
template: use id.ID

### DIFF
--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -277,7 +277,7 @@ func (a *{{.ProtoResource}}Adapter) Export(ctx context.Context) (*unstructured.U
 		return nil, err
 	}
 
-	u.SetName(a.actual.Id)
+	u.SetName(a.id.ID())
 	u.SetGroupVersionKind(krm.{{.Kind}}GVK)
 
 	u.Object = uObj


### PR DESCRIPTION
I noticed that I kept changing this line for conductor/ controllerbuilder. I think the right thing to do here is to use the ID (read name) from the resource identity.