### PR TITLE
Added a merge metadata command.

### DIFF
--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -26,8 +26,11 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -937,4 +940,51 @@ func filterGoFilePaths(repoRootPath string, inputPaths []string) []string {
 		}
 	}
 	return goFilePaths
+}
+
+const COPYRIGHT_HEADER string = `# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+`
+
+type branchAscending []Branch
+
+func (v branchAscending) Len() int {
+	return len(v)
+}
+
+func (v branchAscending) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v branchAscending) Less(i, j int) bool {
+	if v[i].Group != v[j].Group {
+		return v[i].Group < v[j].Group
+	}
+	return v[i].Kind < v[j].Kind
+}
+
+func writeBranchesStableOrder(branches Branches, fileName string) {
+	sort.Sort(branchAscending(branches.Branches))
+	data := []byte(COPYRIGHT_HEADER)
+	yamlData, err := yaml.Marshal(branches)
+	if err != nil {
+		log.Fatal(err)
+	}
+	data = append(data, yamlData...)
+	err = os.WriteFile(fileName, data, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
### Change description

New command 3 merges a separate metadata file into the main and out to branches-new.yaml. Assumes the merge file takes precedense. Also undoes any skips it finds.

Also added a stable order write file. We will take a 1 time hit the first time this is run but the order should be stable after that.

### Tests you have done

./bin/conductor runner --branch-repo=<repo-dir> --logging-dir=./logs --branch-conf=branches-all.yaml --merge-conf=branches-test.yaml --command=3

branches-test.yaml had 2 skip=true resources with other changed. Confirmed the changes came through.
