### PR TITLE
feat: add controller, test and mock support for VMwareEngineExternalAccessRule

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -997,7 +997,6 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEngineNetworkPolicy"}:
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEngineNetworkPeering"}:
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEnginePrivateCloud"}:
-
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEngineExternalAccessRule"}:
 
 			case schema.GroupKind{Group: "vpcaccess.cnrm.cloud.google.com", Kind: "VPCAccessConnector"}:

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -998,6 +998,8 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEngineNetworkPeering"}:
 			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEnginePrivateCloud"}:
 
+			case schema.GroupKind{Group: "vmwareengine.cnrm.cloud.google.com", Kind: "VMwareEngineExternalAccessRule"}:
+
 			case schema.GroupKind{Group: "vpcaccess.cnrm.cloud.google.com", Kind: "VPCAccessConnector"}:
 
 			case schema.GroupKind{Group: "apphub.cnrm.cloud.google.com", Kind: "AppHubApplication"}:

--- a/mockgcp/mockvmwareengine/externalaccessrule.go
+++ b/mockgcp/mockvmwareengine/externalaccessrule.go
@@ -1,0 +1,239 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.cloud.vmwareengine.v1.VmwareEngine
+// proto.message: google.cloud.vmwareengine.v1.ExternalAccessRule
+
+package mockvmwareengine
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/vmwareengine/v1"
+	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+)
+
+func (s *VMwareEngineV1) GetExternalAccessRule(ctx context.Context, req *pb.GetExternalAccessRuleRequest) (*pb.ExternalAccessRule, error) {
+	name, err := s.parseExternalAccessRuleName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.ExternalAccessRule{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%s' was not found", fqn)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *VMwareEngineV1) CreateExternalAccessRule(ctx context.Context, req *pb.CreateExternalAccessRuleRequest) (*longrunningpb.Operation, error) {
+	reqName := req.Parent + "/externalAccessRules/" + req.ExternalAccessRuleId
+	name, err := s.parseExternalAccessRuleName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	// Check if the parent Network Policy exists
+	if _, err := s.GetNetworkPolicy(ctx, &pb.GetNetworkPolicyRequest{Name: name.NetworkPolicyName()}); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.FailedPrecondition, "parent resource '%s' not found", name.NetworkPolicyName())
+		}
+		return nil, err
+	}
+
+	// TODO: Validate destination_ip_ranges external_address references if provided
+
+	now := time.Now()
+
+	obj := proto.Clone(req.GetExternalAccessRule()).(*pb.ExternalAccessRule)
+	obj.Name = fqn
+	obj.CreateTime = timestamppb.New(now)
+	obj.UpdateTime = timestamppb.New(now)
+	obj.State = pb.ExternalAccessRule_ACTIVE // Or CREATING, then update in LRO
+	obj.Uid = fmt.Sprintf("%x", rand.Int63())
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	metadata := &pb.OperationMetadata{
+		ApiVersion: "v1",
+		CreateTime: timestamppb.New(now),
+		Target:     name.String(),
+		Verb:       "create",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		// If state was CREATING, update it to ACTIVE here
+		// obj.State = pb.ExternalAccessRule_ACTIVE
+		// obj.UpdateTime = timestamppb.Now()
+		// if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		// 	return nil, err
+		// }
+		return obj, nil
+	})
+}
+
+func (s *VMwareEngineV1) UpdateExternalAccessRule(ctx context.Context, req *pb.UpdateExternalAccessRuleRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseExternalAccessRuleName(req.GetExternalAccessRule().GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	now := time.Now()
+
+	obj := &pb.ExternalAccessRule{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	// TODO: Validate destination_ip_ranges external_address references if provided
+
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "update_mask must be provided")
+	}
+
+	// For each field mentioned in update_mask, update the corresponding field in the object.
+	for _, path := range paths {
+		switch path {
+		case "description":
+			obj.Description = req.GetExternalAccessRule().GetDescription()
+		case "priority":
+			obj.Priority = req.GetExternalAccessRule().GetPriority()
+		case "action":
+			obj.Action = req.GetExternalAccessRule().GetAction()
+		case "ip_protocol", "ipProtocol":
+			obj.IpProtocol = req.GetExternalAccessRule().GetIpProtocol()
+		case "source_ip_ranges", "sourceIpRanges":
+			obj.SourceIpRanges = req.GetExternalAccessRule().GetSourceIpRanges()
+		case "source_ports", "sourcePorts":
+			obj.SourcePorts = req.GetExternalAccessRule().GetSourcePorts()
+		case "destination_ip_ranges", "destinationIpRanges":
+			obj.DestinationIpRanges = req.GetExternalAccessRule().GetDestinationIpRanges()
+		case "destination_ports", "destinationPorts":
+			obj.DestinationPorts = req.GetExternalAccessRule().GetDestinationPorts()
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid for update", path)
+		}
+	}
+	obj.UpdateTime = timestamppb.New(now)
+
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	metadata := &pb.OperationMetadata{
+		ApiVersion: "v1",
+		CreateTime: timestamppb.New(now),
+		Target:     name.String(),
+		Verb:       "update",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return obj, nil
+	})
+}
+
+func (s *VMwareEngineV1) DeleteExternalAccessRule(ctx context.Context, req *pb.DeleteExternalAccessRuleRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseExternalAccessRuleName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.ExternalAccessRule{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		if status.Code(err) == codes.NotFound {
+			// Deleting a non-existent resource should succeed according to API spec
+		} else {
+			return nil, err
+		}
+	}
+
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	metadata := &pb.OperationMetadata{
+		CreateTime: timestamppb.Now(),
+		Target:     fqn,
+		ApiVersion: "v1",
+		Verb:       "delete",
+	}
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return &emptypb.Empty{}, nil
+	})
+}
+
+type externalAccessRuleName struct {
+	Project              *projects.ProjectData
+	Location             string
+	NetworkPolicyID      string
+	ExternalAccessRuleID string
+}
+
+func (n *externalAccessRuleName) String() string {
+	return fmt.Sprintf("projects/%s/locations/%s/networkPolicies/%s/externalAccessRules/%s", n.Project.ID, n.Location, n.NetworkPolicyID, n.ExternalAccessRuleID)
+}
+
+func (n *externalAccessRuleName) NetworkPolicyName() string {
+	return fmt.Sprintf("projects/%s/locations/%s/networkPolicies/%s", n.Project.ID, n.Location, n.NetworkPolicyID)
+}
+
+// parseExternalAccessRuleName parses a string into an externalAccessRuleName.
+// The expected form is `projects/*/locations/*/networkPolicies/*/externalAccessRules/*`.
+func (s *MockService) parseExternalAccessRuleName(name string) (*externalAccessRuleName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "networkPolicies" && tokens[6] == "externalAccessRules" {
+		project, err := s.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		ruleName := &externalAccessRuleName{
+			Project:              project,
+			Location:             tokens[3],
+			NetworkPolicyID:      tokens[5],
+			ExternalAccessRuleID: tokens[7],
+		}
+
+		return ruleName, nil
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+}

--- a/mockgcp/mockvmwareengine/privatecloud.go
+++ b/mockgcp/mockvmwareengine/privatecloud.go
@@ -211,20 +211,22 @@ func (s *MockService) parsePrivateCloudName(name string) (*privateCloudName, err
 }
 
 func setGeneratedFields(obj *pb.PrivateCloud, name *privateCloudName) {
+	zone := name.Location
+	region := strings.Join(strings.SplitN(zone, "-", 3)[0:2], "-") // e.g. us-west2-a -> us-west2
 	obj.Hcx = &pb.Hcx{
-		Fqdn:       "hcx-414861.c8819727.us-west2.gve.goog",
+		Fqdn:       fmt.Sprintf("hcx-414861.c8819727.%s.gve.goog", region),
 		InternalIp: "192.168.30.3",
 		State:      pb.Hcx_ACTIVE,
 		Version:    "4.10.3.24447633",
 	}
 	obj.Nsx = &pb.Nsx{
-		Fqdn:       "nsx-414860.c8819727.us-west2.gve.goog",
+		Fqdn:       fmt.Sprintf("nsx-414860.c8819727.%s.gve.goog", region),
 		InternalIp: "192.168.30.18",
 		State:      pb.Nsx_ACTIVE,
 		Version:    "3.2.3.1",
 	}
 	obj.Vcenter = &pb.Vcenter{
-		Fqdn:       "vcsa-359395.c8819727.us-west2.gve.goog",
+		Fqdn:       fmt.Sprintf("vcsa-359395.c8819727.%s.gve.goog", region),
 		InternalIp: "192.168.30.2",
 		State:      pb.Vcenter_ACTIVE,
 		Version:    "7.0.3.23085514",

--- a/pkg/controller/direct/vmwareengine/externalaccessrule_controller.go
+++ b/pkg/controller/direct/vmwareengine/externalaccessrule_controller.go
@@ -1,0 +1,282 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:controller
+// proto.service: google.cloud.vmwareengine.v1.VmwareEngine
+// proto.message: google.cloud.vmwareengine.v1.ExternalAccessRule
+// crd.type: VMwareEngineExternalAccessRule
+// crd.version: v1alpha1
+
+package vmwareengine
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	gcp "cloud.google.com/go/vmwareengine/apiv1"
+	pb "cloud.google.com/go/vmwareengine/apiv1/vmwareenginepb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/vmwareengine/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+)
+
+func init() {
+	registry.RegisterModel(krm.VMwareEngineExternalAccessRuleGVK, NewExternalAccessRuleModel)
+}
+
+func NewExternalAccessRuleModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &externalAccessRuleModel{config: *config}, nil
+}
+
+var _ directbase.Model = &externalAccessRuleModel{}
+
+type externalAccessRuleModel struct {
+	config config.ControllerConfig
+}
+
+func (m *externalAccessRuleModel) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	obj := &krm.VMwareEngineExternalAccessRule{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	id, err := krm.NewExternalAccessRuleIdentity(ctx, reader, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// normalize reference fields
+	for _, ipRange := range obj.Spec.DestinationIPRanges {
+		if ipRange.ExternalAddressRef != nil {
+			if _, err := ipRange.ExternalAddressRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, ipRange := range obj.Spec.SourceIPRanges {
+		if ipRange.ExternalAddressRef != nil {
+			if _, err := ipRange.ExternalAddressRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if obj.Spec.NetworkPolicyRef != nil {
+		if _, err := obj.Spec.NetworkPolicyRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
+			return nil, err
+		}
+	}
+
+	// Get VMwareEngine GCP client
+	gcpClient, err := newGCPClient(ctx, &m.config)
+	if err != nil {
+		return nil, err
+	}
+	client, err := gcpClient.newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &externalAccessRuleAdapter{
+		gcpClient: client,
+		id:        id,
+		desired:   obj,
+	}, nil
+}
+
+func (m *externalAccessRuleModel) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// TODO: Support URLs
+	return nil, nil
+}
+
+type externalAccessRuleAdapter struct {
+	gcpClient *gcp.Client
+	id        *krm.ExternalAccessRuleIdentity
+	desired   *krm.VMwareEngineExternalAccessRule
+	actual    *pb.ExternalAccessRule
+}
+
+var _ directbase.Adapter = &externalAccessRuleAdapter{}
+
+func (a *externalAccessRuleAdapter) Find(ctx context.Context) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("getting vmwareengine external access rule", "name", a.id)
+
+	req := &pb.GetExternalAccessRuleRequest{Name: a.id.String()}
+	actual, err := a.gcpClient.GetExternalAccessRule(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting vmwareengine external access rule %q from gcp: %w", a.id.String(), err)
+	}
+
+	a.actual = actual
+	return true, nil
+}
+
+func (a *externalAccessRuleAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("creating vmwareengine external access rule", "name", a.id)
+	mapCtx := &direct.MapContext{}
+
+	desired := a.desired.DeepCopy()
+	resource := VMwareEngineExternalAccessRuleSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+
+	req := &pb.CreateExternalAccessRuleRequest{
+		Parent:               a.id.Parent().String(),
+		ExternalAccessRuleId: a.id.ID(),
+		ExternalAccessRule:   resource,
+	}
+	op, err := a.gcpClient.CreateExternalAccessRule(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating vmwareengine external access rule %s: %w", a.id.String(), err)
+	}
+	created, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("vmwareengine external access rule %s waiting creation: %w", a.id, err)
+	}
+	log.V(2).Info("successfully created vmwareengine external access rule in gcp", "name", a.id)
+
+	status := &krm.VMwareEngineExternalAccessRuleStatus{}
+	status.ObservedState = VMwareEngineExternalAccessRuleObservedState_FromProto(mapCtx, created)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
+	return createOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *externalAccessRuleAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("updating vmwareengine external access rule", "name", a.id)
+	mapCtx := &direct.MapContext{}
+
+	desired := a.desired.DeepCopy()
+	resource := VMwareEngineExternalAccessRuleSpec_ToProto(mapCtx, &desired.Spec)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+
+	paths := []string{}
+	if desired.Spec.Description != nil && !reflect.DeepEqual(resource.Description, a.actual.Description) {
+		paths = append(paths, "description")
+	}
+	if desired.Spec.Priority != nil && !reflect.DeepEqual(resource.Priority, a.actual.Priority) {
+		paths = append(paths, "priority")
+	}
+	if desired.Spec.Action != nil && !reflect.DeepEqual(resource.Action, a.actual.Action) {
+		paths = append(paths, "action")
+	}
+	if desired.Spec.IPProtocol != nil && !reflect.DeepEqual(resource.IpProtocol, a.actual.IpProtocol) {
+		paths = append(paths, "ip_protocol")
+	}
+	if len(desired.Spec.SourceIPRanges) != 0 && !reflect.DeepEqual(resource.SourceIpRanges, a.actual.SourceIpRanges) {
+		paths = append(paths, "source_ip_ranges")
+	}
+	if len(desired.Spec.SourcePorts) != 0 && !reflect.DeepEqual(resource.SourcePorts, a.actual.SourcePorts) {
+		paths = append(paths, "source_ports")
+	}
+	if len(desired.Spec.DestinationIPRanges) != 0 && !reflect.DeepEqual(resource.DestinationIpRanges, a.actual.DestinationIpRanges) {
+		paths = append(paths, "destination_ip_ranges")
+	}
+	if len(desired.Spec.DestinationPorts) != 0 && !reflect.DeepEqual(resource.DestinationPorts, a.actual.DestinationPorts) {
+		paths = append(paths, "destination_ports")
+	}
+
+	if len(paths) == 0 {
+		log.V(2).Info("no field needs update", "name", a.id)
+		return nil
+	}
+
+	resource.Name = a.id.String() // we need to set the name so that GCP API can identify the resource
+	req := &pb.UpdateExternalAccessRuleRequest{
+		ExternalAccessRule: resource,
+		UpdateMask:         &fieldmaskpb.FieldMask{Paths: paths},
+	}
+	op, err := a.gcpClient.UpdateExternalAccessRule(ctx, req)
+	if err != nil {
+		return fmt.Errorf("updating vmwareengine external access rule %s: %w", a.id.String(), err)
+	}
+	updated, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("vmwareengine external access rule %s waiting for update: %w", a.id, err)
+	}
+	log.V(2).Info("successfully updated vmwareengine external access rule", "name", a.id)
+
+	status := &krm.VMwareEngineExternalAccessRuleStatus{}
+	status.ObservedState = VMwareEngineExternalAccessRuleObservedState_FromProto(mapCtx, updated)
+	if mapCtx.Err() != nil {
+		return mapCtx.Err()
+	}
+	return updateOp.UpdateStatus(ctx, status, nil)
+}
+
+func (a *externalAccessRuleAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	if a.actual == nil {
+		return nil, fmt.Errorf("Find() not called")
+	}
+	u := &unstructured.Unstructured{}
+
+	obj := &krm.VMwareEngineExternalAccessRule{}
+	mapCtx := &direct.MapContext{}
+	obj.Spec = direct.ValueOf(VMwareEngineExternalAccessRuleSpec_FromProto(mapCtx, a.actual))
+	if mapCtx.Err() != nil {
+		return nil, mapCtx.Err()
+	}
+	obj.Spec.NetworkPolicyRef = &refs.StringRef{External: a.id.Parent().NetworkPolicyID}
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u.SetName(a.actual.Name)
+	u.SetGroupVersionKind(krm.VMwareEngineExternalAccessRuleGVK)
+	u.Object = uObj
+	return u, nil
+}
+
+// Delete implements the Adapter interface.
+func (a *externalAccessRuleAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := klog.FromContext(ctx)
+	log.V(2).Info("deleting vmwareengine external access rule", "name", a.id)
+
+	req := &pb.DeleteExternalAccessRuleRequest{Name: a.id.String()}
+	op, err := a.gcpClient.DeleteExternalAccessRule(ctx, req)
+	if err != nil {
+		if direct.IsNotFound(err) {
+			log.V(2).Info("skipping delete for non-existent BackupVault, assuming it was already deleted", "name", a.id)
+			return true, nil
+		}
+		return false, fmt.Errorf("deleting vmwareengine external access rule %s: %w", a.id.String(), err)
+	}
+	log.V(2).Info("successfully deleted vmwareengine external access rule", "name", a.id)
+
+	err = op.Wait(ctx)
+	if err != nil {
+		return false, fmt.Errorf("waiting delete BackupVault %s: %w", a.id, err)
+	}
+	return true, nil
+}

--- a/pkg/controller/direct/vmwareengine/externalaccessrule_controller.go
+++ b/pkg/controller/direct/vmwareengine/externalaccessrule_controller.go
@@ -216,6 +216,7 @@ func (a *externalAccessRuleAdapter) Update(ctx context.Context, updateOp *direct
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_generated_object_vmwareengineexternalaccessrule-minimal.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_generated_object_vmwareengineexternalaccessrule-minimal.golden.yaml
@@ -1,0 +1,41 @@
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineExternalAccessRule
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: vmwareengineexternalaccessrule-minimal-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  action: DENY
+  description: Updated description
+  destinationIPRanges:
+  - externalAddressRef:
+      name: vmwareengineexternaladdress-minimal-${uniqueId}
+  destinationPorts:
+  - "443"
+  ipProtocol: TCP
+  networkPolicyRef:
+    name: vmwareenginenetworkpolicy-minimal-${uniqueId}
+  priority: 101
+  sourceIPRanges:
+  - ipAddressRange: 0.0.0.0/0
+  sourcePorts:
+  - "80"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    createTime: "1970-01-01T00:00:00Z"
+    state: ACTIVE
+    uid: 0123456789abcdef
+    updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_http.log
@@ -1,0 +1,4157 @@
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks?%24alt=json%3Benum-encoding%3Dint&vmwareEngineNetworkId=vmwareenginenetwork-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fglobal
+
+{
+  "description": "test dependent VMwareEngine network",
+  "type": 2
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/global/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/global/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.VmwareEngineNetwork",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "test dependent VMwareEngine network",
+    "etag": "abcdef0123A=",
+    "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "state": "ACTIVE",
+    "type": "STANDARD",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "vpcNetworks": [
+      {
+        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "type": "INTERNET"
+      },
+      {
+        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "type": "INTRANET"
+      },
+      {
+        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "type": "GOOGLE_CLOUD"
+      }
+    ]
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds?%24alt=json%3Benum-encoding%3Dint&privateCloudId=vmwareengineprivatecloud-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a
+
+{
+  "description": "test dependent VMwareEngine private cloud",
+  "managementCluster": {
+    "clusterId": "cluster-1",
+    "nodeTypeConfigs": {
+      "standard-72": {
+        "nodeCount": 3
+      }
+    }
+  },
+  "networkConfig": {
+    "managementCidr": "192.168.50.0/24",
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.PrivateCloud",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "test dependent VMwareEngine private cloud",
+    "hcx": {
+      "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.3",
+      "state": "ACTIVE",
+      "version": "4.10.3.24447633"
+    },
+    "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "networkConfig": {
+      "dnsServerIp": "192.168.50.234",
+      "managementCidr": "192.168.50.0/24",
+      "managementIpAddressLayoutVersion": 2,
+      "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+      "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+    },
+    "nsx": {
+      "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.18",
+      "state": "ACTIVE",
+      "version": "3.2.3.1"
+    },
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "vcenter": {
+      "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.2",
+      "state": "ACTIVE",
+      "version": "7.0.3.23085514"
+    }
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies?%24alt=json%3Benum-encoding%3Dint&networkPolicyId=vmwareenginenetworkpolicy-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
+
+{
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true
+  },
+  "internetAccess": {
+    "enabled": true
+  },
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.NetworkPolicy",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "test dependent VMwareEngine network policy",
+    "edgeServicesCidr": "192.168.30.0/26",
+    "externalIp": {
+      "enabled": true,
+      "state": "UNPROVISIONED"
+    },
+    "internetAccess": {
+      "enabled": true,
+      "state": "UNPROVISIONED"
+    },
+    "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 1
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 2
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 2
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 3
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+{
+  "description": "test dependent VMwareEngine external address",
+  "internalIp": "192.168.0.65"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.ExternalAddress",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "test dependent VMwareEngine external address",
+    "externalIp": "34.46.171.217",
+    "internalIp": "192.168.0.65",
+    "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Resource 'projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}' was not found",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules?%24alt=json%3Benum-encoding%3Dint&externalAccessRuleId=vmwareengineexternalaccessrule-minimal-${uniqueId}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+{
+  "action": 2,
+  "description": "Initial description",
+  "destinationIpRanges": [
+    {
+      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+    }
+  ],
+  "destinationPorts": [
+    "443"
+  ],
+  "ipProtocol": "TCP",
+  "priority": 101,
+  "sourceIpRanges": [
+    {
+      "ipAddressRange": "0.0.0.0/0"
+    }
+  ],
+  "sourcePorts": [
+    "80"
+  ]
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "create"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.ExternalAccessRule",
+    "action": "DENY",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Initial description",
+    "destinationIpRanges": [
+      {
+        "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+      }
+    ],
+    "destinationPorts": [
+      "443"
+    ],
+    "ipProtocol": "TCP",
+    "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "priority": 101,
+    "sourceIpRanges": [
+      {
+        "ipAddressRange": "0.0.0.0/0"
+      }
+    ],
+    "sourcePorts": [
+      "80"
+    ],
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 3
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 3
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine external address",
+  "externalIp": "34.46.171.217",
+  "internalIp": "192.168.0.65",
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "action": 2,
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Initial description",
+  "destinationIpRanges": [
+    {
+      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+    }
+  ],
+  "destinationPorts": [
+    "443"
+  ],
+  "ipProtocol": "TCP",
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+  "priority": 101,
+  "sourceIpRanges": [
+    {
+      "ipAddressRange": "0.0.0.0/0"
+    }
+  ],
+  "sourcePorts": [
+    "80"
+  ],
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint&updateMask=description
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: external_access_rule.name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+{
+  "action": 2,
+  "description": "Updated description",
+  "destinationIpRanges": [
+    {
+      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+    }
+  ],
+  "destinationPorts": [
+    "443"
+  ],
+  "ipProtocol": "TCP",
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+  "priority": 101,
+  "sourceIpRanges": [
+    {
+      "ipAddressRange": "0.0.0.0/0"
+    }
+  ],
+  "sourcePorts": [
+    "80"
+  ]
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.ExternalAccessRule",
+    "action": "DENY",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "description": "Updated description",
+    "destinationIpRanges": [
+      {
+        "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+      }
+    ],
+    "destinationPorts": [
+      "443"
+    ],
+    "ipProtocol": "TCP",
+    "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "priority": 101,
+    "sourceIpRanges": [
+      {
+        "ipAddressRange": "0.0.0.0/0"
+      }
+    ],
+    "sourcePorts": [
+      "80"
+    ],
+    "state": "ACTIVE",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 3
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 3
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "action": 2,
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "destinationIpRanges": [
+    {
+      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+    }
+  ],
+  "destinationPorts": [
+    "443"
+  ],
+  "ipProtocol": "TCP",
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+  "priority": 101,
+  "sourceIpRanges": [
+    {
+      "ipAddressRange": "0.0.0.0/0"
+    }
+  ],
+  "sourcePorts": [
+    "80"
+  ],
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 3
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 3
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "action": 2,
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Updated description",
+  "destinationIpRanges": [
+    {
+      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
+    }
+  ],
+  "destinationPorts": [
+    "443"
+  ],
+  "ipProtocol": "TCP",
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+  "priority": 101,
+  "sourceIpRanges": [
+    {
+      "ipAddressRange": "0.0.0.0/0"
+    }
+  ],
+  "sourcePorts": [
+    "80"
+  ],
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine external address",
+  "externalIp": "34.46.171.217",
+  "internalIp": "192.168.0.65",
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine external address",
+  "externalIp": "34.46.171.217",
+  "internalIp": "192.168.0.65",
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network policy",
+  "edgeServicesCidr": "192.168.30.0/26",
+  "externalIp": {
+    "enabled": true,
+    "state": 3
+  },
+  "internetAccess": {
+    "enabled": true,
+    "state": 3
+  },
+  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine private cloud",
+  "hcx": {
+    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.3",
+    "state": 1,
+    "version": "4.10.3.24447633"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+  "networkConfig": {
+    "dnsServerIp": "192.168.50.234",
+    "managementCidr": "192.168.50.0/24",
+    "managementIpAddressLayoutVersion": 2,
+    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+  },
+  "nsx": {
+    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.18",
+    "state": 1,
+    "version": "3.2.3.1"
+  },
+  "state": 1,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vcenter": {
+    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+    "internalIp": "192.168.50.2",
+    "state": 1,
+    "version": "7.0.3.23085514"
+  }
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}"
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "verb": "update"
+  },
+  "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.PrivateCloud",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "deleteTime": "2024-04-01T12:34:56.123456Z",
+    "description": "test dependent VMwareEngine private cloud",
+    "expireTime": "2024-04-01T12:34:56.123456Z",
+    "hcx": {
+      "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.3",
+      "state": "ACTIVE",
+      "version": "4.10.3.24447633"
+    },
+    "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
+    "networkConfig": {
+      "dnsServerIp": "192.168.50.234",
+      "managementCidr": "192.168.50.0/24",
+      "managementIpAddressLayoutVersion": 2,
+      "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+      "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
+    },
+    "nsx": {
+      "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.18",
+      "state": "ACTIVE",
+      "version": "3.2.3.1"
+    },
+    "state": "DELETED",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "vcenter": {
+      "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
+      "internalIp": "192.168.50.2",
+      "state": "ACTIVE",
+      "version": "7.0.3.23085514"
+    }
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}
+
+---
+
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "test dependent VMwareEngine network",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+  "state": 2,
+  "type": 2,
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "vpcNetworks": [
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 2
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 1
+    },
+    {
+      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "type": 3
+    }
+  ]
+}
+
+---
+
+DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
+    "status": "FAILED_PRECONDITION"
+  }
+}

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/_http.log
@@ -44,12 +44,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -80,7 +78,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -97,61 +94,19 @@ X-Xss-Protection: 0
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "vpcNetworks": [
       {
-        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
         "type": "INTERNET"
       },
       {
-        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
         "type": "INTRANET"
       },
       {
-        "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+        "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
         "type": "GOOGLE_CLOUD"
       }
     ]
   }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
 }
 
 ---
@@ -213,58 +168,14 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "verb": "create"
   },
   "name": "projects/${projectId}/locations/us-central1-a/operations/${operationID}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
 }
 
 ---
