### PR TITLE
MockGCP&Controller: Resource dataplex content

### DIFF
--- a/apis/dataplex/v1alpha1/content_identity.go
+++ b/apis/dataplex/v1alpha1/content_identity.go
@@ -31,7 +31,7 @@ type ContentIdentity struct {
 }
 
 func (i *ContentIdentity) String() string {
-	return i.parent.String() + "/contents/" + i.id
+	return i.parent.String() + "/content/" + i.id
 }
 
 func (i *ContentIdentity) ID() string {
@@ -95,8 +95,8 @@ func NewContentIdentity(ctx context.Context, reader client.Reader, obj *Dataplex
 
 func ParseContentExternal(external string) (parent *LakeIdentity, resourceID string, err error) {
 	tokens := strings.Split(external, "/")
-	if len(tokens) != 8 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" || tokens[6] != "contents" {
-		return nil, "", fmt.Errorf("format of DataplexContent external=%q was not known (use projects/{{projectID}}/locations/{{location}}/lakes/{{lakeID}}/contents/{{contentID}})", external)
+	if len(tokens) != 8 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" || tokens[6] != "content" {
+		return nil, "", fmt.Errorf("format of DataplexContent external=%q was not known (use projects/{{projectID}}/locations/{{location}}/lakes/{{lakeID}}/content/{{contentID}})", external)
 	}
 	parent = &LakeIdentity{
 		parent: &LakeParent{

--- a/apis/dataplex/v1alpha1/content_identity.go
+++ b/apis/dataplex/v1alpha1/content_identity.go
@@ -73,8 +73,11 @@ func NewContentIdentity(ctx context.Context, reader client.Reader, obj *Dataplex
 		if err != nil {
 			return nil, err
 		}
-		if actualParent.parent != parent {
-			return nil, fmt.Errorf("parent changed, expect %s, got %s", actualParent.parent, parent)
+		if actualParent.parent.ProjectID != parent.ProjectID {
+			return nil, fmt.Errorf("parent ProjectID changed, expect %s, got %s", actualParent.parent.ProjectID, parent.ProjectID)
+		}
+		if actualParent.parent.Location != parent.Location {
+			return nil, fmt.Errorf("parent location changed, expect %s, got %s", actualParent.parent.Location, parent.Location)
 		}
 		if actualParent.id != lakeId {
 			return nil, fmt.Errorf("spec.lakeRef changed, expect %s, got %s", actualParent.id, lakeId)

--- a/apis/dataplex/v1alpha1/content_identity.go
+++ b/apis/dataplex/v1alpha1/content_identity.go
@@ -38,6 +38,10 @@ func (i *ContentIdentity) ID() string {
 	return i.id
 }
 
+func (i *ContentIdentity) Parent() string {
+	return i.parent.String()
+}
+
 // New builds a ContentIdentity from the Config Connector Content object.
 func NewContentIdentity(ctx context.Context, reader client.Reader, obj *DataplexContent) (*ContentIdentity, error) {
 

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -847,6 +847,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "datastream.cnrm.cloud.google.com", Kind: "DatastreamConnectionProfile"}:
 			case schema.GroupKind{Group: "datastream.cnrm.cloud.google.com", Kind: "DatastreamPrivateConnection"}:
 
+			case schema.GroupKind{Group: "dataplex.cnrm.cloud.google.com", Kind: "DataplexContent"}:
 			case schema.GroupKind{Group: "dataplex.cnrm.cloud.google.com", Kind: "DataplexLake"}:
 
 			case schema.GroupKind{Group: "discoveryengine.cnrm.cloud.google.com", Kind: "DiscoveryEngineDataStore"}:

--- a/mockgcp/mockdataplex/content.go
+++ b/mockgcp/mockdataplex/content.go
@@ -21,7 +21,6 @@ package mockdataplex
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -31,13 +30,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 	"github.com/google/uuid"
 
 	// Note: we use the "real" proto (not mockgcp), because the client uses GRPC.
 	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
-	iampb "google.golang.org/genproto/googleapis/iam/v1"
 )
 
 type ContentService struct {
@@ -70,25 +66,10 @@ func (s *ContentService) GetContent(ctx context.Context, req *pb.GetContentReque
 }
 
 func (s *ContentService) CreateContent(ctx context.Context, req *pb.CreateContentRequest) (*pb.Content, error) {
-	parentName, err := s.parseLakeName(req.GetParent())
-	if err != nil {
-		return nil, err
-	}
-
-	// The ID is derived from the path. Path needs URL encoding.
-	// Path might contain slashes, so the ID needs careful construction.
-	// Let's assume the API automatically handles the full path as the {content} segment identifier.
-	// We need to URL-escape the path to form the final name segment safely.
-	contentID := url.PathEscape(req.GetContent().GetPath())
-	// Double-encode slashes in the path as per API behavior
-	contentID = strings.ReplaceAll(contentID, "%2F", "%252F")
-
-	reqName := fmt.Sprintf("%s/content/%s", req.GetParent(), contentID)
-
-	name, err := s.parseContentName(reqName)
+	name, err := s.parseContentName(req.GetContent().GetName())
 	if err != nil {
 		// This parsing should ideally succeed if parent parsing and contentID construction are correct.
-		return nil, status.Errorf(codes.Internal, "failed to parse constructed content name %q: %v", reqName, err)
+		return nil, status.Errorf(codes.Internal, "failed to parse constructed content name %q: %v", name, err)
 	}
 
 	fqn := name.String()
@@ -114,12 +95,12 @@ func (s *ContentService) CreateContent(ctx context.Context, req *pb.CreateConten
 func (s *ContentService) populateDefaultsForContent(obj *pb.Content) {
 	// No specific defaults mentioned, but ensure oneof fields are valid if needed
 	switch obj.Content.(type) {
-	case *pb.Content_SqlScript:
+	case *pb.Content_SqlScript_:
 		if obj.GetSqlScript().GetEngine() == pb.Content_SqlScript_QUERY_ENGINE_UNSPECIFIED {
 			// Default engine? Let's assume Spark if not specified.
 			// obj.GetSqlScript().Engine = pb.Content_SqlScript_SPARK
 		}
-	case *pb.Content_Notebook:
+	case *pb.Content_Notebook_:
 		if obj.GetNotebook().GetKernelType() == pb.Content_Notebook_KERNEL_TYPE_UNSPECIFIED {
 			// Default kernel? Let's assume PYTHON3 if not specified.
 			// obj.GetNotebook().KernelType = pb.Content_Notebook_PYTHON3
@@ -143,33 +124,23 @@ func (s *ContentService) UpdateContent(ctx context.Context, req *pb.UpdateConten
 	updated := proto.Clone(existing).(*pb.Content)
 	updated.UpdateTime = timestamppb.New(now)
 
-	// Per API documentation: Only supports full resource update.
-	// However, typically `update_mask` is used. Let's follow the mask if provided.
 	paths := req.GetUpdateMask().GetPaths()
-	if len(paths) == 0 {
-		// If no mask, assume full update of mutable fields based on documentation
-		updated.Labels = req.GetContent().GetLabels()
-		updated.Description = req.GetContent().GetDescription()
-		updated.Data = req.GetContent().GetData()       // Update the data oneof
-		updated.Content = req.GetContent().GetContent() // Update the content oneof
-	} else {
-		// Apply partial updates based on the mask
-		// TODO: Use a fieldmask helper if available
-		for _, path := range paths {
-			switch path {
-			case "labels":
-				updated.Labels = req.GetContent().GetLabels()
-			case "description":
-				updated.Description = req.GetContent().GetDescription()
-			case "data_text":
-				updated.Data = &pb.Content_DataText{DataText: req.GetContent().GetDataText()}
-			case "sql_script":
-				updated.Content = &pb.Content_SqlScript_{SqlScript: req.GetContent().GetSqlScript()}
-			case "notebook":
-				updated.Content = &pb.Content_Notebook_{Notebook: req.GetContent().GetNotebook()}
-			default:
-				return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid for Content", path)
-			}
+	for _, path := range paths {
+		switch path {
+		case "labels":
+			updated.Labels = req.GetContent().GetLabels()
+		case "description":
+			updated.Description = req.GetContent().GetDescription()
+		case "path":
+			updated.Path = req.GetContent().GetPath()
+		case "data_text":
+			updated.Data = &pb.Content_DataText{DataText: req.GetContent().GetDataText()}
+		case "sql_script":
+			updated.Content = &pb.Content_SqlScript_{SqlScript: req.GetContent().GetSqlScript()}
+		case "notebook":
+			updated.Content = &pb.Content_Notebook_{Notebook: req.GetContent().GetNotebook()}
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid for Content", path)
 		}
 	}
 
@@ -201,118 +172,27 @@ func (s *ContentService) DeleteContent(ctx context.Context, req *pb.DeleteConten
 	return &emptypb.Empty{}, nil
 }
 
-func (s *ContentService) ListContent(ctx context.Context, req *pb.ListContentRequest) (*pb.ListContentResponse, error) {
-	parentName, err := s.parseLakeName(req.GetParent())
-	if err != nil {
-		return nil, err
-	}
-
-	parentFQNPrefix := parentName.String() + "/content/"
-
-	response := &pb.ListContentResponse{}
-
-	contentKind := (&pb.Content{}).ProtoReflect().Descriptor()
-	if err := s.storage.List(ctx, contentKind, storage.ListOptions{}, func(obj proto.Message) error {
-		content := obj.(*pb.Content)
-		if strings.HasPrefix(content.GetName(), parentFQNPrefix) {
-			// Clear data_text for list requests as per API behavior
-			content.Data = nil
-			response.Content = append(response.Content, content)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	// TODO: Implement filtering if req.Filter is set
-	// TODO: Implement pagination
-
-	return response, nil
-}
-
-func (s *ContentService) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
-	// Mock implementation - return empty policy
-	return &iampb.Policy{}, nil
-}
-
-func (s *ContentService) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
-	// Mock implementation - return the policy passed in
-	return req.Policy, nil
-}
-
-func (s *ContentService) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
-	// Mock implementation - return all permissions passed in
-	return &iampb.TestIamPermissionsResponse{Permissions: req.Permissions}, nil
-}
-
 type contentName struct {
-	Project  *projects.ProjectData
-	Location string
-	Lake     string
-	// Content can contain slashes, representing a path.
-	ContentPath string
+	Lake      string
+	ContentID string
 }
 
 func (n *contentName) String() string {
-	// Use the URL-escaped and slash-encoded version for the final segment
-	escapedContentPath := url.PathEscape(n.ContentPath)
-	encodedContentPath := strings.ReplaceAll(escapedContentPath, "%2F", "%252F")
-	return fmt.Sprintf("projects/%s/locations/%s/lakes/%s/content/%s", n.Project.ID, n.Location, n.Lake, encodedContentPath)
+	return fmt.Sprintf("%s/content/%s", n.Lake, n.ContentID)
 }
 
 // parseContentName parses a string into a contentName.
 // The expected form is `projects/*/locations/*/lakes/*/content/{content_path}`
-// or `projects/*/locations/*/lakes/*/contentitems/{content_path}`
-// where {content_path} can contain multiple segments separated by '/'.
 func (s *MockService) parseContentName(name string) (*contentName, error) {
-	pattern1Prefix := "projects/"
-	pattern1Suffix := "/content/"
-	pattern2Suffix := "/contentitems/"
-
-	var projectID, location, lake, contentPath string
-	var tokens []string
-
-	if strings.Contains(name, pattern1Suffix) {
-		parts := strings.SplitN(name, pattern1Suffix, 2)
-		prefixPart := parts[0]
-		contentPath = parts[1]
-		tokens = strings.Split(prefixPart, "/")
-		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" {
-			return nil, status.Errorf(codes.InvalidArgument, "name %q does not match pattern projects/*/locations/*/lakes/*/content/**", name)
+	tokens := strings.Split(name, "/")
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "lakes" && tokens[6] == "content" {
+		name := &contentName{
+			Lake:      strings.Join(tokens[:len(tokens)-2], "/"),
+			ContentID: tokens[7],
 		}
-	} else if strings.Contains(name, pattern2Suffix) {
-		parts := strings.SplitN(name, pattern2Suffix, 2)
-		prefixPart := parts[0]
-		contentPath = parts[1]
-		tokens = strings.Split(prefixPart, "/")
-		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" {
-			return nil, status.Errorf(codes.InvalidArgument, "name %q does not match pattern projects/*/locations/*/lakes/*/contentitems/**", name)
-		}
-	} else {
-		return nil, status.Errorf(codes.InvalidArgument, "name %q does not contain /content/ or /contentitems/", name)
+
+		return name, nil
 	}
 
-	projectID = tokens[1]
-	location = tokens[3]
-	lake = tokens[5]
-
-	// URL-decode the content path, including the double-encoded slashes
-	decodedContentPath, err := url.PathUnescape(strings.ReplaceAll(contentPath, "%252F", "%2F"))
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid content path encoding in name %q: %v", name, err)
-	}
-
-	project, err := s.Projects.GetProjectByID(projectID)
-	if err != nil {
-		return nil, err // Or wrap with context
-	}
-
-	parsedName := &contentName{
-		Project:     project,
-		Location:    location,
-		Lake:        lake,
-		ContentPath: decodedContentPath,
-	}
-
-	return parsedName, nil
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
 }

--- a/mockgcp/mockdataplex/content.go
+++ b/mockgcp/mockdataplex/content.go
@@ -1,0 +1,318 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.dataplex.v1.ContentService
+// proto.message: google.cloud.dataplex.v1.Content
+
+package mockdataplex
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+	"github.com/google/uuid"
+
+	// Note: we use the "real" proto (not mockgcp), because the client uses GRPC.
+	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
+	iampb "google.golang.org/genproto/googleapis/iam/v1"
+)
+
+type ContentService struct {
+	*MockService
+	pb.UnimplementedContentServiceServer
+}
+
+func (s *ContentService) GetContent(ctx context.Context, req *pb.GetContentRequest) (*pb.Content, error) {
+	name, err := s.parseContentName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.Content{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "content %q not found", name)
+		}
+		return nil, err
+	}
+
+	// Clear data_text for non-GET requests as per API behavior
+	if req.View != pb.GetContentRequest_FULL {
+		obj.Data = nil // Clear the data oneof
+	}
+
+	return obj, nil
+}
+
+func (s *ContentService) CreateContent(ctx context.Context, req *pb.CreateContentRequest) (*pb.Content, error) {
+	parentName, err := s.parseLakeName(req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	// The ID is derived from the path. Path needs URL encoding.
+	// Path might contain slashes, so the ID needs careful construction.
+	// Let's assume the API automatically handles the full path as the {content} segment identifier.
+	// We need to URL-escape the path to form the final name segment safely.
+	contentID := url.PathEscape(req.GetContent().GetPath())
+	// Double-encode slashes in the path as per API behavior
+	contentID = strings.ReplaceAll(contentID, "%2F", "%252F")
+
+	reqName := fmt.Sprintf("%s/content/%s", req.GetParent(), contentID)
+
+	name, err := s.parseContentName(reqName)
+	if err != nil {
+		// This parsing should ideally succeed if parent parsing and contentID construction are correct.
+		return nil, status.Errorf(codes.Internal, "failed to parse constructed content name %q: %v", reqName, err)
+	}
+
+	fqn := name.String()
+	now := time.Now()
+
+	obj := proto.Clone(req.GetContent()).(*pb.Content)
+	obj.Name = fqn
+	obj.Uid = uuid.NewString()
+	obj.CreateTime = timestamppb.New(now)
+	obj.UpdateTime = timestamppb.New(now)
+
+	s.populateDefaultsForContent(obj)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+	// Clear data_text for non-GET requests as per API behavior
+	obj.Data = nil // Clear the data oneof
+
+	return obj, nil
+}
+
+func (s *ContentService) populateDefaultsForContent(obj *pb.Content) {
+	// No specific defaults mentioned, but ensure oneof fields are valid if needed
+	switch obj.Content.(type) {
+	case *pb.Content_SqlScript:
+		if obj.GetSqlScript().GetEngine() == pb.Content_SqlScript_QUERY_ENGINE_UNSPECIFIED {
+			// Default engine? Let's assume Spark if not specified.
+			// obj.GetSqlScript().Engine = pb.Content_SqlScript_SPARK
+		}
+	case *pb.Content_Notebook:
+		if obj.GetNotebook().GetKernelType() == pb.Content_Notebook_KERNEL_TYPE_UNSPECIFIED {
+			// Default kernel? Let's assume PYTHON3 if not specified.
+			// obj.GetNotebook().KernelType = pb.Content_Notebook_PYTHON3
+		}
+	}
+}
+
+func (s *ContentService) UpdateContent(ctx context.Context, req *pb.UpdateContentRequest) (*pb.Content, error) {
+	name, err := s.parseContentName(req.GetContent().GetName())
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	existing := &pb.Content{}
+	if err := s.storage.Get(ctx, fqn, existing); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	updated := proto.Clone(existing).(*pb.Content)
+	updated.UpdateTime = timestamppb.New(now)
+
+	// Per API documentation: Only supports full resource update.
+	// However, typically `update_mask` is used. Let's follow the mask if provided.
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		// If no mask, assume full update of mutable fields based on documentation
+		updated.Labels = req.GetContent().GetLabels()
+		updated.Description = req.GetContent().GetDescription()
+		updated.Data = req.GetContent().GetData()       // Update the data oneof
+		updated.Content = req.GetContent().GetContent() // Update the content oneof
+	} else {
+		// Apply partial updates based on the mask
+		// TODO: Use a fieldmask helper if available
+		for _, path := range paths {
+			switch path {
+			case "labels":
+				updated.Labels = req.GetContent().GetLabels()
+			case "description":
+				updated.Description = req.GetContent().GetDescription()
+			case "data_text":
+				updated.Data = &pb.Content_DataText{DataText: req.GetContent().GetDataText()}
+			case "sql_script":
+				updated.Content = &pb.Content_SqlScript_{SqlScript: req.GetContent().GetSqlScript()}
+			case "notebook":
+				updated.Content = &pb.Content_Notebook_{Notebook: req.GetContent().GetNotebook()}
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid for Content", path)
+			}
+		}
+	}
+
+	s.populateDefaultsForContent(updated) // Re-apply defaults if necessary after update
+
+	if err := s.storage.Update(ctx, fqn, updated); err != nil {
+		return nil, err
+	}
+
+	// Clear data_text for non-GET requests as per API behavior
+	updated.Data = nil // Clear the data oneof
+
+	return updated, nil
+}
+
+func (s *ContentService) DeleteContent(ctx context.Context, req *pb.DeleteContentRequest) (*emptypb.Empty, error) {
+	name, err := s.parseContentName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.Content{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+func (s *ContentService) ListContent(ctx context.Context, req *pb.ListContentRequest) (*pb.ListContentResponse, error) {
+	parentName, err := s.parseLakeName(req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	parentFQNPrefix := parentName.String() + "/content/"
+
+	response := &pb.ListContentResponse{}
+
+	contentKind := (&pb.Content{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, contentKind, storage.ListOptions{}, func(obj proto.Message) error {
+		content := obj.(*pb.Content)
+		if strings.HasPrefix(content.GetName(), parentFQNPrefix) {
+			// Clear data_text for list requests as per API behavior
+			content.Data = nil
+			response.Content = append(response.Content, content)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement filtering if req.Filter is set
+	// TODO: Implement pagination
+
+	return response, nil
+}
+
+func (s *ContentService) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	// Mock implementation - return empty policy
+	return &iampb.Policy{}, nil
+}
+
+func (s *ContentService) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	// Mock implementation - return the policy passed in
+	return req.Policy, nil
+}
+
+func (s *ContentService) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	// Mock implementation - return all permissions passed in
+	return &iampb.TestIamPermissionsResponse{Permissions: req.Permissions}, nil
+}
+
+type contentName struct {
+	Project  *projects.ProjectData
+	Location string
+	Lake     string
+	// Content can contain slashes, representing a path.
+	ContentPath string
+}
+
+func (n *contentName) String() string {
+	// Use the URL-escaped and slash-encoded version for the final segment
+	escapedContentPath := url.PathEscape(n.ContentPath)
+	encodedContentPath := strings.ReplaceAll(escapedContentPath, "%2F", "%252F")
+	return fmt.Sprintf("projects/%s/locations/%s/lakes/%s/content/%s", n.Project.ID, n.Location, n.Lake, encodedContentPath)
+}
+
+// parseContentName parses a string into a contentName.
+// The expected form is `projects/*/locations/*/lakes/*/content/{content_path}`
+// or `projects/*/locations/*/lakes/*/contentitems/{content_path}`
+// where {content_path} can contain multiple segments separated by '/'.
+func (s *MockService) parseContentName(name string) (*contentName, error) {
+	pattern1Prefix := "projects/"
+	pattern1Suffix := "/content/"
+	pattern2Suffix := "/contentitems/"
+
+	var projectID, location, lake, contentPath string
+	var tokens []string
+
+	if strings.Contains(name, pattern1Suffix) {
+		parts := strings.SplitN(name, pattern1Suffix, 2)
+		prefixPart := parts[0]
+		contentPath = parts[1]
+		tokens = strings.Split(prefixPart, "/")
+		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" {
+			return nil, status.Errorf(codes.InvalidArgument, "name %q does not match pattern projects/*/locations/*/lakes/*/content/**", name)
+		}
+	} else if strings.Contains(name, pattern2Suffix) {
+		parts := strings.SplitN(name, pattern2Suffix, 2)
+		prefixPart := parts[0]
+		contentPath = parts[1]
+		tokens = strings.Split(prefixPart, "/")
+		if len(tokens) != 6 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "lakes" {
+			return nil, status.Errorf(codes.InvalidArgument, "name %q does not match pattern projects/*/locations/*/lakes/*/contentitems/**", name)
+		}
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "name %q does not contain /content/ or /contentitems/", name)
+	}
+
+	projectID = tokens[1]
+	location = tokens[3]
+	lake = tokens[5]
+
+	// URL-decode the content path, including the double-encoded slashes
+	decodedContentPath, err := url.PathUnescape(strings.ReplaceAll(contentPath, "%252F", "%2F"))
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid content path encoding in name %q: %v", name, err)
+	}
+
+	project, err := s.Projects.GetProjectByID(projectID)
+	if err != nil {
+		return nil, err // Or wrap with context
+	}
+
+	parsedName := &contentName{
+		Project:     project,
+		Location:    location,
+		Lake:        lake,
+		ContentPath: decodedContentPath,
+	}
+
+	return parsedName, nil
+}

--- a/pkg/controller/direct/dataplex/client.go
+++ b/pkg/controller/direct/dataplex/client.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +tool:controller-client
+// proto.service: google.cloud.dataplex.v1.ContentService
 // proto.service: google.cloud.dataplex.v1.DataplexService
 
 package dataplex
@@ -57,4 +58,28 @@ func (m *gcpClient) client(ctx context.Context) (*api.Client, error) {
 	}
 
 	return grpcClient, err
+}
+
+func (m *gcpClient) newContentClient(ctx context.Context) (*api.ContentClient, error) {
+	opts, err := m.config.RESTClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewContentRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building dataplex content client: %w", err)
+	}
+	return client, err
+}
+
+func (m *gcpClient) newDataplexClient(ctx context.Context) (*api.Client, error) {
+	opts, err := m.config.RESTClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building dataplex client: %w", err)
+	}
+	return client, err
 }

--- a/pkg/controller/direct/dataplex/client.go
+++ b/pkg/controller/direct/dataplex/client.go
@@ -61,25 +61,15 @@ func (m *gcpClient) client(ctx context.Context) (*api.Client, error) {
 }
 
 func (m *gcpClient) newContentClient(ctx context.Context) (*api.ContentClient, error) {
-	opts, err := m.config.RESTClientOptions()
+	opts, err := m.options()
 	if err != nil {
 		return nil, err
 	}
-	client, err := api.NewContentRESTClient(ctx, opts...)
+
+	grpcClient, err := api.NewContentClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("building dataplex content client: %w", err)
 	}
-	return client, err
-}
 
-func (m *gcpClient) newDataplexClient(ctx context.Context) (*api.Client, error) {
-	opts, err := m.config.RESTClientOptions()
-	if err != nil {
-		return nil, err
-	}
-	client, err := api.NewRESTClient(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("building dataplex client: %w", err)
-	}
-	return client, err
+	return grpcClient, err
 }

--- a/pkg/controller/direct/dataplex/content_mapper.go
+++ b/pkg/controller/direct/dataplex/content_mapper.go
@@ -20,11 +20,11 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
-func DataplexContentSpec_FromProto(mapCtx *direct.MapContext, in *pb.Content) *krm.Content {
+func DataplexContentSpec_FromProto(mapCtx *direct.MapContext, in *pb.Content) *krm.DataplexContentSpec {
 	if in == nil {
 		return nil
 	}
-	out := &krm.Content{}
+	out := &krm.DataplexContentSpec{}
 	// MISSING: Name
 	// MISSING: Uid
 	out.Path = direct.LazyPtr(in.GetPath())
@@ -37,7 +37,7 @@ func DataplexContentSpec_FromProto(mapCtx *direct.MapContext, in *pb.Content) *k
 	out.Notebook = Content_Notebook_FromProto(mapCtx, in.GetNotebook())
 	return out
 }
-func DataplexContentSpec_ToProto(mapCtx *direct.MapContext, in *krm.Content) *pb.Content {
+func DataplexContentSpec_ToProto(mapCtx *direct.MapContext, in *krm.DataplexContentSpec) *pb.Content {
 	if in == nil {
 		return nil
 	}
@@ -60,12 +60,11 @@ func DataplexContentSpec_ToProto(mapCtx *direct.MapContext, in *krm.Content) *pb
 	}
 	return out
 }
-func DataplexContentObservedState_FromProto(mapCtx *direct.MapContext, in *pb.Content) *krm.ContentObservedState {
+func DataplexContentObservedState_FromProto(mapCtx *direct.MapContext, in *pb.Content) *krm.DataplexContentObservedState {
 	if in == nil {
 		return nil
 	}
-	out := &krm.ContentObservedState{}
-	out.Name = direct.LazyPtr(in.GetName())
+	out := &krm.DataplexContentObservedState{}
 	out.Uid = direct.LazyPtr(in.GetUid())
 	// MISSING: Path
 	out.CreateTime = direct.StringTimestamp_FromProto(mapCtx, in.GetCreateTime())
@@ -77,12 +76,11 @@ func DataplexContentObservedState_FromProto(mapCtx *direct.MapContext, in *pb.Co
 	// MISSING: Notebook
 	return out
 }
-func DataplexContentObservedState_ToProto(mapCtx *direct.MapContext, in *krm.ContentObservedState) *pb.Content {
+func DataplexContentObservedState_ToProto(mapCtx *direct.MapContext, in *krm.DataplexContentObservedState) *pb.Content {
 	if in == nil {
 		return nil
 	}
 	out := &pb.Content{}
-	out.Name = direct.ValueOf(in.Name)
 	out.Uid = direct.ValueOf(in.Uid)
 	// MISSING: Path
 	out.CreateTime = direct.StringTimestamp_ToProto(mapCtx, in.CreateTime)

--- a/pkg/controller/direct/dataplex/dataplexcontent_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexcontent_controller.go
@@ -28,7 +28,6 @@ import (
 	gcp "cloud.google.com/go/dataplex/apiv1"
 	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/dataplex/v1alpha1"
-	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
@@ -173,7 +172,7 @@ func (a *contentAdapter) Update(ctx context.Context, updateOp *directbase.Update
 	resource.Name = a.id.String()
 
 	updateMask := &fieldmaskpb.FieldMask{}
-	if desired.Spec.DataText != nil && !reflect.DeepEqual(resource.DataText, a.actual.DataText) {
+	if desired.Spec.DataText != nil && !reflect.DeepEqual(resource.GetDataText(), a.actual.GetDataText()) {
 		updateMask.Paths = append(updateMask.Paths, "data_text")
 	}
 	if desired.Spec.Description != nil && !reflect.DeepEqual(resource.Description, a.actual.Description) {
@@ -185,7 +184,7 @@ func (a *contentAdapter) Update(ctx context.Context, updateOp *directbase.Update
 	if desired.Spec.Path != nil && !reflect.DeepEqual(resource.Path, a.actual.Path) {
 		updateMask.Paths = append(updateMask.Paths, "path")
 	}
-	if desired.Spec.SqlScript != nil && !reflect.DeepEqual(resource.GetSqlScript(), a.actual.GetSqlScript()) {
+	if desired.Spec.SQLScript != nil && !reflect.DeepEqual(resource.GetSqlScript(), a.actual.GetSqlScript()) {
 		updateMask.Paths = append(updateMask.Paths, "sql_script")
 	}
 	if desired.Spec.Notebook != nil && !reflect.DeepEqual(resource.GetNotebook(), a.actual.GetNotebook()) {
@@ -231,9 +230,7 @@ func (a *contentAdapter) Export(ctx context.Context) (*unstructured.Unstructured
 	if mapCtx.Err() != nil {
 		return nil, mapCtx.Err()
 	}
-	obj.Spec.ProjectRef = &refs.ProjectRef{External: a.id.ProjectID}
-	obj.Spec.Location = a.id.Location
-	obj.Spec.LakeRef = &refs.DataplexLakeRef{External: a.id.Lake}
+	obj.Spec.LakeRef = &krm.LakeRef{External: a.id.Parent()}
 	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/dataplex/dataplexcontent_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexcontent_controller.go
@@ -64,12 +64,14 @@ func (m *contentModel) AdapterForObject(ctx context.Context, reader client.Reade
 		return nil, err
 	}
 
-	// normalize reference fields
-	if obj.Spec.LakeRef != nil {
-		if _, err := obj.Spec.LakeRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
-			return nil, err
-		}
-	}
+	//// normalize reference fields
+	//if obj.Spec.LakeRef != nil {
+	//	external, err := obj.Spec.LakeRef.NormalizedExternal(ctx, reader, obj.GetNamespace())
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	obj.Spec.LakeRef.External = external
+	//}
 
 	// Get GCP client
 	gcpClient, err := newGCPClient(ctx, m.config)
@@ -132,14 +134,10 @@ func (a *contentAdapter) Create(ctx context.Context, createOp *directbase.Create
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
-
-	parent, err := desired.Spec.LakeRef.NormalizedExternal(ctx, a.reader, desired.GetNamespace())
-	if err != nil {
-		return fmt.Errorf("cannot resolve lakeRef: %w", err)
-	}
+	resource.Name = a.id.String()
 
 	req := &pb.CreateContentRequest{
-		Parent:  parent,
+		Parent:  a.id.Parent(),
 		Content: resource,
 	}
 	created, err := a.gcpClient.CreateContent(ctx, req)

--- a/pkg/controller/direct/dataplex/dataplexcontent_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexcontent_controller.go
@@ -1,0 +1,268 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:controller
+// proto.service: google.cloud.dataplex.v1.ContentService
+// proto.message: google.cloud.dataplex.v1.Content
+// crd.type: DataplexContent
+// crd.version: v1alpha1
+
+package dataplex
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	gcp "cloud.google.com/go/dataplex/apiv1"
+	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/dataplex/v1alpha1"
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	registry.RegisterModel(krm.DataplexContentGVK, NewContentModel)
+}
+
+func NewContentModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &contentModel{config: config}, nil
+}
+
+var _ directbase.Model = &contentModel{}
+
+type contentModel struct {
+	config *config.ControllerConfig
+}
+
+func (m *contentModel) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	obj := &krm.DataplexContent{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	id, err := krm.NewContentIdentity(ctx, reader, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// normalize reference fields
+	if obj.Spec.LakeRef != nil {
+		if _, err := obj.Spec.LakeRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
+			return nil, err
+		}
+	}
+
+	// Get GCP client
+	gcpClient, err := newGCPClient(ctx, m.config)
+	if err != nil {
+		return nil, fmt.Errorf("building gcp client: %w", err)
+	}
+	contentClient, err := gcpClient.newContentClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &contentAdapter{
+		gcpClient: contentClient,
+		id:        id,
+		desired:   obj,
+		reader:    reader,
+	}, nil
+}
+
+func (m *contentModel) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// TODO: Support URLs
+	return nil, nil
+}
+
+type contentAdapter struct {
+	gcpClient *gcp.ContentClient
+	id        *krm.ContentIdentity
+	desired   *krm.DataplexContent
+	actual    *pb.Content
+	reader    client.Reader
+}
+
+var _ directbase.Adapter = &contentAdapter{}
+
+func (a *contentAdapter) Find(ctx context.Context) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("getting dataplex content", "name", a.id)
+
+	req := &pb.GetContentRequest{Name: a.id.String()}
+	actual, err := a.gcpClient.GetContent(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting dataplex content %q from gcp: %w", a.id.String(), err)
+	}
+
+	a.actual = actual
+	return true, nil
+}
+
+func (a *contentAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating dataplex content", "name", a.id)
+
+	mapCtx := &direct.MapContext{}
+	desired := a.desired.DeepCopy()
+
+	resource := DataplexContentSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+
+	parent, err := desired.Spec.LakeRef.NormalizedExternal(ctx, a.reader, desired.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("cannot resolve lakeRef: %w", err)
+	}
+
+	req := &pb.CreateContentRequest{
+		Parent:  parent,
+		Content: resource,
+	}
+	created, err := a.gcpClient.CreateContent(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating dataplex content %s: %w", a.id.String(), err)
+	}
+
+	log.V(2).Info("successfully created dataplex content in gcp", "name", a.id)
+
+	status := &krm.DataplexContentStatus{}
+	status.ObservedState = DataplexContentObservedState_FromProto(mapCtx, created)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	status.ExternalRef = direct.PtrTo(a.id.String())
+	return createOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *contentAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("updating dataplex content", "name", a.id)
+
+	mapCtx := &direct.MapContext{}
+
+	desired := a.desired.DeepCopy()
+	resource := DataplexContentSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	resource.Name = a.id.String()
+
+	updateMask := &fieldmaskpb.FieldMask{}
+	if desired.Spec.DataText != nil && !reflect.DeepEqual(resource.DataText, a.actual.DataText) {
+		updateMask.Paths = append(updateMask.Paths, "data_text")
+	}
+	if desired.Spec.Description != nil && !reflect.DeepEqual(resource.Description, a.actual.Description) {
+		updateMask.Paths = append(updateMask.Paths, "description")
+	}
+	if desired.Spec.Labels != nil && !reflect.DeepEqual(resource.Labels, a.actual.Labels) {
+		updateMask.Paths = append(updateMask.Paths, "labels")
+	}
+	if desired.Spec.Path != nil && !reflect.DeepEqual(resource.Path, a.actual.Path) {
+		updateMask.Paths = append(updateMask.Paths, "path")
+	}
+	if desired.Spec.SqlScript != nil && !reflect.DeepEqual(resource.GetSqlScript(), a.actual.GetSqlScript()) {
+		updateMask.Paths = append(updateMask.Paths, "sql_script")
+	}
+	if desired.Spec.Notebook != nil && !reflect.DeepEqual(resource.GetNotebook(), a.actual.GetNotebook()) {
+		updateMask.Paths = append(updateMask.Paths, "notebook")
+	}
+
+	var updated *pb.Content
+	if len(updateMask.Paths) == 0 {
+		log.V(2).Info("no field needs update", "name", a.id)
+		// even though there is no update, we still want to update KRM status
+		updated = a.actual
+	} else {
+		req := &pb.UpdateContentRequest{
+			UpdateMask: updateMask,
+			Content:    resource,
+		}
+		var err error
+		updated, err = a.gcpClient.UpdateContent(ctx, req)
+		if err != nil {
+			return fmt.Errorf("updating dataplex content %s: %w", a.id.String(), err)
+		}
+		log.V(2).Info("successfully updated dataplex content", "name", a.id)
+	}
+
+	status := &krm.DataplexContentStatus{}
+	status.ObservedState = DataplexContentObservedState_FromProto(mapCtx, updated)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	return updateOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *contentAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	log := klog.FromContext(ctx)
+
+	if a.actual == nil {
+		return nil, fmt.Errorf("Find() not called")
+	}
+
+	obj := &krm.DataplexContent{}
+	mapCtx := &direct.MapContext{}
+	obj.Spec = direct.ValueOf(DataplexContentSpec_FromProto(mapCtx, a.actual))
+	if mapCtx.Err() != nil {
+		return nil, mapCtx.Err()
+	}
+	obj.Spec.ProjectRef = &refs.ProjectRef{External: a.id.ProjectID}
+	obj.Spec.Location = a.id.Location
+	obj.Spec.LakeRef = &refs.DataplexLakeRef{External: a.id.Lake}
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &unstructured.Unstructured{Object: uObj}
+	u.SetName(a.id.ID()) // Use the path-like identifier as the KCC name
+	u.SetGroupVersionKind(krm.DataplexContentGVK)
+
+	log.Info("exported object", "obj", u, "gvk", u.GroupVersionKind())
+	return u, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *contentAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("deleting dataplex content", "name", a.id)
+
+	req := &pb.DeleteContentRequest{Name: a.id.String()}
+	err := a.gcpClient.DeleteContent(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			// Return success if not found (assume it was already deleted).
+			log.V(2).Info("skipping delete for non-existent dataplex content, assuming it was already deleted", "name", a.id)
+			return true, nil
+		}
+		return false, fmt.Errorf("deleting dataplex content %s: %w", a.id.String(), err)
+	}
+	log.V(2).Info("successfully deleted dataplex content", "name", a.id)
+
+	return true, nil
+}

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/_generated_object_dataplexcontent-minimal.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/_generated_object_dataplexcontent-minimal.golden.yaml
@@ -1,0 +1,30 @@
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexContent
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: dataplexcontent-minimal-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  dataText: test-datetext2
+  description: Updated description
+  lakeRef:
+    name: dataplexlake-${uniqueId}
+  path: test-content2
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    createTime: "1970-01-01T00:00:00Z"
+    uid: 0123456789abcdef
+    updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/_http.log
@@ -1,0 +1,303 @@
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+error: rpc error: code = NotFound desc = Resource 'projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}' was not found
+
+{}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/CreateLake
+
+{
+  "lake": {
+    "description": "Initial description"
+  },
+  "lakeId": "dataplexlake-${uniqueId}",
+  "parent": "projects/${projectId}/locations/us-central1"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.Lake",
+    "assetStatus": {},
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Initial description",
+    "metastore": {},
+    "metastoreStatus": {
+      "state": "NONE",
+      "updateTime": "2024-04-01T12:34:56.123456Z"
+    },
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/GetContent
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}"
+}
+
+error: rpc error: code = NotFound desc = content "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}" not found
+
+{}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/CreateContent
+
+{
+  "content": {
+    "dataText": "test-datetext",
+    "description": "Initial description",
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+    "path": "test-content"
+  },
+  "parent": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+  "path": "test-content",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/GetContent
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+  "path": "test-content",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/UpdateContent
+
+{
+  "content": {
+    "dataText": "test-datetext2",
+    "description": "Updated description",
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+    "path": "test-content2"
+  },
+  "updateMask": "dataText,description,path"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+  "path": "test-content2",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/GetContent
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+  "path": "test-content2",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/GetContent
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}",
+  "path": "test-content2",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.ContentService/DeleteContent
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/content/dataplexcontent-minimal-${uniqueId}"
+}
+
+OK
+
+{}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "assetStatus": {
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "metastore": {},
+  "metastoreStatus": {
+    "state": "NONE",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+  "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "assetStatus": {
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "metastore": {},
+  "metastoreStatus": {
+    "state": "NONE",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+  "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/DeleteLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
@@ -17,11 +17,8 @@ kind: DataplexContent
 metadata:
   name: dataplexcontent-minimal-${uniqueId}
 spec:
-  projectRef:
-    external: ${projectId}
-  location: us-central1
   path: "test-content"
-  dataText: ""
+  dataText: "test-datetext"
   lakeRef:
     name: dataplexlake-${uniqueId}
   description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexContent
+metadata:
+  name: dataplexcontent-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/create.yaml
@@ -20,4 +20,8 @@ spec:
   projectRef:
     external: ${projectId}
   location: us-central1
+  path: "test-content"
+  dataText: ""
+  lakeRef:
+    name: dataplexlake-${uniqueId}
   description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/dependencies.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexLake
+metadata:
+  name: dataplexlake-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexContent
+metadata:
+  name: dataplexcontent-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Updated description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
@@ -20,4 +20,8 @@ spec:
   projectRef:
     external: ${projectId}
   location: us-central1
+  path: "test-content"
+  dataText: ""
+  lakeRef:
+    name: dataplexlake-${uniqueId}
   description: "Updated description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexcontent/dataplexcontent-minimal/update.yaml
@@ -17,11 +17,8 @@ kind: DataplexContent
 metadata:
   name: dataplexcontent-minimal-${uniqueId}
 spec:
-  projectRef:
-    external: ${projectId}
-  location: us-central1
-  path: "test-content"
-  dataText: ""
+  path: "test-content2"
+  dataText: "test-datetext2"
   lakeRef:
     name: dataplexlake-${uniqueId}
   description: "Updated description"


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
I'm currently not able to test controller against realGCP, both gcloud and REST request fail:

Status code: 400. Explore is deprecated and it is available only to allowlisted projects. Project xxx is not allowlisted to call Explore Content APIs.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
