### PR TITLE
chore: clean up test skip logic

### DIFF
--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -85,6 +85,14 @@ if [[ -z "${PREBUILT_TEST_BINARY:-}" ]]; then
   go test -c -o ${PREBUILT_TEST_BINARY} ./tests/e2e
 fi
 
+if [[ -n "${SKIP_TEST_APIGROUP:-}" ]]; then
+  echo "Running tests with SKIP_TEST_APIGROUP=${SKIP_TEST_APIGROUP:-}"
+fi
+
+if [[ -n "${ONLY_TEST_APIGROUPS:-}" ]]; then
+  echo "Running tests with ONLY_TEST_APIGROUPS=${ONLY_TEST_APIGROUPS:-}"
+fi
+
 # Run e2e tests
 cd tests/e2e
 GOLDEN_REQUEST_CHECKS=1 \

--- a/pkg/test/resourcefixture/resourcefixture.go
+++ b/pkg/test/resourcefixture/resourcefixture.go
@@ -140,6 +140,12 @@ func loadResourceFixture(t *testing.T, testName string, testType TestType, dir, 
 	if err != nil {
 		t.Fatalf("unable to determine GroupVersionKind for test case named %v: %v", testName, err)
 	}
+	if gvk.Kind == "" {
+		t.Fatalf("got empty kind for test case named %v", testName)
+	}
+	if gvk.Version == "" {
+		t.Fatalf("got empty version for test case named %v", testName)
+	}
 
 	rf := ResourceFixture{
 		Name:      testName,


### PR DESCRIPTION
It looks like tests are not being properly skipped in test-e2e-fixtures

Simplify and add logging.