@@ -291,7 +202,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -301,22 +211,22 @@ X-Xss-Protection: 0
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "test dependent VMwareEngine private cloud",
     "hcx": {
-      "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.3",
+      "fqdn": "hcx-414861.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.3",
       "state": "ACTIVE",
       "version": "4.10.3.24447633"
     },
     "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "networkConfig": {
-      "dnsServerIp": "192.168.50.234",
+      "dnsServerIp": "192.168.30.234",
       "managementCidr": "192.168.50.0/24",
       "managementIpAddressLayoutVersion": 2,
       "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
       "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
     },
     "nsx": {
-      "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.18",
+      "fqdn": "nsx-414860.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.18",
       "state": "ACTIVE",
       "version": "3.2.3.1"
     },
@@ -324,54 +234,12 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "vcenter": {
-      "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.2",
+      "fqdn": "vcsa-359395.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.2",
       "state": "ACTIVE",
       "version": "7.0.3.23085514"
     }
   }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
 }
 
 ---
@@ -429,12 +297,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -465,7 +331,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -477,11 +342,11 @@ X-Xss-Protection: 0
     "edgeServicesCidr": "192.168.30.0/26",
     "externalIp": {
       "enabled": true,
-      "state": "UNPROVISIONED"
+      "state": "ACTIVE"
     },
     "internetAccess": {
       "enabled": true,
-      "state": "UNPROVISIONED"
+      "state": "ACTIVE"
     },
     "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
     "uid": "111111111111111111111",
