### PR TITLE
Support maximal test generation in conductor

### DIFF
--- a/experiments/conductor/cmd/runner/controller_commands.go
+++ b/experiments/conductor/cmd/runner/controller_commands.go
@@ -345,7 +345,6 @@ Respond only with the YAML content, no explanations.`,
 		WorkDir:      opts.branchRepoDir,
 		RetryBackoff: GenerativeCommandRetryBackoff,
 	}
-
 	_, err := executeCommand(opts, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate create.yaml: %w", err)
@@ -465,6 +464,81 @@ func moveTestToSubDir(ctx context.Context, opts *RunnerOptions, branch Branch, e
 	return changedPaths, nil, nil
 }
 
+const CreateFullTestCreatePrompt string = `Generate a ${TEST_DIR}/create.yaml file for testing a Kubernetes controller.
+
+First, read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the schema.
+Replace <pluralized-kind> with the pluralized version of the kind: ${KIND} in the filename.
+
+The file should follow these requirements:
+- Add an Apache 2.0 license header with Copyright ${CURRENT_YEAR} Google LLC
+- Use apiVersion: ${CRD_GROUP}/${CRD_VERSION}
+- Use kind: ${KIND}
+- Include metadata.name: ${KIND_LOWERCASE}-${uniqueId}
+- If the CRD has a "spec.projectRef" field, use projectRef.external: ${projectId}
+- If the CRD has a "spec.location" field, use location: us-central1
+- If the CRD has any field name end with "Ref", it's a reference field. Use its subfield ".name" and set value to be <kind>-${uniqueId}. Replace <kind> with the kind of the reference field. The kind is indicated in the description of the reference field's subfield, "external" field.
+- If any field under the CRD has both subfields "value" and "valueFrom", it's a sensitive field. Use its subfield ".valueFrom" and set value of ".valueFrom.secretKeyRef.name" to "secret-${uniqueId}" and set value of ".valueFrom.secretKeyRef.key" to the field name of the sensitive field.
+- Use as many spec fields in the following list as possible to achieve full coverage: ${MISSING_FIELDS}; if the list is empty, use as many fields under spec as possible to try to reach full coverage
+- Follow the schema defined in the CRD file
+- Do not use any field not defined in the CRD
+- If the value of a field contains any " (double quote), quote it with single quotes
+
+Use ReadFile to read the CRD file.
+Use CreateFile to write the YAML content to the ${TEST_DIR}/create.yaml file if it doesn't exist; or overwrite the existing file.
+Respond only with the YAML content, no explanations.`
+
+const CreateFullTestUpdatePrompt string = `Generate an ${TEST_DIR}/update.yaml file for testing a Kubernetes controller by modifying the create.yaml file.
+
+First, read the ${TEST_DIR}/create.yaml file that was just generated.
+Then modify all the mutable fields to create a valid update scenario.
+Read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the what fields are mutable.
+Replace <pluralized-kind> with the pluralized version of the kind: ${KIND} in the filename.
+
+The file should follow these requirements:
+- Keep the same license header, apiVersion, kind and metadata.name
+- Modify as many fields as possibleb in the spec section to test updates
+- Ensure the changes are valid according to the CRD schema
+- Keep other fields unchanged from create.yaml
+
+Use ReadFile to read the ${TEST_DIR}/create.yaml file.
+Use ReadFile to read the CRD file.
+Use CreateFile to write the YAML content to the ${TEST_DIR}/update.yaml file if it doesn't exist; or overwrite the existing file.
+Respond only with the YAML content, no explanations.`
+
+const CreateFullTestDependenciesPrompt string = `Generate a ${TEST_DIR}/dependencies.yaml file based on the information in the ${TEST_DIR}/create.yaml file and the ${TEST_DIR}/update.yaml.
+
+First, read the ${TEST_DIR}/create.yaml and ${TEST_DIR}/update.yaml file that was just generated.
+If any spec field name ends with "Ref", or if any field value ends with "${uniqueId}", then read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the schema.
+Replace <pluralized-kind> with the pluralized version of the kind: ${KIND} in the filename. If not, do nothing and leave.
+Identify field with subfields "name", "namespace" and "external" in the CRD file. These fields are reference fields.
+Identify the kinds of the reference fields. The kind is indicated in the description of the reference field's subfield, "external" field in the CRD file.
+For each identified kind, read the CRD files with names ending with "<kind>.yaml" under crds/ folder.
+
+Second, generate a ${TEST_DIR}/dependencies.yaml file. The file should follow these requirements:
+- Add an Apache 2.0 license header with Copyright ${CURRENT_YEAR} Google LLC.
+- Identify reference fields and their values in ${TEST_DIR}/create.yaml and ${TEST_DIR}/update.yaml.
+- Create one resource for each reference field that specifies subfield "name" and has a different value of "name".
+- Split each resource with "---" and a new line.
+- For each resource,
+    - The <kind> should be the kind of the reference field.
+    - Use apiVersion: <apiVersion>, where <apiVersion> is defined in the CRD file, whose name ends with "<kind>.yaml".
+    - Use kind: <kind>.
+    - Use metadata.name: <referencedResourceName>, where <referencedResourceName> is the value of the subfield "name" under the reference field.
+    - If the CRD has a "spec.projectRef" field, use projectRef.external: ${projectId}.
+    - If the CRD has a "spec.location" field, use location: us-central1.
+    - Only include required fields from the CRD of <kind>.
+    - Follow the schema defined in the CRD file of <kind>.
+    - Do not add any field not defined in the CRD file of <kind>.
+
+Use ReadFile to read the ${TEST_DIR}/create.yaml file.
+Use ReadFile to read the ${TEST_DIR}/update.yaml file.
+Use ReadFile to read all the CRD files.
+Check all the spec fields including the nested fields in the ${TEST_DIR}/create.yaml file and the ${TEST_DIR}/update.yaml file.
+If any field value in ${TEST_DIR}/create.yaml or ${TEST_DIR}/update.yaml ends with "${uniqueId}", then there must be a ${TEST_DIR}/dependencies.yaml.
+If there is no field name in ${TEST_DIR}/create.yaml or ${TEST_DIR}/update.yaml other than "spec.projectRef" ending with "Ref", do nothing and leave.
+Use CreateFile to write the YAML content to the ${TEST_DIR}/dependencies.yaml file if it doesn't exist; or overwrite the existing file.
+Respond only with the YAML content, no explanations.`
+
 // createFullCoverageTest creates test files aiming for full coverage for the branch.
 func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Branch, execResults *ExecResults) ([]string, *ExecResults, error) {
 	log.Printf("Creating test cases for branch %s", branch.Name)
@@ -555,41 +629,26 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 		if err == nil {
 			// TODO: Add an option to not override the existing test.
 			log.Printf("Overriding test under %s", fullTestDir)
-		}
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("error checking whether test directory %s exists: %w", fullTestDir, err)
 		} else {
-			if err := os.MkdirAll(fullTestDir, 0755); err != nil {
-				return nil, nil, fmt.Errorf("failed to create test directory %s: %w", fullTestDir, err)
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, nil, fmt.Errorf("error checking whether test directory %s exists: %w", fullTestDir, err)
+			} else {
+				if err := os.MkdirAll(fullTestDir, 0755); err != nil {
+					return nil, nil, fmt.Errorf("failed to create test directory %s: %w", fullTestDir, err)
+				}
 			}
 		}
 
 		// 3. Generate testdata.
 		// Use codebot to generate the initial create.yaml content.
-		createPrompt := fmt.Sprintf(`Generate a %s/create.yaml file for testing a Kubernetes controller.
-
-First, read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.%s.cnrm.cloud.google.com.yaml to understand the schema.
-Replace <pluralized-kind> with the pluralized version of the kind: %s in the filename.
-
-The file should follow these requirements:
-- Add an Apache 2.0 license header with Copyright %d Google LLC
-- Use apiVersion: %s/%s
-- Use kind: %s
-- Include metadata.name: %s-${uniqueId}
-- If the CRD has a "spec.projectRef" field, use projectRef.external: ${projectId}
-- If the CRD has a "spec.location" field, use location: us-central1
-- If the CRD has any field name end with "Ref", it's a reference field. Use its subfield ".name" and set value to be <kind>-${uniqueId}. Replace <kind> with the kind of the reference field. The kind is indicated in the description of the reference field's subfield, "external" field.
-- If any field under the CRD has both subfields "value" and "valueFrom", it's a sensitive field. Use its subfield ".valueFrom" and set value of ".valueFrom.secretKeyRef.name" to "secret-${uniqueId}" and set value of ".valueFrom.secretKeyRef.key" to the field name of the sensitive field.
-- Use as many spec fields in the following list as possible to achieve full coverage: %+v; if the list is empty, use as many fields under spec as possible to try to reach full coverage
-- Follow the schema defined in the CRD file
-- Do not use any field not defined in the CRD
-- If the value of a field contains any " (double quote), quote it with single quotes
-
-Use ReadFile to read the CRD file.
-Use CreateFile to write the YAML content to the %s/create.yaml file if it doesn't exist; or overwrite the existing file.
-Respond only with the YAML content, no explanations.`,
-			testDir, branch.Group, branch.Kind, currentYear, crdGroup, crdVersion, branch.Kind, strings.ToLower(branch.Kind), missingFields, testDir)
-
+		createPrompt := strings.ReplaceAll(CreateFullTestCreatePrompt, "${TEST_DIR}", testDir)
+		createPrompt = strings.ReplaceAll(createPrompt, "${GROUP}", branch.Group)
+		createPrompt = strings.ReplaceAll(createPrompt, "${KIND}", branch.Kind)
+		createPrompt = strings.ReplaceAll(createPrompt, "${CURRENT_YEAR}", fmt.Sprintf("%d", currentYear))
+		createPrompt = strings.ReplaceAll(createPrompt, "${CRD_GROUP}", crdGroup)
+		createPrompt = strings.ReplaceAll(createPrompt, "${CRD_VERSION}", crdVersion)
+		createPrompt = strings.ReplaceAll(createPrompt, "${KIND_LOWERCASE}", strings.ToLower(branch.Kind))
+		createPrompt = strings.ReplaceAll(createPrompt, "${MISSING_FIELDS}", fmt.Sprintf("%+v", missingFields))
 		cfg = CommandConfig{
 			Name:         "Generate Create YAML",
 			Cmd:          "codebot",
@@ -598,32 +657,15 @@ Respond only with the YAML content, no explanations.`,
 			WorkDir:      opts.branchRepoDir,
 			RetryBackoff: GenerativeCommandRetryBackoff,
 		}
