### PR TITLE
Conductor: Improvements for Type and Mapper generation

### DIFF
--- a/experiments/conductor/cmd/runner/github_commands.go
+++ b/experiments/conductor/cmd/runner/github_commands.go
@@ -203,7 +203,7 @@ func makeReadyPR(ctx context.Context, opts *RunnerOptions, branch Branch, execRe
 	// Run git push command with force flag
 	if opts.skipMakeReadyPR {
 		log.Printf("Skipping make ready-pr for branch %s (--skip-makereadypr flag is set)", branch.Name)
-		return nil, nil, nil
+		return []string{"."}, nil, nil
 	}
 
 	cfg := CommandConfig{
@@ -220,5 +220,5 @@ func makeReadyPR(ctx context.Context, opts *RunnerOptions, branch Branch, execRe
 	if err != nil {
 		log.Printf("Make ready PR error for branch %s: %v", branch.Name, err)
 	}
-	return nil, &output, err
+	return []string{"."}, &output, err
 }


### PR DESCRIPTION
* Tweak prompts
* Refactor code to move repetitive code under prepareCodebotPrompt (for crd steps)
* Add option to run subset of processors in multi-processor step like
  21. Rationale is to rerun processors that did not generate output.
  *  --processors=p1,p2,....
* Fix bugs with repetititve steps:
  * for step 9 where it was running make ready-pr many times
  * everywhere where changes were not generated