@@ -493,920 +358,6 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network policy",
-  "edgeServicesCidr": "192.168.30.0/26",
-  "externalIp": {
-    "enabled": true,
-    "state": 1
-  },
-  "internetAccess": {
-    "enabled": true,
-    "state": 2
-  },
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network policy",
-  "edgeServicesCidr": "192.168.30.0/26",
-  "externalIp": {
-    "enabled": true,
-    "state": 2
-  },
-  "internetAccess": {
-    "enabled": true,
-    "state": 3
-  },
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "message": "Resource 'projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}' was not found",
-    "status": "NOT_FOUND"
-  }
-}
-
----
-
-POST https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses?%24alt=json%3Benum-encoding%3Dint&externalAddressId=vmwareengineexternaladdress-minimal-${uniqueId}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-{
-  "description": "test dependent VMwareEngine external address",
-  "internalIp": "192.168.0.65"
-}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "External IP address network service is not active in the provided network policy. Enable the network service and wait till it becomes active before continuing.",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
 GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
@@ -1453,12 +404,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -1489,7 +438,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -1498,63 +446,12 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.ExternalAddress",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "description": "test dependent VMwareEngine external address",
-    "externalIp": "34.46.171.217",
+    "externalIp": "34.118.248.97",
     "internalIp": "192.168.0.65",
     "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
     "state": "ACTIVE",
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
   }
 }
 
