### PR TITLE
Revert "conductor: make conductor bot as author"

### DIFF
--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -214,12 +214,8 @@ func gitAdd(ctx context.Context, workDir string, files ...string) error {
 }
 
 func gitCommit(ctx context.Context, workDir string, msg string) error {
-	authorName := "kcc-conductor-bot"
-	authorEmail := "kcc-conductor-bot@google.com"
-	authorFlag := fmt.Sprintf("%s <%s>", authorName, authorEmail)
-
-	log.Printf("COMMAND: git commit -m %q --author=%q", msg, authorFlag)
-	gitcommit := exec.CommandContext(ctx, "git", "commit", "-m", msg, "--author", authorFlag)
+	log.Printf("COMMAND: git commit -m %q", msg)
+	gitcommit := exec.CommandContext(ctx, "git", "commit", "-m", msg)
 	gitcommit.Dir = workDir
 
 	results, err := execCommand(gitcommit)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-config-connector#4209

Will add it back when the bot is allowlisted for "SignCLA".

Initially, I wasn't sure if it was necessary, since developers will open the PRs and the commits will be authored by the bot but committed by the developers. However, it appears we can't bypass the CLA check for the bot.