### PR TITLE
Added updated metadata from gemmahou.

### DIFF
--- a/experiments/conductor/branches-all.yaml
+++ b/experiments/conductor/branches-all.yaml
@@ -67,13 +67,13 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: accesscontextmanager-accesscontextmanagerauthorizedorgs
-      local: resource-accesscontextmanager-accesscontextmanagerauthorizedorgs
-      remote: resource-accesscontextmanager-accesscontextmanagerauthorizedorgs
-      command: gcloud access-context-manager authorized-orgs
+    - name: accesscontextmanager-accesscontextmanageraccesslevelconditions
+      local: resource-accesscontextmanager-accesscontextmanageraccesslevelconditions
+      remote: resource-accesscontextmanager-accesscontextmanageraccesslevelconditions
+      command: ""
       group: accesscontextmanager
-      resource: accesscontextmanagerauthorizedorgs
-      controller: unknown
+      resource: accesscontextmanageraccesslevelconditions
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -84,13 +84,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: accesscontextmanager-accesscontextmanageraccesslevelconditions
-      local: resource-accesscontextmanager-accesscontextmanageraccesslevelconditions
-      remote: resource-accesscontextmanager-accesscontextmanageraccesslevelconditions
-      command: ""
+    - name: accesscontextmanager-accesscontextmanagerauthorizedorgs
+      local: resource-accesscontextmanager-accesscontextmanagerauthorizedorgs
+      remote: resource-accesscontextmanager-accesscontextmanagerauthorizedorgs
+      command: gcloud access-context-manager authorized-orgs
       group: accesscontextmanager
-      resource: accesscontextmanageraccesslevelconditions
-      controller: terraform
+      resource: accesscontextmanagerauthorizedorgs
+      controller: unknown
       skip: false
       kind: ""
       package: ""
@@ -220,12 +220,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: activedirectory-peerings
-      local: resource-activedirectory-peerings
-      remote: resource-activedirectory-peerings
-      command: gcloud active-directory peerings
+    - name: activedirectory-operations
+      local: resource-activedirectory-operations
+      remote: resource-activedirectory-operations
+      command: gcloud active-directory operations
       group: activedirectory
-      resource: peerings
+      resource: operations
       controller: unknown
       skip: false
       kind: ""
@@ -237,12 +237,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: activedirectory-operations
-      local: resource-activedirectory-operations
-      remote: resource-activedirectory-operations
-      command: gcloud active-directory operations
+    - name: activedirectory-peerings
+      local: resource-activedirectory-peerings
+      remote: resource-activedirectory-peerings
+      command: gcloud active-directory peerings
       group: activedirectory
-      resource: operations
+      resource: peerings
       controller: unknown
       skip: false
       kind: ""
@@ -290,57 +290,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: ai-endpoints
-      local: resource-ai-endpoints
-      remote: resource-ai-endpoints
-      command: gcloud ai endpoints
-      group: ai
-      resource: endpoints
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: ai-indexendpoints
-      local: resource-ai-indexendpoints
-      remote: resource-ai-indexendpoints
-      command: gcloud ai index-endpoints
-      group: ai
-      resource: indexendpoints
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: ai-tensorboards
-      local: resource-ai-tensorboards
-      remote: resource-ai-tensorboards
-      command: gcloud ai tensorboards
-      group: ai
-      resource: tensorboards
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: ai-customjobs
       local: resource-ai-customjobs
       remote: resource-ai-customjobs
@@ -358,12 +307,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: ai-persistentresources
-      local: resource-ai-persistentresources
-      remote: resource-ai-persistentresources
-      command: gcloud ai persistent-resources
+    - name: ai-endpoints
+      local: resource-ai-endpoints
+      remote: resource-ai-endpoints
+      command: gcloud ai endpoints
       group: ai
-      resource: persistentresources
+      resource: endpoints
       controller: Unknown
       skip: false
       kind: ""
@@ -392,12 +341,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: ai-modelmonitoringjobs
-      local: resource-ai-modelmonitoringjobs
-      remote: resource-ai-modelmonitoringjobs
-      command: gcloud ai model-monitoring-jobs
+    - name: ai-indexendpoints
+      local: resource-ai-indexendpoints
+      remote: resource-ai-indexendpoints
+      command: gcloud ai index-endpoints
       group: ai
-      resource: modelmonitoringjobs
+      resource: indexendpoints
       controller: Unknown
       skip: false
       kind: ""
@@ -415,6 +364,57 @@ branches:
       command: gcloud ai indexes
       group: ai
       resource: indexes
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: ai-modelmonitoringjobs
+      local: resource-ai-modelmonitoringjobs
+      remote: resource-ai-modelmonitoringjobs
+      command: gcloud ai model-monitoring-jobs
+      group: ai
+      resource: modelmonitoringjobs
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: ai-persistentresources
+      local: resource-ai-persistentresources
+      remote: resource-ai-persistentresources
+      command: gcloud ai persistent-resources
+      group: ai
+      resource: persistentresources
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: ai-tensorboards
+      local: resource-ai-tensorboards
+      remote: resource-ai-tensorboards
+      command: gcloud ai tensorboards
+      group: ai
+      resource: tensorboards
       controller: Unknown
       skip: false
       kind: ""
@@ -585,23 +585,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: aiplatform-versions
-      local: resource-aiplatform-versions
-      remote: resource-aiplatform-versions
-      command: gcloud ai-platform versions
-      group: aiplatform
-      resource: versions
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: aiplatform-local
       local: resource-aiplatform-local
       remote: resource-aiplatform-local
@@ -625,6 +608,23 @@ branches:
       command: gcloud ai-platform operations
       group: aiplatform
       resource: operations
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: aiplatform-versions
+      local: resource-aiplatform-versions
+      remote: resource-aiplatform-versions
+      command: gcloud ai-platform versions
+      group: aiplatform
+      resource: versions
       controller: Unknown
       skip: false
       kind: ""
@@ -1661,40 +1661,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: alloydb-alloydbinstances
-      local: resource-alloydb-alloydbinstances
-      remote: resource-alloydb-alloydbinstances
-      command: ""
-      group: alloydb
-      resource: alloydbinstances
-      controller: direct
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: alloydb-alloydbusers
-      local: resource-alloydb-alloydbusers
-      remote: resource-alloydb-alloydbusers
-      command: ""
-      group: alloydb
-      resource: alloydbusers
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: alloydb-alloydbbackups
       local: resource-alloydb-alloydbbackups
       remote: resource-alloydb-alloydbbackups
@@ -1718,6 +1684,40 @@ branches:
       command: ""
       group: alloydb
       resource: alloydbclusters
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: alloydb-alloydbinstances
+      local: resource-alloydb-alloydbinstances
+      remote: resource-alloydb-alloydbinstances
+      command: ""
+      group: alloydb
+      resource: alloydbinstances
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: alloydb-alloydbusers
+      local: resource-alloydb-alloydbusers
+      remote: resource-alloydb-alloydbusers
+      command: ""
+      group: alloydb
+      resource: alloydbusers
       controller: terraform
       skip: false
       kind: ""
@@ -2190,12 +2190,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: apigateway-apigatewayapis
-      local: resource-apigateway-apigatewayapis
-      remote: resource-apigateway-apigatewayapis
+    - name: apigateway-apigatewayapiconfigs
+      local: resource-apigateway-apigatewayapiconfigs
+      remote: resource-apigateway-apigatewayapiconfigs
       command: ""
       group: apigateway
-      resource: apigatewayapis
+      resource: apigatewayapiconfigs
       controller: terraform
       skip: false
       kind: ""
@@ -2207,12 +2207,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: apigateway-apigatewayapiconfigs
-      local: resource-apigateway-apigatewayapiconfigs
-      remote: resource-apigateway-apigatewayapiconfigs
+    - name: apigateway-apigatewayapis
+      local: resource-apigateway-apigatewayapis
+      remote: resource-apigateway-apigatewayapis
       command: ""
       group: apigateway
-      resource: apigatewayapiconfigs
+      resource: apigatewayapis
       controller: terraform
       skip: false
       kind: ""
@@ -2309,12 +2309,63 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: apigee-apigeeaddonsconfigs
+      local: resource-apigee-apigeeaddonsconfigs
+      remote: resource-apigee-apigeeaddonsconfigs
+      command: ""
+      group: apigee
+      resource: apigeeaddonsconfigs
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: apigee-apigeeendpointattachments
+      local: resource-apigee-apigeeendpointattachments
+      remote: resource-apigee-apigeeendpointattachments
+      command: ""
+      group: apigee
+      resource: apigeeendpointattachments
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: apigee-apigeeenvgroupattachments
       local: resource-apigee-apigeeenvgroupattachments
       remote: resource-apigee-apigeeenvgroupattachments
       command: ""
       group: apigee
       resource: apigeeenvgroupattachments
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: apigee-apigeeenvgroups
+      local: resource-apigee-apigeeenvgroups
+      remote: resource-apigee-apigeeenvgroups
+      command: ""
+      group: apigee
+      resource: apigeeenvgroups
       controller: direct
       skip: false
       kind: ""
@@ -2343,80 +2394,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: apigee-apigeesyncauthorizations
-      local: resource-apigee-apigeesyncauthorizations
-      remote: resource-apigee-apigeesyncauthorizations
-      command: ""
-      group: apigee
-      resource: apigeesyncauthorizations
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: apigee-apigeenataddresses
-      local: resource-apigee-apigeenataddresses
-      remote: resource-apigee-apigeenataddresses
-      command: ""
-      group: apigee
-      resource: apigeenataddresses
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: apigee-apigeeinstanceattachments
       local: resource-apigee-apigeeinstanceattachments
       remote: resource-apigee-apigeeinstanceattachments
       command: ""
       group: apigee
       resource: apigeeinstanceattachments
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: apigee-apigeeorganizations
-      local: resource-apigee-apigeeorganizations
-      remote: resource-apigee-apigeeorganizations
-      command: ""
-      group: apigee
-      resource: apigeeorganizations
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: apigee-apigeeaddonsconfigs
-      local: resource-apigee-apigeeaddonsconfigs
-      remote: resource-apigee-apigeeaddonsconfigs
-      command: ""
-      group: apigee
-      resource: apigeeaddonsconfigs
       controller: terraform
       skip: false
       kind: ""
@@ -2445,12 +2428,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: apigee-apigeeendpointattachments
-      local: resource-apigee-apigeeendpointattachments
-      remote: resource-apigee-apigeeendpointattachments
+    - name: apigee-apigeenataddresses
+      local: resource-apigee-apigeenataddresses
+      remote: resource-apigee-apigeenataddresses
       command: ""
       group: apigee
-      resource: apigeeendpointattachments
+      resource: apigeenataddresses
       controller: terraform
       skip: false
       kind: ""
@@ -2462,13 +2445,30 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: apigee-apigeeenvgroups
-      local: resource-apigee-apigeeenvgroups
-      remote: resource-apigee-apigeeenvgroups
+    - name: apigee-apigeeorganizations
+      local: resource-apigee-apigeeorganizations
+      remote: resource-apigee-apigeeorganizations
       command: ""
       group: apigee
-      resource: apigeeenvgroups
-      controller: direct
+      resource: apigeeorganizations
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: apigee-apigeesyncauthorizations
+      local: resource-apigee-apigeesyncauthorizations
+      remote: resource-apigee-apigeesyncauthorizations
+      command: ""
+      group: apigee
+      resource: apigeesyncauthorizations
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -2953,118 +2953,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: appengine-log
-      local: resource-appengine-log
-      remote: resource-appengine-log
-      command: gcloud app logs
-      group: appengine
-      resource: log
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - appengine.googleapis.com
-    - name: appengine-appengineservicesplittraffics
-      local: resource-appengine-appengineservicesplittraffics
-      remote: resource-appengine-appengineservicesplittraffics
-      command: ""
-      group: appengine
-      resource: appengineservicesplittraffics
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: appengine-operation
-      local: resource-appengine-operation
-      remote: resource-appengine-operation
-      command: gcloud app operations
-      group: appengine
-      resource: operation
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - appengine.googleapis.com
-    - name: appengine-version
-      local: resource-appengine-version
-      remote: resource-appengine-version
-      command: gcloud app versions
-      group: appengine
-      resource: version
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - 'Further research needed: Only supports delete.'
-      apis-enabled:
-        - appengine.googleapis.com
-    - name: appengine-region
-      local: resource-appengine-region
-      remote: resource-appengine-region
-      command: gcloud app regions
-      group: appengine
-      resource: region
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - appengine.googleapis.com
-    - name: appengine-runtime
-      local: resource-appengine-runtime
-      remote: resource-appengine-runtime
-      command: gcloud app runtimes
-      group: appengine
-      resource: runtime
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - appengine.googleapis.com
     - name: appengine-appenginedomainmappings
       local: resource-appengine-appenginedomainmappings
       remote: resource-appengine-appenginedomainmappings
@@ -3116,6 +3004,116 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: appengine-appengineservicesplittraffics
+      local: resource-appengine-appengineservicesplittraffics
+      remote: resource-appengine-appengineservicesplittraffics
+      command: ""
+      group: appengine
+      resource: appengineservicesplittraffics
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: appengine-appenginestandardappversion
+      local: resource-appengine-appenginestandardappversion
+      remote: resource-appengine-appenginestandardappversion
+      command: ""
+      group: appengine
+      resource: appenginestandardappversion
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: appengine-log
+      local: resource-appengine-log
+      remote: resource-appengine-log
+      command: gcloud app logs
+      group: appengine
+      resource: log
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - appengine.googleapis.com
+    - name: appengine-operation
+      local: resource-appengine-operation
+      remote: resource-appengine-operation
+      command: gcloud app operations
+      group: appengine
+      resource: operation
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - appengine.googleapis.com
+    - name: appengine-region
+      local: resource-appengine-region
+      remote: resource-appengine-region
+      command: gcloud app regions
+      group: appengine
+      resource: region
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - appengine.googleapis.com
+    - name: appengine-runtime
+      local: resource-appengine-runtime
+      remote: resource-appengine-runtime
+      command: gcloud app runtimes
+      group: appengine
+      resource: runtime
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - appengine.googleapis.com
     - name: appengine-service
       local: resource-appengine-service
       remote: resource-appengine-service
@@ -3135,13 +3133,13 @@ branches:
         - 'Further research needed: Only supports update and delete.'
       apis-enabled:
         - appengine.googleapis.com
-    - name: appengine-appenginestandardappversion
-      local: resource-appengine-appenginestandardappversion
-      remote: resource-appengine-appenginestandardappversion
-      command: ""
+    - name: appengine-version
+      local: resource-appengine-version
+      remote: resource-appengine-version
+      command: gcloud app versions
       group: appengine
-      resource: appenginestandardappversion
-      controller: terraform
+      resource: version
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -3150,8 +3148,10 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
-      apis-enabled: []
+      notes:
+        - 'Further research needed: Only supports delete.'
+      apis-enabled:
+        - appengine.googleapis.com
     - name: appengine-domainmapping
       local: resource-appengine-domainmapping
       remote: resource-appengine-domainmapping
@@ -3233,23 +3233,6 @@ branches:
         - 'stat /usr/local/google/home/maqiuyu/go/src/github.com/maqiuyujoyce/7-k8s-config-connector/pkg/controller/direct/appengine: no such file or directory'
       apis-enabled:
         - appengine.googleapis.com
-    - name: apphub-versions
-      local: resource-apphub-versions
-      remote: resource-apphub-versions
-      command: gcloud apphub versions
-      group: apphub
-      resource: versions
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: apphub-locations
       local: resource-apphub-locations
       remote: resource-apphub-locations
@@ -3290,6 +3273,23 @@ branches:
       command: gcloud apphub service-projects
       group: apphub
       resource: serviceprojects
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: apphub-versions
+      local: resource-apphub-versions
+      remote: resource-apphub-versions
+      command: gcloud apphub versions
+      group: apphub
+      resource: versions
       controller: Unknown
       skip: false
       kind: ""
@@ -4443,12 +4443,29 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: beyondcorp-beyondcorpappgateways
-      local: resource-beyondcorp-beyondcorpappgateways
-      remote: resource-beyondcorp-beyondcorpappgateways
+    - name: beyondcorp-app
+      local: resource-beyondcorp-app
+      remote: resource-beyondcorp-app
+      command: gcloud beta beyondcorp app
+      group: beyondcorp
+      resource: app
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: beyondcorp-beyondcorpappconnections
+      local: resource-beyondcorp-beyondcorpappconnections
+      remote: resource-beyondcorp-beyondcorpappconnections
       command: ""
       group: beyondcorp
-      resource: beyondcorpappgateways
+      resource: beyondcorpappconnections
       controller: terraform
       skip: false
       kind: ""
@@ -4477,29 +4494,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: beyondcorp-app
-      local: resource-beyondcorp-app
-      remote: resource-beyondcorp-app
-      command: gcloud beta beyondcorp app
-      group: beyondcorp
-      resource: app
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: beyondcorp-beyondcorpappconnections
-      local: resource-beyondcorp-beyondcorpappconnections
-      remote: resource-beyondcorp-beyondcorpappconnections
+    - name: beyondcorp-beyondcorpappgateways
+      local: resource-beyondcorp-beyondcorpappgateways
+      remote: resource-beyondcorp-beyondcorpappgateways
       command: ""
       group: beyondcorp
-      resource: beyondcorpappconnections
+      resource: beyondcorpappgateways
       controller: terraform
       skip: false
       kind: ""
@@ -4617,12 +4617,29 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigquery-bigquerytables
-      local: resource-bigquery-bigquerytables
-      remote: resource-bigquery-bigquerytables
+    - name: bigquery-bigquerydatasets
+      local: resource-bigquery-bigquerydatasets
+      remote: resource-bigquery-bigquerydatasets
       command: ""
       group: bigquery
-      resource: bigquerytables
+      resource: bigquerydatasets
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: bigquery-bigqueryjobs
+      local: resource-bigquery-bigqueryjobs
+      remote: resource-bigquery-bigqueryjobs
+      command: ""
+      group: bigquery
+      resource: bigqueryjobs
       controller: terraform
       skip: false
       kind: ""
@@ -4651,13 +4668,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigquery-jobs
-      local: resource-bigquery-jobs
-      remote: resource-bigquery-jobs
-      command: gcloud alpha bq jobs
+    - name: bigquery-bigquerytables
+      local: resource-bigquery-bigquerytables
+      remote: resource-bigquery-bigquerytables
+      command: ""
       group: bigquery
-      resource: jobs
-      controller: Unknown
+      resource: bigquerytables
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -4685,30 +4702,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigquery-bigqueryjobs
-      local: resource-bigquery-bigqueryjobs
-      remote: resource-bigquery-bigqueryjobs
-      command: ""
+    - name: bigquery-jobs
+      local: resource-bigquery-jobs
+      remote: resource-bigquery-jobs
+      command: gcloud alpha bq jobs
       group: bigquery
-      resource: bigqueryjobs
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: bigquery-bigquerydatasets
-      local: resource-bigquery-bigquerydatasets
-      remote: resource-bigquery-bigquerydatasets
-      command: ""
-      group: bigquery
-      resource: bigquerydatasets
-      controller: terraform
+      resource: jobs
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -5182,23 +5182,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigqueryreservation-bigqueryreservationreservations
-      local: resource-bigqueryreservation-bigqueryreservationreservations
-      remote: resource-bigqueryreservation-bigqueryreservationreservations
-      command: ""
-      group: bigqueryreservation
-      resource: bigqueryreservationreservations
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: bigqueryreservation-bigqueryreservationcapacitycommitments
       local: resource-bigqueryreservation-bigqueryreservationcapacitycommitments
       remote: resource-bigqueryreservation-bigqueryreservationcapacitycommitments
@@ -5216,12 +5199,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigtable-bigtabletables
-      local: resource-bigtable-bigtabletables
-      remote: resource-bigtable-bigtabletables
+    - name: bigqueryreservation-bigqueryreservationreservations
+      local: resource-bigqueryreservation-bigqueryreservationreservations
+      remote: resource-bigqueryreservation-bigqueryreservationreservations
       command: ""
-      group: bigtable
-      resource: bigtabletables
+      group: bigqueryreservation
+      resource: bigqueryreservationreservations
       controller: terraform
       skip: false
       kind: ""
@@ -5284,13 +5267,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: bigtable-operations
-      local: resource-bigtable-operations
-      remote: resource-bigtable-operations
-      command: gcloud bigtable operations
+    - name: bigtable-bigtabletables
+      local: resource-bigtable-bigtabletables
+      remote: resource-bigtable-bigtabletables
+      command: ""
       group: bigtable
-      resource: operations
-      controller: Unknown
+      resource: bigtabletables
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -5313,10 +5296,11 @@ branches:
       package: google.bigtable.admin.v2
       proto: AppProfile
       proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.AppProfile
-      host-name: ""
-      notes: []
+      host-name: bigtableadmin.googleapis.com
+      notes:
+        - TF beta
       apis-enabled: []
     - name: bigtable-authorizedview
       local: resource-bigtable-authorizedview
@@ -5329,10 +5313,10 @@ branches:
       kind: BigtableAuthorizedView
       package: google.bigtable.admin.v2
       proto: AuthorizedView
-      proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-path: google/bigtable/admin/v2/bigtable_table_admin.proto
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.AuthorizedView
-      host-name: ""
+      host-name: bigtableadmin.googleapis.com
       notes: []
       apis-enabled: []
     - name: bigtable-backup