@@ -1624,12 +521,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -1660,7 +555,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "create"
   },
@@ -1693,112 +587,6 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network policy",
-  "edgeServicesCidr": "192.168.30.0/26",
-  "externalIp": {
-    "enabled": true,
-    "state": 3
-  },
-  "internetAccess": {
-    "enabled": true,
-    "state": 3
-  },
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine external address",
-  "externalIp": "34.46.171.217",
-  "internalIp": "192.168.0.65",
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---
@@ -1888,12 +676,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "update"
   },
@@ -1924,7 +710,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "update"
   },
@@ -1957,258 +742,6 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z"
   }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network policy",
-  "edgeServicesCidr": "192.168.30.0/26",
-  "externalIp": {
-    "enabled": true,
-    "state": 3
-  },
-  "internetAccess": {
-    "enabled": true,
-    "state": 3
-  },
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}%2FexternalAccessRules%2Fvmwareengineexternalaccessrule-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "action": 2,
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "Updated description",
-  "destinationIpRanges": [
-    {
-      "externalAddress": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}"
-    }
-  ],
-  "destinationPorts": [
-    "443"
-  ],
-  "ipProtocol": "TCP",
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
-  "priority": 101,
-  "sourceIpRanges": [
-    {
-      "ipAddressRange": "0.0.0.0/0"
-    }
-  ],
-  "sourcePorts": [
-    "80"
-  ],
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2FnetworkPolicies%2Fvmwareenginenetworkpolicy-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network policy",
-  "edgeServicesCidr": "192.168.30.0/26",
-  "externalIp": {
-    "enabled": true,
-    "state": 3
-  },
-  "internetAccess": {
-    "enabled": true,
-    "state": 3
-  },
-  "name": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
 }
 
 ---
