### PR TITLE
tf: Add annotation to BigqueryTable to ignore schema change during update

### DIFF
--- a/config/servicemappings/bigquery.yaml
+++ b/config/servicemappings/bigquery.yaml
@@ -202,6 +202,8 @@ spec:
         supportsConditions: true
       ignoredFields:
         - deletion_protection
+      directives:
+        - unmanaged
       resourceReferences:
         - key: datasetRef
           tfField: dataset_id

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_export_bigquerytable-ignore-schema-changes.golden
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_export_bigquerytable-ignore-schema-changes.golden
@@ -1,0 +1,22 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  labels:
+    cnrm-test: "true"
+    managed-by-cnrm: "true"
+  name: bigquerytablesample${uniqueId}
+spec:
+  datasetRef:
+    external: bigquerydatasetsample${uniqueId}
+  externalDataConfiguration:
+    autodetect: true
+    compression: NONE
+    sourceFormat: CSV
+    sourceUris:
+    - gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt
+  friendlyName: bigquerytable-sample-updated
+  requirePartitionFilter: true
+  resourceID: bigquerytablesample${uniqueId}
+  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","type":"STRING"}]'

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_export_bigquerytable-ignore-schema-changes.golden
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_export_bigquerytable-ignore-schema-changes.golden
@@ -17,6 +17,5 @@ spec:
     sourceUris:
     - gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt
   friendlyName: bigquerytable-sample-updated
-  requirePartitionFilter: true
   resourceID: bigquerytablesample${uniqueId}
-  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","type":"STRING"}]'
+  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","policyTags":{},"type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","policyTags":{},"type":"STRING"}]'

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_object_bigquerytable-ignore-schema-changes.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_object_bigquerytable-ignore-schema-changes.golden.yaml
@@ -1,0 +1,43 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+    cnrm.cloud.google.com/unmanaged: spec.schema
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: bigquerytablesample${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  datasetRef:
+    name: bigquerydatasetsample${uniqueId}
+  externalDataConfiguration:
+    autodetect: true
+    sourceFormat: CSV
+    sourceUris:
+    - gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt
+  friendlyName: bigquerytable-sample-updated
+  requirePartitionFilter: false
+  resourceID: bigquerytablesample${uniqueId}
+  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","type":"STRING"},{"description":"First
+    name","mode":"NULLABLE","name":"first_name","type":"STRING"}]'
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  creationTime: "1970-01-01T00:00:00Z"
+  etag: abcdef123456
+  lastModifiedTime: "1970-01-01T00:00:00Z"
+  location: us-central1
+  observedGeneration: 3
+  selfLink: https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}
+  type: EXTERNAL

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_object_bigquerytable-ignore-schema-changes.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_generated_object_bigquerytable-ignore-schema-changes.golden.yaml
@@ -37,7 +37,7 @@ status:
   creationTime: "1970-01-01T00:00:00Z"
   etag: abcdef123456
   lastModifiedTime: "1970-01-01T00:00:00Z"
