### PR TITLE
doc: add BigQueryReservation resources to release note

### DIFF
--- a/docs/releasenotes/release-1.131.md
+++ b/docs/releasenotes/release-1.131.md
@@ -6,6 +6,8 @@
 
 ## New Alpha Resources (Direct Reconciler):
 
+* `BigQueryReservationReservation` (available in 1.130+)
+* `BigQueryReservationAssignment` (available in 1.130+)
 * `ComputeNetworkAttachment`
 * `ComputeNetworkEdgeSecurityService`
 * `DataplexEntryGroup`


### PR DESCRIPTION
Technically, they were released in version 1.130. However, I was told that updating a release document already published on GCP might not be easy.