@@ -5346,10 +5330,10 @@ branches:
       kind: BigtableBackup
       package: google.bigtable.admin.v2
       proto: Backup
-      proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-path: google/bigtable/admin/v2/bigtable_table_admin.proto
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.Backup
-      host-name: ""
+      host-name: bigtableadmin.googleapis.com
       notes: []
       apis-enabled: []
     - name: bigtable-cluster
@@ -5364,10 +5348,11 @@ branches:
       package: google.bigtable.admin.v2
       proto: Cluster
       proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.Cluster
-      host-name: ""
-      notes: []
+      host-name: bigtableadmin.googleapis.com
+      notes:
+        - mock exists
       apis-enabled: []
     - name: bigtable-hottablet
       local: resource-bigtable-hottablet
@@ -5381,10 +5366,11 @@ branches:
       package: google.bigtable.admin.v2
       proto: HotTablet
       proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.HotTablet
-      host-name: ""
-      notes: []
+      host-name: bigtableadmin.googleapis.com
+      notes:
+        - gcloud command does not contain any of create/update/delete
       apis-enabled: []
     - name: bigtable-instance
       local: resource-bigtable-instance
@@ -5398,10 +5384,12 @@ branches:
       package: google.bigtable.admin.v2
       proto: Instance
       proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.Instance
-      host-name: ""
-      notes: []
+      host-name: bigtableadmin.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
       apis-enabled: []
     - name: bigtable-snapshot
       local: resource-bigtable-snapshot
@@ -5433,10 +5421,11 @@ branches:
       package: google.bigtable.admin.v2
       proto: Table
       proto-path: google/bigtable/admin/v2/bigtable_instance_admin.proto
-      proto-service: ""
+      proto-service: google.bigtable.admin.v2.Bigtable
       proto-msg: google.bigtable.admin.v2.Table
-      host-name: ""
-      notes: []
+      host-name: bigtableadmin.googleapis.com
+      notes:
+        - TF beta
       apis-enabled: []
     - name: billing-projects
       local: resource-billing-projects
@@ -5560,12 +5549,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: binaryauthorization-binaryauthorizationpolicies
-      local: resource-binaryauthorization-binaryauthorizationpolicies
-      remote: resource-binaryauthorization-binaryauthorizationpolicies
+    - name: binaryauthorization-binaryauthorizationattestors
+      local: resource-binaryauthorization-binaryauthorizationattestors
+      remote: resource-binaryauthorization-binaryauthorizationattestors
       command: ""
       group: binaryauthorization
-      resource: binaryauthorizationpolicies
+      resource: binaryauthorizationattestors
       controller: dcl
       skip: false
       kind: ""
@@ -5577,12 +5566,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: binaryauthorization-binaryauthorizationattestors
-      local: resource-binaryauthorization-binaryauthorizationattestors
-      remote: resource-binaryauthorization-binaryauthorizationattestors
+    - name: binaryauthorization-binaryauthorizationpolicies
+      local: resource-binaryauthorization-binaryauthorizationpolicies
+      remote: resource-binaryauthorization-binaryauthorizationpolicies
       command: ""
       group: binaryauthorization
-      resource: binaryauthorizationattestors
+      resource: binaryauthorizationpolicies
       controller: dcl
       skip: false
       kind: ""
@@ -5648,13 +5637,30 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: certificatemanager-maps
-      local: resource-certificatemanager-maps
-      remote: resource-certificatemanager-maps
-      command: gcloud certificate-manager maps
+    - name: certificatemanager-certificatemanagercertificatemapentries
+      local: resource-certificatemanager-certificatemanagercertificatemapentries
+      remote: resource-certificatemanager-certificatemanagercertificatemapentries
+      command: ""
       group: certificatemanager
-      resource: maps
-      controller: Unknown
+      resource: certificatemanagercertificatemapentries
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: certificatemanager-certificatemanagercertificatemaps
+      local: resource-certificatemanager-certificatemanagercertificatemaps
+      remote: resource-certificatemanager-certificatemanagercertificatemaps
+      command: ""
+      group: certificatemanager
+      resource: certificatemanagercertificatemaps
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -5699,30 +5705,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: certificatemanager-certificatemanagercertificatemapentries
-      local: resource-certificatemanager-certificatemanagercertificatemapentries
-      remote: resource-certificatemanager-certificatemanagercertificatemapentries
-      command: ""
+    - name: certificatemanager-maps
+      local: resource-certificatemanager-maps
+      remote: resource-certificatemanager-maps
+      command: gcloud certificate-manager maps
       group: certificatemanager
-      resource: certificatemanagercertificatemapentries
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: certificatemanager-certificatemanagercertificatemaps
-      local: resource-certificatemanager-certificatemanagercertificatemaps
-      remote: resource-certificatemanager-certificatemanagercertificatemaps
-      command: ""
-      group: certificatemanager
-      resource: certificatemanagercertificatemaps
-      controller: terraform
+      resource: maps
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -6070,12 +6059,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudasset-cloudassetprojectfeeds
-      local: resource-cloudasset-cloudassetprojectfeeds
-      remote: resource-cloudasset-cloudassetprojectfeeds
+    - name: cloudasset-cloudassetorganizationfeeds
+      local: resource-cloudasset-cloudassetorganizationfeeds
+      remote: resource-cloudasset-cloudassetorganizationfeeds
       command: ""
       group: cloudasset
-      resource: cloudassetprojectfeeds
+      resource: cloudassetorganizationfeeds
       controller: terraform
       skip: false
       kind: ""
@@ -6087,12 +6076,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudasset-cloudassetorganizationfeeds
-      local: resource-cloudasset-cloudassetorganizationfeeds
-      remote: resource-cloudasset-cloudassetorganizationfeeds
+    - name: cloudasset-cloudassetprojectfeeds
+      local: resource-cloudasset-cloudassetprojectfeeds
+      remote: resource-cloudasset-cloudassetprojectfeeds
       command: ""
       group: cloudasset
-      resource: cloudassetorganizationfeeds
+      resource: cloudassetprojectfeeds
       controller: terraform
       skip: false
       kind: ""
@@ -6546,13 +6535,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudidentity-cloudidentitymembership
-      local: resource-cloudidentity-cloudidentitymembership
-      remote: resource-cloudidentity-cloudidentitymembership
+    - name: cloudidentity-cloudidentitygroup
+      local: resource-cloudidentity-cloudidentitygroup
+      remote: resource-cloudidentity-cloudidentitygroup
       command: ""
       group: cloudidentity
-      resource: cloudidentitymembership
-      controller: dcl
+      resource: cloudidentitygroup
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -6563,13 +6552,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudidentity-cloudidentitygroup
-      local: resource-cloudidentity-cloudidentitygroup
-      remote: resource-cloudidentity-cloudidentitygroup
+    - name: cloudidentity-cloudidentitymembership
+      local: resource-cloudidentity-cloudidentitymembership
+      remote: resource-cloudidentity-cloudidentitymembership
       command: ""
       group: cloudidentity
-      resource: cloudidentitygroup
-      controller: terraform
+      resource: cloudidentitymembership
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -6597,12 +6586,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudiot-cloudiotdevices
-      local: resource-cloudiot-cloudiotdevices
-      remote: resource-cloudiot-cloudiotdevices
+    - name: cloudiot-cloudiotdeviceregistries
+      local: resource-cloudiot-cloudiotdeviceregistries
+      remote: resource-cloudiot-cloudiotdeviceregistries
       command: ""
       group: cloudiot
-      resource: cloudiotdevices
+      resource: cloudiotdeviceregistries
       controller: terraform
       skip: false
       kind: ""
@@ -6614,12 +6603,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: cloudiot-cloudiotdeviceregistries
-      local: resource-cloudiot-cloudiotdeviceregistries
-      remote: resource-cloudiot-cloudiotdeviceregistries
+    - name: cloudiot-cloudiotdevices
+      local: resource-cloudiot-cloudiotdevices
+      remote: resource-cloudiot-cloudiotdevices
       command: ""
       group: cloudiot
-      resource: cloudiotdeviceregistries
+      resource: cloudiotdevices
       controller: terraform
       skip: false
       kind: ""
@@ -6864,57 +6853,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computeinstances
-      local: resource-compute-computeinstances
-      remote: resource-compute-computeinstances
-      command: gcloud compute instances
-      group: compute
-      resource: computeinstances
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computeimages
-      local: resource-compute-computeimages
-      remote: resource-compute-computeimages
-      command: gcloud compute images
-      group: compute
-      resource: computeimages
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computefirewallpolicyrules
-      local: resource-compute-computefirewallpolicyrules
-      remote: resource-compute-computefirewallpolicyrules
-      command: gcloud compute firewall-rules
-      group: compute
-      resource: computefirewallpolicyrules
-      controller: direct
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: compute-computeaddresses
       local: resource-compute-computeaddresses
       remote: resource-compute-computeaddresses
@@ -6956,57 +6894,6 @@ branches:
       group: compute
       resource: computebackendbuckets
       controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-commitments
-      local: resource-compute-commitments
-      remote: resource-compute-commitments
-      command: gcloud compute commitments
-      group: compute
-      resource: commitments
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computefirewallpolicyassociations
-      local: resource-compute-computefirewallpolicyassociations
-      remote: resource-compute-computefirewallpolicyassociations
-      command: ""
-      group: compute
-      resource: computefirewallpolicyassociations
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computeinstancegroupmanagers
-      local: resource-compute-computeinstancegroupmanagers
-      remote: resource-compute-computeinstancegroupmanagers
-      command: ""
-      group: compute
-      resource: computeinstancegroupmanagers
-      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -7136,13 +7023,64 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computeinstantsnapshots
-      local: resource-compute-computeinstantsnapshots
-      remote: resource-compute-computeinstantsnapshots
-      command: gcloud compute instant-snapshots
+    - name: compute-computefirewallpolicies
+      local: resource-compute-computefirewallpolicies
+      remote: resource-compute-computefirewallpolicies
+      command: gcloud compute firewall-policies
       group: compute
-      resource: computeinstantsnapshots
-      controller: unknown
+      resource: computefirewallpolicies
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computefirewallpolicyassociations
+      local: resource-compute-computefirewallpolicyassociations
+      remote: resource-compute-computefirewallpolicyassociations
+      command: ""
+      group: compute
+      resource: computefirewallpolicyassociations
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computefirewallpolicyrules
+      local: resource-compute-computefirewallpolicyrules
+      remote: resource-compute-computefirewallpolicyrules
+      command: gcloud compute firewall-rules
+      group: compute
+      resource: computefirewallpolicyrules
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computefirewalls
+      local: resource-compute-computefirewalls
+      remote: resource-compute-computefirewalls
+      command: ""
+      group: compute
+      resource: computefirewalls
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -7187,193 +7125,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computevpntunnels
-      local: resource-compute-computevpntunnels
-      remote: resource-compute-computevpntunnels
-      command: gcloud compute vpn-tunnels
-      group: compute
-      resource: computevpntunnels
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computevpngateways
-      local: resource-compute-computevpngateways
-      remote: resource-compute-computevpngateways
-      command: gcloud compute vpn-gateways
-      group: compute
-      resource: computevpngateways
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computeurlmaps
-      local: resource-compute-computeurlmaps
-      remote: resource-compute-computeurlmaps
-      command: gcloud compute url-maps
-      group: compute
-      resource: computeurlmaps
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargetvpngateways
-      local: resource-compute-computetargetvpngateways
-      remote: resource-compute-computetargetvpngateways
-      command: gcloud compute target-vpn-gateways
-      group: compute
-      resource: computetargetvpngateways
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargettcpproxies
-      local: resource-compute-computetargettcpproxies
-      remote: resource-compute-computetargettcpproxies
-      command: gcloud compute target-tcp-proxies
-      group: compute
-      resource: computetargettcpproxies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargetsslproxies
-      local: resource-compute-computetargetsslproxies
-      remote: resource-compute-computetargetsslproxies
-      command: gcloud compute target-ssl-proxies
-      group: compute
-      resource: computetargetsslproxies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computepacketmirrorings
-      local: resource-compute-computepacketmirrorings
-      remote: resource-compute-computepacketmirrorings
-      command: gcloud compute packet-mirrorings
-      group: compute
-      resource: computepacketmirrorings
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargetpools
-      local: resource-compute-computetargetpools
-      remote: resource-compute-computetargetpools
-      command: gcloud compute target-pools
-      group: compute
-      resource: computetargetpools
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargetinstances
-      local: resource-compute-computetargetinstances
-      remote: resource-compute-computetargetinstances
-      command: gcloud compute target-instances
-      group: compute
-      resource: computetargetinstances
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computepublicadvertisedprefixes
-      local: resource-compute-computepublicadvertisedprefixes
-      remote: resource-compute-computepublicadvertisedprefixes
-      command: gcloud compute public-advertised-prefixes
-      group: compute
-      resource: computepublicadvertisedprefixes
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computepublicdelegatedprefixes
-      local: resource-compute-computepublicdelegatedprefixes
-      remote: resource-compute-computepublicdelegatedprefixes
-      command: gcloud compute public-delegated-prefixes
-      group: compute
-      resource: computepublicdelegatedprefixes
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: compute-computeglobalnetworkendpoints
       local: resource-compute-computeglobalnetworkendpoints
       remote: resource-compute-computeglobalnetworkendpoints
@@ -7398,23 +7149,6 @@ branches:
       group: compute
       resource: computehealthchecks
       controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computeserviceattachments
-      local: resource-compute-computeserviceattachments
-      remote: resource-compute-computeserviceattachments
-      command: gcloud compute service-attachments
-      group: compute
-      resource: computeserviceattachments
-      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -7459,12 +7193,29 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computefirewallpolicies
-      local: resource-compute-computefirewallpolicies
-      remote: resource-compute-computefirewallpolicies
-      command: gcloud compute firewall-policies
+    - name: compute-computeimages
+      local: resource-compute-computeimages
+      remote: resource-compute-computeimages
+      command: gcloud compute images
       group: compute
-      resource: computefirewallpolicies
+      resource: computeimages
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computeinstancegroupmanagers
+      local: resource-compute-computeinstancegroupmanagers
+      remote: resource-compute-computeinstancegroupmanagers
+      command: ""
+      group: compute
+      resource: computeinstancegroupmanagers
       controller: dcl
       skip: false
       kind: ""
@@ -7510,6 +7261,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: compute-computeinstances
+      local: resource-compute-computeinstances
+      remote: resource-compute-computeinstances
+      command: gcloud compute instances
+      group: compute
+      resource: computeinstances
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: compute-computeinstancetemplates
       local: resource-compute-computeinstancetemplates
       remote: resource-compute-computeinstancetemplates
@@ -7517,6 +7285,23 @@ branches:
       group: compute
       resource: computeinstancetemplates
       controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computeinstantsnapshots
+      local: resource-compute-computeinstantsnapshots
+      remote: resource-compute-computeinstantsnapshots
+      command: gcloud compute instant-snapshots
+      group: compute
+      resource: computeinstantsnapshots
+      controller: unknown
       skip: false
       kind: ""
       package: ""
@@ -7612,13 +7397,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computenetworkendpointgroups
-      local: resource-compute-computenetworkendpointgroups
-      remote: resource-compute-computenetworkendpointgroups
-      command: gcloud compute network-endpoint-groups
+    - name: compute-computenetworkedgesecurityservices
+      local: resource-compute-computenetworkedgesecurityservices
+      remote: resource-compute-computenetworkedgesecurityservices
+      command: gcloud compute network-edge-security-services
       group: compute
-      resource: computenetworkendpointgroups
-      controller: terraform
+      resource: computenetworkedgesecurityservices
+      controller: unknown
       skip: false
       kind: ""
       package: ""
@@ -7629,13 +7414,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computenetworkedgesecurityservices
-      local: resource-compute-computenetworkedgesecurityservices
-      remote: resource-compute-computenetworkedgesecurityservices
-      command: gcloud compute network-edge-security-services
+    - name: compute-computenetworkendpointgroups
+      local: resource-compute-computenetworkendpointgroups
+      remote: resource-compute-computenetworkendpointgroups
+      command: gcloud compute network-endpoint-groups
       group: compute
-      resource: computenetworkedgesecurityservices
-      controller: unknown
+      resource: computenetworkendpointgroups
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -7833,23 +7618,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computenetworksvpcaccessoperations
-      local: resource-compute-computenetworksvpcaccessoperations
-      remote: resource-compute-computenetworksvpcaccessoperations
-      command: gcloud compute networks vpc-access operations
-      group: compute
-      resource: computenetworksvpcaccessoperations
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: compute-computenodegroups
       local: resource-compute-computenodegroups
       remote: resource-compute-computenodegroups
@@ -7935,30 +7703,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-osloginsshkeys
-      local: resource-compute-osloginsshkeys
-      remote: resource-compute-osloginsshkeys
-      command: gcloud compute os-login ssh-keys
+    - name: compute-computepacketmirrorings
+      local: resource-compute-computepacketmirrorings
+      remote: resource-compute-computepacketmirrorings
+      command: gcloud compute packet-mirrorings
       group: compute
-      resource: osloginsshkeys
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-projectinfo
-      local: resource-projectinfo
-      remote: resource-projectinfo
-      command: gcloud compute project-info
-      group: compute
-      resource: projectinfo
-      controller: Unknown
+      resource: computepacketmirrorings
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -7993,6 +7744,40 @@ branches:
       group: compute
       resource: computeprojectmetadatas
       controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computepublicadvertisedprefixes
+      local: resource-compute-computepublicadvertisedprefixes
+      remote: resource-compute-computepublicadvertisedprefixes
+      command: gcloud compute public-advertised-prefixes
+      group: compute
+      resource: computepublicadvertisedprefixes
+      controller: unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computepublicdelegatedprefixes
+      local: resource-compute-computepublicdelegatedprefixes
+      remote: resource-compute-computepublicdelegatedprefixes
+      command: gcloud compute public-delegated-prefixes
+      group: compute
+      resource: computepublicdelegatedprefixes
+      controller: unknown
       skip: false
       kind: ""
       package: ""
@@ -8054,12 +7839,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computesharedvpcserviceprojects
-      local: resource-compute-computesharedvpcserviceprojects
-      remote: resource-compute-computesharedvpcserviceprojects
-      command: gcloud compute shared-vpc associated-projects
+    - name: compute-computeregionperinstanceconfigs
+      local: resource-compute-computeregionperinstanceconfigs
+      remote: resource-compute-computeregionperinstanceconfigs
+      command: ""
       group: compute
-      resource: computesharedvpcserviceprojects
+      resource: computeregionperinstanceconfigs
       controller: terraform
       skip: false
       kind: ""
@@ -8071,12 +7856,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computesnapshots
-      local: resource-compute-computesnapshots
-      remote: resource-compute-computesnapshots
-      command: gcloud compute snapshots
+    - name: compute-computeregionsslpolicies
+      local: resource-compute-computeregionsslpolicies
+      remote: resource-compute-computeregionsslpolicies
+      command: ""
       group: compute
-      resource: computesnapshots
+      resource: computeregionsslpolicies
       controller: terraform
       skip: false
       kind: ""
@@ -8224,6 +8009,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: compute-computeserviceattachments
+      local: resource-compute-computeserviceattachments
+      remote: resource-compute-computeserviceattachments
+      command: gcloud compute service-attachments
+      group: compute
+      resource: computeserviceattachments
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: compute-computesharedvpchostprojects
       local: resource-compute-computesharedvpchostprojects
       remote: resource-compute-computesharedvpchostprojects
@@ -8241,12 +8043,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computeregionperinstanceconfigs
-      local: resource-compute-computeregionperinstanceconfigs
-      remote: resource-compute-computeregionperinstanceconfigs
-      command: ""
+    - name: compute-computesharedvpcserviceprojects
+      local: resource-compute-computesharedvpcserviceprojects
+      remote: resource-compute-computesharedvpcserviceprojects
+      command: gcloud compute shared-vpc associated-projects
       group: compute
-      resource: computeregionperinstanceconfigs
+      resource: computesharedvpcserviceprojects
       controller: terraform
       skip: false
       kind: ""
@@ -8258,12 +8060,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computeregionsslpolicies
-      local: resource-compute-computeregionsslpolicies
-      remote: resource-compute-computeregionsslpolicies
-      command: ""
+    - name: compute-computesnapshots
+      local: resource-compute-computesnapshots
+      remote: resource-compute-computesnapshots
+      command: gcloud compute snapshots
       group: compute
-      resource: computeregionsslpolicies
+      resource: computesnapshots
       controller: terraform
       skip: false
       kind: ""
@@ -8275,12 +8077,29 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computefirewalls
-      local: resource-compute-computefirewalls
-      remote: resource-compute-computefirewalls
-      command: ""
+    - name: compute-computesnapshotsettings
+      local: resource-compute-computesnapshotsettings
+      remote: resource-compute-computesnapshotsettings
+      command: gcloud compute snapshot-settings
       group: compute
-      resource: computefirewalls
+      resource: computesnapshotsettings
+      controller: unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computesslcertificates
+      local: resource-compute-computesslcertificates
+      remote: resource-compute-computesslcertificates
+      command: gcloud compute ssl-certificates
+      group: compute
+      resource: computesslcertificates
       controller: terraform
       skip: false
       kind: ""