-  location: us-central1
+  location: US
   observedGeneration: 3
   selfLink: https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}
   type: EXTERNAL

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_http.log
@@ -1,0 +1,686 @@
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Dataset ${projectId}:bigquerydatasetsample${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Dataset ${projectId}:bigquerydatasetsample${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}"
+  },
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "location": "us-central1"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    },
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    },
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "maxTimeTravelHours": "168",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: Table ${projectId}:bigquerydatasetsample${uniqueId}.bigquerytablesample${uniqueId}",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: Table ${projectId}:bigquerydatasetsample${uniqueId}.bigquerytablesample${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "policyTags": {},
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "policyTags": {},
+        "type": "STRING"
+      }
+    ]
+  },
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+PATCH https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+POST https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}:getIamPolicy?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "options": {
+    "requestedPolicyVersion": 1
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "etag": "abcdef0123A="
+}
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTime": "123456789",
+  "etag": "abcdef0123A=",
+  "externalDataConfiguration": {
+    "autodetect": true,
+    "compression": "NONE",
+    "sourceFormat": "CSV",
+    "sourceUris": [
+      "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+    ]
+  },
+  "friendlyName": "bigquerytable-sample-updated",
+  "id": "000000000000000000000",
+  "kind": "bigquery#table",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "numActiveLogicalBytes": "0",
+  "numBytes": "0",
+  "numLongTermBytes": "0",
+  "numLongTermLogicalBytes": "0",
+  "numRows": "0",
+  "numTotalLogicalBytes": "0",
+  "requirePartitionFilter": true,
+  "schema": {
+    "fields": [
+      {
+        "description": "Name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Email",
+        "mode": "NULLABLE",
+        "name": "email",
+        "type": "STRING"
+      }
+    ]
+  },
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}/tables/bigquerytablesample${uniqueId}",
+  "tableReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}",
+    "tableId": "bigquerytablesample${uniqueId}"
+  },
+  "type": "EXTERNAL"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}/tables/bigquerytablesample${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+
+---
+
+GET https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "access": [
+    {
+      "role": "OWNER",
+      "specialGroup": "projectOwners"
+    },
+    {
+      "role": "OWNER",
+      "userByEmail": "user@google.com"
+    },
+    {
+      "role": "READER",
+      "specialGroup": "projectReaders"
+    },
+    {
+      "role": "WRITER",
+      "specialGroup": "projectWriters"
+    }
+  ],
+  "creationTime": "123456789",
+  "datasetReference": {
+    "datasetId": "bigquerydatasetsample${uniqueId}",
+    "projectId": "${projectId}"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "kind": "bigquery#dataset",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lastModifiedTime": "123456789",
+  "location": "us-central1",
+  "maxTimeTravelHours": "168",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/bigquerydatasetsample${uniqueId}",
+  "type": "DEFAULT"
+}
+
+---
+
+DELETE https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/datasets/${datasetID}?alt=json&deleteContents=false
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+204 No Content
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/_http.log
@@ -250,7 +250,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "lastModifiedTime": "123456789",
-  "location": "us-central1",
+  "location": "US",
   "numActiveLogicalBytes": "0",
   "numBytes": "0",
   "numLongTermBytes": "0",
@@ -264,12 +264,14 @@ X-Xss-Protection: 0
         "description": "Name",
         "mode": "NULLABLE",
         "name": "name",
+        "policyTags": {},
         "type": "STRING"
       },
       {
         "description": "Email",
         "mode": "NULLABLE",
         "name": "email",
+        "policyTags": {},
         "type": "STRING"
       }
     ]
@@ -317,7 +319,7 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "lastModifiedTime": "123456789",
-  "location": "us-central1",
+  "location": "US",
   "numActiveLogicalBytes": "0",
   "numBytes": "0",
   "numLongTermBytes": "0",
@@ -331,12 +333,14 @@ X-Xss-Protection: 0
         "description": "Name",
         "mode": "NULLABLE",
         "name": "name",
+        "policyTags": {},
         "type": "STRING"
       },
       {
         "description": "Email",
         "mode": "NULLABLE",
         "name": "email",
+        "policyTags": {},
         "type": "STRING"
       }
     ]
@@ -406,26 +410,28 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "lastModifiedTime": "123456789",
-  "location": "us-central1",
+  "location": "US",
   "numActiveLogicalBytes": "0",
   "numBytes": "0",
   "numLongTermBytes": "0",
   "numLongTermLogicalBytes": "0",
   "numRows": "0",
   "numTotalLogicalBytes": "0",
