### PR TITLE
MockGCP&Controller: Resource dataplex environment

### DIFF
--- a/apis/dataplex/v1alpha1/environment_identity.go
+++ b/apis/dataplex/v1alpha1/environment_identity.go
@@ -38,6 +38,10 @@ func (i *EnvironmentIdentity) ID() string {
 	return i.id
 }
 
+func (i *EnvironmentIdentity) Parent() string {
+	return i.parent.String()
+}
+
 // New builds a EnvironmentIdentity from the Config Connector Environment object.
 func NewEnvironmentIdentity(ctx context.Context, reader client.Reader, obj *DataplexEnvironment) (*EnvironmentIdentity, error) {
 

--- a/apis/dataplex/v1alpha1/environment_identity.go
+++ b/apis/dataplex/v1alpha1/environment_identity.go
@@ -73,8 +73,11 @@ func NewEnvironmentIdentity(ctx context.Context, reader client.Reader, obj *Data
 		if err != nil {
 			return nil, err
 		}
-		if actualParent.parent != parent {
-			return nil, fmt.Errorf("parent changed, expect %s, got %s", actualParent.parent, parent)
+		if actualParent.parent.ProjectID != parent.ProjectID {
+			return nil, fmt.Errorf("parent ProjectID changed, expect %s, got %s", actualParent.parent.ProjectID, parent.ProjectID)
+		}
+		if actualParent.parent.Location != parent.Location {
+			return nil, fmt.Errorf("parent location changed, expect %s, got %s", actualParent.parent.Location, parent.Location)
 		}
 		if actualParent.id != lakeId {
 			return nil, fmt.Errorf("spec.lakeRef changed, expect %s, got %s", actualParent.id, lakeId)

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -848,6 +848,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "datastream.cnrm.cloud.google.com", Kind: "DatastreamPrivateConnection"}:
 
 			case schema.GroupKind{Group: "dataplex.cnrm.cloud.google.com", Kind: "DataplexLake"}:
+			case schema.GroupKind{Group: "dataplex.cnrm.cloud.google.com", Kind: "DataplexEnvironment"}:
 
 			case schema.GroupKind{Group: "discoveryengine.cnrm.cloud.google.com", Kind: "DiscoveryEngineDataStore"}:
 

--- a/mockgcp/mockdataplex/environment.go
+++ b/mockgcp/mockdataplex/environment.go
@@ -1,0 +1,269 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.dataplex.v1.DataplexService
+// proto.message: google.cloud.dataplex.v1.Environment
+
+package mockdataplex
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/dataplex/v1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+	"github.com/google/uuid"
+	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+)
+
+func (s *DataplexV1) GetEnvironment(ctx context.Context, req *pb.GetEnvironmentRequest) (*pb.Environment, error) {
+	name, err := s.parseEnvironmentName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.Environment{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%s' was not found", fqn)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *DataplexV1) CreateEnvironment(ctx context.Context, req *pb.CreateEnvironmentRequest) (*longrunningpb.Operation, error) {
+	reqName := fmt.Sprintf("%s/environments/%s", req.GetParent(), req.GetEnvironmentId())
+	name, err := s.parseEnvironmentName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	now := time.Now()
+
+	obj := proto.Clone(req.GetEnvironment()).(*pb.Environment)
+	obj.Name = fqn
+	obj.Uid = uuid.NewString()
+	obj.CreateTime = timestamppb.New(now)
+	obj.UpdateTime = timestamppb.New(now)
+	obj.State = pb.State_ACTIVE
+	s.populateEnvironmentDefaults(obj)
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	metadata := &pb.OperationMetadata{
+		CreateTime: timestamppb.New(now),
+		Target:     fqn,
+		Verb:       "create",
+		ApiVersion: "v1",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return obj, nil
+	})
+}
+
+func (s *DataplexV1) UpdateEnvironment(ctx context.Context, req *pb.UpdateEnvironmentRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseEnvironmentName(req.GetEnvironment().GetName())
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	obj := &pb.Environment{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "update_mask must be provided")
+	}
+
+	// Only care about fields we support for update.
+	for _, path := range paths {
+		switch path {
+		case "description":
+			obj.Description = req.GetEnvironment().GetDescription()
+		case "display_name":
+			obj.DisplayName = req.GetEnvironment().GetDisplayName()
+		case "labels":
+			obj.Labels = req.GetEnvironment().GetLabels()
+		case "infrastructure_spec":
+			obj.InfrastructureSpec = req.GetEnvironment().GetInfrastructureSpec()
+		case "session_spec":
+			obj.SessionSpec = req.GetEnvironment().GetSessionSpec()
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
+		}
+	}
+
+	obj.UpdateTime = timestamppb.New(now)
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	metadata := &pb.OperationMetadata{
+		CreateTime: timestamppb.New(now),
+		Target:     fqn,
+		Verb:       "update",
+		ApiVersion: "v1",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return obj, nil
+	})
+}
+
+func (s *DataplexV1) DeleteEnvironment(ctx context.Context, req *pb.DeleteEnvironmentRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseEnvironmentName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.Environment{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	now := time.Now()
+	metadata := &pb.OperationMetadata{
+		CreateTime: timestamppb.New(now),
+		Target:     fqn,
+		Verb:       "delete",
+		ApiVersion: "v1",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.New(now)
+		return &emptypb.Empty{}, nil
+	})
+}
+
+func (s *DataplexV1) ListEnvironments(ctx context.Context, req *pb.ListEnvironmentsRequest) (*pb.ListEnvironmentsResponse, error) {
+	parent, err := s.parseLakeName(req.Parent)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &pb.ListEnvironmentsResponse{}
+
+	environmentKind := (&pb.Environment{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, environmentKind, storage.ListOptions{}, func(obj proto.Message) error {
+		env := obj.(*pb.Environment)
+		if strings.HasPrefix(env.GetName(), parent.String()+"/environments/") {
+			response.Environments = append(response.Environments, env)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *DataplexV1) populateEnvironmentDefaults(obj *pb.Environment) {
+	if obj.SessionSpec == nil {
+		obj.SessionSpec = &pb.Environment_SessionSpec{}
+	}
+	if obj.SessionSpec.MaxIdleDuration == nil {
+		obj.SessionSpec.MaxIdleDuration = durationpb.New(3 * time.Hour) // 10800s
+	}
+	if obj.SessionStatus == nil {
+		obj.SessionStatus = &pb.Environment_SessionStatus{Active: true}
+	}
+	if obj.InfrastructureSpec == nil {
+		obj.InfrastructureSpec = &pb.Environment_InfrastructureSpec{}
+	}
+	if obj.InfrastructureSpec.GetOsImage() == nil {
+		obj.InfrastructureSpec.Runtime = &pb.Environment_InfrastructureSpec_OsImage{
+			OsImage: &pb.Environment_InfrastructureSpec_OsImageRuntime{
+				ImageVersion: "1.0.0", // Default if not provided?
+			},
+		}
+	}
+	if obj.InfrastructureSpec.GetCompute() == nil {
+		obj.InfrastructureSpec.Resources = &pb.Environment_InfrastructureSpec_Compute{
+			Compute: &pb.Environment_InfrastructureSpec_ComputeResources{
+				DiskSizeGb: 100, // Default disk size
+			},
+		}
+	}
+	if obj.Endpoints == nil {
+		obj.Endpoints = &pb.Environment_Endpoints{
+			Notebooks: fmt.Sprintf("https://notebooks.dataplex.goog/%s", obj.Name), // Example format
+			Sql:       fmt.Sprintf("https://sql.dataplex.goog/%s", obj.Name),       // Example format
+		}
+	}
+}
+
+type environmentName struct {
+	Project       *projects.ProjectData
+	Location      string
+	LakeID        string
+	EnvironmentID string
+}
+
+func (n *environmentName) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s/lakes/%s/environments/%s", n.Project.ID, n.Location, n.LakeID, n.EnvironmentID)
+}
+
+// parseEnvironmentName parses a string into an environmentName.
+// The expected form is `projects/*/locations/*/lakes/*/environments/*`.
+func (s *MockService) parseEnvironmentName(name string) (*environmentName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "lakes" && tokens[6] == "environments" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &environmentName{
+			Project:       project,
+			Location:      tokens[3],
+			LakeID:        tokens[5],
+			EnvironmentID: tokens[7],
+		}
+
+		return name, nil
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+}

--- a/mockgcp/mockdataplex/service.go
+++ b/mockgcp/mockdataplex/service.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	grpcpb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/google/cloud/dataplex/v1"
+	grpcpb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/dataplex/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 
 	// Note: we use the "real" proto (not mockgcp), because the client uses GRPC.
@@ -70,4 +70,9 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 	}
 
 	return mux, nil
+}
+
+type DataplexV1 struct {
+	*MockService
+	pb.UnimplementedDataplexServiceServer
 }

--- a/mockgcp/mockdataplex/service.go
+++ b/mockgcp/mockdataplex/service.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/httpmux"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/operations"
-	grpcpb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/dataplex/v1"
+	grpcpb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/google/cloud/dataplex/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
 
 	// Note: we use the "real" proto (not mockgcp), because the client uses GRPC.
@@ -70,9 +70,4 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 	}
 
 	return mux, nil