@@ -2274,95 +807,14 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "delete"
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}%2FexternalAddresses%2Fvmwareengineexternaladdress-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine external address",
-  "externalIp": "34.46.171.217",
-  "internalIp": "192.168.0.65",
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
 }
 
 ---
@@ -2389,7 +841,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}/externalAccessRules/vmwareengineexternalaccessrule-minimal-${uniqueId}",
     "verb": "delete"
   },
@@ -2419,7 +870,7 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "test dependent VMwareEngine external address",
-  "externalIp": "34.46.171.217",
+  "externalIp": "34.118.248.97",
   "internalIp": "192.168.0.65",
   "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
   "state": 1,
@@ -2445,12 +896,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
     "verb": "delete"
   },
@@ -2481,7 +930,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}/externalAddresses/vmwareengineexternaladdress-minimal-${uniqueId}",
     "verb": "delete"
   },
@@ -2545,160 +993,14 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
     "verb": "delete"
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1-a%2FprivateClouds%2Fvmwareengineprivatecloud-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine private cloud",
-  "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
-    "state": 1,
-    "version": "4.10.3.24447633"
-  },
-  "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
-  "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
-    "managementCidr": "192.168.50.0/24",
-    "managementIpAddressLayoutVersion": 2,
-    "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-    "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
-  },
-  "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
-    "state": 1,
-    "version": "3.2.3.1"
-  },
-  "state": 1,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
-    "state": 1,
-    "version": "7.0.3.23085514"
-  }
 }
 
 ---