-  "requirePartitionFilter": true,
+  "requirePartitionFilter": false,
   "schema": {
     "fields": [
       {
         "description": "Name",
         "mode": "NULLABLE",
         "name": "name",
+        "policyTags": {},
         "type": "STRING"
       },
       {
         "description": "Email",
         "mode": "NULLABLE",
         "name": "email",
+        "policyTags": {},
         "type": "STRING"
       }
     ]
@@ -473,26 +479,28 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "lastModifiedTime": "123456789",
-  "location": "us-central1",
+  "location": "US",
   "numActiveLogicalBytes": "0",
   "numBytes": "0",
   "numLongTermBytes": "0",
   "numLongTermLogicalBytes": "0",
   "numRows": "0",
   "numTotalLogicalBytes": "0",
-  "requirePartitionFilter": true,
+  "requirePartitionFilter": false,
   "schema": {
     "fields": [
       {
         "description": "Name",
         "mode": "NULLABLE",
         "name": "name",
+        "policyTags": {},
         "type": "STRING"
       },
       {
         "description": "Email",
         "mode": "NULLABLE",
         "name": "email",
+        "policyTags": {},
         "type": "STRING"
       }
     ]
@@ -566,26 +574,28 @@ X-Xss-Protection: 0
     "managed-by-cnrm": "true"
   },
   "lastModifiedTime": "123456789",
-  "location": "us-central1",
+  "location": "US",
   "numActiveLogicalBytes": "0",
   "numBytes": "0",
   "numLongTermBytes": "0",
   "numLongTermLogicalBytes": "0",
   "numRows": "0",
   "numTotalLogicalBytes": "0",
-  "requirePartitionFilter": true,
+  "requirePartitionFilter": false,
   "schema": {
     "fields": [
       {
         "description": "Name",
         "mode": "NULLABLE",
         "name": "name",
+        "policyTags": {},
         "type": "STRING"
       },
       {
         "description": "Email",
         "mode": "NULLABLE",
         "name": "email",
+        "policyTags": {},
         "type": "STRING"
       }
     ]

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/create.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  name: bigquerytablesample${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/unmanaged: "spec.schema"
+spec:
+  friendlyName: bigquerytable-sample
+  datasetRef:
+    name: bigquerydatasetsample${uniqueId}
+  requirePartitionFilter: true
+  externalDataConfiguration:
+    autodetect: true
+    sourceFormat: CSV
+    sourceUris:
+      - "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","type":"STRING"}]'

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/dependencies.yaml
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataset
+metadata:
+  name: bigquerydatasetsample${uniqueId}
+spec: 
+  location: us-central1

--- a/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigquery/v1beta1/bigquerytable-ignore-schema-changes/update.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  name: bigquerytablesample${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/unmanaged: "spec.schema"
+spec:
+  friendlyName: bigquerytable-sample-updated
+  datasetRef:
+    name: bigquerydatasetsample${uniqueId}
+  requirePartitionFilter: false
+  externalDataConfiguration:
+    autodetect: true
+    sourceFormat: CSV
+    sourceUris:
+      - "gs://gcp-public-data-landsat/LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_ANG.txt"
+  schema: '[{"description":"Name","mode":"NULLABLE","name":"name","type":"STRING"},{"description":"Email","mode":"NULLABLE","name":"email","type":"STRING"},{"description":"First name","mode":"NULLABLE","name":"first_name","type":"STRING"}]'

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/bigquery/bigquerytable.md
@@ -88,6 +88,9 @@
     <tr>
         <td><code>cnrm.cloud.google.com/project-id</code></td>
     </tr>
+    <tr>
+        <td><code>cnrm.cloud.google.com/unmanaged</code></td>
+    </tr>
 </tbody>
 </table>
 

--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -202,7 +202,6 @@
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.rangePartitioning.range.end" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.rangePartitioning.range.interval" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.rangePartitioning.range.start" is not set in unstructured objects
-[missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.schema" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.tableConstraints.foreignKeys[].name" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.tableConstraints.foreignKeys[].referencedTable.datasetId" is not set in unstructured objects
 [missing_field] crd=bigquerytables.bigquery.cnrm.cloud.google.com version=v1beta1: field ".spec.tableConstraints.foreignKeys[].referencedTable.projectId" is not set in unstructured objects


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Add new `unmanaged` directive to TF controller for BQ Table. The spec fields specified in the annotation is unmanaged during Update call. The only spec field supported is `spec.schema` at the moment.

Add new test case for the directives, TF controller makes a PATCH call instead of PUT call. The table object has nil schema to avoid schema to be updated.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