-
 		_, err = executeCommand(opts, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to generate create.yaml: %w", err)
 		}
 
 		// Use codebot to generate the update.yaml content by modifying create.yaml
-		updatePrompt := fmt.Sprintf(`Generate an %s/update.yaml file for testing a Kubernetes controller by modifying the create.yaml file.
-
-First, read the %s/create.yaml file that was just generated.
-Then modify all the mutable fields to create a valid update scenario.
-Read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.%s.cnrm.cloud.google.com.yaml to understand the what fields are mutable.
-Replace <pluralized-kind> with the pluralized version of the kind: %s in the filename.
-
-The file should follow these requirements:
-- Keep the same license header, apiVersion, kind and metadata.name
-- Modify as many fields as possibleb in the spec section to test updates
-- Ensure the changes are valid according to the CRD schema
-- Keep other fields unchanged from create.yaml
-
-Use ReadFile to read the %s/create.yaml file.
-Use ReadFile to read the CRD file.
-Use CreateFile to write the YAML content to the %s/update.yaml file if it doesn't exist; or overwrite the existing file.
-Respond only with the YAML content, no explanations.`,
-			testDir, testDir, branch.Group, branch.Kind, testDir, testDir)
-
+		updatePrompt := strings.ReplaceAll(CreateFullTestUpdatePrompt, "${TEST_DIR}", testDir)
+		updatePrompt = strings.ReplaceAll(updatePrompt, "${GROUP}", branch.Group)
+		updatePrompt = strings.ReplaceAll(updatePrompt, "${KIND}", branch.Kind)
 		cfg = CommandConfig{
 			Name:         "Generate Update YAML",
 			Cmd:          "codebot",
@@ -632,48 +674,16 @@ Respond only with the YAML content, no explanations.`,
 			WorkDir:      opts.branchRepoDir,
 			RetryBackoff: GenerativeCommandRetryBackoff,
 		}
-
 		_, err = executeCommand(opts, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to generate update.yaml: %w", err)
 		}
 
 		// Use codebot to generate the dependencies.yaml content based on create.yaml and update.yaml.
-		dependenciesPrompt := fmt.Sprintf(`Generate a %s/dependencies.yaml file based on the information in the %s/create.yaml file and the %s/update.yaml.
-
-First, read the %s/create.yaml and %s/update.yaml file that was just generated.
-If any spec field name ends with "Ref", or if any field value ends with "${uniqueId}", then read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.%s.cnrm.cloud.google.com.yaml to understand the schema.
-Replace <pluralized-kind> with the pluralized version of the kind: %s in the filename. If not, do nothing and leave.
-Identify field with subfields "name", "namespace" and "external" in the CRD file. These fields are reference fields.
-Identify the kinds of the reference fields. The kind is indicated in the description of the reference field's subfield, "external" field in the CRD file.
-For each identified kind, read the CRD files with names ending with "<kind>.yaml" under crds/ folder.
-
-Second, generate a %s/dependencies.yaml file. The file should follow these requirements:
-- Add an Apache 2.0 license header with Copyright %d Google LLC.
-- Identify reference fields and their values in %s/create.yaml and %s/update.yaml.
-- Create one resource for each reference field that specifies subfield "name" and has a different value of "name".
-- Split each resource with "---" and a new line.
-- For each resource,
-    - The <kind> should be the kind of the reference field.
-    - Use apiVersion: <apiVersion>, where <apiVersion> is defined in the CRD file, whose name ends with "<kind>.yaml".
-    - Use kind: <kind>.
-    - Use metadata.name: <referencedResourceName>, where <referencedResourceName> is the value of the subfield "name" under the reference field.
-    - If the CRD has a "spec.projectRef" field, use projectRef.external: ${projectId}.
-    - If the CRD has a "spec.location" field, use location: us-central1.
-    - Only include required fields from the CRD of <kind>.
-    - Follow the schema defined in the CRD file of <kind>.
-    - Do not add any field not defined in the CRD file of <kind>.
-
-Use ReadFile to read the %s/create.yaml file.
-Use ReadFile to read the %s/update.yaml file.
-Use ReadFile to read all the CRD files.
-Check all the spec fields including the nested fields in the %s/create.yaml file and the %s/update.yaml file.
-If any field value in %s/create.yaml or %s/update.yaml ends with "${uniqueId}", then there must be a %s/dependencies.yaml.
-If there is no field name in %s/create.yaml or %s/update.yaml other than "spec.projectRef" ending with "Ref", do nothing and leave.
-Use CreateFile to write the YAML content to the %s/dependencies.yaml file if it doesn't exist; or overwrite the existing file.
-Respond only with the YAML content, no explanations.`,
-			testDir, testDir, testDir, testDir, testDir, branch.Group, branch.Kind, testDir, currentYear, testDir, testDir, testDir, testDir, testDir, testDir, testDir, testDir, testDir, testDir, testDir, testDir)
-
+		dependenciesPrompt := strings.ReplaceAll(CreateFullTestDependenciesPrompt, "${TEST_DIR}", testDir)
+		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${GROUP}", branch.Group)
+		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${KIND}", branch.Kind)
+		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${CURRENT_YEAR}", fmt.Sprintf("%d", currentYear))
 		cfg = CommandConfig{
 			Name:         "Generate Dependencies YAML",
 			Cmd:          "codebot",
@@ -682,7 +692,6 @@ Respond only with the YAML content, no explanations.`,
 			WorkDir:      opts.branchRepoDir,
 			RetryBackoff: GenerativeCommandRetryBackoff,
 		}