@@ -8292,63 +8111,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computetargethttpsproxies
-      local: resource-compute-computetargethttpsproxies
-      remote: resource-compute-computetargethttpsproxies
-      command: gcloud compute target-https-proxies
+    - name: compute-computesslpolicies
+      local: resource-compute-computesslpolicies
+      remote: resource-compute-computesslpolicies
+      command: gcloud compute ssl-policies
       group: compute
-      resource: computetargethttpsproxies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargethttpproxies
-      local: resource-compute-computetargethttpproxies
-      remote: resource-compute-computetargethttpproxies
-      command: gcloud compute target-http-proxies
-      group: compute
-      resource: computetargethttpproxies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computetargetgrpcproxies
-      local: resource-compute-computetargetgrpcproxies
-      remote: resource-compute-computetargetgrpcproxies
-      command: gcloud compute target-grpc-proxies
-      group: compute
-      resource: computetargetgrpcproxies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: compute-computesubnetworks
-      local: resource-compute-computesubnetworks
-      remote: resource-compute-computesubnetworks
-      command: ""
-      group: compute
-      resource: computesubnetworks
+      resource: computesslpolicies
       controller: terraform
       skip: false
       kind: ""
@@ -8377,12 +8145,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computesslpolicies
-      local: resource-compute-computesslpolicies
-      remote: resource-compute-computesslpolicies
-      command: gcloud compute ssl-policies
+    - name: compute-computesubnetworks
+      local: resource-compute-computesubnetworks
+      remote: resource-compute-computesubnetworks
+      command: ""
       group: compute
-      resource: computesslpolicies
+      resource: computesubnetworks
       controller: terraform
       skip: false
       kind: ""
@@ -8394,12 +8162,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computesslcertificates
-      local: resource-compute-computesslcertificates
-      remote: resource-compute-computesslcertificates
-      command: gcloud compute ssl-certificates
+    - name: compute-computetargetgrpcproxies
+      local: resource-compute-computetargetgrpcproxies
+      remote: resource-compute-computetargetgrpcproxies
+      command: gcloud compute target-grpc-proxies
       group: compute
-      resource: computesslcertificates
+      resource: computetargetgrpcproxies
       controller: terraform
       skip: false
       kind: ""
@@ -8411,12 +8179,182 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: compute-computesnapshotsettings
-      local: resource-compute-computesnapshotsettings
-      remote: resource-compute-computesnapshotsettings
-      command: gcloud compute snapshot-settings
+    - name: compute-computetargethttpproxies
+      local: resource-compute-computetargethttpproxies
+      remote: resource-compute-computetargethttpproxies
+      command: gcloud compute target-http-proxies
       group: compute
-      resource: computesnapshotsettings
+      resource: computetargethttpproxies
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargethttpsproxies
+      local: resource-compute-computetargethttpsproxies
+      remote: resource-compute-computetargethttpsproxies
+      command: gcloud compute target-https-proxies
+      group: compute
+      resource: computetargethttpsproxies
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargetinstances
+      local: resource-compute-computetargetinstances
+      remote: resource-compute-computetargetinstances
+      command: gcloud compute target-instances
+      group: compute
+      resource: computetargetinstances
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargetpools
+      local: resource-compute-computetargetpools
+      remote: resource-compute-computetargetpools
+      command: gcloud compute target-pools
+      group: compute
+      resource: computetargetpools
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargetsslproxies
+      local: resource-compute-computetargetsslproxies
+      remote: resource-compute-computetargetsslproxies
+      command: gcloud compute target-ssl-proxies
+      group: compute
+      resource: computetargetsslproxies
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargettcpproxies
+      local: resource-compute-computetargettcpproxies
+      remote: resource-compute-computetargettcpproxies
+      command: gcloud compute target-tcp-proxies
+      group: compute
+      resource: computetargettcpproxies
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computetargetvpngateways
+      local: resource-compute-computetargetvpngateways
+      remote: resource-compute-computetargetvpngateways
+      command: gcloud compute target-vpn-gateways
+      group: compute
+      resource: computetargetvpngateways
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computeurlmaps
+      local: resource-compute-computeurlmaps
+      remote: resource-compute-computeurlmaps
+      command: gcloud compute url-maps
+      group: compute
+      resource: computeurlmaps
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computevpngateways
+      local: resource-compute-computevpngateways
+      remote: resource-compute-computevpngateways
+      command: gcloud compute vpn-gateways
+      group: compute
+      resource: computevpngateways
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-computevpntunnels
+      local: resource-compute-computevpntunnels
+      remote: resource-compute-computevpntunnels
+      command: gcloud compute vpn-tunnels
+      group: compute
+      resource: computevpntunnels
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: compute-networksvpcaccessconnector
+      local: resource-compute-networksvpcaccessconnector
+      remote: resource-compute-networksvpcaccessconnector
+      command: gcloud compute networks vpc-access connectors
+      group: compute
+      resource: networksvpcaccessconnector
       controller: unknown
       skip: false
       kind: ""
@@ -8426,7 +8364,1103 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
+      notes:
+        - no proto found
+      apis-enabled: []
+    - name: compute-osloginsshkey
+      local: resource-compute-osloginsshkey
+      remote: resource-compute-osloginsshkey
+      command: gcloud compute os-login ssh-keys
+      group: compute
+      resource: osloginsshkey
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no proto found
+      apis-enabled: []
+    - name: compute-osloginsshkeys
+      local: resource-compute-osloginsshkeys
+      remote: resource-compute-osloginsshkeys
+      command: gcloud compute os-login ssh-keys
+      group: compute
+      resource: osloginsshkeys
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
       notes: []
+      apis-enabled: []
+    - name: compute-projectinfo
+      local: resource-projectinfo
+      remote: resource-projectinfo
+      command: gcloud compute project-info
+      group: compute
+      resource: projectinfo
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no proto found
+      apis-enabled: []
+    - name: compute-sharedvpchostproject
+      local: resource-compute-sharedvpchostproject
+      remote: resource-compute-sharedvpchostproject
+      command: gcloud compute shared-vpc
+      group: compute
+      resource: sharedvpchostproject
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
+      apis-enabled: []
+    - name: compute-sharedvpcserviceproject
+      local: resource-compute-sharedvpcserviceproject
+      remote: resource-compute-sharedvpcserviceproject
+      command: gcloud compute shared-vpc associated-projects
+      group: compute
+      resource: sharedvpcserviceproject
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
+      apis-enabled: []
+    - name: compute-address
+      local: resource-compute-address
+      remote: resource-compute-address
+      command: gcloud compute addresses
+      group: compute
+      resource: address
+      controller: terraform
+      skip: false
+      kind: ComputeAddress
+      package: google.cloud.compute.v1
+      proto: Address
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Addresses
+      proto-msg: google.cloud.compute.v1.Address
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-backendbucket
+      local: resource-compute-backendbucket
+      remote: resource-compute-backendbucket
+      command: gcloud compute backend-buckets
+      group: compute
+      resource: backendbucket
+      controller: terraform
+      skip: false
+      kind: ComputeBackendBucket
+      package: google.cloud.compute.v1
+      proto: BackendBucket
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.BackendBuckets
+      proto-msg: google.cloud.compute.v1.BackendBucket
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-backendservice
+      local: resource-compute-backendservice
+      remote: resource-compute-backendservice
+      command: gcloud compute backend-services
+      group: compute
+      resource: backendservice
+      controller: terraform
+      skip: false
+      kind: ComputeBackendService
+      package: google.cloud.compute.v1
+      proto: BackendService
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.BackendServices
+      proto-msg: google.cloud.compute.v1.BackendService
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-commitment
+      local: resource-compute-commitment
+      remote: resource-compute-commitment
+      command: gcloud compute commitments
+      group: compute
+      resource: commitments
+      controller: unknown
+      skip: false
+      kind: ComputeCommitment
+      package: google.cloud.compute.v1
+      proto: Commitment
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Commitments
+      proto-msg: google.cloud.compute.v1.Commitment
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-disk
+      local: resource-compute-disk
+      remote: resource-compute-disk
+      command: gcloud compute disks
+      group: compute
+      resource: computedisk
+      controller: terraform
+      skip: false
+      kind: ComputeDisk
+      package: google.cloud.compute.v1
+      proto: Disk
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Disks
+      proto-msg: google.cloud.compute.v1.Disk
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-disksbulk
+      local: resource-compute-disksbulk
+      remote: resource-compute-disksbulk
+      command: gcloud compute disks bulk
+      group: compute
+      resource: disksbulk
+      controller: unknown
+      skip: false
+      kind: ComputeDisksBulk
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: ""
+      host-name: compute.googleapis.com
+      notes:
+        - no proto found
+        - a bulk method of disk CRUD
+      apis-enabled: []
+    - name: compute-externalvpngateway
+      local: resource-compute-externalvpngateway
+      remote: resource-compute-externalvpngateway
+      command: gcloud compute external-vpn-gateways
+      group: compute
+      resource: externalvpngateway
+      controller: terraform
+      skip: false
+      kind: ComputeExternalVpnGateway
+      package: google.cloud.compute.v1
+      proto: ExternalVpnGateway
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.ExternalVpnGateways
+      proto-msg: google.cloud.compute.v1.ExternalVpnGateway
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-firewallpolicy
+      local: resource-compute-firewallpolicy
+      remote: resource-compute-firewallpolicy
+      command: gcloud compute firewall-policies
+      group: compute
+      resource: firewallpolicy
+      controller: dcl
+      skip: false
+      kind: ComputeFirewallPolicy
+      package: google.cloud.compute.v1
+      proto: FirewallPolicy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.FirewallPolicies
+      proto-msg: google.cloud.compute.v1.FirewallPolicy
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - DCL beta
+      apis-enabled: []
+    - name: compute-firewallpolicyrule
+      local: resource-compute-firewallpolicyrule
+      remote: resource-compute-firewallpolicyrule
+      command: gcloud compute firewall-rules
+      group: compute
+      resource: firewallpolicyrule
+      controller: direct
+      skip: false
+      kind: ComputeFirewallPolicyRule
+      package: google.cloud.compute.v1
+      proto: FirewallPolicyRule
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.FirewallPolicyRules
+      proto-msg: google.cloud.compute.v1.FirewallPolicyRule
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - direct beta
+      apis-enabled: []
+    - name: compute-forwardingrule
+      local: resource-compute-forwardingrule
+      remote: resource-compute-forwardingrules
+      command: gcloud compute forwarding-rule
+      group: compute
+      resource: forwardingrule
+      controller: terraform
+      skip: false
+      kind: ComputeForwardingRule
+      package: google.cloud.compute.v1
+      proto: ForwardingRule
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.ForwardingRules
+      proto-msg: google.cloud.compute.v1.ForwardingRule
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-httphealthcheck
+      local: resource-compute-httphealthcheck
+      remote: resource-compute-httphealthcheck
+      command: gcloud compute http-health-checks
+      group: compute
+      resource: httphealthcheck
+      controller: terraform
+      skip: false
+      kind: ComputeHTTPHealthCheck
+      package: google.cloud.compute.v1
+      proto: HTTPHealthCheck
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.HTTPHealthChecks
+      proto-msg: google.cloud.compute.v1.HTTPHealthCheck
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-httpshealthcheck
+      local: resource-compute-httpshealthcheck
+      remote: resource-compute-httpshealthcheck
+      command: gcloud compute https-health-checks
+      group: compute
+      resource: httpshealthcheck
+      controller: terraform
+      skip: false
+      kind: ComputeHTTPSHealthCheck
+      package: google.cloud.compute.v1
+      proto: HTTPSHealthCheck
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.HTTPSHealthChecks
+      proto-msg: google.cloud.compute.v1.HTTPSHealthCheck
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-healthcheck
+      local: resource-compute-healthcheck
+      remote: resource-compute-healthcheck
+      command: gcloud compute health-checks
+      group: compute
+      resource: healthcheck
+      controller: terraform
+      skip: false
+      kind: ComputeHealthCheck
+      package: google.cloud.compute.v1
+      proto: HealthCheck
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.HealthChecks
+      proto-msg: google.cloud.compute.v1.HealthCheck
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-image
+      local: resource-compute-image
+      remote: resource-compute-image
+      command: gcloud compute images
+      group: compute
+      resource: image
+      controller: terraform
+      skip: false
+      kind: ComputeImage
+      package: google.cloud.compute.v1
+      proto: Image
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Images
+      proto-msg: google.cloud.compute.v1.Image
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-instance
+      local: resource-compute-instance
+      remote: resource-compute-instance
+      command: gcloud compute instances
+      group: compute
+      resource: instance
+      controller: terraform
+      skip: false
+      kind: ComputeInstance
+      package: google.cloud.compute.v1
+      proto: Instance
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Instances
+      proto-msg: google.cloud.compute.v1.Instance
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-instancegroup
+      local: resource-compute-instancegroup
+      remote: resource-compute-instancegroup
+      command: gcloud compute instance-groups
+      group: compute
+      resource: instancegroup
+      controller: terraform
+      skip: false
+      kind: ComputeInstanceGroup
+      package: google.cloud.compute.v1
+      proto: InstanceGroup
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.InstanceGroups
+      proto-msg: google.cloud.compute.v1.InstanceGroup
+      host-name: compute.googleapis.com
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - TF beta
+      apis-enabled: []
+    - name: compute-instancetemplate
+      local: resource-compute-instancetemplate
+      remote: resource-compute-instancetemplate
+      command: gcloud compute instance-templates
+      group: compute
+      resource: instancetemplate
+      controller: terraform
+      skip: false
+      kind: ComputeInstanceTemplate
+      package: google.cloud.compute.v1
+      proto: InstanceTemplate
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.InstanceTemplates
+      proto-msg: google.cloud.compute.v1.InstanceTemplate
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-instantsnapshot
+      local: resource-compute-instantsnapshot
+      remote: resource-compute-instantsnapshot
+      command: gcloud compute instant-snapshots
+      group: compute
+      resource: instantsnapshot
+      controller: unknown
+      skip: false
+      kind: ComputeInstantSnapshot
+      package: google.cloud.compute.v1
+      proto: InstantSnapshot
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.InstantSnapshots
+      proto-msg: google.cloud.compute.v1.InstantSnapshot
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-interconnect
+      local: resource-compute-interconnect
+      remote: resource-compute-interconnect
+      command: gcloud compute interconnects
+      group: compute
+      resource: interconnect
+      controller: unknown
+      skip: false
+      kind: ComputeInterconnect
+      package: google.cloud.compute.v1
+      proto: Interconnect
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Interconnects
+      proto-msg: google.cloud.compute.v1.Interconnect
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-interconnectattachment
+      local: resource-compute-interconnectattachment
+      remote: resource-compute-interconnectattachment
+      command: gcloud compute interconnects attachments
+      group: compute
+      resource: interconnectattachment
+      controller: terraform
+      skip: false
+      kind: ComputeInterconnectAttachment
+      package: google.cloud.compute.v1
+      proto: InterconnectAttachment
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.InterconnectAttachments
+      proto-msg: google.cloud.compute.v1.InterconnectAttachment
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-machineimage
+      local: resource-compute-machineimage
+      remote: resource-compute-machineimage
+      command: gcloud compute machine-images
+      group: compute
+      resource: machineimage
+      controller: terraform
+      skip: false
+      kind: ComputeMachineImage
+      package: google.cloud.compute.v1
+      proto: MachineImage
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.MachineImages
+      proto-msg: google.cloud.compute.v1.MachineImage
+      host-name: compute.googleapis.com
+      notes:
+        - TF alpha
+      apis-enabled: []
+    - name: compute-network
+      local: resource-compute-network
+      remote: resource-compute-network
+      command: gcloud compute networks
+      group: compute
+      resource: network
+      controller: terraform
+      skip: false
+      kind: ComputeNetwork
+      package: google.cloud.compute.v1
+      proto: Network
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Networks
+      proto-msg: google.cloud.compute.v1.Network
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-networkattachment
+      local: resource-compute-networkattachment
+      remote: resource-compute-networkattachment
+      command: gcloud compute network-attachments
+      group: compute
+      resource: networkattachment
+      controller: unknown
+      skip: false
+      kind: ComputeNetworkAttachment
+      package: google.cloud.compute.v1
+      proto: NetworkAttachment
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.NetworkAttachments
+      proto-msg: google.cloud.compute.v1.NetworkAttachment
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-networkedgesecurityservice
+      local: resource-compute-networkedgesecurityservice
+      remote: resource-compute-networkedgesecurityservice
+      command: gcloud compute network-edge-security-services
+      group: compute
+      resource: networkedgesecurityservice
+      controller: unknown
+      skip: false
+      kind: ComputeNetworkEdgeSecurityService
+      package: google.cloud.compute.v1
+      proto: NetworkEdgeSecurityService
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.NetworkEdgeSecurityServices
+      proto-msg: google.cloud.compute.v1.NetworkEdgeSecurityService
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-networkendpointgroup
+      local: resource-compute-networkendpointgroup
+      remote: resource-compute-networkendpointgroup
+      command: gcloud compute network-endpoint-groups
+      group: compute
+      resource: networkendpointgroup
+      controller: terraform
+      skip: false
+      kind: ComputeNetworkEndpointGroup
+      package: google.cloud.compute.v1
+      proto: NetworkEndpointGroup
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.NetworkEndpointGroups
+      proto-msg: google.cloud.compute.v1.NetworkEndpointGroup
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-networkfirewallpolicy
+      local: resource-compute-networkfirewallpolicy
+      remote: resource-compute-networkfirewallpolicy
+      command: gcloud compute network-firewall-policies
+      group: compute
+      resource: networkfirewallpolicy
+      controller: terraform
+      skip: false
+      kind: ComputeNetworkFirewallPolicy
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: ""
+      host-name: compute.googleapis.com
+      notes:
+        - TF alpha
+        - proto not found
+      apis-enabled: []
+    - name: compute-networkpeering
+      local: resource-compute-networkpeering
+      remote: resource-compute-networkpeering
+      command: gcloud compute networks peerings
+      group: compute
+      resource: networkpeering
+      controller: unknown
+      skip: false
+      kind: ComputeNetworkPeering
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: google.cloud.compute.v1.NetworkPeering
+      host-name: ""
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-packetmirroring
+      local: resource-compute-packetmirroring
+      remote: resource-compute-packetmirroring
+      command: gcloud compute packet-mirrorings
+      group: compute
+      resource: packetmirroring
+      controller: dcl
+      skip: false
+      kind: ComputePacketMirroring
+      package: google.cloud.compute.v1
+      proto: PacketMirroring
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.PacketMirrorings
+      proto-msg: google.cloud.compute.v1.PacketMirroring
+      host-name: compute.googleapis.com
+      notes:
+        - DCL Beta
+      apis-enabled: []
+    - name: compute-computeprojectmetadata
+      local: resource-compute-projectmetadata
+      remote: resource-compute-projectmetadata
+      command: gcloud compute project-zonal-metadata
+      group: compute
+      resource: projectmetadata
+      controller: terraform
+      skip: false
+      kind: ComputeProjectMetadata
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: ""
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+        - no proto found
+      apis-enabled: []
+    - name: compute-publicadvertisedprefix
+      local: resource-compute-publicadvertisedprefix
+      remote: resource-compute-publicadvertisedprefix
+      command: gcloud compute public-advertised-prefixes
+      group: compute
+      resource: publicadvertisedprefix
+      controller: unknown
+      skip: false
+      kind: ComputePublicAdvertisedPrefix
+      package: google.cloud.compute.v1
+      proto: PublicAdvertisedPrefix
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.PublicAdvertisedPrefixes
+      proto-msg: google.cloud.compute.v1.PublicAdvertisedPrefix
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-publicdelegatedprefix
+      local: resource-compute-publicdelegatedprefix
+      remote: resource-compute-publicdelegatedprefix
+      command: gcloud compute public-delegated-prefixes
+      group: compute
+      resource: publicdelegatedprefix
+      controller: unknown
+      skip: false
+      kind: ComputePublicDelegatedPrefix
+      package: google.cloud.compute.v1
+      proto: PublicDelegatedPrefix
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.PublicDelegatedPrefixes
+      proto-msg: google.cloud.compute.v1.PublicDelegatedPrefix
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-reservation
+      local: resource-compute-reservation
+      remote: resource-compute-reservation
+      command: gcloud compute reservations
+      group: compute
+      resource: reservation
+      controller: terraform
+      skip: false
+      kind: ComputeReservation
+      package: google.cloud.compute.v1
+      proto: Reservation
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Reservations
+      proto-msg: google.cloud.compute.v1.Reservation
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-resourcepolicy
+      local: resource-compute-resourcepolicy
+      remote: resource-compute-resourcepolicy
+      command: gcloud compute resource-policies
+      group: compute
+      resource: resourcepolicy
+      controller: terraform
+      skip: false
+      kind: ComputeResourcePolicy
+      package: google.cloud.compute.v1
+      proto: ResourcePolicy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.ResourcePolicies
+      proto-msg: google.cloud.compute.v1.ResourcePolicy
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-route
+      local: resource-compute-route
+      remote: resource-compute-route
+      command: gcloud compute routes
+      group: compute
+      resource: route
+      controller: terraform
+      skip: false
+      kind: ComputeRoute
+      package: google.cloud.compute.v1
+      proto: Route
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Routes
+      proto-msg: google.cloud.compute.v1.Route
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-router
+      local: resource-compute-router
+      remote: resource-compute-router
+      command: gcloud compute routers
+      group: compute
+      resource: router
+      controller: terraform
+      skip: false
+      kind: ComputeRouter
+      package: google.cloud.compute.v1
+      proto: Router
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Routers
+      proto-msg: google.cloud.compute.v1.Router
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-routernat
+      local: resource-compute-routernat
+      remote: resource-compute-routernat
+      command: gcloud compute routers nats
+      group: compute
+      resource: routernat
+      controller: terraform
+      skip: false
+      kind: ComputeRouterNat
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: google.cloud.compute.v1.RouterNat
+      host-name: ""
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-securitypolicy
+      local: resource-compute-securitypolicy
+      remote: resource-compute-securitypolicy
+      command: gcloud compute security-policies
+      group: compute
+      resource: securitypolicy
+      controller: terraform
+      skip: false
+      kind: ComputeSecurityPolicy
+      package: google.cloud.compute.v1
+      proto: SecurityPolicy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.SecurityPolicies
+      proto-msg: google.cloud.compute.v1.SecurityPolicy
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-serviceattachment
+      local: resource-compute-serviceattachment
+      remote: resource-compute-serviceattachment
+      command: gcloud compute service-attachments
+      group: compute
+      resource: serviceattachment
+      controller: dcl
+      skip: false
+      kind: ComputeServiceAttachment
+      package: google.cloud.compute.v1
+      proto: ServiceAttachment
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.ServiceAttachments
+      proto-msg: google.cloud.compute.v1.ServiceAttachment
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - DCL beta
+      apis-enabled: []
+    - name: compute-snapshot
+      local: resource-compute-snapshot
+      remote: resource-compute-snapshot
+      command: gcloud compute snapshots
+      group: compute
+      resource: snapshot
+      controller: terraform
+      skip: false
+      kind: ComputeSnapshot
+      package: google.cloud.compute.v1
+      proto: ""
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: ""
+      proto-msg: google.cloud.compute.v1.Snapshot
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-snapshotsettings
+      local: resource-compute-snapshotsettings
+      remote: resource-compute-snapshotsettings
+      command: gcloud compute snapshot-settings
+      group: compute
+      resource: snapshotsettings
+      controller: unknown
+      skip: false
+      kind: ComputeSnapshotSettings
+      package: google.cloud.compute.v1
+      proto: SnapshotSettings
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.SnapshotSettingsService
+      proto-msg: google.cloud.compute.v1.SnapshotSettings
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-sslcertificate
+      local: resource-compute-sslcertificate
+      remote: resource-compute-sslcertificate
+      command: gcloud compute ssl-certificates
+      group: compute
+      resource: sslcertificate
+      controller: terraform
+      skip: false
+      kind: ComputeSslCertificate
+      package: google.cloud.compute.v1
+      proto: SslCertificate
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.SslCertificates
+      proto-msg: google.cloud.compute.v1.SslCertificate
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-sslpolicy
+      local: resource-compute-sslpolicy
+      remote: resource-compute-sslpolicy
+      command: gcloud compute ssl-policies
+      group: compute
+      resource: sslpolicy
+      controller: terraform
+      skip: false
+      kind: ComputeSslPolicy
+      package: google.cloud.compute.v1
+      proto: SslPolicy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.SslPolicies
+      proto-msg: google.cloud.compute.v1.SslPolicy
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-storagepool
+      local: resource-compute-storagepool
+      remote: resource-compute-storagepool
+      command: gcloud compute storage-pools
+      group: compute
+      resource: storagepool
+      controller: unknown
+      skip: false
+      kind: ComputeStoragePool
+      package: google.cloud.compute.v1
+      proto: StoragePool
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.StoragePools
+      proto-msg: google.cloud.compute.v1.StoragePool
+      host-name: compute.googleapis.com
+      notes: []
+      apis-enabled: []
+    - name: compute-subnetwork
+      local: resource-compute-subnetwork
+      remote: resource-compute-subnetwork
+      command: gcloud compute networks subnets
+      group: compute
+      resource: subnetwork
+      controller: unknown
+      skip: false
+      kind: ComputeSubnetwork
+      package: google.cloud.compute.v1
+      proto: Subnetwork
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.Subnetworks
+      proto-msg: google.cloud.compute.v1.Subnetwork
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-targetgrpcproxy
+      local: resource-compute-targetgrpcproxy
+      remote: resource-compute-targetgrpcproxy
+      command: gcloud compute target-grpc-proxies
+      group: compute
+      resource: targetgrpcproxy
+      controller: terraform
+      skip: false
+      kind: ComputeTargetGrpcProxy
+      package: google.cloud.compute.v1
+      proto: TargetGrpcProxy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetGrpcProxies
+      proto-msg: google.cloud.compute.v1.TargetGrpcProxy
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-targethttpproxy
+      local: resource-compute-targethttpproxy
+      remote: resource-compute-targethttpproxy
+      command: gcloud compute target-http-proxies
+      group: compute
+      resource: targethttpproxy
+      controller: terraform
+      skip: false
+      kind: ComputeTargetHttpProxy
+      package: google.cloud.compute.v1
+      proto: TargetHttpProxy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetHttpProxies
+      proto-msg: google.cloud.compute.v1.TargetHttpProxy
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-targethttpsproxy
+      local: resource-compute-targethttpsproxy
+      remote: resource-compute-targethttpsproxy
+      command: gcloud compute target-https-proxies
+      group: compute
+      resource: targethttpsproxy
+      controller: terraform
+      skip: false
+      kind: ComputeTargetHttpsProxy
+      package: google.cloud.compute.v1
+      proto: TargetHttpsProxy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetHttpsProxies
+      proto-msg: google.cloud.compute.v1.TargetHttpsProxy
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-targetinstance
+      local: resource-compute-targetinstance
+      remote: resource-compute-targetinstance
+      command: gcloud compute target-instances
+      group: compute
+      resource: targetinstance
+      controller: terraform
+      skip: false
+      kind: ComputeTargetInstance
+      package: google.cloud.compute.v1
+      proto: TargetInstance
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetInstances
+      proto-msg: google.cloud.compute.v1.TargetInstance
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-targetpool
+      local: resource-compute-targetpool
+      remote: resource-compute-targetpool
+      command: gcloud compute target-pools
+      group: compute
+      resource: targetpool
+      controller: terraform
+      skip: false
+      kind: ComputeTargetPool
+      package: google.cloud.compute.v1
+      proto: TargetPool
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetPools
+      proto-msg: google.cloud.compute.v1.TargetPool
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-targetsslproxy
+      local: resource-compute-targetsslproxy
+      remote: resource-compute-targetsslproxy
+      command: gcloud compute target-ssl-proxies
+      group: compute
+      resource: targetsslproxy
+      controller: terraform
+      skip: false
+      kind: ComputeTargetSslProxy
+      package: google.cloud.compute.v1
+      proto: TargetSslProxy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetSslProxies
+      proto-msg: google.cloud.compute.v1.TargetSslProxy
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-targettcpproxy
+      local: resource-compute-targettcpproxy
+      remote: resource-compute-targettcpproxy
+      command: gcloud compute target-tcp-proxies
+      group: compute
+      resource: targettcpproxy
+      controller: terraform
+      skip: false
+      kind: ComputeTargetTcpProxy
+      package: google.cloud.compute.v1
+      proto: TargetTcpProxy
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetTcpProxies
+      proto-msg: google.cloud.compute.v1.TargetTcpProxy
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-targetvpngateway
+      local: resource-compute-targetvpngateway
+      remote: resource-compute-targetvpngateway
+      command: gcloud compute target-vpn-gateways
+      group: compute
+      resource: targetvpngateway
+      controller: terraform
+      skip: false
+      kind: ComputeTargetVpnGateway
+      package: google.cloud.compute.v1
+      proto: TargetVpnGateway
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.TargetVpnGateways
+      proto-msg: google.cloud.compute.v1.TargetVpnGateway
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
+      apis-enabled: []
+    - name: compute-urlmap
+      local: resource-compute-urlmap
+      remote: resource-compute-urlmap
+      command: gcloud compute url-maps
+      group: compute
+      resource: urlmap
+      controller: terraform
+      skip: false
+      kind: ComputeUrlMap
+      package: google.cloud.compute.v1
+      proto: UrlMap
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.UrlMaps
+      proto-msg: google.cloud.compute.v1.UrlMap
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-vpngateway
+      local: resource-compute-vpngateway
+      remote: resource-compute-vpngateway
+      command: gcloud compute vpn-gateways
+      group: compute
+      resource: vpngateway
+      controller: terraform
+      skip: false
+      kind: ComputeVpnGateway
+      package: google.cloud.compute.v1
+      proto: VpnGateway
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.VpnGateways
+      proto-msg: google.cloud.compute.v1.VpnGateway
+      host-name: compute.googleapis.com
+      notes:
+        - mock exists
+        - TF beta
+      apis-enabled: []
+    - name: compute-vpntunnel
+      local: resource-compute-vpntunnel
+      remote: resource-compute-vpntunnel
+      command: gcloud compute vpn-tunnels
+      group: compute
+      resource: vpntunnel
+      controller: terraform
+      skip: false
+      kind: ComputeVpnTunnel
+      package: google.cloud.compute.v1
+      proto: VpnTunnel
+      proto-path: google/cloud/compute/v1/compute.proto
+      proto-service: google.cloud.compute.v1.VpnTunnels
+      proto-msg: google.cloud.compute.v1.VpnTunnel
+      host-name: compute.googleapis.com
+      notes:
+        - TF beta
       apis-enabled: []
     - name: confidentialcomputing-challenge
       local: resource-confidentialcomputing-challenge
