### PR TITLE
ci: Split presubmit fixtures test into more API groups

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -172,7 +172,44 @@ jobs:
         with:
           name: artifacts-tests-e2e-fixtures-bigquery
           path: /tmp/artifacts/
+          
+  tests-e2e-fixtures-bigtable:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-bigtable"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-bigtable
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-bigtable
+          path: /tmp/artifacts/
 
+  tests-e2e-fixtures-certificatemanager:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-certificatemanager"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-certificatemanager
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-certificatemanager
+          path: /tmp/artifacts/
 
   tests-e2e-fixtures-compute:
     runs-on: ubuntu-latest
@@ -233,6 +270,24 @@ jobs:
           name: artifacts-tests-e2e-fixtures-monitoring
           path: /tmp/artifacts/
 
+  tests-e2e-fixtures-resourcemanager:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-resourcemanager"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-resourcemanager
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-resourcemanager
+          path: /tmp/artifacts/
 
   tests-e2e-fixtures-secretmanager:
     runs-on: ubuntu-latest
@@ -253,6 +308,24 @@ jobs:
           name: artifacts-tests-e2e-fixtures-secretmanager
           path: /tmp/artifacts/
 
+  tests-e2e-fixtures-spanner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-spanner"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-spanner
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-spanner
+          path: /tmp/artifacts/
 
   tests-e2e-fixtures-sql:
     runs-on: ubuntu-latest
@@ -311,6 +384,25 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-tests-e2e-fixtures-vmwareengine
+          path: /tmp/artifacts/
+
+  tests-e2e-fixtures-workstations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run scripts/github-actions/tests-e2e-fixtures-workstations"
+        run: |
+          ./scripts/github-actions/tests-e2e-fixtures-workstations
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-tests-e2e-fixtures-workstations
           path: /tmp/artifacts/
 
 

--- a/scripts/github-actions/tests-e2e-fixtures
+++ b/scripts/github-actions/tests-e2e-fixtures
@@ -24,17 +24,22 @@ SKIP_TEST_APIGROUPS=(
     "apigee.cnrm.cloud.google.com"
     "backupdr.cnrm.cloud.google.com"
     "bigquery.cnrm.cloud.google.com"
+    "bigtable.cnrm.cloud.google.com"
     "bigqueryanalyticshub.cnrm.cloud.google.com"
     "bigqueryconnection.cnrm.cloud.google.com"
     "bigquerydatatransfer.cnrm.cloud.google.com"
     "bigqueryreservation.cnrm.cloud.google.com"
+    "certificatemananger.cnrm.cloud.google.com"
     "compute.cnrm.cloud.google.com"
     "gkehub.cnrm.cloud.google.com"
     "monitoring.cnrm.cloud.google.com"
+    "resourcemanager.cnrm.cloud.google.com"
     "secretmanager.cnrm.cloud.google.com"
+    "spanner.cnrm.cloud.google.com"
     "sql.cnrm.cloud.google.com"
     "vertexai.cnrm.cloud.google.com"
     "vmwareengine.cnrm.cloud.google.com"
+    "workstations.cnrm.cloud.google.com"
 )
 
 export SKIP_TEST_APIGROUP=$(IFS=, ; echo "${SKIP_TEST_APIGROUPS[*]}")

--- a/scripts/github-actions/tests-e2e-fixtures-bigtable
+++ b/scripts/github-actions/tests-e2e-fixtures-bigtable
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_APIGROUPS="bigtable.cnrm.cloud.google.com"
+
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-certificatemanager
+++ b/scripts/github-actions/tests-e2e-fixtures-certificatemanager
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_APIGROUPS="certificatemanager.cnrm.cloud.google.com"
+
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-resourcemanager
+++ b/scripts/github-actions/tests-e2e-fixtures-resourcemanager
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_APIGROUPS="resourcemanager.cnrm.cloud.google.com"
+
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-spanner
+++ b/scripts/github-actions/tests-e2e-fixtures-spanner
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_APIGROUPS="spanner.cnrm.cloud.google.com"
+
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/scripts/github-actions/tests-e2e-fixtures-workstations
+++ b/scripts/github-actions/tests-e2e-fixtures-workstations
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_APIGROUPS="workstations.cnrm.cloud.google.com"
+
+${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Split bigtable, certificatemanager, resourcemanager spanner, workstation

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
