### PR TITLE
[WIP] feat: add resource managedkafka consumergroup controller

### DIFF
--- a/apis/managedkafka/v1alpha1/consumergroup_identity.go
+++ b/apis/managedkafka/v1alpha1/consumergroup_identity.go
@@ -32,7 +32,7 @@ type ConsumerGroupIdentity struct {
 }
 
 func (i *ConsumerGroupIdentity) String() string {
-	return i.parent.String() + "/consumergroups/" + i.id
+	return i.parent.String() + "/consumerGroups/" + i.id
 }
 
 func (i *ConsumerGroupIdentity) ID() string {
@@ -111,8 +111,8 @@ func NewConsumerGroupIdentity(ctx context.Context, reader client.Reader, obj *Ma
 
 func ParseConsumerGroupExternal(external string) (parent *ConsumerGroupParent, resourceID string, err error) {
 	tokens := strings.Split(external, "/")
-	if len(tokens) != 8 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "clusters" || tokens[6] != "consumergroups" {
-		return nil, "", fmt.Errorf("format of ManagedKafkaConsumerGroup external=%q was not known (use projects/{{projectID}}/locations/{{location}}/clusters/{{cluster}}/consumergroups/{{consumergroupID}})", external)
+	if len(tokens) != 8 || tokens[0] != "projects" || tokens[2] != "locations" || tokens[4] != "clusters" || tokens[6] != "consumerGroups" {
+		return nil, "", fmt.Errorf("format of ManagedKafkaConsumerGroup external=%q was not known (use projects/{{projectID}}/locations/{{location}}/clusters/{{cluster}}/consumerGroups/{{consumergroupID}})", external)
 	}
 	parent = &ConsumerGroupParent{
 		ProjectID:   tokens[1],

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -881,6 +881,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 
 			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaCluster"}:
 			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaTopic"}:
+			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaConsumerGroup"}:
 
 			case schema.GroupKind{Group: "monitoring.cnrm.cloud.google.com", Kind: "MonitoringAlertPolicy"}:
 			case schema.GroupKind{Group: "monitoring.cnrm.cloud.google.com", Kind: "MonitoringDashboard"}:

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -881,7 +881,6 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 
 			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaCluster"}:
 			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaTopic"}:
-			case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaConsumerGroup"}:
 
 			case schema.GroupKind{Group: "monitoring.cnrm.cloud.google.com", Kind: "MonitoringAlertPolicy"}:
 			case schema.GroupKind{Group: "monitoring.cnrm.cloud.google.com", Kind: "MonitoringDashboard"}:

--- a/mockgcp/mockmanagedkafka/consumergroup.go
+++ b/mockgcp/mockmanagedkafka/consumergroup.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.managedkafka.v1.ManagedKafka
+// proto.message: google.cloud.managedkafka.v1.Cluster
+
+package mockmanagedkafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/managedkafka/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func (s *managedKafka) GetConsumerGroup(ctx context.Context, req *pb.GetConsumerGroupRequest) (*pb.ConsumerGroup, error) {
+	name, err := s.parseConsumerGroupName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.ConsumerGroup{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%v' was not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *managedKafka) UpdateConsumerGroup(ctx context.Context, req *pb.UpdateConsumerGroupRequest) (*pb.ConsumerGroup, error) {
+	name, err := s.parseConsumerGroupName(req.GetConsumerGroup().GetName())
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+	obj := &pb.ConsumerGroup{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "update_mask must be provided")
+	}
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *managedKafka) DeleteConsumerGroup(ctx context.Context, req *pb.DeleteConsumerGroupRequest) (*emptypb.Empty, error) {
+	name, err := s.parseConsumerGroupName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.ConsumerGroup{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+	return &emptypb.Empty{}, nil
+}
+
+type ConsumerGroupName struct {
+	Project       *projects.ProjectData
+	Location      string
+	Cluster       string
+	ConsumerGroup string
+}
+
+func (n *ConsumerGroupName) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s/clusters/%s/consumerGroups/%s", n.Project.ID, n.Location, n.Cluster, n.ConsumerGroup)
+}
+
+func (s *MockService) parseConsumerGroupName(name string) (*ConsumerGroupName, error) {
+	tokens := strings.Split(name, "/")
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "clusters" && tokens[6] == "consumerGroups" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		return &ConsumerGroupName{
+			Project:       project,
+			Location:      tokens[3],
+			Cluster:       tokens[5],
+			ConsumerGroup: tokens[7],
+		}, nil
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument, "invalid consumer group name %q", name)
+}

--- a/pkg/controller/direct/managedkafka/consumergroup_controller.go
+++ b/pkg/controller/direct/managedkafka/consumergroup_controller.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedkafka
+
+import (
+	"context"
+	"fmt"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/managedkafka/v1alpha1"
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+
+	gcp "cloud.google.com/go/managedkafka/apiv1"
+	managedkafkapb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	registry.RegisterModel(krm.ManagedKafkaConsumerGroupGVK, NewConsumerGroupModel)
+}
+
+func NewConsumerGroupModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &modelConsumerGroup{config: *config}, nil
+}
+
+var _ directbase.Model = &modelConsumerGroup{}
+
+type modelConsumerGroup struct {
+	config config.ControllerConfig
+}
+
+func (m *modelConsumerGroup) client(ctx context.Context) (*gcp.Client, error) {
+	var opts []option.ClientOption
+	opts, err := m.config.RESTClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	gcpClient, err := gcp.NewRESTClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building ConsumerGroup client: %w", err)
+	}
+	return gcpClient, err
+}
+
+func (m *modelConsumerGroup) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	obj := &krm.ManagedKafkaConsumerGroup{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	id, err := krm.NewConsumerGroupIdentity(ctx, reader, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get managedkafka GCP client
+	gcpClient, err := m.client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &ConsumerGroupAdapter{
+		id:        id,
+		gcpClient: gcpClient,
+		desired:   obj,
+	}, nil
+}
+
+func (m *modelConsumerGroup) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// TODO: Support URLs
+	return nil, nil
+}
+
+type ConsumerGroupAdapter struct {
+	id        *krm.ConsumerGroupIdentity
+	gcpClient *gcp.Client
+	desired   *krm.ManagedKafkaConsumerGroup
+	actual    *managedkafkapb.ConsumerGroup
+}
+
+var _ directbase.Adapter = &ConsumerGroupAdapter{}
+
+// Find retrieves the GCP resource.
+// Return true means the object is found. This triggers Adapter `Update` call.
+// Return false means the object is not found. This triggers Adapter `Create` call.
+// Return a non-nil error requeues the requests.
+func (a *ConsumerGroupAdapter) Find(ctx context.Context) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("getting ConsumerGroup", "name", a.id)
+
+	req := &managedkafkapb.GetConsumerGroupRequest{Name: a.id.String()}
+	consumergrouppb, err := a.gcpClient.GetConsumerGroup(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting ConsumerGroup %q: %w", a.id, err)
+	}
+
+	a.actual = consumergrouppb
+	return true, nil
+}
+
+// Create creates the resource in GCP based on `spec` and update the Config Connector object `status` based on the GCP response.
+func (a *ConsumerGroupAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating ConsumerGroup", "name", a.id)
+
+	status := &krm.ManagedKafkaConsumerGroupStatus{}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
+	return createOp.UpdateStatus(ctx, status, nil)
+}
+
+// Update updates the resource in GCP based on `spec` and update the Config Connector object `status` based on the GCP response.
+func (a *ConsumerGroupAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("updating ConsumerGroup", "name", a.id)
+	mapCtx := &direct.MapContext{}
+
+	desiredPb := ManagedKafkaConsumerGroupSpec_ToProto(mapCtx, &a.desired.DeepCopy().Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+
+	paths := make(sets.Set[string])
+	var err error
+	paths, err = common.CompareProtoMessage(desiredPb, a.actual, common.BasicDiff)
+	if err != nil {
+		return err
+	}
+	updated := a.actual
+	if len(paths) == 0 {
+		log.V(2).Info("no field needs update", "name", a.id)
+	} else {
+		log.V(2).Info("fields need update", "name", a.id, "paths", paths)
+		updateMask := &fieldmaskpb.FieldMask{
+			Paths: sets.List(paths),
+		}
+
+		// TODO(contributor): Complete the gcp "UPDATE" or "PATCH" request.
+		req := &managedkafkapb.UpdateConsumerGroupRequest{
+			UpdateMask:    updateMask,
+			ConsumerGroup: desiredPb,
+		}
+		updated, err = a.gcpClient.UpdateConsumerGroup(ctx, req)
+		if err != nil {
+			return fmt.Errorf("updating ConsumerGroup %s: %w", a.id, err)
+		}
+		log.V(2).Info("successfully updated ConsumerGroup", "name", a.id)
+	}
+
+	status := &krm.ManagedKafkaConsumerGroupStatus{}
+	status.ObservedState = ManagedKafkaConsumerGroupObservedState_FromProto(mapCtx, updated)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	return updateOp.UpdateStatus(ctx, status, nil)
+}
+
+// Export maps the GCP object to a Config Connector resource `spec`.
+func (a *ConsumerGroupAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	if a.actual == nil {
+		return nil, fmt.Errorf("Find() not called")
+	}
+	u := &unstructured.Unstructured{}
+
+	obj := &krm.ManagedKafkaConsumerGroup{}
+	mapCtx := &direct.MapContext{}
+	obj.Spec = direct.ValueOf(ManagedKafkaConsumerGroupSpec_FromProto(mapCtx, a.actual))
+	if mapCtx.Err() != nil {
+		return nil, mapCtx.Err()
+	}
+	obj.Spec.ProjectRef = &refs.ProjectRef{External: a.id.Parent().ProjectID}
+	obj.Spec.Location = a.id.Parent().Location
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u.SetName(a.id.ID())
+	u.SetGroupVersionKind(krm.ManagedKafkaConsumerGroupGVK)
+
+	u.Object = uObj
+	return u, nil
+}
+
+// Delete the resource from GCP service when the corresponding Config Connector resource is deleted.
+func (a *ConsumerGroupAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("deleting ConsumerGroup", "name", a.id)
+
+	req := &managedkafkapb.DeleteConsumerGroupRequest{Name: a.id.String()}
+	err := a.gcpClient.DeleteConsumerGroup(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			// Return success if not found (assume it was already deleted).
+			log.V(2).Info("skipping delete for non-existent ConsumerGroup, assuming it was already deleted", "name", a.id)
+			return true, nil
+		}
+		return false, fmt.Errorf("deleting ConsumerGroup %s: %w", a.id, err)
+	}
+	log.V(2).Info("successfully deleted ConsumerGroup", "name", a.id)
+	return true, nil
+}

--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/create.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: managedkafka.cnrm.cloud.google.com/v1alpha1
+kind: ManagedKafkaConsumerGroup
+metadata:
+  name: managedkafkaconsumergroup-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  clusterRef:
+    name: managedkafkacluster-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/dependencies.yaml
@@ -1,0 +1,64 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: computenetwork-${uniqueId}
+spec:
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: computesubnetwork-${uniqueId}
+spec:
+  region: us-central1
+  networkRef:
+    name: computenetwork-${uniqueId}
+  ipCidrRange: 10.0.0.0/24
+---
+apiVersion: managedkafka.cnrm.cloud.google.com/v1beta1
+kind: ManagedKafkaCluster
+metadata:
+  name: managedkafkacluster-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  capacityConfig:
+    vcpuCount: 3
+    memoryBytes: 3221225472 # 3GB
+  gcpConfig:
+    accessConfig:
+      networkConfigs:
+      - subnetworkRef:
+          name: computesubnetwork-${uniqueId}
+  rebalanceConfig:
+    mode: NO_REBALANCE
+---
+apiVersion: managedkafka.cnrm.cloud.google.com/v1beta1
+kind: ManagedKafkaTopic
+metadata:
+  name: managedkafkatopic-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  clusterRef:
+    name: managedkafkacluster-${uniqueId}
+  partitionCount: 2
+  replicationFactor: 3
+  configs:
+    cleanup.policy: compact

--- a/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/managedkafka/v1alpha1/managedkafkaconsumergroup/managedkafkaconsumergroup-minimal/update.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: managedkafka.cnrm.cloud.google.com/v1alpha1
+kind: ManagedKafkaConsumerGroup
+metadata:
+  name: managedkafkaconsumergroup-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  clusterRef:
+    name: managedkafkacluster-${uniqueId}


### PR DESCRIPTION
This resource does not support CREATE. Follow this [guide](https://cloud.google.com/managed-service-for-apache-kafka/docs/quickstart#set_up_a_client_machine) to create this resource.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