@@ -2725,7 +1027,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/networkPolicies/vmwareenginenetworkpolicy-minimal-${uniqueId}",
     "verb": "delete"
   },
@@ -2756,22 +1057,22 @@ X-Xss-Protection: 0
   "createTime": "2024-04-01T12:34:56.123456Z",
   "description": "test dependent VMwareEngine private cloud",
   "hcx": {
-    "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.3",
+    "fqdn": "hcx-414861.c8819727.us-central1.gve.goog",
+    "internalIp": "192.168.30.3",
     "state": 1,
     "version": "4.10.3.24447633"
   },
   "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
   "networkConfig": {
-    "dnsServerIp": "192.168.50.234",
+    "dnsServerIp": "192.168.30.234",
     "managementCidr": "192.168.50.0/24",
     "managementIpAddressLayoutVersion": 2,
     "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
     "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
   },
   "nsx": {
-    "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.18",
+    "fqdn": "nsx-414860.c8819727.us-central1.gve.goog",
+    "internalIp": "192.168.30.18",
     "state": 1,
     "version": "3.2.3.1"
   },
@@ -2779,8 +1080,8 @@ X-Xss-Protection: 0
   "uid": "111111111111111111111",
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "vcenter": {
-    "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-    "internalIp": "192.168.50.2",
+    "fqdn": "vcsa-359395.c8819727.us-central1.gve.goog",
+    "internalIp": "192.168.30.2",
     "state": 1,
     "version": "7.0.3.23085514"
   }
