### PR TITLE
Fix ordering when kind is empty.

### DIFF
--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -972,7 +972,10 @@ func (v branchAscending) Less(i, j int) bool {
 	if v[i].Group != v[j].Group {
 		return v[i].Group < v[j].Group
 	}
-	return v[i].Kind < v[j].Kind
+	if v[i].Kind != v[j].Kind {
+		return v[i].Kind < v[j].Kind
+	}
+	return v[i].Name < v[j].Name
 }
 
 func writeBranchesStableOrder(branches Branches, fileName string) {


### PR DESCRIPTION
### Change description

Kind should not be empty but we have a few cases still where it is. Stabilizing the order for these cases.
Using name for this case.
Assuming name will usually approximate group-kind so should be a similar order.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