-
 		_, err = executeCommand(opts, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to generate dependencies.yaml: %w", err)
@@ -738,9 +747,6 @@ func matchLineInFileByPrefix(path, prefix string) ([]string, error) {
 }
 
 func pluralOf(word string) string {
-	if strings.HasSuffix(word, "f") {
-		return replaceLast(word, "f", "ves")
-	}
 	if strings.HasSuffix(word, "fe") {
 		return replaceLast(word, "fe", "ves")
 	}

--- a/experiments/conductor/cmd/runner/github_commands_test.go
+++ b/experiments/conductor/cmd/runner/github_commands_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestCommitMessageRegex(t *testing.T) {
+	tests := []struct {
+		name           string
+		regex          *regexp.Regexp
+		input          string
+		expectedResult bool
+	}{
+		{
+			name:           "Match REGEX_MSG_50",
+			regex:          REGEX_MSG_50,
+			input:          "TestKind: Move existing test to subdirectory",
+			expectedResult: true,
+		},
+		{
+			name:           "No match REGEX_MSG_50",
+			regex:          REGEX_MSG_50,
+			input:          ": Move existing test to subdirectory",
+			expectedResult: false,
+		},
+		{
+			name:           "Match REGEX_MSG_51A",
+			regex:          REGEX_MSG_51A,
+			input:          "TestKind: Move existing test to subdirectory before creating maximal test",
+			expectedResult: true,
+		},
+		{
+			name:           "No match REGEX_MSG_51A",
+			regex:          REGEX_MSG_51A,
+			input:          ": Move existing test to subdirectory before creating maximal test",
+			expectedResult: false,
+		},
+		{
+			name:           "Match REGEX_MSG_51 using COMMIT_MSG_51B",
+			regex:          REGEX_MSG_51,
+			input:          "TestKind: Create maximal test",
+			expectedResult: true,
+		},
+		{
+			name:           "Match REGEX_MSG_51 using COMMIT_MSG_51C",
+			regex:          REGEX_MSG_51,
+			input:          "TestKind: Enable test with mockgcp",
+			expectedResult: true,
+		},
+		{
+			name:  "Match REGEX_MSG_51 using COMMIT_MSG_51B and COMMIT_MSG_51C",
+			regex: REGEX_MSG_51,
+			// According to the regex `*([a-zA-Z]+: Create maximal test)|([a-zA-Z]+: Enable test with mockgcp).*$`,
+			// when there are text after `[a-zA-Z]+: Create maximal test`, it's also a match.
+			input:          "TestKind: Create maximal test | TestKind: Enable test with mockgcp",
+			expectedResult: true,
+		},
+		{
+			name:           "No match REGEX_MSG_51 using COMMIT_MSG_51A",
+			regex:          REGEX_MSG_51,
+			input:          "TestKind: Move existing test to subdirectory before creating maximal test",
+			expectedResult: false,
+		},
+		{
+			name:           "No match REGEX_MSG_51",
+			regex:          REGEX_MSG_51,
+			input:          ": Create maximal test",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.regex.MatchString(tc.input)
+			if actual != tc.expectedResult {
+				t.Errorf("got '%t', want '%t'", actual, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -201,6 +201,9 @@ func (opts *RunnerOptions) validateAndDefaultFlags() error {
 		case cmdCreateFullTest:
 			opts.testDirSuffix = "full"
 		}
+	} else {
+		// Ensure the suffix is in lowercase.
+		opts.testDirSuffix = strings.ToLower(opts.testDirSuffix)
 	}
 	return nil
 }

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -44,6 +44,7 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	loggingDirFlag          = "logging-dir"
 	readFileTypeFlag        = "file-type"
 	controllerFilterFlag    = "controller-filter"
+	testDirSuffixFlag       = "test-suffix"
 
 	// Command values
 	cmdDeleteGitBranch              = -5
@@ -82,6 +83,7 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdCaptureGoldenMockOutput      = 47
 	cmdRunAndFixGoldenMockOutput    = 48
 	cmdMoveExistingTest             = 50
+	cmdCreateFullTest               = 51
 
 	typeScriptYaml = "scriptyaml"
 	typeHttpLog    = "httplog"
@@ -141,6 +143,8 @@ func BuildRunnerCmd() *cobra.Command {
 		"", "", "Type of controller to filter for. (Eg terraform-v1beta1)")
 	cmd.Flags().StringVarP(&opts.handleLocalChange, "handle-local-change",
 		"", "", "Option to handle uncommitted local changes before switching to a different branch, available values: 'CLEANUP', 'COMMIT', 'FAIL'.")
+	cmd.Flags().StringVarP(&opts.testDirSuffix, testDirSuffixFlag,
+		"", "", "Suffix of the test to generate/run/fix for each branch")
 
 	return cmd
 }
@@ -164,19 +168,39 @@ type RunnerOptions struct {
 	processors        string // Comma-separated list of processor function names to run
 	controllerFilter  string // Filter the metadata for 1 type of controller. (Eg terraform-v1beta1)
 	handleLocalChange string // Option to handle uncommitted local changes before switching to a different branch
+	testDirSuffix     string // Suffix for test directory
 }
 
-func (opts *RunnerOptions) validateFlags() error {
+func (opts *RunnerOptions) validateAndDefaultFlags() error {
 	if opts.defaultRetries < 0 {
 		return fmt.Errorf("retries flag cannot be negative, got %d", opts.defaultRetries)
 	}
+
 	switch opts.handleLocalChange {
 	case "":
 		// When the handle local change option is unset, each command will handle it differently.
+		switch opts.command {
+		case cmdCreateFullTest:
+			opts.handleLocalChange = handleLocalChangeOptionCommit
+		default:
+			opts.handleLocalChange = handleLocalChangeOptionCleanUp
+		}
 	case handleLocalChangeOptionCleanUp, handleLocalChangeOptionCommit, handleLocalChangeOptionFail:
 	default:
 		return fmt.Errorf("handle-local-change flag must be set with one of %q, %q, %q but it is set to %q",
 			handleLocalChangeOptionCleanUp, handleLocalChangeOptionCommit, handleLocalChangeOptionFail, opts.handleLocalChange)
+	}
+
+	if opts.testDirSuffix == "" {
+		// When the test directory suffix is unset, each command will handle it differently.
+		switch opts.command {
+		case cmdControllerCreateTest, cmdCaptureGoldenRealGCPOutput,
+			cmdRunAndFixGoldenRealGCPOutput, cmdCaptureGoldenMockOutput,
+			cmdRunAndFixGoldenMockOutput:
+			opts.testDirSuffix = "minimal"
+		case cmdCreateFullTest:
+			opts.testDirSuffix = "full"
+		}
 	}
 	return nil
 }
@@ -239,7 +263,7 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		opts.loggingDir = filepath.Join(cwd, opts.loggingDir)
 	}
 
-	if err := opts.validateFlags(); err != nil {
+	if err := opts.validateAndDefaultFlags(); err != nil {
 		return err
 	}
 
@@ -458,6 +482,12 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		processBranches(ctx, opts, REGEX_MSG_48, branches.Branches, "Fix Mock GCP Tests", []BranchProcessor{{Fn: fixMockGcpForGoldenTests, CommitMsgTemplate: COMMIT_MSG_48, VerifyFn: runGoldenMockTests, VerifyAttempts: 5, AttemptsOnNoChange: 2}})
 	case cmdMoveExistingTest: // 50
 		processBranches(ctx, opts, REGEX_MSG_50, branches.Branches, "Move Existing Test", []BranchProcessor{{Fn: moveTestToSubDir, CommitMsgTemplate: COMMIT_MSG_50, AttemptsOnNoChange: 0, CommitOptional: true}})
+	case cmdCreateFullTest: // 51
+		processBranches(ctx, opts, REGEX_MSG_51, branches.Branches, "Create Maximal Test", []BranchProcessor{
+			{Fn: moveTestToSubDir, CommitMsgTemplate: COMMIT_MSG_51A, AttemptsOnNoChange: 0, CommitOptional: true, SkipProcessorOnMsg: skipPost51A},
+			{Fn: createFullCoverageTest, CommitMsgTemplate: COMMIT_MSG_51B, CommitOptional: true},
+			{Fn: updateTestHarness, CommitMsgTemplate: COMMIT_MSG_51C, CommitOptional: true},
+		})
 	default:
 		log.Fatalf("unrecognized command: %d", opts.command)
 	}
@@ -502,6 +532,7 @@ func printHelp() {
 	log.Println("\t47 - [Controller] Capture golden logs for mock GCP tests for each branch")
 	log.Println("\t48 - [Controller] Run and Fix mock GCP tests for each branch")
 	log.Println("\t50 - [Test] Move test data to subdirectory if the test files are directly under <version>/<kind> directory for each branch")
+	log.Println("\t51 - [Test] Create a maximal test for each branch")
 }
 
 func checkRepoDir(ctx context.Context, opts *RunnerOptions, branches Branches) {

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -65,6 +65,7 @@ var commandMap = map[int64]string{
 	cmdCaptureGoldenMockOutput:      "capturegoldenmockoutput",
 	cmdRunAndFixGoldenMockOutput:    "runandfixgoldenmockoutput",
 	cmdMoveExistingTest:             "moveexistingtest",
+	cmdCreateFullTest:               "createfulltest",
 }
 
 type exitBash func()
@@ -134,7 +135,7 @@ func cdRepoBranchDirBash(opts *RunnerOptions, subdir string, stdin io.WriteClose
 	return msg
 }
 
-func checkLocalChanges(ctx context.Context, branch Branch, workDir string, option string) {
+func handleLocalChanges(ctx context.Context, branch Branch, workDir string, option string) {
 	log.Print("Checking uncommitted changes: git status --porcelain")
 	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	statusCmd.Dir = workDir
@@ -873,7 +874,7 @@ func processBranch(ctx context.Context, opts *RunnerOptions, branch Branch, skip
 	if opts.handleLocalChange == "" {
 		opts.handleLocalChange = handleLocalChangeOptionCleanUp
 	}
-	checkLocalChanges(ctx, branch, opts.branchRepoDir, opts.handleLocalChange)
+	handleLocalChanges(ctx, branch, opts.branchRepoDir, opts.handleLocalChange)
 	checkoutBranch(ctx, branch, opts.branchRepoDir)
 
 	// Run git diff command

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -18,7 +18,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 make -C operator test
-UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/...  ./scripts/resource-autogen/... ./tests/... | grep -v tests/e2e)
+UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/...  ./scripts/resource-autogen/... ./tests/... ./experiments/conductor/cmd/runner/... | grep -v tests/e2e)
 if [ -z ${GITHUB_ACTION+x} ]; then
     go run gotest.tools/gotestsum@latest --format testname -- ${UNIT_TEST_PACKAGES} -coverprofile cover.out -count=1
 else


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Added the command that generates test cases to increase coverage for supported resources:
* Currently, the command attempt to generate the test at least once and at most three times to ensure most coverage.
* Use the updated result of tests/apichecks/testdata/exceptions/missingfields.txt to determine whether the test cases cover all the supported fields and gets a list of uncovered fields. We ignore `XXXRef.external` fields as we want to test references via `.name` field. We also ignore `value` field under sensitive fields as we encourage usage of `valueFrom` and currently are focusing on testing the encouraged option.
  * Uncovered fields extraction is not done by LLM because several lines of functions do a better job than codebot.
* Use LLM to generate the create.yaml to cover as many fields in the list of uncovered fields as possible. This includes reference fields.
* Use LLM to generate the dependencies.yaml for the referenced resources in create.yaml.
* Use LLM to generate the update.yaml based on create.yaml that changes as many fields in create.yaml as possible.
* Return the parent directory of the test cases as the changed fields even when the LLM steps error out because sometimes they still generate the files. This is to ensure the next branch can be processed as expected.

Also supported the configuration of the suffix for the generated test cases across commands and enabled skip regex for more than one commit message.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