@@ -8948,23 +9982,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: container-containerfleet
-      local: resource-container-containerfleet
-      remote: resource-container-containerfleet
-      command: gcloud container fleet
-      group: container
-      resource: containerfleet
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: container-containerbaremetaladminclusters
       local: resource-container-containerbaremetaladminclusters
       remote: resource-container-containerbaremetaladminclusters
@@ -8999,12 +10016,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: container-containernodepools
-      local: resource-container-containernodepools
-      remote: resource-container-containernodepools
-      command: gcloud container node-pools
+    - name: container-containerclusters
+      local: resource-container-containerclusters
+      remote: resource-container-containerclusters
+      command: gcloud container clusters
       group: container
-      resource: containernodepools
+      resource: containerclusters
       controller: terraform
       skip: false
       kind: ""
@@ -9016,12 +10033,29 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: container-containerclusters
-      local: resource-container-containerclusters
-      remote: resource-container-containerclusters
-      command: gcloud container clusters
+    - name: container-containerfleet
+      local: resource-container-containerfleet
+      remote: resource-container-containerfleet
+      command: gcloud container fleet
       group: container
-      resource: containerclusters
+      resource: containerfleet
+      controller: unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: container-containernodepools
+      local: resource-container-containernodepools
+      remote: resource-container-containernodepools
+      command: gcloud container node-pools
+      group: container
+      resource: containernodepools
       controller: terraform
       skip: false
       kind: ""
@@ -9174,23 +10208,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: datacatalog-datacatalogtags
-      local: resource-datacatalog-datacatalogtags
-      remote: resource-datacatalog-datacatalogtags
-      command: ""
-      group: datacatalog
-      resource: datacatalogtags
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: datacatalog-datacatalogentries
       local: resource-datacatalog-datacatalogentries
       remote: resource-datacatalog-datacatalogentries
@@ -9225,23 +10242,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: datacatalog-datacatalogtaxonomies
-      local: resource-datacatalog-datacatalogtaxonomies
-      remote: resource-datacatalog-datacatalogtaxonomies
-      command: ""
-      group: datacatalog
-      resource: datacatalogtaxonomies
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: datacatalog-datacatalogpolicytags
       local: resource-datacatalog-datacatalogpolicytags
       remote: resource-datacatalog-datacatalogpolicytags
@@ -9259,12 +10259,46 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: datacatalog-datacatalogtags
+      local: resource-datacatalog-datacatalogtags
+      remote: resource-datacatalog-datacatalogtags
+      command: ""
+      group: datacatalog
+      resource: datacatalogtags
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: datacatalog-datacatalogtagtemplates
       local: resource-datacatalog-datacatalogtagtemplates
       remote: resource-datacatalog-datacatalogtagtemplates
       command: ""
       group: datacatalog
       resource: datacatalogtagtemplates
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: datacatalog-datacatalogtaxonomies
+      local: resource-datacatalog-datacatalogtaxonomies
+      remote: resource-datacatalog-datacatalogtaxonomies
+      command: ""
+      group: datacatalog
+      resource: datacatalogtaxonomies
       controller: terraform
       skip: false
       kind: ""
@@ -9451,6 +10485,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: dataflow-dataflowflextemplatejobs
+      local: resource-dataflow-dataflowflextemplatejobs
+      remote: resource-dataflow-dataflowflextemplatejobs
+      command: gcloud dataflow flex-template
+      group: dataflow
+      resource: dataflowflextemplatejobs
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: dataflow-dataflowjobs
       local: resource-dataflow-dataflowjobs
       remote: resource-dataflow-dataflowjobs
@@ -9475,23 +10526,6 @@ branches:
       group: dataflow
       resource: dataflowsnapshots
       controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: dataflow-dataflowflextemplatejobs
-      local: resource-dataflow-dataflowflextemplatejobs
-      remote: resource-dataflow-dataflowflextemplatejobs
-      command: gcloud dataflow flex-template
-      group: dataflow
-      resource: dataflowflextemplatejobs
-      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -9836,10 +10870,11 @@ branches:
       package: google.cloud.dataplex.v1
       proto: AspectType
       proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-service: google.cloud.dataplex.v1.CatalogService
       proto-msg: google.cloud.dataplex.v1.AspectType
-      host-name: ""
-      notes: []
+      host-name: dataplex.googleapis.com
+      notes:
+        - proto contains recursive fields
       apis-enabled: []
     - name: dataplex-asset
       local: resource-dataplex-asset
@@ -9852,10 +10887,10 @@ branches:
       kind: DataplexAsset
       package: google.cloud.dataplex.v1
       proto: Asset
-      proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/resources.proto
+      proto-service: google.cloud.dataplex.v1.DataplexService
       proto-msg: google.cloud.dataplex.v1.Asset
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-content
@@ -9869,12 +10904,11 @@ branches:
       kind: DataplexContent
       package: google.cloud.dataplex.v1
       proto: Content
-      proto-path: google/cloud/dataplex/v1/content.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/analyze.proto
+      proto-service: google.cloud.dataplex.v1.ContentService
       proto-msg: google.cloud.dataplex.v1.Content
