### PR TITLE
chore: fix NetworkRef normalization in `BackupDRManagementServer` controller

### DIFF
--- a/pkg/controller/direct/backupdr/managementserver_controller.go
+++ b/pkg/controller/direct/backupdr/managementserver_controller.go
@@ -255,12 +255,10 @@ func (a *ManagementServerAdapter) Delete(ctx context.Context, deleteOp *directba
 
 func (a *ManagementServerAdapter) normalizeReferenceFields(ctx context.Context) error {
 	obj := a.desired
-	if obj.Spec.Networks != nil {
-		for _, network := range obj.Spec.Networks {
-			if network.NetworkRef != nil {
-				if err := network.NetworkRef.Normalize(ctx, a.reader, obj); err != nil {
-					return err
-				}
+	for i := range obj.Spec.Networks {
+		if obj.Spec.Networks[i].NetworkRef != nil {
+			if err := obj.Spec.Networks[i].NetworkRef.Normalize(ctx, a.reader, obj); err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
The previous implementation is technically correct but somewhat unclear. It normalizes the reference in `network`, which is a copy of `obj.Spec.Networks[i]`. This works only because `network.NetworkRef` is a pointer—modifying the copy inadvertently updates the original. The new implementation clarifies the intent and improves readability and maintainability.