### PR TITLE
mockGCP: More fidelity for CloudIdentityMembership mock

### DIFF
--- a/mockgcp/mockcloudidentity/groupsmembership.go
+++ b/mockgcp/mockcloudidentity/groupsmembership.go
@@ -20,13 +20,13 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/google/apps/cloudidentity/groups/v1beta1"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
-	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/google/apps/cloudidentity/groups/v1beta1"
 )
 
 type groupsMembershipsServer struct {
@@ -46,7 +46,7 @@ func (s *groupsMembershipsServer) GetGroupsMembership(ctx context.Context, req *
 	obj := &pb.Membership{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
 		if status.Code(err) == codes.NotFound {
-			return nil, status.Errorf(codes.PermissionDenied, "Error(2017): Permission denied for group resource '%s' (or it may not exist).", fqn)
+			return nil, status.Errorf(codes.NotFound, "Error(4006): Membership does not exist.")
 		}
 		return nil, err
 	}
@@ -74,16 +74,19 @@ func (s *groupsMembershipsServer) CreateGroupsMembership(ctx context.Context, re
 	obj.Name = PtrTo(fmt.Sprintf("%s", name.String()))
 	obj.CreateTime = now
 	obj.UpdateTime = now
-
-	obj.Type = PtrTo("USER")              // TODO: logic for this value ?
-	obj.DeliverySetting = PtrTo("DIGEST") // TODO: logic for this value ?
+	obj.Type = PtrTo("USER")
+	// Legacy field, not available in API v1 but in v1beta1
+	obj.MemberKey = obj.PreferredMemberKey
 
 	if err := s.storage.Create(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
 
-	// TODO: is this all for LRO ?
 	retObj := proto.Clone(obj).(*pb.Membership)
+	// output-only fields are not populated in LRO
+	retObj.CreateTime = nil
+	retObj.UpdateTime = nil
+	retObj.Type = nil
 	return buildLRO(retObj)
 }
 
@@ -110,33 +113,31 @@ func (s *groupsMembershipsServer) ModifyMembershipRolesGroupsMembership(ctx cont
 
 	obj := &pb.Membership{}
 	if err := s.storage.Get(ctx, fqn, obj); err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, status.Errorf(codes.PermissionDenied, "Error(2017): Permission denied for group resource '%s' (or it may not exist).", fqn)
-		}
 		return nil, err
-	}
-
-	retObj := proto.Clone(obj).(*pb.Membership)
-	response := &pb.ModifyMembershipRolesResponse{
-		Membership: retObj,
 	}
 
 	gm := req.GetGroupsMembership()
 	if gm == nil {
-		return response, nil
+		return &pb.ModifyMembershipRolesResponse{
+			Membership: &pb.Membership{Name: obj.Name, Roles: obj.Roles},
+		}, nil
 	}
 
+	// Only contains the added/removed/updated roles in response
+	var modifiedRoles []*pb.MembershipRole
 	for i := range gm.RemoveRoles {
-		for j := range retObj.Roles {
-			if gm.RemoveRoles[i] == *retObj.Roles[j].Name {
-				retObj.Roles = append(retObj.Roles[:j], retObj.Roles[j+1:]...)
+		for j, role := range obj.Roles {
+			if gm.RemoveRoles[i] == *obj.Roles[j].Name {
+				obj.Roles = append(obj.Roles[:j], obj.Roles[j+1:]...)
+				modifiedRoles = append(modifiedRoles, role)
 				break
 			}
 		}
 	}
 
 	for _, role := range gm.AddRoles {
-		retObj.Roles = append(retObj.Roles, role)
+		obj.Roles = append(obj.Roles, role)
+		modifiedRoles = append(modifiedRoles, role)
 	}
 
 	// From proto defn:
@@ -162,18 +163,19 @@ func (s *groupsMembershipsServer) ModifyMembershipRolesGroupsMembership(ctx cont
 			continue
 		}
 
-		for j := range retObj.Roles {
-			if *umr.Name == *retObj.Roles[j].Name {
-				retObj.Roles[j].ExpiryDetail = proto.Clone(umr.ExpiryDetail).(*pb.ExpiryDetail)
+		for j, role := range obj.Roles {
+			if *umr.Name == *obj.Roles[j].Name {
+				obj.Roles[j].ExpiryDetail = proto.Clone(umr.ExpiryDetail).(*pb.ExpiryDetail)
+				modifiedRoles = append(modifiedRoles, role)
 				break
 			}
 		}
 	}
 
-	if err := s.storage.Update(ctx, fqn, retObj); err != nil {
+	if err := s.storage.Update(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
-	return response, nil
+	return &pb.ModifyMembershipRolesResponse{Membership: &pb.Membership{Name: obj.Name, Roles: modifiedRoles}}, nil
 }
 
 func (s *groupsMembershipsServer) DeleteGroupsMembership(ctx context.Context, req *pb.DeleteGroupsMembershipRequest) (*longrunning.Operation, error) {
@@ -205,7 +207,7 @@ func (n *membershipName) String() string {
 }
 
 func (s *MockService) parseMembershipName(name string) (*membershipName, error) {
-	//From GET https://cloudidentity.googleapis.com/v1/{name=groups/*/memberships/*}
+	// From GET https://cloudidentity.googleapis.com/v1/{name=groups/*/memberships/*}
 	// name: groups/{group}/memberships/{membership}
 	tokens := strings.Split(name, "/")
 

--- a/mockgcp/mockcloudidentity/service.go
+++ b/mockgcp/mockcloudidentity/service.go
@@ -66,6 +66,13 @@ func (s *MockService) NewHTTPMux(ctx context.Context, conn *grpc.ClientConn) (ht
 		return nil, err
 	}
 
+	// Returns slightly non-standard errors
+	mux.RewriteError = func(ctx context.Context, error *httpmux.ErrorResponse) {
+		if error.Code == 404 && strings.Contains(error.Message, "Membership") {
+			error.Errors = nil
+		}
+	}
+
 	// DCL sends a trailing slash, but that is not technically correct
 	// and it trips up grpc-gateway (https://github.com/grpc-ecosystem/grpc-gateway/issues/472)
 	// e.g. POST https://cloudidentity.googleapis.com/v1beta1/groups/1946c1f7c26/memberships/?alt=json

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_generated_object_addexpirydatecloudidentitymembership.golden.yaml
@@ -30,7 +30,6 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  deliverySetting: DIGEST
   observedGeneration: 3
   type: USER
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
@@ -149,8 +149,9 @@ X-Xss-Protection: 0
   "done": true,
   "response": {
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "deliverySetting": "DIGEST",
+    "memberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
     "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -159,9 +160,7 @@ X-Xss-Protection: 0
       {
         "name": "MEMBER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    ]
   }
 }
 
@@ -183,7 +182,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -232,12 +233,7 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-17T18:51:02.320337735Z",
-    "deliverySetting": "DIGEST",
     "name": "groups/${groupID}/memberships/${membershipID}",
-    "preferredMemberKey": {
-      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
-    },
     "roles": [
       {
         "expiryDetail": {
@@ -245,9 +241,7 @@ X-Xss-Protection: 0
         },
         "name": "MEMBER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2025-01-17T18:51:02.320337735Z"
+    ]
   }
 }
 
@@ -269,7 +263,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -312,7 +308,7 @@ GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/$
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
-403 Forbidden
+404 Not Found
 Content-Type: application/json; charset=UTF-8
 Server: ESF
 Vary: Origin
@@ -324,9 +320,9 @@ X-Xss-Protection: 0
 
 {
   "error": {
-    "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
-    "status": "PERMISSION_DENIED"
+    "code": 404,
+    "message": "Error(4006): Membership does not exist.",
+    "status": "NOT_FOUND"
   }
 }
 
@@ -387,6 +383,45 @@ X-Xss-Protection: 0
 
 {
   "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addexpirydatecloudidentitymembership/_http.log
@@ -391,45 +391,6 @@ GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "additionalGroupKeys": [
-    {
-      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
-    },
-    {
-      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
-    }
-  ],
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
-  "displayName": "Cloud Identity Group Name",
-  "groupKey": {
-    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
-  },
-  "labels": {
-    "cloudidentity.googleapis.com/groups.discussion_forum": ""
-  },
-  "name": "groups/${groupID}",
-  "parent": "customers/C00qzcxfe",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
 403 Forbidden
 Content-Type: application/json; charset=UTF-8
 Server: ESF

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_generated_object_addrolecloudidentitymembership.golden.yaml
@@ -29,7 +29,6 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  deliverySetting: DIGEST
   observedGeneration: 3
   type: USER
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
@@ -149,8 +149,9 @@ X-Xss-Protection: 0
   "done": true,
   "response": {
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "deliverySetting": "DIGEST",
+    "memberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
     "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -159,9 +160,7 @@ X-Xss-Protection: 0
       {
         "name": "MEMBER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    ]
   }
 }
 
@@ -183,7 +182,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -227,22 +228,12 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-17T18:51:02.320337735Z",
-    "deliverySetting": "DIGEST",
     "name": "groups/${groupID}/memberships/${membershipID}",
-    "preferredMemberKey": {
-      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
-    },
     "roles": [
-      {
-        "name": "MEMBER"
-      },
       {
         "name": "MANAGER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2025-01-17T18:51:02.320337735Z"
+    ]
   }
 }
 
@@ -264,7 +255,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -307,7 +300,7 @@ GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/$
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
-403 Forbidden
+404 Not Found
 Content-Type: application/json; charset=UTF-8
 Server: ESF
 Vary: Origin
@@ -319,9 +312,9 @@ X-Xss-Protection: 0
 
 {
   "error": {
-    "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
-    "status": "PERMISSION_DENIED"
+    "code": 404,
+    "message": "Error(4006): Membership does not exist.",
+    "status": "NOT_FOUND"
   }
 }
 
@@ -382,6 +375,45 @@ X-Xss-Protection: 0
 
 {
   "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "additionalGroupKeys": [
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+    },
+    {
+      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
+    }
+  ],
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
+  "displayName": "Cloud Identity Group Name",
+  "groupKey": {
+    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
+  },
+  "labels": {
+    "cloudidentity.googleapis.com/groups.discussion_forum": ""
+  },
+  "name": "groups/${groupID}",
+  "parent": "customers/C00qzcxfe",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/addrolecloudidentitymembership/_http.log
@@ -383,45 +383,6 @@ GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "additionalGroupKeys": [
-    {
-      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
-    },
-    {
-      "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}.test-google-a.com"
-    }
-  ],
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "description": "This is a test CloudIdentityGroup. It should be modified before use as a sample.",
-  "displayName": "Cloud Identity Group Name",
-  "groupKey": {
-    "id": "${uniqueId}-group@${ISOLATED_TEST_ORG_NAME}"
-  },
-  "labels": {
-    "cloudidentity.googleapis.com/groups.discussion_forum": ""
-  },
-  "name": "groups/${groupID}",
-  "parent": "customers/C00qzcxfe",
-  "updateTime": "2024-04-01T12:34:56.123456Z"
-}
-
----
-
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
 403 Forbidden
 Content-Type: application/json; charset=UTF-8
 Server: ESF

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_generated_object_removerolecloudidentitymembership.golden.yaml
@@ -28,7 +28,6 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
-  deliverySetting: DIGEST
   observedGeneration: 3
   type: USER
   updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
@@ -398,30 +398,6 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "message": "Error(2028): Permission denied for resource groups/${groupID} (or it may not exist).",
-    "status": "PERMISSION_DENIED"
-  }
-}
-
----
-
-GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-403 Forbidden
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 403,
     "message": "Error(2017): Permission denied for group resource 'groups/${groupID}' (or it may not exist).",
     "status": "PERMISSION_DENIED"
   }

--- a/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudidentity/v1beta1/cloudidentitymembership/removerolecloudidentitymembership/_http.log
@@ -152,8 +152,9 @@ X-Xss-Protection: 0
   "done": true,
   "response": {
     "@type": "type.googleapis.com/google.apps.cloudidentity.groups.v1beta1.Membership",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "deliverySetting": "DIGEST",
+    "memberKey": {
+      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+    },
     "name": "groups/${groupID}/memberships/${membershipID}",
     "preferredMemberKey": {
       "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -165,9 +166,7 @@ X-Xss-Protection: 0
       {
         "name": "MANAGER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2024-04-01T12:34:56.123456Z"
+    ]
   }
 }
 
@@ -189,7 +188,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -232,19 +233,12 @@ X-Xss-Protection: 0
 
 {
   "membership": {
-    "createTime": "2025-01-17T18:51:02.320337735Z",
-    "deliverySetting": "DIGEST",
     "name": "groups/${groupID}/memberships/${membershipID}",
-    "preferredMemberKey": {
-      "id": "test2@${ISOLATED_TEST_ORG_NAME}"
-    },
     "roles": [
       {
-        "name": "MEMBER"
+        "name": "MANAGER"
       }
-    ],
-    "type": "USER",
-    "updateTime": "2025-01-17T18:51:02.320337735Z"
+    ]
   }
 }
 
@@ -266,7 +260,9 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "deliverySetting": "DIGEST",
+  "memberKey": {
+    "id": "test2@${ISOLATED_TEST_ORG_NAME}"
+  },
   "name": "groups/${groupID}/memberships/${membershipID}",
   "preferredMemberKey": {
     "id": "test2@${ISOLATED_TEST_ORG_NAME}"
@@ -306,7 +302,7 @@ GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}/memberships/$
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} DeclarativeClientLib/0.0.1
 