@@ -2804,12 +1105,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "verb": "update"
   },
@@ -2840,7 +1139,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "verb": "update"
   },
@@ -2852,22 +1150,22 @@ X-Xss-Protection: 0
     "description": "test dependent VMwareEngine private cloud",
     "expireTime": "2024-04-01T12:34:56.123456Z",
     "hcx": {
-      "fqdn": "hcx-420970.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.3",
+      "fqdn": "hcx-414861.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.3",
       "state": "ACTIVE",
       "version": "4.10.3.24447633"
     },
     "name": "projects/${projectId}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}",
     "networkConfig": {
-      "dnsServerIp": "192.168.50.234",
+      "dnsServerIp": "192.168.30.234",
       "managementCidr": "192.168.50.0/24",
       "managementIpAddressLayoutVersion": 2,
       "vmwareEngineNetwork": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
       "vmwareEngineNetworkCanonical": "projects/${projectNumber}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}"
     },
     "nsx": {
-      "fqdn": "nsx-420969.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.18",
+      "fqdn": "nsx-414860.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.18",
       "state": "ACTIVE",
       "version": "3.2.3.1"
     },
@@ -2875,8 +1173,8 @@ X-Xss-Protection: 0
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "vcenter": {
-      "fqdn": "vcsa-357604.f9ae2d9e.us-central1.gve.goog",
-      "internalIp": "192.168.50.2",
+      "fqdn": "vcsa-359395.c8819727.us-central1.gve.goog",
+      "internalIp": "192.168.30.2",
       "state": "ACTIVE",
       "version": "7.0.3.23085514"
     }
@@ -2911,15 +1209,15 @@ X-Xss-Protection: 0
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "vpcNetworks": [
     {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
       "type": 2
     },
     {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
       "type": 1
     },
     {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
+      "network": "projects/b3e854f0b4bedfea6-tp/global/networks/${networkId}",
       "type": 3
     }
   ]
@@ -2928,31 +1226,6 @@ X-Xss-Protection: 0
 ---
 
 DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
