### PR TITLE
Update status in adapter Update() even without change

### DIFF
--- a/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
+++ b/pkg/controller/direct/privilegedaccessmanager/entitlement_controller.go
@@ -357,6 +357,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 			return mapCtx.Err()
 		}
 		status.ObservedState = observedState
+		status.ExternalRef = a.id.AsExternalRef()
 		return setStatus(u, status)
 	}
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
I kept the `if` check to update status only when `status.externalRef` is not set for AlloyDBCluster and AlloyDBInstance. This is to reduce unnecessary updates.

In the future, I think we should update status in Update() when:
1.  Drift is detected and fixed.
2. `status.externalRef` is unset.
3. `status.observedState` is updated.

Right now for many controllers we update status regardlessly, and I'm a bit concerned this will impact scalability when there are many resources. Though it might be cheap/free to update status (?); we need to discuss further.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
