### PR TITLE
Support moving existing test to subdir in preparation for adding more test cases

### DIFF
--- a/experiments/conductor/cmd/runner/github_commands.go
+++ b/experiments/conductor/cmd/runner/github_commands.go
@@ -59,6 +59,7 @@ const (
 	COMMIT_MSG_46  = "{{kind}}: Verify and Fix real GCP tests"
 	COMMIT_MSG_47  = "{{kind}}: Record golden logs for mock GCP tests"
 	COMMIT_MSG_48  = "{{kind}}: Verify and Fix mock GCP tests"
+	COMMIT_MSG_50  = "{{kind}}: Move existing test to subdirectory"
 )
 
 var REGEX_MSG_9A = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_9A))
@@ -96,6 +97,7 @@ var REGEX_MSG_45 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_45))
 var REGEX_MSG_46 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_46))
 var REGEX_MSG_47 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_47))
 var REGEX_MSG_48 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_48))
+var REGEX_MSG_50 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_50))
 
 func skipPost21A(msg string) bool {
 	return REGEX_MSG_21A.MatchString(msg)

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -442,7 +442,7 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 	case cmdRunAndFixGoldenMockOutput: // 48
 		processBranches(ctx, opts, REGEX_MSG_48, branches.Branches, "Fix Mock GCP Tests", []BranchProcessor{{Fn: fixMockGcpForGoldenTests, CommitMsgTemplate: COMMIT_MSG_48, VerifyFn: runGoldenMockTests, VerifyAttempts: 5, AttemptsOnNoChange: 2}})
 	case cmdMoveExistingTest: // 50
-		processBranches(ctx, opts, REGEX_MSG_50, branches.Branches, "Move existing test", []BranchProcessor{{Fn: moveTestToSubDir, CommitMsgTemplate: COMMIT_MSG_50, AttemptsOnNoChange: 0}})
+		processBranches(ctx, opts, REGEX_MSG_50, branches.Branches, "Move Existing Test", []BranchProcessor{{Fn: moveTestToSubDir, CommitMsgTemplate: COMMIT_MSG_50, AttemptsOnNoChange: 0, CommitOptional: true}})
 	default:
 		log.Fatalf("unrecognized command: %d", opts.command)
 	}

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -81,6 +81,7 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdRunAndFixGoldenRealGCPOutput = 46
 	cmdCaptureGoldenMockOutput      = 47
 	cmdRunAndFixGoldenMockOutput    = 48
+	cmdMoveExistingTest             = 50
 
 	typeScriptYaml = "scriptyaml"
 	typeHttpLog    = "httplog"
@@ -440,6 +441,8 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 		processBranches(ctx, opts, REGEX_MSG_47, branches.Branches, "Record Golden Mock Tests", []BranchProcessor{{Fn: runGoldenMockTests, CommitMsgTemplate: COMMIT_MSG_47, AttemptsOnNoChange: 1}})
 	case cmdRunAndFixGoldenMockOutput: // 48
 		processBranches(ctx, opts, REGEX_MSG_48, branches.Branches, "Fix Mock GCP Tests", []BranchProcessor{{Fn: fixMockGcpForGoldenTests, CommitMsgTemplate: COMMIT_MSG_48, VerifyFn: runGoldenMockTests, VerifyAttempts: 5, AttemptsOnNoChange: 2}})
+	case cmdMoveExistingTest: // 50
+		processBranches(ctx, opts, REGEX_MSG_50, branches.Branches, "Move existing test", []BranchProcessor{{Fn: moveTestToSubDir, CommitMsgTemplate: COMMIT_MSG_50, AttemptsOnNoChange: 0}})
 	default:
 		log.Fatalf("unrecognized command: %d", opts.command)
 	}
@@ -483,6 +486,7 @@ func printHelp() {
 	log.Println("\t46 - [Controller] Run and Fix real GCP tests for each branch")
 	log.Println("\t47 - [Controller] Capture golden logs for mock GCP tests for each branch")
 	log.Println("\t48 - [Controller] Run and Fix mock GCP tests for each branch")
+	log.Println("\t50 - [Test] Move test data to subdirectory if the test files are directly under <version>/<kind> directory for each branch")
 }
 
 func checkRepoDir(ctx context.Context, opts *RunnerOptions, branches Branches) {
@@ -1084,6 +1088,9 @@ func determineCommandByCommit(opts *RunnerOptions, branch Branch) {
 	case REGEX_MSG_48.MatchString(message):
 		log.Printf("%s: command 48\n", branch.Name)
 		fmt.Printf("%s: command 48\n", branch.Name)
+	case REGEX_MSG_50.MatchString(message):
+		log.Printf("%s: command 50\n", branch.Name)
+		fmt.Printf("%s: command 50\n", branch.Name)
 	default:
 		log.Printf("%s: unrecognized command for message %s\n", branch.Name, message)
 		fmt.Printf("%s: unrecognized command for message %s\n", branch.Name, message)

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -64,6 +64,7 @@ var commandMap = map[int64]string{
 	cmdRunAndFixGoldenRealGCPOutput: "runandfixgoldenrealgcpoutput",
 	cmdCaptureGoldenMockOutput:      "capturegoldenmockoutput",
 	cmdRunAndFixGoldenMockOutput:    "runandfixgoldenmockoutput",
+	cmdMoveExistingTest:             "moveexistingtest",
 }
 
 type exitBash func()

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -581,6 +581,7 @@ type BranchProcessor struct {
 	VerifyAttempts     int
 	AttemptsOnChanges  int // Number of attempts to run the processor if changes are detected
 	SkipProcessorOnMsg SkipProcessorOnMsgFn
+	CommitOptional     bool // Whether a commit is optional or required; default to be required
 }
 
 func (b *BranchProcessor) CommitMsg(branch Branch) string {
@@ -633,9 +634,11 @@ func runBranchFnWithRetriesAndCommit(ctx context.Context, opts *RunnerOptions, b
 			}
 		}
 
-		// If commitMsg is not set, we don't need to commit the changes
-		// we assume there are no changes to commit
-		if commitMsg == "" {
+		// If commitMsg is not set, we don't need to commit the changes,
+		// we assume there are no changes to commit.
+		// If CommitOptional is explicitly set to true and there is no change,
+		// we assume there are no changes to commit.
+		if commitMsg == "" || processor.CommitOptional && !someChanged {
 			return changesCommitted, execResults, nil
 		}
 


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
A lot of resources only have one test case and they are directly under `pkg/test/resourcefixture/testdata/basic/<group>/v1beta1/<kind>` directory.

To support new test cases, we need to move these test cases to a sub directory first.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [N/A] Run `make ready-pr` to ensure this PR is ready for review.
- [N/A] Perform necessary E2E testing for changed resources.
