### PR TITLE
fuzzgen: use examples from the same API group

### DIFF
--- a/dev/tools/controllerbuilder/pkg/toolbot/csv.go
+++ b/dev/tools/controllerbuilder/pkg/toolbot/csv.go
@@ -216,9 +216,8 @@ func (x *CSVExporter) pickExamples(input *DataPoint) []*DataPoint {
 		}
 		switch dataPoint.Type {
 		case "fuzz-gen":
-			// only include data points with "api.group" marker
-			if dataPoint.Input["api.group"] == "" {
-				continue
+			if dataPoint.Input["api.group"] == input.Input["api.group"] {
+				sameAPIGroupExamples = append(sameAPIGroupExamples, dataPoint)
 			}
 		case "mockgcp-support", "controller":
 			// collect examples with the same proto service (API group)


### PR DESCRIPTION
Now that we have many more fuzzers, we could prioritize selecting examples from the same API group whenever possible.
This also helps reduce the total number of examples sent to the LLM, avoid potentially exceeding the token limit.