### PR TITLE
tool: fix a bug when annotating types file

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -137,6 +137,8 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 		}
 		out := g.getOutputFile(k)
 
+		out.fileAnnotation = g.generatedFileAnnotation
+
 		goTypeName := GoNameForProtoMessage(msg)
 		skipGenerated := true
 		goType, err := g.findTypeDeclaration(goTypeName, out.OutputDir(), skipGenerated)

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -132,9 +132,6 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 		}
 		resourceAnnotations = append(resourceAnnotations, fmt.Sprintf("%s:%s", resource.Kind, resource.ProtoName))
 	}
-	if err := typeGenerator.WriteVisitedMessages(); err != nil {
-		return err
-	}
 
 	generatedFileAnnotation := &annotations.FileAnnotation{
 		Key: "+generated:types",
@@ -146,6 +143,11 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 		},
 	}
 	typeGenerator = typeGenerator.WithGeneratedFileAnnotation(generatedFileAnnotation)
+
+	if err := typeGenerator.WriteVisitedMessages(); err != nil {
+		return err
+	}
+
 	if err := typeGenerator.WriteOutputMessages(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix a bug that was missed in PR #4075.

Write visited messages AFTER the file annotation is added.