### PR TITLE
Conductor improvements and switch controllerbuilder to new default model

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt.go
@@ -165,7 +165,7 @@ func RunPrompt(ctx context.Context, o *PromptOptions) error {
 
 	model := os.Getenv("LLM_MODEL")
 	if model == "" {
-		model = "gemini-2.0-pro-exp-02-05"
+		model = "gemini-2.5-pro-exp-03-25"
 	}
 	log.Info("using model", "model", model)
 

--- a/dev/tools/controllerbuilder/pkg/llm/gemini.go
+++ b/dev/tools/controllerbuilder/pkg/llm/gemini.go
@@ -42,7 +42,7 @@ func BuildGeminiClient(ctx context.Context) (Client, error) {
 
 	return &GeminiClient{
 		client: client,
-		model:  "gemini-2.0-pro-exp-02-05",
+		model:  "gemini-2.5-pro-exp-03-25",
 	}, nil
 }
 

--- a/dev/tools/controllerbuilder/pkg/llm/vertexai.go
+++ b/dev/tools/controllerbuilder/pkg/llm/vertexai.go
@@ -74,7 +74,7 @@ func BuildVertexAIClient(ctx context.Context, options ...GCPOptions) (*VertexAIC
 	if err != nil {
 		return nil, fmt.Errorf("building vertexai client: %w", err)
 	}
-	model := "gemini-2.0-pro-exp-02-05"
+	model := "gemini-2.5-pro-exp-03-25"
 	return &VertexAIClient{
 		client: client,
 		model:  model,

--- a/experiments/conductor/cmd/runner/github_commands.go
+++ b/experiments/conductor/cmd/runner/github_commands.go
@@ -203,7 +203,7 @@ func makeReadyPR(ctx context.Context, opts *RunnerOptions, branch Branch, execRe
 	// Run git push command with force flag
 	if opts.skipMakeReadyPR {
 		log.Printf("Skipping make ready-pr for branch %s (--skip-makereadypr flag is set)", branch.Name)
-		return nil, nil, nil
+		return []string{"."}, nil, nil
 	}
 
 	cfg := CommandConfig{
@@ -220,5 +220,5 @@ func makeReadyPR(ctx context.Context, opts *RunnerOptions, branch Branch, execRe
 	if err != nil {
 		log.Printf("Make ready PR error for branch %s: %v", branch.Name, err)
 	}
-	return nil, &output, err
+	return []string{"."}, &output, err
 }


### PR DESCRIPTION
controllerbuilder: switch to new default model

Conductor: Improvements for Type and Mapper generation
* Tweak prompts
* Refactor code to move repetitive code under prepareCodebotPrompt (for
  crd steps)
* Add option to run subset of processors in multi-processor step like
  21. Rationale is to rerun processors that did not generate output.
  *  --processors=p1,p2,....
* Fix bugs with repetititve steps:
  * for step 9 where it was running make ready-pr many times
  * everywhere where changes were not generated

