### PR TITLE
codebot: improvements to use gemini 2.5 model via gemini api

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codebot/tool_verify_code.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/tool_verify_code.go
@@ -100,8 +100,13 @@ func (t *VerifyCode) BuildFunctionDefinition() *llm.FunctionDefinition {
 Verifies the result of changes by trying to build, lint and vet the code.
 `,
 		Parameters: &llm.Schema{
-			Type:       llm.TypeObject,
-			Properties: map[string]*llm.Schema{},
+			Type: llm.TypeObject,
+			Properties: map[string]*llm.Schema{
+				"ignore_errors": {
+					Type:        llm.TypeBoolean,
+					Description: `Ignore errors from the build.`,
+				},
+			},
 		},
 	}
 	// TODO: Response?

--- a/dev/tools/controllerbuilder/pkg/llm/gemini.go
+++ b/dev/tools/controllerbuilder/pkg/llm/gemini.go
@@ -30,11 +30,15 @@ import (
 // BuildGeminiClient builds a client for the Gemini API.
 func BuildGeminiClient(ctx context.Context) (Client, error) {
 	var opts []option.ClientOption
-
 	if s := os.Getenv("GEMINI_API_KEY"); s != "" {
 		opts = append(opts, option.WithAPIKey(s))
 	}
 
+	model := os.Getenv("GEMINI_MODEL")
+	if model == "" {
+		model = "gemini-2.0-pro-exp-02-05"
+		// model = "gemini-2.5-pro-exp-03-25"
+	}
 	client, err := genai.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("building gemini client: %w", err)
@@ -42,7 +46,7 @@ func BuildGeminiClient(ctx context.Context) (Client, error) {
 
 	return &GeminiClient{
 		client: client,
-		model:  "gemini-2.0-pro-exp-02-05",
+		model:  model,
 	}, nil
 }
 
@@ -67,7 +71,7 @@ func (c *GeminiClient) StartChat(systemPrompt string) Chat {
 	model.SetTemperature(1)
 	model.SetTopK(40)
 	model.SetTopP(0.95)
-	model.SetMaxOutputTokens(8192)
+	model.SetMaxOutputTokens(65536)
 	model.ResponseMIMEType = "text/plain"
 
 	model.SystemInstruction = &genai.Content{


### PR DESCRIPTION
* add --llmclient=(vertexai*|gemini) option to select API endpoint.
* default is vertexai which is current behavior
* GEMINI 2.5 is only available in gemini api today
* add CODEBOT_LLM_CLIENT env to override --llmclient param
* add GEMINI_MODEL env to select gemini model to use
* gemini 2.5 requires tools to have schema pros. so adding a param to VerifyCode