-}
-
-type DataplexV1 struct {
-	*MockService
-	pb.UnimplementedDataplexServiceServer
 }

--- a/pkg/controller/direct/dataplex/client.go
+++ b/pkg/controller/direct/dataplex/client.go
@@ -22,15 +22,15 @@ import (
 	"fmt"
 
 	api "cloud.google.com/go/dataplex/apiv1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	kcc_config "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"google.golang.org/api/option"
 )
 
 type gcpClient struct {
-	config config.ControllerConfig
+	config kcc_config.ControllerConfig
 }
 
-func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, config *kcc_config.ControllerConfig) (*gcpClient, error) {
 	gcpClient := &gcpClient{
 		config: *config,
 	}
@@ -38,6 +38,7 @@ func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpCli
 }
 
 func (m *gcpClient) options() ([]option.ClientOption, error) {
+	// Dataplex uses gRPC, so get GRPC options
 	opts, err := m.config.GRPCClientOptions()
 	if err != nil {
 		return nil, err

--- a/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
@@ -177,7 +177,7 @@ func (a *environmentAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if desired.Spec.Labels != nil && !reflect.DeepEqual(environment.Labels, a.actual.Labels) {
 		updateMask.Paths = append(updateMask.Paths, "labels")
 	}
-	if desired.Spec.InfrastructureSpec != nil && !reflect.DeepEqual(environment.InfrastructureSpec, a.actual.InfrastructureSpec) {
+	if desired.Spec.InfrastructureSpec != nil && !reflect.DeepEqual(environment.InfrastructureSpec.GetOsImage(), a.actual.InfrastructureSpec.GetOsImage()) {
 		updateMask.Paths = append(updateMask.Paths, "infrastructure_spec")
 	}
 	if desired.Spec.SessionSpec != nil && !reflect.DeepEqual(environment.SessionSpec, a.actual.SessionSpec) {

--- a/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
@@ -1,0 +1,267 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:controller
+// proto.service: google.cloud.dataplex.v1.DataplexService
+// proto.message: google.cloud.dataplex.v1.Environment
+// crd.type: DataplexEnvironment
+// crd.version: v1alpha1
+
+package dataplex
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	gcp "cloud.google.com/go/dataplex/apiv1"
+	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/dataplex/v1alpha1"
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	registry.RegisterModel(krm.DataplexEnvironmentGVK, NewEnvironmentModel)
+}
+
+func NewEnvironmentModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &environmentModel{config: config}, nil
+}
+
+var _ directbase.Model = &environmentModel{}
+
+type environmentModel struct {
+	config *config.ControllerConfig
+}
+
+func (m *environmentModel) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	obj := &krm.DataplexEnvironment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	id, err := krm.NewEnvironmentIdentity(ctx, reader, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	environmentAdapter := &environmentAdapter{
+		id:      id,
+		desired: obj,
+		reader:  reader,
+	}
+
+	// Get GCP client
+	gcpClient, err := newGCPClient(ctx, m.config)
+	if err != nil {
+		return nil, fmt.Errorf("building gcp client: %w", err)
+	}
+	environmentClient, err := gcpClient.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	environmentAdapter.gcpClient = environmentClient
+
+	return environmentAdapter, nil
+}
+
+func (m *environmentModel) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// TODO: Support URLs
+	return nil, nil
+}
+
+type environmentAdapter struct {
+	gcpClient *gcp.Client
+	id        *krm.EnvironmentIdentity
+	desired   *krm.DataplexEnvironment
+	actual    *pb.Environment
+	reader    client.Reader
+}
+
+var _ directbase.Adapter = &environmentAdapter{}
+
+func (a *environmentAdapter) Find(ctx context.Context) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("getting dataplex environment", "name", a.id)
+
+	req := &pb.GetEnvironmentRequest{Name: a.id.String()}
+	actual, err := a.gcpClient.GetEnvironment(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting dataplex environment %q: %w", a.id, err)
+	}
+
+	a.actual = actual
+	return true, nil
+}
+
+func (a *environmentAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating dataplex environment", "name", a.id)
+
+	mapCtx := &direct.MapContext{}
+	desired := a.desired.DeepCopy()
+
+	environment := DataplexEnvironmentSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+
+	req := &pb.CreateEnvironmentRequest{
+		Parent:        a.id.Parent().String(),
+		Environment:   environment,
+		EnvironmentId: a.id.ID(),
+	}
+	op, err := a.gcpClient.CreateEnvironment(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating dataplex environment %s: %w", a.id.String(), err)
+	}
+
+	created, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting create dataplex environment %s failed: %w", a.id, err)
+	}
+
+	log.V(2).Info("successfully created dataplex environment in gcp", "name", a.id)
+
+	status := &krm.DataplexEnvironmentStatus{}
+	status.ObservedState = DataplexEnvironmentObservedState_FromProto(mapCtx, created)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	status.ExternalRef = direct.PtrTo(a.id.String())
+	return createOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *environmentAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("updating dataplex environment", "name", a.id)
+
+	mapCtx := &direct.MapContext{}
+
+	desired := a.desired.DeepCopy()
+	environment := DataplexEnvironmentSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	environment.Name = a.id.String()
+
+	updateMask := &fieldmaskpb.FieldMask{}
+	if desired.Spec.DisplayName != nil && !reflect.DeepEqual(environment.DisplayName, a.actual.DisplayName) {
+		updateMask.Paths = append(updateMask.Paths, "display_name")
+	}
+	if desired.Spec.Description != nil && !reflect.DeepEqual(environment.Description, a.actual.Description) {
+		updateMask.Paths = append(updateMask.Paths, "description")
+	}
+	if desired.Spec.Labels != nil && !reflect.DeepEqual(environment.Labels, a.actual.Labels) {
+		updateMask.Paths = append(updateMask.Paths, "labels")
+	}
+	if desired.Spec.InfrastructureSpec != nil && !reflect.DeepEqual(environment.InfrastructureSpec, a.actual.InfrastructureSpec) {
+		updateMask.Paths = append(updateMask.Paths, "infrastructure_spec")
+	}
+	if desired.Spec.SessionSpec != nil && !reflect.DeepEqual(environment.SessionSpec, a.actual.SessionSpec) {
+		updateMask.Paths = append(updateMask.Paths, "session_spec")
+	}
+
+	var updated *pb.Environment
+	if len(updateMask.Paths) == 0 {
+		log.V(2).Info("no field needs update", "name", a.id)
+		updated = a.actual
+	} else {
+		req := &pb.UpdateEnvironmentRequest{
+			UpdateMask:  updateMask,
+			Environment: environment,
+		}
+		op, err := a.gcpClient.UpdateEnvironment(ctx, req)
+		if err != nil {
+			return fmt.Errorf("updating dataplex environment %s: %w", a.id.String(), err)
+		}
+		updated, err = op.Wait(ctx)
+		if err != nil {
+			return fmt.Errorf("waiting for update of dataplex environment %s: %w", a.id.String(), err)
+		}
+		log.V(2).Info("successfully updated dataplex environment", "name", a.id)
+	}
+
+	status := &krm.DataplexEnvironmentStatus{}
+	status.ObservedState = DataplexEnvironmentObservedState_FromProto(mapCtx, updated)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	return updateOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *environmentAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	log := klog.FromContext(ctx)
+
+	if a.actual == nil {
+		return nil, fmt.Errorf("Find() not called")
+	}
+
+	obj := &krm.DataplexEnvironment{}
+	mapCtx := &direct.MapContext{}
+	obj.Spec = direct.ValueOf(DataplexEnvironmentSpec_FromProto(mapCtx, a.actual))
+	if mapCtx.Err() != nil {
+		return nil, mapCtx.Err()
+	}
+	obj.Spec.ProjectRef = &refs.ProjectRef{External: a.id.Parent().Parent().ProjectID}
+	obj.Spec.Location = a.id.Parent().Parent().Location
+	obj.Spec.LakeRef = &refs.DataplexLakeRef{External: a.id.Parent().String()}
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &unstructured.Unstructured{Object: uObj}
+	u.SetName(a.id.ID())
+	u.SetGroupVersionKind(krm.DataplexEnvironmentGVK)
+
+	log.Info("exported object", "obj", u, "gvk", u.GroupVersionKind())
+	return u, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *environmentAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("deleting dataplex environment", "name", a.id)
+
+	req := &pb.DeleteEnvironmentRequest{Name: a.id.String()}
+	op, err := a.gcpClient.DeleteEnvironment(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			// Return success if not found (assume it was already deleted).
+			log.V(2).Info("skipping delete for non-existent dataplex environment, assuming it was already deleted", "name", a.id)
+			return true, nil
+		}
+		return false, fmt.Errorf("deleting dataplex environment %s: %w", a.id.String(), err)
+	}
+	log.V(2).Info("successfully deleted dataplex environment", "name", a.id)
+
+	err = op.Wait(ctx)
+	if err != nil {
+		return false, fmt.Errorf("waiting for deletion of dataplex environment %s: %w", a.id.String(), err)
+	}
+	return true, nil
+}