-403 Forbidden
+404 Not Found
 Content-Type: application/json; charset=UTF-8
 Server: ESF
 Vary: Origin
@@ -318,9 +314,9 @@ X-Xss-Protection: 0
 
 {
   "error": {
-    "code": 403,
-    "message": "Error(2017): Permission denied for group resource 'groups/${groupID}/memberships/${membershipID}' (or it may not exist).",
-    "status": "PERMISSION_DENIED"
+    "code": 404,
+    "message": "Error(4006): Membership does not exist.",
+    "status": "NOT_FOUND"
   }
 }
 
@@ -381,6 +377,30 @@ X-Xss-Protection: 0
 
 {
   "done": true
+}
+
+---
+
+GET https://cloudidentity.googleapis.com/v1beta1/groups/${groupID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+403 Forbidden
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "message": "Error(2028): Permission denied for resource groups/${groupID} (or it may not exist).",
+    "status": "PERMISSION_DENIED"
+  }
 }
 
 ---


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
1st commit https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4443/commits/7f27152b577120ca48a95bd1f0e8efce41224a58: collect realGCP logs. Triggered a prow job in [CL#73200](https://cnrm-review.git.corp.google.com/c/cnrm/+/73200)(the -1 is expected, since we start a new pipeline for each run, there's no golden log to compare with. Other than the diff I don't see other errors), realGCP logs located in GCS storage: https://pantheon.corp.google.com/storage/browser/cnrm-prow/pr-logs/pull/cnrm-review.googlesource.com_cnrm/73200/cnrm-test/1915505218699661312/artifacts?e=13802955&mods=pan_ng2&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))

2nd commit https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4443/commits/6a1af1075efcdfb0a01ce92197a9ac2515a5a9b6: Update mock server and re-collect mockGCP logs. Only the extra GET group requests after deletion call is missing. I think that's acceptable.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