@@ -2968,61 +1241,22 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/global/operations/${operationID}"
 }
 
 ---
 
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/operations/${operationID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2Foperations%2F${operationID}
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -3035,1123 +1269,17 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
-  }
-}
-
----
-
-GET https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "test dependent VMwareEngine network",
-  "etag": "abcdef0123A=",
-  "name": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
-  "state": 2,
-  "type": 2,
-  "uid": "111111111111111111111",
-  "updateTime": "2024-04-01T12:34:56.123456Z",
-  "vpcNetworks": [
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 2
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 1
-    },
-    {
-      "network": "projects/e597227f915e3d4d3-tp/global/networks/${networkId}",
-      "type": 3
-    }
-  ]
-}
-
----
-
-DELETE https://vmwareengine.googleapis.com/v1/projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fglobal%2FvmwareEngineNetworks%2Fvmwareenginenetwork-minimal-${uniqueId}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "message": "The resource `projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}` is being used by other resources. To delete this resource, you must first delete the following resources: `projects/${projectNumber}/locations/us-central1-a/privateClouds/vmwareengineprivatecloud-minimal-${uniqueId}`",
-    "status": "FAILED_PRECONDITION"
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.vmwareengine.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/global/vmwareEngineNetworks/vmwareenginenetwork-minimal-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/global/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
   }
 }

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/create.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineExternalAccessRule
+metadata:
+  name: vmwareengineexternalaccessrule-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Initial description"

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/create.yaml
@@ -17,7 +17,18 @@ kind: VMwareEngineExternalAccessRule
 metadata:
   name: vmwareengineexternalaccessrule-minimal-${uniqueId}
 spec:
-  projectRef:
-    external: ${projectId}
-  location: us-central1
   description: "Initial description"
+  networkPolicyRef:
+    name: vmwareenginenetworkpolicy-minimal-${uniqueId}
+  priority: 101
+  action: "DENY"
+  ipProtocol: "TCP"
+  sourceIPRanges:
+    - ipAddressRange: "0.0.0.0/0"
+  sourcePorts:
+    - "80"
+  destinationIPRanges:
+    - externalAddressRef:
+        name: vmwareengineexternaladdress-minimal-${uniqueId}
+  destinationPorts:
+    - "443"

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/dependencies.yaml
@@ -1,0 +1,70 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineNetwork
+metadata:
+  name: vmwareenginenetwork-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: global
+  description: "test dependent VMwareEngine network"
+  type: STANDARD
+---
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEnginePrivateCloud
+metadata:
+  name: vmwareengineprivatecloud-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1-a # Private clouds of type STANDARD and TIME_LIMITED are zonal resources, STRETCHED private clouds are regional. 
+  description: "test dependent VMwareEngine private cloud"
+  networkConfig:
+    vmwareEngineNetworkRef:
+      name: vmwareenginenetwork-minimal-${uniqueId}
+    managementCIDR: "192.168.50.0/24"
+  managementCluster:
+    clusterID: "cluster-1"
+    nodeTypeConfigs:
+      - nodeTypeID: "standard-72"
+        nodeCount: 3
+---
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineNetworkPolicy
+metadata:
+  name: vmwareenginenetworkpolicy-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "test dependent VMwareEngine network policy"
+  edgeServicesCIDR: "192.168.30.0/26"
+  vmwareEngineNetworkRef:
+    name: vmwareenginenetwork-minimal-${uniqueId}
+  externalIP:
+    enabled: true
+  internetAccess:
+    enabled: true
+---
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineExternalAddress
+metadata:
+  name: vmwareengineexternaladdress-minimal-${uniqueId}
+spec:
+  privateCloudRef:
+    name: vmwareengineprivatecloud-minimal-${uniqueId}
+  description: "test dependent VMwareEngine external address"
+  internalIP: "192.168.0.65"

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/update.yaml
@@ -17,7 +17,18 @@ kind: VMwareEngineExternalAccessRule
 metadata:
   name: vmwareengineexternalaccessrule-minimal-${uniqueId}
 spec:
-  projectRef:
-    external: ${projectId}
-  location: us-central1
   description: "Updated description"
+  networkPolicyRef:
+    name: vmwareenginenetworkpolicy-minimal-${uniqueId}
+  priority: 101
+  action: "DENY"
+  ipProtocol: "TCP"
+  sourceIPRanges:
+    - ipAddressRange: "0.0.0.0/0"
+  sourcePorts:
+    - "80"
+  destinationIPRanges:
+    - externalAddressRef:
+        name: vmwareengineexternaladdress-minimal-${uniqueId}
+  destinationPorts:
+    - "443"

--- a/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/vmwareengine/v1alpha1/vmwareengineexternalaccessrule/vmwareengineexternalaccessrule-minimal/update.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vmwareengine.cnrm.cloud.google.com/v1alpha1
+kind: VMwareEngineExternalAccessRule
+metadata:
+  name: vmwareengineexternalaccessrule-minimal-${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us-central1
+  description: "Updated description"


### PR DESCRIPTION
HTTP log: real vs. mock (only includes requests relevant to this resource):
https://www.diffchecker.com/GdM306Ad/
The diff includes additional GET requests related to VMware networks, network policies, and similar resources. I think these are triggered by periodic reconciliations that occur roughly every 10 minutes during testing against real GCP, which takes considerably longer.