-      host-name: ""
-      notes:
-        - API deprecated(https://b.corp.google.com/issues/408235607#comment4)
+      host-name: dataplex.googleapis.com
+      notes: []
       apis-enabled: []
     - name: dataplex-dataattribute
       local: resource-dataplex-dataattribute
@@ -9924,9 +10958,9 @@ branches:
       package: google.cloud.dataplex.v1
       proto: DataScan
       proto-path: google/cloud/dataplex/v1/datascans.proto
-      proto-service: ""
+      proto-service: google.cloud.dataplex.v1.DataScanService
       proto-msg: google.cloud.dataplex.v1.DataScan
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-datascanjob
@@ -9995,9 +11029,9 @@ branches:
       package: google.cloud.dataplex.v1
       proto: Entry
       proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-service: google.cloud.dataplex.v1.CatalogService
       proto-msg: google.cloud.dataplex.v1.Entry
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-entrygroup
@@ -10012,9 +11046,9 @@ branches:
       package: google.cloud.dataplex.v1
       proto: EntryGroup
       proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-service: google.cloud.dataplex.v1.CatalogService
       proto-msg: google.cloud.dataplex.v1.EntryGroup
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-entrytype
@@ -10029,9 +11063,9 @@ branches:
       package: google.cloud.dataplex.v1
       proto: EntryType
       proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-service: google.cloud.dataplex.v1.CatalogService
       proto-msg: google.cloud.dataplex.v1.EntryType
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-environment
@@ -10045,12 +11079,11 @@ branches:
       kind: DataplexEnvironment
       package: google.cloud.dataplex.v1
       proto: Environment
-      proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/analyze.proto
+      proto-service: google.cloud.dataplex.v1.DataplexService
       proto-msg: google.cloud.dataplex.v1.Environment
-      host-name: ""
-      notes:
-        - API deprecated(https://b.corp.google.com/issues/408235607#comment4)
+      host-name: dataplex.googleapis.com
+      notes: []
       apis-enabled: []
     - name: dataplex-job
       local: resource-dataplex-job
@@ -10081,10 +11114,10 @@ branches:
       kind: DataplexLake
       package: google.cloud.dataplex.v1
       proto: Lake
-      proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/resources.proto
+      proto-service: google.cloud.dataplex.v1.DataplexService
       proto-msg: google.cloud.dataplex.v1.Lake
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-metadatajob
@@ -10152,10 +11185,10 @@ branches:
       kind: DataplexTask
       package: google.cloud.dataplex.v1
       proto: Task
-      proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/tasks.proto
+      proto-service: google.cloud.dataplex.v1.DataplexService
       proto-msg: google.cloud.dataplex.v1.Task
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataplex-zone
@@ -10169,27 +11202,10 @@ branches:
       kind: DataplexZone
       package: google.cloud.dataplex.v1
       proto: Zone
-      proto-path: google/cloud/dataplex/v1/catalog.proto
-      proto-service: ""
+      proto-path: google/cloud/dataplex/v1/resources.proto
+      proto-service: google.cloud.dataplex.v1.DataplexService
       proto-msg: google.cloud.dataplex.v1.Zone
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: dataproc-dataprocclusters
-      local: resource-dataproc-dataprocclusters
-      remote: resource-dataproc-dataprocclusters
-      command: ""
-      group: dataproc
-      resource: dataprocclusters
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
+      host-name: dataplex.googleapis.com
       notes: []
       apis-enabled: []
     - name: dataproc-clusters
@@ -10226,6 +11242,40 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: dataproc-dataprocclusters
+      local: resource-dataproc-dataprocclusters
+      remote: resource-dataproc-dataprocclusters
+      command: ""
+      group: dataproc
+      resource: dataprocclusters
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: dataproc-dataprocworkflowtemplates
+      local: resource-dataproc-dataprocworkflowtemplates
+      remote: resource-dataproc-dataprocworkflowtemplates
+      command: ""
+      group: dataproc
+      resource: dataprocworkflowtemplates
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: dataproc-jobs
       local: resource-dataproc-jobs
       remote: resource-dataproc-jobs
@@ -10250,23 +11300,6 @@ branches:
       group: dataproc
       resource: operations
       controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: dataproc-dataprocworkflowtemplates
-      local: resource-dataproc-dataprocworkflowtemplates
-      remote: resource-dataproc-dataprocworkflowtemplates
-      command: ""
-      group: dataproc
-      resource: dataprocworkflowtemplates
-      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -10415,23 +11448,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: datastream-locations
-      local: resource-datastream-locations
-      remote: resource-datastream-locations
-      command: gcloud datastream locations
-      group: datastream
-      resource: locations
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: datastream-datastreamprivateconnections
       local: resource-datastream-datastreamprivateconnections
       remote: resource-datastream-datastreamprivateconnections
@@ -10466,12 +11482,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: datastream-operations
-      local: resource-datastream-operations
-      remote: resource-datastream-operations
-      command: gcloud datastream operations
+    - name: datastream-locations
+      local: resource-datastream-locations
+      remote: resource-datastream-locations
+      command: gcloud datastream locations
       group: datastream
-      resource: operations
+      resource: locations
       controller: Unknown
       skip: false
       kind: ""
@@ -10489,6 +11505,23 @@ branches:
       command: gcloud datastream objects
       group: datastream
       resource: objects
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: datastream-operations
+      local: resource-datastream-operations
+      remote: resource-datastream-operations
+      command: gcloud datastream operations
+      group: datastream
+      resource: operations
       controller: Unknown
       skip: false
       kind: ""
@@ -11562,57 +12595,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: dialogflowcx-dialogflowcxwebhooks
-      local: resource-dialogflowcx-dialogflowcxwebhooks
-      remote: resource-dialogflowcx-dialogflowcxwebhooks
-      command: ""
-      group: dialogflowcx
-      resource: dialogflowcxwebhooks
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: dialogflowcx-dialogflowcxpages
-      local: resource-dialogflowcx-dialogflowcxpages
-      remote: resource-dialogflowcx-dialogflowcxpages
-      command: ""
-      group: dialogflowcx
-      resource: dialogflowcxpages
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: dialogflowcx-dialogflowcxintents
-      local: resource-dialogflowcx-dialogflowcxintents
-      remote: resource-dialogflowcx-dialogflowcxintents
-      command: ""
-      group: dialogflowcx
-      resource: dialogflowcxintents
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: dialogflowcx-dialogflowcxagents
       local: resource-dialogflowcx-dialogflowcxagents
       remote: resource-dialogflowcx-dialogflowcxagents
@@ -11664,6 +12646,57 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: dialogflowcx-dialogflowcxintents
+      local: resource-dialogflowcx-dialogflowcxintents
+      remote: resource-dialogflowcx-dialogflowcxintents
+      command: ""
+      group: dialogflowcx
+      resource: dialogflowcxintents
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: dialogflowcx-dialogflowcxpages
+      local: resource-dialogflowcx-dialogflowcxpages
+      remote: resource-dialogflowcx-dialogflowcxpages
+      command: ""
+      group: dialogflowcx
+      resource: dialogflowcxpages
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: dialogflowcx-dialogflowcxwebhooks
+      local: resource-dialogflowcx-dialogflowcxwebhooks
+      remote: resource-dialogflowcx-dialogflowcxwebhooks
+      command: ""
+      group: dialogflowcx
+      resource: dialogflowcxwebhooks
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: dialogflow-entitytype
       local: resource-dialogflow-entitytype
       remote: resource-dialogflow-entitytype
@@ -11704,12 +12737,12 @@ branches:
         - 'Creation error: No DesignTimeAgent found for project'
       apis-enabled:
         - dialogflow.googleapis.com
-    - name: discoveryengine-discoveryengineengines
-      local: resource-discoveryengine-discoveryengineengines
-      remote: resource-discoveryengine-discoveryengineengines
+    - name: discoveryengine-discoveryenginedatastores
+      local: resource-discoveryengine-discoveryenginedatastores
+      remote: resource-discoveryengine-discoveryenginedatastores
       command: ""
       group: discoveryengine
-      resource: discoveryengineengines
+      resource: discoveryenginedatastores
       controller: direct
       skip: false
       kind: ""
@@ -11738,12 +12771,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: discoveryengine-discoveryenginedatastores
-      local: resource-discoveryengine-discoveryenginedatastores
-      remote: resource-discoveryengine-discoveryenginedatastores
+    - name: discoveryengine-discoveryengineengines
+      local: resource-discoveryengine-discoveryengineengines
+      remote: resource-discoveryengine-discoveryengineengines
       command: ""
       group: discoveryengine
-      resource: discoveryenginedatastores
+      resource: discoveryengineengines
       controller: direct
       skip: false
       kind: ""
@@ -12149,12 +13182,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: dlp-dlpstoredinfotypes
-      local: resource-dlp-dlpstoredinfotypes
-      remote: resource-dlp-dlpstoredinfotypes
+    - name: dlp-dlpjobtriggers
+      local: resource-dlp-dlpjobtriggers
+      remote: resource-dlp-dlpjobtriggers
       command: ""
       group: dlp
-      resource: dlpstoredinfotypes
+      resource: dlpjobtriggers
       controller: dcl
       skip: false
       kind: ""
@@ -12166,12 +13199,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: dlp-dlpjobtriggers
-      local: resource-dlp-dlpjobtriggers
-      remote: resource-dlp-dlpjobtriggers
+    - name: dlp-dlpstoredinfotypes
+      local: resource-dlp-dlpstoredinfotypes
+      remote: resource-dlp-dlpstoredinfotypes
       command: ""
       group: dlp
-      resource: dlpjobtriggers
+      resource: dlpstoredinfotypes
       controller: dcl
       skip: false
       kind: ""
@@ -12427,23 +13460,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: edgecache-services
-      local: resource-edgecache-services
-      remote: resource-edgecache-services
-      command: gcloud edge-cache services
-      group: edge
-      resource: edgecacheservices
-      controller: unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: edgecache-keysets
       local: resource-edgecache-keysets
       remote: resource-edgecache-keysets
@@ -12478,13 +13494,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: edgecontainer-zones
-      local: resource-edgecontainer-zones
-      remote: resource-edgecontainer-zones
-      command: gcloud edge-cloud container zones
-      group: edgecontainer
-      resource: zones
-      controller: Unknown
+    - name: edgecache-services
+      local: resource-edgecache-services
+      remote: resource-edgecache-services
+      command: gcloud edge-cache services
+      group: edge
+      resource: edgecacheservices
+      controller: unknown
       skip: false
       kind: ""
       package: ""
@@ -12495,13 +13511,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: edgecontainer-operations
-      local: resource-edgecontainer-operations
-      remote: resource-edgecontainer-operations
-      command: gcloud edge-cloud container operations
+    - name: edgecontainer-edgecontainerclusters
+      local: resource-edgecontainer-edgecontainerclusters
+      remote: resource-edgecontainer-edgecontainerclusters
+      command: ""
       group: edgecontainer
-      resource: operations
-      controller: Unknown
+      resource: edgecontainerclusters
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -12546,13 +13562,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: edgecontainer-edgecontainerclusters
-      local: resource-edgecontainer-edgecontainerclusters
-      remote: resource-edgecontainer-edgecontainerclusters
-      command: ""
+    - name: edgecontainer-operations
+      local: resource-edgecontainer-operations
+      remote: resource-edgecontainer-operations
+      command: gcloud edge-cloud container operations
       group: edgecontainer
-      resource: edgecontainerclusters
-      controller: terraform
+      resource: operations
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -12569,6 +13585,23 @@ branches:
       command: gcloud edge-cloud container regions
       group: edgecontainer
       resource: regions
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: edgecontainer-zones
+      local: resource-edgecontainer-zones
+      remote: resource-edgecontainer-zones
+      command: gcloud edge-cloud container zones
+      group: edgecontainer
+      resource: zones
       controller: Unknown
       skip: false
       kind: ""
@@ -12889,13 +13922,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: eventarc-locations
-      local: resource-eventarc-locations
-      remote: resource-eventarc-locations
-      command: gcloud eventarc locations
+    - name: eventarc-eventarctriggers
+      local: resource-eventarc-eventarctriggers
+      remote: resource-eventarc-eventarctriggers
+      command: ""
       group: eventarc
-      resource: locations
-      controller: Unknown
+      resource: eventarctriggers
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -12906,13 +13939,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: eventarc-eventarctriggers
-      local: resource-eventarc-eventarctriggers
-      remote: resource-eventarc-eventarctriggers
-      command: ""
+    - name: eventarc-locations
+      local: resource-eventarc-locations
+      remote: resource-eventarc-locations
+      command: gcloud eventarc locations
       group: eventarc
-      resource: eventarctriggers
-      controller: dcl
+      resource: locations
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -13116,23 +14149,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: filestore-filestoreinstances
-      local: resource-filestore-filestoreinstances
-      remote: resource-filestore-filestoreinstances
-      command: ""
-      group: filestore
-      resource: filestoreinstances
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: filestore-filestorebackups
       local: resource-filestore-filestorebackups
       remote: resource-filestore-filestorebackups
@@ -13150,13 +14166,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: filestore-operation
-      local: resource-filestore-operation
-      remote: resource-filestore-operation
-      command: gcloud filestore operations
+    - name: filestore-filestoreinstances
+      local: resource-filestore-filestoreinstances
+      remote: resource-filestore-filestoreinstances
+      command: ""
       group: filestore
-      resource: operation
-      controller: Unknown
+      resource: filestoreinstances
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -13165,29 +14181,8 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - file.googleapis.com
-    - name: filestore-zone
-      local: resource-filestore-zone
-      remote: resource-filestore-zone
-      command: gcloud filestore zones
-      group: filestore
-      resource: zone
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - file.googleapis.com
+      notes: []
+      apis-enabled: []
     - name: filestore-filestoresnapshots
       local: resource-filestore-filestoresnapshots
       remote: resource-filestore-filestoresnapshots
@@ -13224,12 +14219,50 @@ branches:
         - no create, update or delete
       apis-enabled:
         - file.googleapis.com
+    - name: filestore-operation
+      local: resource-filestore-operation
+      remote: resource-filestore-operation
+      command: gcloud filestore operations
+      group: filestore
+      resource: operation
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - file.googleapis.com
     - name: filestore-region
       local: resource-filestore-region
       remote: resource-filestore-region
       command: gcloud filestore regions
       group: filestore
       resource: region
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - file.googleapis.com
+    - name: filestore-zone
+      local: resource-filestore-zone
+      remote: resource-filestore-zone
+      command: gcloud filestore zones
+      group: filestore
+      resource: zone
       controller: Unknown
       skip: false
       kind: ""
@@ -13317,23 +14350,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: firebase-firebasewebapps
-      local: resource-firebase-firebasewebapps
-      remote: resource-firebase-firebasewebapps
-      command: ""
-      group: firebase
-      resource: firebasewebapps
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: firebase-firebaseandroidapps
       local: resource-firebase-firebaseandroidapps
       remote: resource-firebase-firebaseandroidapps
@@ -13368,12 +14384,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: firebasedatabase-firebasedatabaseinstances
-      local: resource-firebasedatabase-firebasedatabaseinstances
-      remote: resource-firebasedatabase-firebasedatabaseinstances
+    - name: firebase-firebasewebapps
+      local: resource-firebase-firebasewebapps
+      remote: resource-firebase-firebasewebapps
       command: ""
-      group: firebasedatabase
-      resource: firebasedatabaseinstances
+      group: firebase
+      resource: firebasewebapps
       controller: terraform
       skip: false
       kind: ""
@@ -13385,12 +14401,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: firebasehosting-firebasehostingsites
-      local: resource-firebasehosting-firebasehostingsites
-      remote: resource-firebasehosting-firebasehostingsites
+    - name: firebasedatabase-firebasedatabaseinstances
+      local: resource-firebasedatabase-firebasedatabaseinstances
+      remote: resource-firebasedatabase-firebasedatabaseinstances
       command: ""
-      group: firebasehosting
-      resource: firebasehostingsites
+      group: firebasedatabase
+      resource: firebasedatabaseinstances
       controller: terraform
       skip: false
       kind: ""
@@ -13419,6 +14435,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: firebasehosting-firebasehostingsites
+      local: resource-firebasehosting-firebasehostingsites
+      remote: resource-firebasehosting-firebasehostingsites
+      command: ""
+      group: firebasehosting
+      resource: firebasehostingsites
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: firebasestorage-firebasestoragebucket
       local: resource-firebasestorage-firebasestoragebucket
       remote: resource-firebasestorage-firebasestoragebucket
@@ -13436,25 +14469,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: firestore-operation
-      local: resource-firestore-operation
-      remote: resource-firestore-operation
-      command: gcloud firestore operations
-      group: firestore
-      resource: operation
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - 'Further research needed: Only supports delete.'
-      apis-enabled:
-        - firestore.googleapis.com
     - name: firestore-firestoreindexes
       local: resource-firestore-firestoreindexes
       remote: resource-firestore-firestoreindexes
@@ -13489,6 +14503,25 @@ branches:
       host-name: ""
       notes:
         - no create, update or delete
+      apis-enabled:
+        - firestore.googleapis.com
+    - name: firestore-operation
+      local: resource-firestore-operation
+      remote: resource-firestore-operation
+      command: gcloud firestore operations
+      group: firestore
+      resource: operation
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - 'Further research needed: Only supports delete.'
       apis-enabled:
         - firestore.googleapis.com
     - name: firestore-backup
@@ -13584,6 +14617,25 @@ branches:
         - already supported as a v1beta1 KCC resource
       apis-enabled:
         - firestore.googleapis.com
+    - name: functions-eventtype
+      local: resource-functions-eventtype
+      remote: resource-functions-eventtype
+      command: gcloud functions event-types
+      group: functions
+      resource: eventtype
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
+      apis-enabled: []
     - name: functions-eventtypes
       local: resource-functions-eventtypes
       remote: resource-functions-eventtypes
@@ -13601,29 +14653,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: functions-regions
-      local: resource-functions-regions
-      remote: resource-functions-regions
-      command: gcloud functions regions
-      group: functions
-      resource: regions
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: functions-logs
-      local: resource-functions-logs
-      remote: resource-functions-logs
+    - name: functions-log
+      local: resource-functions-log
+      remote: resource-functions-log
       command: gcloud functions logs
       group: functions
-      resource: logs
+      resource: log
       controller: Unknown
       skip: false
       kind: ""
@@ -13633,14 +14668,16 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
       apis-enabled: []
-    - name: functions-runtimes
-      local: resource-functions-runtimes
-      remote: resource-functions-runtimes
+    - name: functions-runtime
+      local: resource-functions-runtime
+      remote: resource-functions-runtime
       command: gcloud functions runtimes
       group: functions
-      resource: runtimes
+      resource: runtime
       controller: Unknown
       skip: false
       kind: ""
@@ -13650,7 +14687,9 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
       apis-enabled: []
     - name: functions-cloudfunction
       local: resource-functions-cloudfunction
@@ -13688,6 +14727,23 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
+    - name: gemini-coderepositoryindexes
+      local: resource-gemini-coderepositoryindexes
+      remote: resource-gemini-coderepositoryindexes
+      command: gcloud gemini code-repository-indexes
+      group: gemini
+      resource: gemini-coderepositoryindexes
+      controller: unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: gemini-coderepositoryindexesrepositorygroups
       local: resource-gemini-coderepositoryindexesrepositorygroups
       remote: resource-gemini-coderepositoryindexesrepositorygroups
@@ -13705,13 +14761,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: gemini-coderepositoryindexes
-      local: resource-gemini-coderepositoryindexes
-      remote: resource-gemini-coderepositoryindexes
-      command: gcloud gemini code-repository-indexes
-      group: gemini
-      resource: gemini-coderepositoryindexes
-      controller: unknown
+    - name: gkebackup-gkebackupbackupplans
+      local: resource-gkebackup-gkebackupbackupplans
+      remote: resource-gkebackup-gkebackupbackupplans
+      command: ""
+      group: gkebackup
+      resource: gkebackupbackupplans
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -13746,23 +14802,6 @@ branches:
       group: gkebackup
       resource: operations
       controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: gkebackup-gkebackupbackupplans
-      local: resource-gkebackup-gkebackupbackupplans
-      remote: resource-gkebackup-gkebackupbackupplans
-      command: ""
-      group: gkebackup
-      resource: gkebackupbackupplans
-      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -13875,13 +14914,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: gkehub-gkehubfeatures
-      local: resource-gkehub-gkehubfeatures
-      remote: resource-gkehub-gkehubfeatures
+    - name: gkehub-gkehubfeaturememberships
+      local: resource-gkehub-gkehubfeaturememberships
+      remote: resource-gkehub-gkehubfeaturememberships
       command: ""
       group: gkehub
-      resource: gkehubfeatures
-      controller: dcl
+      resource: gkehubfeaturememberships
+      controller: direct
       skip: false
       kind: ""
       package: ""
@@ -13892,13 +14931,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: gkehub-gkehubfeaturememberships
-      local: resource-gkehub-gkehubfeaturememberships
-      remote: resource-gkehub-gkehubfeaturememberships
+    - name: gkehub-gkehubfeatures
+      local: resource-gkehub-gkehubfeatures
+      remote: resource-gkehub-gkehubfeatures
       command: ""
       group: gkehub
-      resource: gkehubfeaturememberships
-      controller: direct
+      resource: gkehubfeatures
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -14193,23 +15232,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: healthcare-healthcarehl7v2stores
-      local: resource-healthcare-healthcarehl7v2stores
-      remote: resource-healthcare-healthcarehl7v2stores
-      command: gcloud healthcare hl7v2-stores
-      group: healthcare
-      resource: healthcarehl7v2stores
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: healthcare-healthcaredatasets
       local: resource-healthcare-healthcaredatasets
       remote: resource-healthcare-healthcaredatasets
@@ -14261,6 +15283,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: healthcare-healthcarehl7v2stores
+      local: resource-healthcare-healthcarehl7v2stores
+      remote: resource-healthcare-healthcarehl7v2stores
+      command: gcloud healthcare hl7v2-stores
+      group: healthcare
+      resource: healthcarehl7v2stores
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: hybrididentity-auth
       local: resource-hybrididentity-auth
       remote: resource-hybrididentity-auth
@@ -14278,13 +15317,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iam-iampolicy
-      local: resource-iam-iampolicy
-      remote: resource-iam-iampolicy
+    - name: iam-accessboundarypolicy
+      local: resource-iam-accessboundarypolicy
+      remote: resource-iam-accessboundarypolicy
       command: ""
       group: iam
-      resource: iampolicy
-      controller: direct
+      resource: iamaccessboundarypolicy
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -14295,13 +15334,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iam-simulator
-      local: resource-iam-simulator
-      remote: resource-iam-simulator
-      command: gcloud iam simulator
+    - name: iam-auditconfig
+      local: resource-iam-auditconfig
+      remote: resource-iam-auditconfig
+      command: ""
       group: iam
-      resource: simulator
-      controller: Unknown
+      resource: iamauditconfig
+      controller: direct
       skip: false
       kind: ""
       package: ""
@@ -14329,13 +15368,30 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iam-policymember
-      local: resource-iam-policymember
-      remote: resource-iam-policymember
+    - name: iam-iampolicy
+      local: resource-iam-iampolicy
+      remote: resource-iam-iampolicy
       command: ""
       group: iam
-      resource: iampolicymember
+      resource: iampolicy
       controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: iam-oauthclient
+      local: resource-iam-oauthclient
+      remote: resource-iam-oauthclient
+      command: gcloud iam oauth-clients
+      group: iam
+      resource: oauthclient
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -14380,6 +15436,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: iam-policymember
+      local: resource-iam-policymember
+      remote: resource-iam-policymember
+      command: ""
+      group: iam
+      resource: iampolicymember
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: iam-role
       local: resource-iam-role
       remote: resource-iam-role
@@ -14397,30 +15470,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iam-oauthclient
-      local: resource-iam-oauthclient
-      remote: resource-iam-oauthclient
-      command: gcloud iam oauth-clients
+    - name: iam-simulator
+      local: resource-iam-simulator
+      remote: resource-iam-simulator
+      command: gcloud iam simulator
       group: iam
-      resource: oauthclient
+      resource: simulator
       controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: iam-auditconfig
-      local: resource-iam-auditconfig
-      remote: resource-iam-auditconfig
-      command: ""
-      group: iam
-      resource: iamauditconfig
-      controller: direct
       skip: false
       kind: ""
       package: ""
@@ -14438,23 +15494,6 @@ branches:
       group: iam
       resource: iamworkforcepool
       controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: iam-accessboundarypolicy
-      local: resource-iam-accessboundarypolicy
-      remote: resource-iam-accessboundarypolicy
-      command: ""
-      group: iam
-      resource: iamaccessboundarypolicy
-      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -14567,6 +15606,40 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: iap-iapbrands
+      local: resource-iap-iapbrands
+      remote: resource-iap-iapbrands
+      command: ""
+      group: iap
+      resource: iapbrands
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: iap-iapidentityawareproxyclients
+      local: resource-iap-iapidentityawareproxyclients
+      remote: resource-iap-iapidentityawareproxyclients
+      command: ""
+      group: iap
+      resource: iapidentityawareproxyclients
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: iap-iapsettings
       local: resource-iap-iapsettings
       remote: resource-iap-iapsettings
@@ -14584,46 +15657,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iap-web
-      local: resource-iap-web
-      remote: resource-iap-web
-      command: gcloud iap web
+    - name: iap-oauthbrands
+      local: resource-iap-oauthbrands
+      remote: resource-iap-oauthbrands
+      command: gcloud iap oauth-brands
       group: iap
-      resource: web
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: iap-tcp
-      local: resource-iap-tcp
-      remote: resource-iap-tcp
-      command: gcloud iap tcp
-      group: iap
-      resource: tcp
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: iap-settings
-      local: resource-iap-settings
-      remote: resource-iap-settings
-      command: gcloud iap settings
-      group: iap
-      resource: settings
+      resource: oauthbrands
       controller: Unknown
       skip: false
       kind: ""
@@ -14652,12 +15691,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iap-oauthbrands
-      local: resource-iap-oauthbrands
-      remote: resource-iap-oauthbrands
-      command: gcloud iap oauth-brands
+    - name: iap-settings
+      local: resource-iap-settings
+      remote: resource-iap-settings
+      command: gcloud iap settings
       group: iap
-      resource: oauthbrands
+      resource: settings
       controller: Unknown
       skip: false
       kind: ""
@@ -14669,13 +15708,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iap-iapbrands
-      local: resource-iap-iapbrands
-      remote: resource-iap-iapbrands
-      command: ""
+    - name: iap-tcp
+      local: resource-iap-tcp
+      remote: resource-iap-tcp
+      command: gcloud iap tcp
       group: iap
-      resource: iapbrands
-      controller: dcl
+      resource: tcp
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -14686,13 +15725,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: iap-iapidentityawareproxyclients
-      local: resource-iap-iapidentityawareproxyclients
-      remote: resource-iap-iapidentityawareproxyclients
-      command: ""
+    - name: iap-web
+      local: resource-iap-web
+      remote: resource-iap-web
+      command: gcloud iap web
       group: iap
-      resource: iapidentityawareproxyclients
-      controller: dcl
+      resource: web
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -14738,63 +15777,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: identityplatform-identityplatformtenantinboundsamlconfigs
-      local: resource-identityplatform-identityplatformtenantinboundsamlconfigs
-      remote: resource-identityplatform-identityplatformtenantinboundsamlconfigs
-      command: ""
-      group: identityplatform
-      resource: identityplatformtenantinboundsamlconfigs
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: identityplatform-identityplatformconfigs
       local: resource-identityplatform-identityplatformconfigs
       remote: resource-identityplatform-identityplatformconfigs
       command: ""
       group: identityplatform
       resource: identityplatformconfigs
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: identityplatform-identityplatformprojectdefaultconfigs
-      local: resource-identityplatform-identityplatformprojectdefaultconfigs
-      remote: resource-identityplatform-identityplatformprojectdefaultconfigs
-      command: ""
-      group: identityplatform
-      resource: identityplatformprojectdefaultconfigs
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: identityplatform-identityplatformtenantoauthidpconfigs
-      local: resource-identityplatform-identityplatformtenantoauthidpconfigs
-      remote: resource-identityplatform-identityplatformtenantoauthidpconfigs
-      command: ""
-      group: identityplatform
-      resource: identityplatformtenantoauthidpconfigs
       controller: dcl
       skip: false
       kind: ""
@@ -14840,13 +15828,30 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: identityplatform-identityplatformtenants
-      local: resource-identityplatform-identityplatformtenants
-      remote: resource-identityplatform-identityplatformtenants
+    - name: identityplatform-identityplatformoauthidpconfigs
+      local: resource-identityplatform-identityplatformoauthidpconfigs
+      remote: resource-identityplatform-identityplatformoauthidpconfigs
       command: ""
       group: identityplatform
-      resource: identityplatformtenants
+      resource: identityplatformoauthidpconfigs
       controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: identityplatform-identityplatformprojectdefaultconfigs
+      local: resource-identityplatform-identityplatformprojectdefaultconfigs
+      remote: resource-identityplatform-identityplatformprojectdefaultconfigs
+      command: ""
+      group: identityplatform
+      resource: identityplatformprojectdefaultconfigs
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -14874,12 +15879,46 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: identityplatform-identityplatformoauthidpconfigs
-      local: resource-identityplatform-identityplatformoauthidpconfigs
-      remote: resource-identityplatform-identityplatformoauthidpconfigs
+    - name: identityplatform-identityplatformtenantinboundsamlconfigs
+      local: resource-identityplatform-identityplatformtenantinboundsamlconfigs
+      remote: resource-identityplatform-identityplatformtenantinboundsamlconfigs
       command: ""
       group: identityplatform
-      resource: identityplatformoauthidpconfigs
+      resource: identityplatformtenantinboundsamlconfigs
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: identityplatform-identityplatformtenantoauthidpconfigs
+      local: resource-identityplatform-identityplatformtenantoauthidpconfigs
+      remote: resource-identityplatform-identityplatformtenantoauthidpconfigs
+      command: ""
+      group: identityplatform
+      resource: identityplatformtenantoauthidpconfigs
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: identityplatform-identityplatformtenants
+      local: resource-identityplatform-identityplatformtenants
+      remote: resource-identityplatform-identityplatformtenants
+      command: ""
+      group: identityplatform
+      resource: identityplatformtenants
       controller: dcl
       skip: false
       kind: ""
@@ -15020,25 +16059,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: kms-location
-      local: resource-kms-location
-      remote: resource-kms-location
-      command: gcloud kms locations
-      group: kms
-      resource: location
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes:
-        - no create, update or delete
-      apis-enabled:
-        - kms.googleapis.com
     - name: kms-inventory
       local: resource-kms-inventory
       remote: resource-kms-inventory
@@ -15058,23 +16078,6 @@ branches:
         - no create, update or delete
       apis-enabled:
         - kms.googleapis.com
-    - name: kms-kmsecretciphertext
-      local: resource-kms-secretciphertext
-      remote: resource-kms-secretciphertext
-      command: ""
-      group: kms
-      resource: kmssecretciphertext
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: kms-keyringimportjob
       local: resource-kms-keyringimportjob
       remote: resource-kms-keyringimportjob
@@ -15092,6 +16095,42 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: kms-kmsecretciphertext
+      local: resource-kms-secretciphertext
+      remote: resource-kms-secretciphertext
+      command: ""
+      group: kms
+      resource: kmssecretciphertext
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: kms-location
+      local: resource-kms-location
+      remote: resource-kms-location
+      command: gcloud kms locations
+      group: kms
+      resource: location
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no create, update or delete
+      apis-enabled:
+        - kms.googleapis.com
     - name: kms-autokeyconfig
       local: resource-kms-autokeyconfig
       remote: resource-kms-autokeyconfig
@@ -15288,40 +16327,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: logging-metrics
-      local: resource-logging-metrics
-      remote: resource-logging-metrics
-      command: gcloud logging metrics
-      group: logging
-      resource: metrics
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: logging-scopes
-      local: resource-logging-scopes
-      remote: resource-logging-scopes
-      command: gcloud logging scopes
-      group: logging
-      resource: scopes
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: logging-buckets
       local: resource-logging-buckets
       remote: resource-logging-buckets
@@ -15356,6 +16361,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: logging-metrics
+      local: resource-logging-metrics
+      remote: resource-logging-metrics
+      command: gcloud logging metrics
+      group: logging
+      resource: metrics
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: logging-resourcedescriptors
       local: resource-logging-resourcedescriptors
       remote: resource-logging-resourcedescriptors
@@ -15373,12 +16395,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: logging-views
-      local: resource-logging-views
-      remote: resource-logging-views
-      command: gcloud logging views
+    - name: logging-scopes
+      local: resource-logging-scopes
+      remote: resource-logging-scopes
+      command: gcloud logging scopes
       group: logging
-      resource: views
+      resource: scopes
       controller: Unknown
       skip: false
       kind: ""
@@ -15396,6 +16418,23 @@ branches:
       command: gcloud logging sinks
       group: logging
       resource: sinks
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: logging-views
+      local: resource-logging-views
+      remote: resource-logging-views
+      command: gcloud logging views
+      group: logging
+      resource: views
       controller: Unknown
       skip: false
       kind: ""
@@ -15650,23 +16689,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: memcache-regions
-      local: resource-memcache-regions
-      remote: resource-memcache-regions
-      command: gcloud memcache regions
-      group: memcache
-      resource: regions
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: memcache-memcacheinstances
       local: resource-memcache-memcacheinstances
       remote: resource-memcache-memcacheinstances
@@ -15690,6 +16712,23 @@ branches:
       command: gcloud memcache operations
       group: memcache
       resource: operations
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: memcache-regions
+      local: resource-memcache-regions
+      remote: resource-memcache-regions
+      command: gcloud memcache regions
+      group: memcache
+      resource: regions
       controller: Unknown
       skip: false
       kind: ""
@@ -15890,29 +16929,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: migration-vmsmachineimageimports
-      local: resource-migration-vmsmachineimageimports
-      remote: resource-migration-vmsmachineimageimports
-      command: gcloud migration vms machine-image-imports
-      group: migration
-      resource: migrationvmsmachineimageimports
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: migration-vmsimageimports
-      local: resource-migration-vmsimageimports
-      remote: resource-migration-vmsimageimports
+    - name: migration-vmsimageimport
+      local: resource-migration-vmsimageimport
+      remote: resource-migration-vmsimageimport
       command: gcloud migration vms image-imports
       group: migration
-      resource: migrationvmsimageimports
+      resource: migrationvmsimageimport
       controller: Unknown
       skip: false
       kind: ""
@@ -15922,7 +16944,26 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - no proto found
+      apis-enabled: []
+    - name: migration-vmsmachineimageimport
+      local: resource-migration-vmsmachineimageimport
+      remote: resource-migration-vmsmachineimageimport
+      command: gcloud migration vms machine-image-imports
+      group: migration
+      resource: migrationvmsmachineimageimport
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes:
+        - no proto found
       apis-enabled: []
     - name: migrationcenter-asset
       local: resource-migrationcenter-asset
@@ -16104,13 +17145,13 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: mlengine-mlenginemodels
-      local: resource-mlengine-mlenginemodels
-      remote: resource-mlengine-mlenginemodels
-      command: ""
+    - name: mlengine-jobs
+      local: resource-mlengine-jobs
+      remote: resource-mlengine-jobs
+      command: gcloud ml-engine jobs
       group: mlengine
-      resource: mlenginemodels
-      controller: terraform
+      resource: mlengine-jobs
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -16121,13 +17162,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: mlengine-jobs
-      local: resource-mlengine-jobs
-      remote: resource-mlengine-jobs
-      command: gcloud ml-engine jobs
+    - name: mlengine-mlenginemodels
+      local: resource-mlengine-mlenginemodels
+      remote: resource-mlengine-mlenginemodels
+      command: ""
       group: mlengine
-      resource: mlengine-jobs
-      controller: Unknown
+      resource: mlenginemodels
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -16184,10 +17225,11 @@ branches:
       package: google.cloud.modelarmor.v1
       proto: FloorSetting
       proto-path: google/cloud/modelarmor/v1/service.proto
-      proto-service: ""
+      proto-service: google.cloud.modelarmor.v1.ModelArmor
       proto-msg: google.cloud.modelarmor.v1.FloorSetting
-      host-name: ""
-      notes: []
+      host-name: modelarmor.googleapis.com
+      notes:
+        - only Get and Update methods
       apis-enabled: []
     - name: modelarmor-template
       local: resource-modelarmor-template
@@ -16201,18 +17243,18 @@ branches:
       package: google.cloud.modelarmor.v1
       proto: Template
       proto-path: google/cloud/modelarmor/v1/service.proto
-      proto-service: ""
+      proto-service: google.cloud.modelarmor.v1.ModelArmor
       proto-msg: google.cloud.modelarmor.v1.Template
-      host-name: ""
+      host-name: modelarmor.googleapis.com
       notes: []
       apis-enabled: []
-    - name: monitoring-metricdescriptor
-      local: resource-monitoring-metricdescriptor
-      remote: resource-monitoring-metricdescriptor
+    - name: monitoring-alertpolicies
+      local: resource-monitoring-alertpolicies
+      remote: resource-monitoring-alertpolicies
       command: ""
       group: monitoring
-      resource: monitoringmetricdescriptor
-      controller: dcl
+      resource: monitoringalertpolicies
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -16223,13 +17265,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: monitoring-alertpolicies
-      local: resource-monitoring-alertpolicies
-      remote: resource-monitoring-alertpolicies
+    - name: monitoring-metricdescriptor
+      local: resource-monitoring-metricdescriptor
+      remote: resource-monitoring-metricdescriptor
       command: ""
       group: monitoring
-      resource: monitoringalertpolicies
-      controller: terraform
+      resource: monitoringmetricdescriptor
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -16656,13 +17698,30 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: networkconnectivity-networkconnectivityserviceconnectionpolicies
-      local: resource-networkconnectivity-networkconnectivityserviceconnectionpolicies
-      remote: resource-networkconnectivity-networkconnectivityserviceconnectionpolicies
-      command: ""
+    - name: networkconnectivity-internalranges
+      local: resource-networkconnectivity-internalranges
+      remote: resource-networkconnectivity-internalranges
+      command: gcloud network-connectivity internal-ranges
       group: networkconnectivity
-      resource: networkconnectivityserviceconnectionpolicies
-      controller: direct
+      resource: internalranges
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkconnectivity-locations
+      local: resource-networkconnectivity-locations
+      remote: resource-networkconnectivity-locations
+      command: gcloud network-connectivity locations
+      group: networkconnectivity
+      resource: locations
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -16690,6 +17749,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: networkconnectivity-networkconnectivityserviceconnectionpolicies
+      local: resource-networkconnectivity-networkconnectivityserviceconnectionpolicies
+      remote: resource-networkconnectivity-networkconnectivityserviceconnectionpolicies
+      command: ""
+      group: networkconnectivity
+      resource: networkconnectivityserviceconnectionpolicies
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: networkconnectivity-networkconnectivityspokes
       local: resource-networkconnectivity-networkconnectivityspokes
       remote: resource-networkconnectivity-networkconnectivityspokes
@@ -16697,40 +17773,6 @@ branches:
       group: networkconnectivity
       resource: networkconnectivityspokes
       controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkconnectivity-internalranges
-      local: resource-networkconnectivity-internalranges
-      remote: resource-networkconnectivity-internalranges
-      command: gcloud network-connectivity internal-ranges
-      group: networkconnectivity
-      resource: internalranges
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkconnectivity-locations
-      local: resource-networkconnectivity-locations
-      remote: resource-networkconnectivity-locations
-      command: gcloud network-connectivity locations
-      group: networkconnectivity
-      resource: locations
-      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -16880,6 +17922,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: networkmanagement-networkmanagementconnectivitytests
+      local: resource-networkmanagement-networkmanagementconnectivitytests
+      remote: resource-networkmanagement-networkmanagementconnectivitytests
+      command: ""
+      group: networkmanagement
+      resource: networkmanagementconnectivitytests
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: networkmanagement-operation
       local: resource-networkmanagement-operation
       remote: resource-networkmanagement-operation
@@ -16899,23 +17958,6 @@ branches:
         - no create, update or delete
       apis-enabled:
         - networkmanagement.googleapis.com
-    - name: networkmanagement-networkmanagementconnectivitytests
-      local: resource-networkmanagement-networkmanagementconnectivitytests
-      remote: resource-networkmanagement-networkmanagementconnectivitytests
-      command: ""
-      group: networkmanagement
-      resource: networkmanagementconnectivitytests
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: networkmanagement-connectivitytest
       local: resource-networkmanagement-connectivitytest
       remote: resource-networkmanagement-connectivitytest
@@ -16954,233 +17996,12 @@ branches:
         - Creation requires an interconnect, which can only be configured manually.
       apis-enabled:
         - networkmanagement.googleapis.com
-    - name: networksecurity-orgaddressgroups
-      local: resource-networksecurity-orgaddressgroups
-      remote: resource-networksecurity-orgaddressgroups
-      command: gcloud network-security org-address-groups
+    - name: networksecurity-addressgroups
+      local: resource-networksecurity-addressgroups
+      remote: resource-networksecurity-addressgroups
+      command: gcloud network-security address-groups
       group: networksecurity
-      resource: orgaddressgroups
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-mirroringendpointgroups
-      local: resource-networksecurity-mirroringendpointgroups
-      remote: resource-networksecurity-mirroringendpointgroups
-      command: gcloud network-security mirroring-endpoint-groups
-      group: networksecurity
-      resource: mirroringendpointgroups
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-mirroringdeployments
-      local: resource-networksecurity-mirroringdeployments
-      remote: resource-networksecurity-mirroringdeployments
-      command: gcloud network-security mirroring-deployments
-      group: networksecurity
-      resource: mirroringdeployments
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-networksecurityclienttlspolicies
-      local: resource-networksecurity-networksecurityclienttlspolicies
-      remote: resource-networksecurity-networksecurityclienttlspolicies
-      command: ""
-      group: networksecurity
-      resource: networksecurityclienttlspolicies
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-securityprofiles
-      local: resource-networksecurity-securityprofiles
-      remote: resource-networksecurity-securityprofiles
-      command: gcloud network-security security-profiles
-      group: networksecurity
-      resource: securityprofiles
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-mirroringdeploymentgroups
-      local: resource-networksecurity-mirroringdeploymentgroups
-      remote: resource-networksecurity-mirroringdeploymentgroups
-      command: gcloud network-security mirroring-deployment-groups
-      group: networksecurity
-      resource: mirroringdeploymentgroups
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-securityprofilegroups
-      local: resource-networksecurity-securityprofilegroups
-      remote: resource-networksecurity-securityprofilegroups
-      command: gcloud network-security security-profile-groups
-      group: networksecurity
-      resource: securityprofilegroups
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-networksecurityauthorizationpolicies
-      local: resource-networksecurity-networksecurityauthorizationpolicies
-      remote: resource-networksecurity-networksecurityauthorizationpolicies
-      command: ""
-      group: networksecurity
-      resource: networksecurityauthorizationpolicies
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-mirroringendpointgroupassociations
-      local: resource-networksecurity-mirroringendpointgroupassociations
-      remote: resource-networksecurity-mirroringendpointgroupassociations
-      command: gcloud network-security mirroring-endpoint-group-associations
-      group: networksecurity
-      resource: mirroringendpointgroupassociations
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-urllists
-      local: resource-networksecurity-urllists
-      remote: resource-networksecurity-urllists
-      command: gcloud network-security url-lists
-      group: networksecurity
-      resource: urllists
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-gatewaysecuritypolicies
-      local: resource-networksecurity-gatewaysecuritypolicies
-      remote: resource-networksecurity-gatewaysecuritypolicies
-      command: gcloud network-security gateway-security-policies
-      group: networksecurity
-      resource: gatewaysecuritypolicies
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-firewallendpoints
-      local: resource-networksecurity-firewallendpoints
-      remote: resource-networksecurity-firewallendpoints
-      command: gcloud network-security firewall-endpoints
-      group: networksecurity
-      resource: firewallendpoints
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-networksecurityservertlspolicies
-      local: resource-networksecurity-networksecurityservertlspolicies
-      remote: resource-networksecurity-networksecurityservertlspolicies
-      command: ""
-      group: networksecurity
-      resource: networksecurityservertlspolicies
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networksecurity-tlsinspectionpolicies
-      local: resource-networksecurity-tlsinspectionpolicies
-      remote: resource-networksecurity-tlsinspectionpolicies
-      command: gcloud network-security tls-inspection-policies
-      group: networksecurity
-      resource: tlsinspectionpolicies
+      resource: addressgroups
       controller: Unknown
       skip: false
       kind: ""
@@ -17209,12 +18030,233 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: networksecurity-addressgroups
-      local: resource-networksecurity-addressgroups
-      remote: resource-networksecurity-addressgroups
-      command: gcloud network-security address-groups
+    - name: networksecurity-firewallendpoints
+      local: resource-networksecurity-firewallendpoints
+      remote: resource-networksecurity-firewallendpoints
+      command: gcloud network-security firewall-endpoints
       group: networksecurity
-      resource: addressgroups
+      resource: firewallendpoints
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-gatewaysecuritypolicies
+      local: resource-networksecurity-gatewaysecuritypolicies
+      remote: resource-networksecurity-gatewaysecuritypolicies
+      command: gcloud network-security gateway-security-policies
+      group: networksecurity
+      resource: gatewaysecuritypolicies
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-mirroringdeploymentgroups
+      local: resource-networksecurity-mirroringdeploymentgroups
+      remote: resource-networksecurity-mirroringdeploymentgroups
+      command: gcloud network-security mirroring-deployment-groups
+      group: networksecurity
+      resource: mirroringdeploymentgroups
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-mirroringdeployments
+      local: resource-networksecurity-mirroringdeployments
+      remote: resource-networksecurity-mirroringdeployments
+      command: gcloud network-security mirroring-deployments
+      group: networksecurity
+      resource: mirroringdeployments
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-mirroringendpointgroupassociations
+      local: resource-networksecurity-mirroringendpointgroupassociations
+      remote: resource-networksecurity-mirroringendpointgroupassociations
+      command: gcloud network-security mirroring-endpoint-group-associations
+      group: networksecurity
+      resource: mirroringendpointgroupassociations
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-mirroringendpointgroups
+      local: resource-networksecurity-mirroringendpointgroups
+      remote: resource-networksecurity-mirroringendpointgroups
+      command: gcloud network-security mirroring-endpoint-groups
+      group: networksecurity
+      resource: mirroringendpointgroups
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-networksecurityauthorizationpolicies
+      local: resource-networksecurity-networksecurityauthorizationpolicies
+      remote: resource-networksecurity-networksecurityauthorizationpolicies
+      command: ""
+      group: networksecurity
+      resource: networksecurityauthorizationpolicies
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-networksecurityclienttlspolicies
+      local: resource-networksecurity-networksecurityclienttlspolicies
+      remote: resource-networksecurity-networksecurityclienttlspolicies
+      command: ""
+      group: networksecurity
+      resource: networksecurityclienttlspolicies
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-networksecurityservertlspolicies
+      local: resource-networksecurity-networksecurityservertlspolicies
+      remote: resource-networksecurity-networksecurityservertlspolicies
+      command: ""
+      group: networksecurity
+      resource: networksecurityservertlspolicies
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-orgaddressgroups
+      local: resource-networksecurity-orgaddressgroups
+      remote: resource-networksecurity-orgaddressgroups
+      command: gcloud network-security org-address-groups
+      group: networksecurity
+      resource: orgaddressgroups
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-securityprofilegroups
+      local: resource-networksecurity-securityprofilegroups
+      remote: resource-networksecurity-securityprofilegroups
+      command: gcloud network-security security-profile-groups
+      group: networksecurity
+      resource: securityprofilegroups
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-securityprofiles
+      local: resource-networksecurity-securityprofiles
+      remote: resource-networksecurity-securityprofiles
+      command: gcloud network-security security-profiles
+      group: networksecurity
+      resource: securityprofiles
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-tlsinspectionpolicies
+      local: resource-networksecurity-tlsinspectionpolicies
+      remote: resource-networksecurity-tlsinspectionpolicies
+      command: gcloud network-security tls-inspection-policies
+      group: networksecurity
+      resource: tlsinspectionpolicies
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networksecurity-urllists
+      local: resource-networksecurity-urllists
+      remote: resource-networksecurity-urllists
+      command: gcloud network-security url-lists
+      group: networksecurity
+      resource: urllists
       controller: Unknown
       skip: false
       kind: ""
@@ -17277,12 +18319,114 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: networkservices-networkservicesedgecachekeysets
+      local: resource-networkservices-networkservicesedgecachekeysets
+      remote: resource-networkservices-networkservicesedgecachekeysets
+      command: ""
+      group: networkservices
+      resource: networkservicesedgecachekeysets
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkservices-networkservicesedgecacheorigins
+      local: resource-networkservices-networkservicesedgecacheorigins
+      remote: resource-networkservices-networkservicesedgecacheorigins
+      command: ""
+      group: networkservices
+      resource: networkservicesedgecacheorigins
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkservices-networkservicesedgecacheservices
+      local: resource-networkservices-networkservicesedgecacheservices
+      remote: resource-networkservices-networkservicesedgecacheservices
+      command: ""
+      group: networkservices
+      resource: networkservicesedgecacheservices
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkservices-networkservicesendpointpolicies
+      local: resource-networkservices-networkservicesendpointpolicies
+      remote: resource-networkservices-networkservicesendpointpolicies
+      command: ""
+      group: networkservices
+      resource: networkservicesendpointpolicies
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkservices-networkservicesgateways
+      local: resource-networkservices-networkservicesgateways
+      remote: resource-networkservices-networkservicesgateways
+      command: ""
+      group: networkservices
+      resource: networkservicesgateways
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: networkservices-networkservicesgrpcroutes
       local: resource-networkservices-networkservicesgrpcroutes
       remote: resource-networkservices-networkservicesgrpcroutes
       command: ""
       group: networkservices
       resource: networkservicesgrpcroutes
+      controller: dcl
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: networkservices-networkserviceshttproutes
+      local: resource-networkservices-networkserviceshttproutes
+      remote: resource-networkservices-networkserviceshttproutes
+      command: ""
+      group: networkservices
+      resource: networkserviceshttproutes
       controller: dcl
       skip: false
       kind: ""
@@ -17345,57 +18489,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: networkservices-networkserviceshttproutes
-      local: resource-networkservices-networkserviceshttproutes
-      remote: resource-networkservices-networkserviceshttproutes
-      command: ""
-      group: networkservices
-      resource: networkserviceshttproutes
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkservices-servicelbpolicies
-      local: resource-networkservices-servicelbpolicies
-      remote: resource-networkservices-servicelbpolicies
-      command: gcloud network-services service-lb-policies
-      group: networkservices
-      resource: servicelbpolicies
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkservices-networkservicesgateways
-      local: resource-networkservices-networkservicesgateways
-      remote: resource-networkservices-networkservicesgateways
-      command: ""
-      group: networkservices
-      resource: networkservicesgateways
-      controller: dcl
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: networkservices-routeviews
       local: resource-networkservices-routeviews
       remote: resource-networkservices-routeviews
@@ -17413,64 +18506,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: networkservices-networkservicesedgecacheservices
-      local: resource-networkservices-networkservicesedgecacheservices
-      remote: resource-networkservices-networkservicesedgecacheservices
-      command: ""
+    - name: networkservices-servicelbpolicies
+      local: resource-networkservices-servicelbpolicies
+      remote: resource-networkservices-servicelbpolicies
+      command: gcloud network-services service-lb-policies
       group: networkservices
-      resource: networkservicesedgecacheservices
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkservices-networkservicesedgecacheorigins
-      local: resource-networkservices-networkservicesedgecacheorigins
-      remote: resource-networkservices-networkservicesedgecacheorigins
-      command: ""
-      group: networkservices
-      resource: networkservicesedgecacheorigins
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkservices-networkservicesedgecachekeysets
-      local: resource-networkservices-networkservicesedgecachekeysets
-      remote: resource-networkservices-networkservicesedgecachekeysets
-      command: ""
-      group: networkservices
-      resource: networkservicesedgecachekeysets
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: networkservices-networkservicesendpointpolicies
-      local: resource-networkservices-networkservicesendpointpolicies
-      remote: resource-networkservices-networkservicesendpointpolicies
-      command: ""
-      group: networkservices
-      resource: networkservicesendpointpolicies
-      controller: dcl
+      resource: servicelbpolicies
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -17670,23 +18712,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: notebooks-locations
-      local: resource-notebooks-locations
-      remote: resource-notebooks-locations
-      command: gcloud notebooks locations
-      group: notebooks
-      resource: locations
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: notebooks-environment
       local: resource-notebooks-environment
       remote: resource-notebooks-environment
@@ -17698,11 +18723,13 @@ branches:
       kind: NotebooksEnvironment
       package: google.cloud.notebooks.v1
       proto: Environment
-      proto-path: google/cloud/notebooks/v1/managed_service.proto
-      proto-service: ""
+      proto-path: google/cloud/notebooks/v1/environment.proto
+      proto-service: google.cloud.notebooks.v1.NotebookService
       proto-msg: google.cloud.notebooks.v1.Environment
-      host-name: ""
-      notes: []
+      host-name: notebooks.googleapis.com
+      notes:
+        - mock exists
+        - direct Beta
       apis-enabled: []
     - name: notebooks-execution
       local: resource-notebooks-execution
@@ -17734,10 +18761,11 @@ branches:
       package: google.cloud.notebooks.v2
       proto: Instance
       proto-path: google/cloud/notebooks/v2/service.proto
-      proto-service: ""
+      proto-service: google.cloud.notebooks.v1.NotebookService
       proto-msg: google.cloud.notebooks.v2.Instance
-      host-name: ""
-      notes: []
+      host-name: notebooks.googleapis.com
+      notes:
+        - mock exists
       apis-enabled: []
     - name: notebooks-runtime
       local: resource-notebooks-runtime
@@ -17750,10 +18778,10 @@ branches:
       kind: NotebooksRuntime
       package: google.cloud.notebooks.v1
       proto: Runtime
-      proto-path: google/cloud/notebooks/v1/managed_service.proto
-      proto-service: ""
+      proto-path: google/cloud/notebooks/v1/runtime.proto
+      proto-service: google.cloud.notebooks.v1.ManagedNotebookService
       proto-msg: google.cloud.notebooks.v1.Runtime
-      host-name: ""
+      host-name: notebooks.googleapis.com
       notes: []
       apis-enabled: []
     - name: notebooks-schedule
@@ -18106,13 +19134,13 @@ branches:
         - Supported by contributor right now
       apis-enabled:
         - orgpolicy.googleapis.com
-    - name: osconfig-osconfigpatchdeployments
-      local: resource-osconfig-osconfigpatchdeployments
-      remote: resource-osconfig-osconfigpatchdeployments
+    - name: osconfig-osconfigguestpolicies
+      local: resource-osconfig-osconfigguestpolicies
+      remote: resource-osconfig-osconfigguestpolicies
       command: ""
       group: osconfig
-      resource: osconfigpatchdeployments
-      controller: terraform
+      resource: osconfigguestpolicies
+      controller: dcl
       skip: false
       kind: ""
       package: ""
@@ -18140,13 +19168,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: osconfig-projectfeaturesettings
-      local: resource-osconfig-projectfeaturesettings
-      remote: resource-osconfig-projectfeaturesettings
-      command: gcloud compute os-config project-feature-settings
+    - name: osconfig-osconfigpatchdeployments
+      local: resource-osconfig-osconfigpatchdeployments
+      remote: resource-osconfig-osconfigpatchdeployments
+      command: ""
       group: osconfig
-      resource: projectfeaturesettings
-      controller: Unknown
+      resource: osconfigpatchdeployments
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -18157,13 +19185,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: osconfig-osconfigguestpolicies
-      local: resource-osconfig-osconfigguestpolicies
-      remote: resource-osconfig-osconfigguestpolicies
-      command: ""
+    - name: osconfig-projectfeaturesettings
+      local: resource-osconfig-projectfeaturesettings
+      remote: resource-osconfig-projectfeaturesettings
+      command: gcloud compute os-config project-feature-settings
       group: osconfig
-      resource: osconfigguestpolicies
-      controller: dcl
+      resource: projectfeaturesettings
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -18329,12 +19357,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: parallelstore-operation
-      local: resource-parallelstore-operation
-      remote: resource-parallelstore-operation
-      command: gcloud parallelstore operations
+    - name: parallelstore-location
+      local: resource-parallelstore-location
+      remote: resource-parallelstore-location
+      command: gcloud parallelstore locations
       group: parallelstore
-      resource: operation
+      resource: location
       controller: Unknown
       skip: false
       kind: ""
@@ -18348,12 +19376,12 @@ branches:
         - no create, update or delete
       apis-enabled:
         - parallelstore.googleapis.com
-    - name: parallelstore-location
-      local: resource-parallelstore-location
-      remote: resource-parallelstore-location
-      command: gcloud parallelstore locations
+    - name: parallelstore-operation
+      local: resource-parallelstore-operation
+      remote: resource-parallelstore-operation
+      command: gcloud parallelstore operations
       group: parallelstore
-      resource: location
+      resource: operation
       controller: Unknown
       skip: false
       kind: ""
@@ -19063,12 +20091,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: pubsub-litereservations
-      local: resource-pubsub-litereservations
-      remote: resource-pubsub-litereservations
-      command: gcloud pubsub lite-reservations
+    - name: pubsub-liteoperations
+      local: resource-pubsub-liteoperations
+      remote: resource-pubsub-liteoperations
+      command: gcloud pubsub lite-operations
       group: pubsub
-      resource: litereservations
+      resource: liteoperations
       controller: Unknown
       skip: false
       kind: ""
@@ -19080,12 +20108,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: pubsub-liteoperations
-      local: resource-pubsub-liteoperations
-      remote: resource-pubsub-liteoperations
-      command: gcloud pubsub lite-operations
+    - name: pubsub-litereservations
+      local: resource-pubsub-litereservations
+      remote: resource-pubsub-litereservations
+      command: gcloud pubsub lite-reservations
       group: pubsub
-      resource: liteoperations
+      resource: litereservations
       controller: Unknown
       skip: false
       kind: ""
@@ -19148,23 +20176,6 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: pubsub-schema
-      local: resource-pubsub-schema
-      remote: resource-pubsub-schema
-      command: ""
-      group: pubsub
-      resource: pubsubschema
-      controller: terraform
-      skip: false
-      kind: PubSubSchema
-      package: google.pubsub.v1
-      proto: Schema
-      proto-path: google/pubsub/v1/schema.proto
-      proto-service: ""
-      proto-msg: google.pubsub.v1.Schema
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: pubsub-snapshot
       local: resource-pubsub-snapshot
       remote: resource-pubsub-snapshot
@@ -19177,9 +20188,9 @@ branches:
       package: google.pubsub.v1
       proto: Snapshot
       proto-path: google/pubsub/v1/pubsub.proto
-      proto-service: ""
+      proto-service: google.pubsub.v1.Subscriber
       proto-msg: google.pubsub.v1.Snapshot
-      host-name: ""
+      host-name: pubsub.googleapis.com
       notes: []
       apis-enabled: []
     - name: pubsub-subscription
@@ -19216,56 +20227,77 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: pubsub-schema
+      local: resource-pubsub-schema
+      remote: resource-pubsub-schema
+      command: gcloud pubsub schemas
+      group: pubsub
+      resource: schema
+      controller: Unknown
+      skip: false
+      kind: PubsubSchema
+      package: google.pubsub.v1
+      proto: Schema
+      proto-path: google/pubsub/v1/schema.proto
+      proto-service: google.pubsub.v1.SchemaService
+      proto-msg: google.pubsub.v1.Schema
+      host-name: pubsub.googleapis.com
+      notes: []
+      apis-enabled: []
     - name: pubsublite-reservation
       local: resource-pubsublite-reservation
       remote: resource-pubsublite-reservation
-      command: ""
+      command: gcloud pubsub lite-reservations
       group: pubsublite
       resource: reservation
-      controller: terraform
+      controller: Unknown
       skip: false
-      kind: PubSubliteReservation
+      kind: PubsubLiteReservation
       package: google.cloud.pubsublite.v1
       proto: Reservation
-      proto-path: google/cloud/pubsublite/v1/admin.proto
-      proto-service: ""
+      proto-path: google/cloud/pubsublite/v1/common.proto
+      proto-service: google.cloud.pubsublite.v1.AdminService
       proto-msg: google.cloud.pubsublite.v1.Reservation
-      host-name: ""
-      notes: []
+      host-name: pubsublite.googleapis.com
+      notes:
+        - TF beta
       apis-enabled: []
     - name: pubsublite-subscription
       local: resource-pubsublite-subscription
       remote: resource-pubsublite-subscription
-      command: ""
+      command: gcloud pubsub lite-subscriptions
       group: pubsublite
       resource: subscription
-      controller: terraform
+      controller: Unknown
       skip: false
-      kind: PubSubliteSubscription
+      kind: PubsubLiteSubscription
       package: google.cloud.pubsublite.v1
-      proto: Subscription
-      proto-path: google/cloud/pubsublite/v1/admin.proto
-      proto-service: ""
+      proto: Reservation
+      proto-path: google/cloud/pubsublite/v1/common.proto
+      proto-service: google.cloud.pubsublite.v1.AdminService
       proto-msg: google.cloud.pubsublite.v1.Subscription
-      host-name: ""
-      notes: []
+      host-name: pubsublite.googleapis.com
+      notes:
+        - TF alpha
       apis-enabled: []
     - name: pubsublite-topic
       local: resource-pubsublite-topic
       remote: resource-pubsublite-topic
-      command: ""
+      command: gcloud pubsub lite-topics
       group: pubsublite
       resource: topic
-      controller: terraform
+      controller: Unknown
       skip: false
-      kind: PubSubliteTopic
+      kind: PubsubLiteTopic
       package: google.cloud.pubsublite.v1
-      proto: Topic
-      proto-path: google/cloud/pubsublite/v1/topic_stats.proto
-      proto-service: ""
+      proto: Reservation
+      proto-path: google/cloud/pubsublite/v1/common.proto
+      proto-service: google.cloud.pubsublite.v1.AdminService
       proto-msg: google.cloud.pubsublite.v1.Topic
-      host-name: ""
-      notes: []
+      host-name: pubsublite.googleapis.com
+      notes:
+        - mock exists
+        - TF alpha
       apis-enabled: []
     - name: rapidmigrationassessment-annotation
       local: resource-rapidmigrationassessment-annotation
@@ -19441,11 +20473,12 @@ branches:
       kind: RecommenderInsight
       package: google.cloud.recommender.v1
       proto: Insight
-      proto-path: google/cloud/recommender/v1/recommender_service.proto
-      proto-service: ""
+      proto-path: google/cloud/recommender/v1/insight.proto
+      proto-service: google.cloud.recommender.v1.Recommender
       proto-msg: google.cloud.recommender.v1.Insight
-      host-name: ""
-      notes: []
+      host-name: recommender.googleapis.com
+      notes:
+        - gcloud command does not contain any of create/update/delete
       apis-enabled: []
     - name: recommender-insighttype
       local: resource-recommender-insighttype
@@ -19476,10 +20509,10 @@ branches:
       kind: RecommenderInsightTypeConfig
       package: google.cloud.recommender.v1
       proto: InsightTypeConfig
-      proto-path: google/cloud/recommender/v1/recommender_service.proto
-      proto-service: ""
+      proto-path: google/cloud/recommender/v1/insight_type_config.proto
+      proto-service: google.cloud.recommender.v1.Recommender
       proto-msg: google.cloud.recommender.v1.InsightTypeConfig
-      host-name: ""
+      host-name: recommender.googleapis.com
       notes: []
       apis-enabled: []
     - name: recommender-recommendation
@@ -19493,11 +20526,12 @@ branches:
       kind: RecommenderRecommendation
       package: google.cloud.recommender.v1
       proto: Recommendation
-      proto-path: google/cloud/recommender/v1/recommender_service.proto
-      proto-service: ""
+      proto-path: google/cloud/recommender/v1/recommendation.proto
+      proto-service: google.cloud.recommender.v1.Recommender
       proto-msg: google.cloud.recommender.v1.Recommendation
-      host-name: ""
-      notes: []
+      host-name: recommender.googleapis.com
+      notes:
+        - gcloud command does not contain any of create/update/delete
       apis-enabled: []
     - name: recommender-recommenderconfig
       local: resource-recommender-recommenderconfig
@@ -19510,10 +20544,10 @@ branches:
       kind: RecommenderRecommenderConfig
       package: google.cloud.recommender.v1
       proto: RecommenderConfig
-      proto-path: google/cloud/recommender/v1/recommender_service.proto
-      proto-service: ""
+      proto-path: google/cloud/recommender/v1/recommender_config.proto
+      proto-service: google.cloud.recommender.v1.Recommender
       proto-msg: google.cloud.recommender.v1.RecommenderConfig
-      host-name: ""
+      host-name: recommender.googleapis.com
       notes: []
       apis-enabled: []
     - name: recommender-recommendertype
@@ -19533,23 +20567,6 @@ branches:
       host-name: ""
       notes:
         - No gcloud command found
-      apis-enabled: []
-    - name: redis-zones
-      local: resource-redis-zones
-      remote: resource-redis-zones
-      command: gcloud redis zones
-      group: redis
-      resource: zones
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
       apis-enabled: []
     - name: redis-operations
       local: resource-redis-operations
@@ -19574,6 +20591,23 @@ branches:
       command: gcloud redis regions
       group: redis
       resource: regions
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: redis-zones
+      local: resource-redis-zones
+      remote: resource-redis-zones
+      command: gcloud redis zones
+      group: redis
+      resource: zones
       controller: Unknown
       skip: false
       kind: ""
@@ -19691,13 +20725,13 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: resourcemanager-resourcemanagerliens
-      local: resource-resourcemanager-resourcemanagerliens
-      remote: resource-resourcemanager-resourcemanagerliens
-      command: ""
+    - name: resourcemanager-orgpolicies
+      local: resource-resourcemanager-orgpolicies
+      remote: resource-resourcemanager-orgpolicies
+      command: gcloud resource-manager org-policies
       group: resourcemanager
-      resource: resourcemanagerliens
-      controller: terraform
+      resource: orgpolicies
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -19714,6 +20748,23 @@ branches:
       command: ""
       group: resourcemanager
       resource: projects
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: resourcemanager-resourcemanagerliens
+      local: resource-resourcemanager-resourcemanagerliens
+      remote: resource-resourcemanager-resourcemanagerliens
+      command: ""
+      group: resourcemanager
+      resource: resourcemanagerliens
       controller: terraform
       skip: false
       kind: ""
@@ -19748,23 +20799,6 @@ branches:
       command: gcloud resource-manager tags
       group: resourcemanager
       resource: tags
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: resourcemanager-orgpolicies
-      local: resource-resourcemanager-orgpolicies
-      remote: resource-resourcemanager-orgpolicies
-      command: gcloud resource-manager org-policies
-      group: resourcemanager
-      resource: orgpolicies
       controller: Unknown
       skip: false
       kind: ""
@@ -20207,23 +21241,6 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: run-runjobs
-      local: resource-run-runjobs
-      remote: resource-run-runjobs
-      command: ""
-      group: run
-      resource: runjobs
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
     - name: run-domainmappings
       local: resource-run-domainmappings
       remote: resource-run-domainmappings
@@ -20241,12 +21258,29 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: run-runservices
-      local: resource-run-runservices
-      remote: resource-run-runservices
+    - name: run-regions
+      local: resource-run-regions
+      remote: resource-run-regions
+      command: gcloud run regions
+      group: run
+      resource: regions
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: run-runjobs
+      local: resource-run-runjobs
+      remote: resource-run-runjobs
       command: ""
       group: run
-      resource: runservices
+      resource: runjobs
       controller: terraform
       skip: false
       kind: ""
@@ -20258,13 +21292,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: run-regions
-      local: resource-run-regions
-      remote: resource-run-regions
-      command: gcloud run regions
+    - name: run-runservices
+      local: resource-run-runservices
+      remote: resource-run-runservices
+      command: ""
       group: run
-      resource: regions
-      controller: Unknown
+      resource: runservices
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -20431,12 +21465,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: secrets-replication
-      local: resource-secrets-replication
-      remote: resource-secrets-replication
-      command: gcloud secrets replication
+    - name: secrets-location
+      local: resource-secrets-location
+      remote: resource-secrets-location
+      command: gcloud secrets locations
       group: secrets
-      resource: replication
+      resource: location
       controller: Unknown
       skip: false
       kind: ""
@@ -20450,12 +21484,12 @@ branches:
         - Replaced by SecretManager
       apis-enabled:
         - secretmanager.googleapis.com
-    - name: secrets-location
-      local: resource-secrets-location
-      remote: resource-secrets-location
-      command: gcloud secrets locations
+    - name: secrets-replication
+      local: resource-secrets-replication
+      remote: resource-secrets-replication
+      command: gcloud secrets replication
       group: secrets
-      resource: location
+      resource: replication
       controller: Unknown
       skip: false
       kind: ""
@@ -20507,12 +21541,12 @@ branches:
         - Replaced by SecretManager
       apis-enabled:
         - secretmanager.googleapis.com
-    - name: securesourcemanager-securesourcemanagerrepositories
-      local: resource-securesourcemanager-securesourcemanagerrepositories
-      remote: resource-securesourcemanager-securesourcemanagerrepositories
+    - name: securesourcemanager-securesourcemanagerinstances
+      local: resource-securesourcemanager-securesourcemanagerinstances
+      remote: resource-securesourcemanager-securesourcemanagerinstances
       command: ""
       group: securesourcemanager
-      resource: securesourcemanagerrepositories
+      resource: securesourcemanagerinstances
       controller: direct
       skip: false
       kind: ""
@@ -20524,12 +21558,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: securesourcemanager-securesourcemanagerinstances
-      local: resource-securesourcemanager-securesourcemanagerinstances
-      remote: resource-securesourcemanager-securesourcemanagerinstances
+    - name: securesourcemanager-securesourcemanagerrepositories
+      local: resource-securesourcemanager-securesourcemanagerrepositories
+      remote: resource-securesourcemanager-securesourcemanagerrepositories
       command: ""
       group: securesourcemanager
-      resource: securesourcemanagerinstances
+      resource: securesourcemanagerrepositories
       controller: direct
       skip: false
       kind: ""
@@ -20703,63 +21737,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: securitycenter-posturedeployments
-      local: resource-securitycenter-posturedeployments
-      remote: resource-securitycenter-posturedeployments
-      command: gcloud scc posture-deployments
+    - name: securitycenter-custommodules
+      local: resource-securitycenter-custommodules
+      remote: resource-securitycenter-custommodules
+      command: gcloud scc custom-modules
       group: securitycenter
-      resource: posturedeployments
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: securitycenter-operations
-      local: resource-securitycenter-operations
-      remote: resource-securitycenter-operations
-      command: gcloud scc operations
-      group: securitycenter
-      resource: operations
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: securitycenter-notifications
-      local: resource-securitycenter-notifications
-      remote: resource-securitycenter-notifications
-      command: gcloud scc notifications
-      group: securitycenter
-      resource: notifications
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: securitycenter-manage
-      local: resource-securitycenter-manage
-      remote: resource-securitycenter-manage
-      command: gcloud scc manage
-      group: securitycenter
-      resource: manage
+      resource: custommodules
       controller: Unknown
       skip: false
       kind: ""
@@ -20788,12 +21771,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: securitycenter-custommodules
-      local: resource-securitycenter-custommodules
-      remote: resource-securitycenter-custommodules
-      command: gcloud scc custom-modules
+    - name: securitycenter-manage
+      local: resource-securitycenter-manage
+      remote: resource-securitycenter-manage
+      command: gcloud scc manage
       group: securitycenter
-      resource: custommodules
+      resource: manage
       controller: Unknown
       skip: false
       kind: ""
@@ -20805,12 +21788,46 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: securitycenter-posturetemplates
-      local: resource-securitycenter-posturetemplates
-      remote: resource-securitycenter-posturetemplates
-      command: gcloud scc posture-templates
+    - name: securitycenter-notifications
+      local: resource-securitycenter-notifications
+      remote: resource-securitycenter-notifications
+      command: gcloud scc notifications
       group: securitycenter
-      resource: posturetemplates
+      resource: notifications
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: securitycenter-operations
+      local: resource-securitycenter-operations
+      remote: resource-securitycenter-operations
+      command: gcloud scc operations
+      group: securitycenter
+      resource: operations
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: securitycenter-posturedeployments
+      local: resource-securitycenter-posturedeployments
+      remote: resource-securitycenter-posturedeployments
+      command: gcloud scc posture-deployments
+      group: securitycenter
+      resource: posturedeployments
       controller: Unknown
       skip: false
       kind: ""
@@ -20828,6 +21845,23 @@ branches:
       command: gcloud scc postures
       group: securitycenter
       resource: postures
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: securitycenter-posturetemplates
+      local: resource-securitycenter-posturetemplates
+      remote: resource-securitycenter-posturetemplates
+      command: gcloud scc posture-templates
+      group: securitycenter
+      resource: posturetemplates
       controller: Unknown
       skip: false
       kind: ""
@@ -21393,12 +22427,12 @@ branches:
         - no create, update or delete
       apis-enabled:
         - servicedirectory.googleapis.com
-    - name: servicedirectory-servicedirectoryservices
-      local: resource-servicedirectory-servicedirectoryservices
-      remote: resource-servicedirectory-servicedirectoryservices
+    - name: servicedirectory-servicedirectoryendpoints
+      local: resource-servicedirectory-servicedirectoryendpoints
+      remote: resource-servicedirectory-servicedirectoryendpoints
       command: ""
       group: servicedirectory
-      resource: servicedirectoryservices
+      resource: servicedirectoryendpoints
       controller: terraform
       skip: false
       kind: ""
@@ -21427,12 +22461,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: servicedirectory-servicedirectoryendpoints
-      local: resource-servicedirectory-servicedirectoryendpoints
-      remote: resource-servicedirectory-servicedirectoryendpoints
+    - name: servicedirectory-servicedirectoryservices
+      local: resource-servicedirectory-servicedirectoryservices
+      remote: resource-servicedirectory-servicedirectoryservices
       command: ""
       group: servicedirectory
-      resource: servicedirectoryendpoints
+      resource: servicedirectoryservices
       controller: terraform
       skip: false
       kind: ""
@@ -21644,7 +22678,7 @@ branches:
     - name: shell-environment
       local: resource-shell-environment
       remote: resource-shell-environment
-      command: gcloud shell Environment
+      command: ""
       group: shell
       resource: environment
       controller: Unknown
@@ -21653,9 +22687,9 @@ branches:
       package: google.cloud.shell.v1
       proto: Environment
       proto-path: google/cloud/shell/v1/cloudshell.proto
-      proto-service: ""
+      proto-service: google.cloud.shell.v1.CloudShellService
       proto-msg: google.cloud.shell.v1.Environment
-      host-name: ""
+      host-name: cloudshell.googleapis.com
       notes:
         - No gcloud command found
       apis-enabled: []
@@ -21691,24 +22725,8 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: spanner-operation
-      local: resource-spanner-operation
-      remote: resource-spanner-operation
-      command: gcloud spanner operations
-      group: spanner
-      resource: operation
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
+      notes:
+        - no proto found
       apis-enabled: []
     - name: spanner-sample
       local: resource-spanner-sample
@@ -21725,7 +22743,9 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
       apis-enabled: []
     - name: spanner-backup
       local: resource-spanner-backup
@@ -21738,11 +22758,12 @@ branches:
       kind: SpannerBackup
       package: google.spanner.admin.database.v1
       proto: Backup
-      proto-path: google/spanner/admin/database/v1/spanner_database_admin.proto
-      proto-service: ""
+      proto-path: google/spanner/admin/database/v1/backup.proto
+      proto-service: google.spanner.admin.database.v1.DatabaseAdmin
       proto-msg: google.spanner.admin.database.v1.Backup
-      host-name: ""
-      notes: []
+      host-name: spanner.googleapis.com
+      notes:
+        - require special handling(Anh)
       apis-enabled: []
     - name: spanner-backupschedule
       local: resource-spanner-backupschedule
@@ -21755,10 +22776,10 @@ branches:
       kind: SpannerBackupSchedule
       package: google.spanner.admin.database.v1
       proto: BackupSchedule
-      proto-path: google/spanner/admin/database/v1/spanner_database_admin.proto
-      proto-service: ""
+      proto-path: google/spanner/admin/database/v1/backup_schedule.proto
+      proto-service: google.spanner.admin.database.v1.DatabaseAdmin
       proto-msg: google.spanner.admin.database.v1.BackupSchedule
-      host-name: ""
+      host-name: spanner.googleapis.com
       notes: []
       apis-enabled: []
     - name: spanner-database
@@ -21825,9 +22846,9 @@ branches:
       package: google.spanner.admin.instance.v1
       proto: InstanceConfig
       proto-path: google/spanner/admin/instance/v1/spanner_instance_admin.proto
-      proto-service: ""
+      proto-service: google.spanner.admin.instance.v1.InstanceAdmin
       proto-msg: google.spanner.admin.instance.v1.InstanceConfig
-      host-name: ""
+      host-name: spanner.googleapis.com
       notes: []
       apis-enabled: []
     - name: spanner-instancepartition
@@ -21954,6 +22975,40 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: sql-sqldatabases
+      local: resource-sql-sqldatabases
+      remote: resource-sql-sqldatabases
+      command: ""
+      group: sql
+      resource: sqldatabases
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: sql-sqlinstances
+      local: resource-sql-sqlinstances
+      remote: resource-sql-sqlinstances
+      command: ""
+      group: sql
+      resource: sqlinstances
+      controller: direct
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: sql-sqlsslcerts
       local: resource-sql-sqlsslcerts
       remote: resource-sql-sqlsslcerts
@@ -21988,29 +23043,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: sql-sqlinstances
-      local: resource-sql-sqlinstances
-      remote: resource-sql-sqlinstances
+    - name: storage-bucketaccesscontrol
+      local: resource-storage-bucketaccesscontrol
+      remote: resource-storage-bucketaccesscontrol
       command: ""
-      group: sql
-      resource: sqlinstances
-      controller: direct
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: sql-sqldatabases
-      local: resource-sql-sqldatabases
-      remote: resource-sql-sqldatabases
-      command: ""
-      group: sql
-      resource: sqldatabases
+      group: storage
+      resource: storagebucketaccesscontrol
       controller: terraform
       skip: false
       kind: ""
@@ -22022,47 +23060,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: storage-insight
-      local: resource-storage-insight
-      remote: resource-storage-insight
-      command: gcloud storage insights
+    - name: storage-defaultobjectaccesscontrol
+      local: resource-storage-defaultobjectaccesscontrol
+      remote: resource-storage-defaultobjectaccesscontrol
+      command: ""
       group: storage
-      resource: insight
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: storage-object
-      local: resource-storage-object
-      remote: resource-storage-object
-      command: gcloud storage objects
-      group: storage
-      resource: object
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: storage-operation
-      local: resource-storage-operation
-      remote: resource-storage-operation
-      command: gcloud storage operations
-      group: storage
-      resource: operation
-      controller: Unknown
+      resource: storagedefaultobjectaccesscontrol
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -22107,6 +23111,23 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: storage-insight
+      local: resource-storage-insight
+      remote: resource-storage-insight
+      command: gcloud storage insights
+      group: storage
+      resource: insight
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: storage-notification
       local: resource-storage-notification
       remote: resource-storage-notification
@@ -22124,13 +23145,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: storage-defaultobjectaccesscontrol
-      local: resource-storage-defaultobjectaccesscontrol
-      remote: resource-storage-defaultobjectaccesscontrol
-      command: ""
+    - name: storage-object
+      local: resource-storage-object
+      remote: resource-storage-object
+      command: gcloud storage objects
       group: storage
-      resource: storagedefaultobjectaccesscontrol
-      controller: terraform
+      resource: object
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -22141,13 +23162,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: storage-bucketaccesscontrol
-      local: resource-storage-bucketaccesscontrol
-      remote: resource-storage-bucketaccesscontrol
-      command: ""
+    - name: storage-operation
+      local: resource-storage-operation
+      remote: resource-storage-operation
+      command: gcloud storage operations
       group: storage
-      resource: storagebucketaccesscontrol
-      controller: terraform
+      resource: operation
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -22263,13 +23284,13 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: storagetransfer-storagetransferagentpools
-      local: resource-storagetransfer-storagetransferagentpools
-      remote: resource-storagetransfer-storagetransferagentpools
-      command: ""
+    - name: storagetransfer-agents
+      local: resource-storagetransfer-agents
+      remote: resource-storagetransfer-agents
+      command: gcloud transfer agents
       group: storagetransfer
-      resource: storagetransferagentpools
-      controller: terraform
+      resource: agents
+      controller: Unknown
       skip: false
       kind: ""
       package: ""
@@ -22297,12 +23318,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: storagetransfer-storagetransferjobs
-      local: resource-storagetransfer-storagetransferjobs
-      remote: resource-storagetransfer-storagetransferjobs
+    - name: storagetransfer-storagetransferagentpools
+      local: resource-storagetransfer-storagetransferagentpools
+      remote: resource-storagetransfer-storagetransferagentpools
       command: ""
       group: storagetransfer
-      resource: storagetransferjobs
+      resource: storagetransferagentpools
       controller: terraform
       skip: false
       kind: ""
@@ -22314,13 +23335,13 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: storagetransfer-agents
-      local: resource-storagetransfer-agents
-      remote: resource-storagetransfer-agents
-      command: gcloud transfer agents
+    - name: storagetransfer-storagetransferjobs
+      local: resource-storagetransfer-storagetransferjobs
+      remote: resource-storagetransfer-storagetransferjobs
+      command: ""
       group: storagetransfer
-      resource: agents
-      controller: Unknown
+      resource: storagetransferjobs
+      controller: terraform
       skip: false
       kind: ""
       package: ""
@@ -22402,12 +23423,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: tags-tagstagkeys
-      local: resource-tags-tagstagkeys
-      remote: resource-tags-tagstagkeys
+    - name: tags-tagslocationtagbindings
+      local: resource-tags-tagslocationtagbindings
+      remote: resource-tags-tagslocationtagbindings
       command: ""
       group: tags
-      resource: tagstagkeys
+      resource: tagslocationtagbindings
       controller: terraform
       skip: false
       kind: ""
@@ -22436,12 +23457,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: tags-tagslocationtagbindings
-      local: resource-tags-tagslocationtagbindings
-      remote: resource-tags-tagslocationtagbindings
+    - name: tags-tagstagkeys
+      local: resource-tags-tagstagkeys
+      remote: resource-tags-tagstagkeys
       command: ""
       group: tags
-      resource: tagslocationtagbindings
+      resource: tagstagkeys
       controller: terraform
       skip: false
       kind: ""
@@ -22524,12 +23545,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: tasks-locations
-      local: resource-tasks-locations
-      remote: resource-tasks-locations
-      command: gcloud tasks locations
+    - name: tasks-cmekconfig
+      local: resource-tasks-cmekconfig
+      remote: resource-tasks-cmekconfig
+      command: gcloud tasks cmek-config
       group: tasks
-      resource: locations
+      resource: cmekconfig
       controller: Unknown
       skip: false
       kind: ""
@@ -22541,12 +23562,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: tasks-cmekconfig
-      local: resource-tasks-cmekconfig
-      remote: resource-tasks-cmekconfig
-      command: gcloud tasks cmek-config
+    - name: tasks-locations
+      local: resource-tasks-locations
+      remote: resource-tasks-locations
+      command: gcloud tasks locations
       group: tasks
-      resource: cmekconfig
+      resource: locations
       controller: Unknown
       skip: false
       kind: ""
@@ -22752,12 +23773,12 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
-    - name: tpu-version
-      local: resource-tpu-version
-      remote: resource-tpu-version
-      command: gcloud compute tpus versions
+    - name: tpu-executiongroup
+      local: resource-tpu-executiongroup
+      remote: resource-tpu-executiongroup
+      command: gcloud compute tpus execution-groups
       group: tpu
-      resource: version
+      resource: executiongroup
       controller: Unknown
       skip: false
       kind: ""
@@ -22767,24 +23788,8 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: tpu-vm
-      local: resource-tpu-vm
-      remote: resource-tpu-vm
-      command: gcloud compute tpus tpu-vm
-      group: tpu
-      resource: tpuvm
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
+      notes:
+        - no proto found
       apis-enabled: []
     - name: tpu-topology
       local: resource-tpu-topology
@@ -22801,14 +23806,16 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
       apis-enabled: []
-    - name: tpu-location
-      local: resource-tpu-location
-      remote: resource-tpu-location
-      command: gcloud compute tpus locations
+    - name: tpu-version
+      local: resource-tpu-version
+      remote: resource-tpu-version
+      command: gcloud compute tpus versions
       group: tpu
-      resource: location
+      resource: version
       controller: Unknown
       skip: false
       kind: ""
@@ -22818,14 +23825,16 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - gcloud command does not contain any of create/update/delete
+        - no proto found
       apis-enabled: []
-    - name: tpu-executiongroup
-      local: resource-tpu-executiongroup
-      remote: resource-tpu-executiongroup
-      command: gcloud compute tpus execution-groups
+    - name: tpu-vm
+      local: resource-tpu-vm
+      remote: resource-tpu-vm
+      command: gcloud compute tpus tpu-vm
       group: tpu
-      resource: executiongroup
+      resource: vm
       controller: Unknown
       skip: false
       kind: ""
@@ -22835,7 +23844,8 @@ branches:
       proto-service: ""
       proto-msg: ""
       host-name: ""
-      notes: []
+      notes:
+        - no proto found
       apis-enabled: []
     - name: tpu-acceleratortype
       local: resource-tpu-acceleratortype
@@ -22849,10 +23859,11 @@ branches:
       package: google.cloud.tpu.v2
       proto: AcceleratorType
       proto-path: google/cloud/tpu/v2/cloud_tpu.proto
-      proto-service: ""
+      proto-service: google.cloud.tpu.v2.Tpu
       proto-msg: google.cloud.tpu.v2.AcceleratorType
-      host-name: ""
-      notes: []
+      host-name: tpu.googleapis.com
+      notes:
+        - gcloud command does not contain any of create/update/delete
       apis-enabled: []
     - name: tpu-node
       local: resource-tpu-node
@@ -22866,10 +23877,12 @@ branches:
       package: google.cloud.tpu.v2
       proto: Node
       proto-path: google/cloud/tpu/v2/cloud_tpu.proto
-      proto-service: ""
+      proto-service: google.cloud.tpu.v2.Tpu
       proto-msg: google.cloud.tpu.v2.Node
-      host-name: ""
-      notes: []
+      host-name: tpu.googleapis.com
+      notes:
+        - mock exists
+        - TF alpha
       apis-enabled: []
     - name: tpu-queuedresource
       local: resource-tpu-queuedresource
@@ -22883,9 +23896,9 @@ branches:
       package: google.cloud.tpu.v2
       proto: QueuedResource
       proto-path: google/cloud/tpu/v2/cloud_tpu.proto
-      proto-service: ""
+      proto-service: google.cloud.tpu.v2.Tpu
       proto-msg: google.cloud.tpu.v2.QueuedResource
-      host-name: ""
+      host-name: tpu.googleapis.com
       notes: []
       apis-enabled: []
     - name: tpu-runtimeversion
@@ -23076,46 +24089,12 @@ branches:
         - No gcloud command found
         - No matching generated proto
       apis-enabled: []
-    - name: vertexai-vertexaiindexes
-      local: resource-vertexai-vertexaiindexes
-      remote: resource-vertexai-vertexaiindexes
+    - name: vertexai-vertexaidatasets
+      local: resource-vertexai-vertexaidatasets
+      remote: resource-vertexai-vertexaidatasets
       command: ""
       group: vertexai
-      resource: vertexaiindexes
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: vertexai-vertexaifeaturestores
-      local: resource-vertexai-vertexaifeaturestores
-      remote: resource-vertexai-vertexaifeaturestores
-      command: ""
-      group: vertexai
-      resource: vertexaifeaturestores
-      controller: terraform
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: vertexai-vertexaifeaturestoreentitytypes
-      local: resource-vertexai-vertexaifeaturestoreentitytypes
-      remote: resource-vertexai-vertexaifeaturestoreentitytypes
-      command: ""
-      group: vertexai
-      resource: vertexaifeaturestoreentitytypes
+      resource: vertexaidatasets
       controller: terraform
       skip: false
       kind: ""
@@ -23161,6 +24140,40 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
+    - name: vertexai-vertexaifeaturestoreentitytypes
+      local: resource-vertexai-vertexaifeaturestoreentitytypes
+      remote: resource-vertexai-vertexaifeaturestoreentitytypes
+      command: ""
+      group: vertexai
+      resource: vertexaifeaturestoreentitytypes
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
+    - name: vertexai-vertexaifeaturestores
+      local: resource-vertexai-vertexaifeaturestores
+      remote: resource-vertexai-vertexaifeaturestores
+      command: ""
+      group: vertexai
+      resource: vertexaifeaturestores
+      controller: terraform
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: vertexai-vertexaiindexendpoints
       local: resource-vertexai-vertexaiindexendpoints
       remote: resource-vertexai-vertexaiindexendpoints
@@ -23178,12 +24191,12 @@ branches:
       host-name: ""
       notes: []
       apis-enabled: []
-    - name: vertexai-vertexaidatasets
-      local: resource-vertexai-vertexaidatasets
-      remote: resource-vertexai-vertexaidatasets
+    - name: vertexai-vertexaiindexes
+      local: resource-vertexai-vertexaiindexes
+      remote: resource-vertexai-vertexaiindexes
       command: ""
       group: vertexai
-      resource: vertexaidatasets
+      resource: vertexaiindexes
       controller: terraform
       skip: false
       kind: ""
@@ -24127,6 +25140,23 @@ branches:
       notes:
         - No gcloud command found
       apis-enabled: []
+    - name: vmwareengine-locations
+      local: resource-vmwareengine-locations
+      remote: resource-vmwareengine-locations
+      command: gcloud vmware locations
+      group: vmwareengine
+      resource: locations
+      controller: Unknown
+      skip: false
+      kind: ""
+      package: ""
+      proto: ""
+      proto-path: ""
+      proto-service: ""
+      proto-msg: ""
+      host-name: ""
+      notes: []
+      apis-enabled: []
     - name: vmwareengine-networks
       local: resource-vmwareengine-networks
       remote: resource-vmwareengine-networks
@@ -24150,23 +25180,6 @@ branches:
       command: gcloud vmware operations
       group: vmwareengine
       resource: operations
-      controller: Unknown
-      skip: false
-      kind: ""
-      package: ""
-      proto: ""
-      proto-path: ""
-      proto-service: ""
-      proto-msg: ""
-      host-name: ""
-      notes: []
-      apis-enabled: []
-    - name: vmwareengine-locations
-      local: resource-vmwareengine-locations
-      remote: resource-vmwareengine-locations
-      command: gcloud vmware locations
-      group: vmwareengine
-      resource: locations
       controller: Unknown
       skip: false
       kind: ""


### PR DESCRIPTION
### Change description

This includes a list of additional metadata from the compute group. Removed metadata entries marked as not needed by gemmahou.
- bigtable-operations
- functions-regions
- notebooks-locations
- spanner-operation
- tpu-location
- compute-computenetworksvpcaccessoperations

### Tests you have done

Ran conductor command 1 to ensure metadata looked ok.
Visually inspected metadata.
Checked on the additional resources which had been added.

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
