### PR TITLE
chore: update externalRef in adapter update

### DIFF
--- a/pkg/controller/direct/backupdr/backupvault_controller.go
+++ b/pkg/controller/direct/backupdr/backupvault_controller.go
@@ -216,6 +216,7 @@ func (a *BackupVaultAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/gkebackup/backup_controller.go
+++ b/pkg/controller/direct/gkebackup/backup_controller.go
@@ -201,6 +201,7 @@ func (a *backupAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/gkebackup/backupplan_controller.go
+++ b/pkg/controller/direct/gkebackup/backupplan_controller.go
@@ -220,6 +220,7 @@ func (a *backupPlanAdapter) Update(ctx context.Context, updateOp *directbase.Upd
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/gkebackup/restore_controller.go
+++ b/pkg/controller/direct/gkebackup/restore_controller.go
@@ -203,6 +203,7 @@ func (a *restoreAdapter) Update(ctx context.Context, updateOp *directbase.Update
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/gkebackup/restoreplan_controller.go
+++ b/pkg/controller/direct/gkebackup/restoreplan_controller.go
@@ -211,6 +211,7 @@ func (a *restorePlanAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/speech/customclass_controller.go
+++ b/pkg/controller/direct/speech/customclass_controller.go
@@ -202,6 +202,7 @@ func (a *customClassAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/vmwareengine/externaladdress_controller.go
+++ b/pkg/controller/direct/vmwareengine/externaladdress_controller.go
@@ -195,6 +195,7 @@ func (a *externalAddressAdapter) Update(ctx context.Context, updateOp *directbas
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/vmwareengine/networkpeering_controller.go
+++ b/pkg/controller/direct/vmwareengine/networkpeering_controller.go
@@ -228,6 +228,7 @@ func (a *networkPeeringAdapter) Update(ctx context.Context, updateOp *directbase
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/vmwareengine/networkpolicy_controller.go
+++ b/pkg/controller/direct/vmwareengine/networkpolicy_controller.go
@@ -213,6 +213,7 @@ func (a *networkPolicyAdapter) Update(ctx context.Context, updateOp *directbase.
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/vmwareengine/privatecloud_controller.go
+++ b/pkg/controller/direct/vmwareengine/privatecloud_controller.go
@@ -203,6 +203,7 @@ func (a *privateCloudAdapter) Update(ctx context.Context, updateOp *directbase.U
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/pkg/controller/direct/vmwareengine/vmwareenginenetwork_controller.go
+++ b/pkg/controller/direct/vmwareengine/vmwareenginenetwork_controller.go
@@ -195,6 +195,7 @@ func (a *networkAdapter) Update(ctx context.Context, updateOp *directbase.Update
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
+	status.ExternalRef = direct.LazyPtr(a.id.String())
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 


### PR DESCRIPTION
Following up on a comment in #4403 - add `externalRef` in "update" for some of the controllers I recently added.