--- a/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
+++ b/pkg/controller/direct/dataplex/dataplexenvironment_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 	gcp "cloud.google.com/go/dataplex/apiv1"
 	pb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/dataplex/v1alpha1"
-	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
@@ -130,7 +129,7 @@ func (a *environmentAdapter) Create(ctx context.Context, createOp *directbase.Cr
 	}
 
 	req := &pb.CreateEnvironmentRequest{
-		Parent:        a.id.Parent().String(),
+		Parent:        a.id.Parent(),
 		Environment:   environment,
 		EnvironmentId: a.id.ID(),
 	}
@@ -226,9 +225,7 @@ func (a *environmentAdapter) Export(ctx context.Context) (*unstructured.Unstruct
 	if mapCtx.Err() != nil {
 		return nil, mapCtx.Err()
 	}
-	obj.Spec.ProjectRef = &refs.ProjectRef{External: a.id.Parent().Parent().ProjectID}
-	obj.Spec.Location = a.id.Parent().Parent().Location
-	obj.Spec.LakeRef = &refs.DataplexLakeRef{External: a.id.Parent().String()}
+	obj.Spec.LakeRef = krm.LakeRef{External: a.id.Parent()}
 	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/_generated_object_dataplexenvironment-minimal.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/_generated_object_dataplexenvironment-minimal.golden.yaml
@@ -1,0 +1,32 @@
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexEnvironment
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: dataplexenvironment-minimal-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  description: Updated description
+  infrastructureSpec:
+    osImage:
+      imageVersion: "1.0"
+  lakeRef:
+    name: dataplexlake-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    createTime: "1970-01-01T00:00:00Z"
+    state: ACTIVE
+    uid: 0123456789abcdef
+    updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/_http.log
@@ -1,0 +1,437 @@
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+error: rpc error: code = NotFound desc = Resource 'projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}' was not found
+
+{}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/CreateLake
+
+{
+  "lake": {
+    "description": "Initial description"
+  },
+  "lakeId": "dataplexlake-${uniqueId}",
+  "parent": "projects/${projectId}/locations/us-central1"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.Lake",
+    "assetStatus": {},
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Initial description",
+    "metastore": {},
+    "metastoreStatus": {
+      "state": "NONE",
+      "updateTime": "2024-04-01T12:34:56.123456Z"
+    },
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetEnvironment
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+}
+
+error: rpc error: code = NotFound desc = Resource 'projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}' was not found
+
+{}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/CreateEnvironment
+
+{
+  "environment": {
+    "description": "Initial description",
+    "infrastructureSpec": {
+      "osImage": {
+        "imageVersion": "1.0"
+      }
+    }
+  },
+  "environmentId": "dataplexenvironment-minimal-${uniqueId}",
+  "parent": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.Environment",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Initial description",
+    "infrastructureSpec": {
+      "osImage": {
+        "imageVersion": "1.0"
+      }
+    },
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetEnvironment
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "infrastructureSpec": {
+    "osImage": {
+      "imageVersion": "1.0"
+    }
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/UpdateEnvironment
+
+{
+  "environment": {
+    "description": "Updated description",
+    "infrastructureSpec": {
+      "osImage": {
+        "imageVersion": "1.0"
+      }
+    },
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+  },
+  "updateMask": "description,infrastructureSpec"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.Environment",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Updated description",
+    "infrastructureSpec": {
+      "osImage": {
+        "imageVersion": "1.0"
+      }
+    },
+    "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetEnvironment
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "infrastructureSpec": {
+    "osImage": {
+      "imageVersion": "1.0"
+    }
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetEnvironment
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "infrastructureSpec": {
+    "osImage": {
+      "imageVersion": "1.0"
+    }
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/DeleteEnvironment
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}/environments/dataplexenvironment-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "assetStatus": {
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "metastore": {},
+  "metastoreStatus": {
+    "state": "NONE",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+  "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/GetLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "assetStatus": {
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "metastore": {},
+  "metastoreStatus": {
+    "state": "NONE",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+  "serviceAccount": "service-${projectNumber}@gcp-sa-dataplex.iam.gserviceaccount.com",
+  "state": "ACTIVE",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GRPC /google.cloud.dataplex.v1.DataplexService/DeleteLake
+
+{
+  "name": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}"
+}
+
+OK
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GRPC /google.longrunning.Operations/GetOperation
+
+{
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+OK
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.dataplex.v1.OperationMetadata",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/lakes/dataplexlake-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
@@ -17,7 +17,10 @@ kind: DataplexEnvironment
 metadata:
   name: dataplexenvironment-minimal-${uniqueId}
 spec:
-  projectRef:
-    external: ${projectId}
-  location: us-central1
+  lakeRef:
+    name: dataplexlake-${uniqueId}
   description: "Initial description"
+  infrastructureSpec:
+    oSImage:
+      imageVersion: 1.0
+

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexEnvironment
+metadata:
+  name: dataplexenvironment-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/create.yaml
@@ -21,6 +21,6 @@ spec:
     name: dataplexlake-${uniqueId}
   description: "Initial description"
   infrastructureSpec:
-    oSImage:
-      imageVersion: 1.0
+    osImage:
+      imageVersion: "1.0"
 

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/dependencies.yaml
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
-kind: DataplexEnvironment
+kind: DataplexLake
 metadata:
-  name: dataplexenvironment-minimal-${uniqueId}
+  name: dataplexlake-${uniqueId}
 spec:
-  lakeRef:
-    name: dataplexlake-${uniqueId}
-  description: "Updated description"
-  infrastructureSpec:
-    oSImage:
-      imageVersion: 1.0
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/update.yaml
@@ -21,5 +21,5 @@ spec:
     name: dataplexlake-${uniqueId}
   description: "Updated description"
   infrastructureSpec:
-    oSImage:
-      imageVersion: 1.0
+    osImage:
+      imageVersion: "1.0"

--- a/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/dataplex/v1alpha1/dataplexenvironment/dataplexenvironment-minimal/update.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: dataplex.cnrm.cloud.google.com/v1alpha1
+kind: DataplexEnvironment
+metadata:
+  name: dataplexenvironment-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Updated description"


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

I'm currently not able to test controller against realGCP, both gcloud and REST request fail:

Status code: 400. Explore is deprecated and it is available only to allowlisted projects. Project xxx is not allowlisted to call Explore Content APIs.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
