### PR TITLE
preview mode: introduce reconcile end event

### DIFF
--- a/pkg/cli/preview/preview_test.go
+++ b/pkg/cli/preview/preview_test.go
@@ -125,10 +125,19 @@ spec:
 
 	timeoutAt := time.Now().Add(2 * time.Minute)
 	for {
+		// Wait for the object to be reconciled
 		if len(recorder.objects) > 0 {
-			// Object has reconciled
-			// TODO: I guess we _might_ catch the reconcileStart event but not the kubeAction/gcpAction ... so maybe we need a reconcileEnd event?
-			break
+			hasReconciled := make(map[GKNN]bool)
+			for gknn, obj := range recorder.objects {
+				for _, event := range obj.events {
+					if event.eventType == EventTypeReconcileEnd {
+						hasReconciled[gknn] = true
+					}
+				}
+			}
+			if len(hasReconciled) > 0 {
+				break
+			}
 		}
 		if time.Now().After(timeoutAt) {
 			t.Fatalf("did not see captured object in recorder")
@@ -147,8 +156,12 @@ spec:
 			switch event.eventType {
 			case EventTypeDiff:
 				t.Logf("  diff %+v", event.diff)
+
 			case EventTypeReconcileStart:
 				t.Logf("  reconcileStart %+v", event.object)
+
+			case EventTypeReconcileEnd:
+				t.Logf("  reconcileEnd %+v", event.object)
 
 			case EventTypeKubeAction:
 				t.Logf("  kubeAction %+v", event.kubeAction)
@@ -185,7 +198,7 @@ spec:
 				// We aren't expected changes
 				t.Errorf("unexpected gcpAction in changelist: %+v", event.gcpAction)
 
-			case EventTypeReconcileStart:
+			case EventTypeReconcileStart, EventTypeReconcileEnd:
 				// We do expect this!
 
 			default:

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -180,6 +180,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	}
 
 	structuredreporting.ReportReconcileStart(ctx, u)
+	defer structuredreporting.ReportReconcileEnd(ctx, u, res, err)
 
 	skip, err := resourceactuation.ShouldSkip(u)
 	if err != nil {

--- a/pkg/structuredreporting/context.go
+++ b/pkg/structuredreporting/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type contextKey string
@@ -53,4 +54,6 @@ type Listener interface {
 	OnDiff(ctx context.Context, diffs *Diff)
 	// OnReconcileStart is called when a controller calls ReportReconcileStart
 	OnReconcileStart(ctx context.Context, u *unstructured.Unstructured)
+	// OnReconcileEnd is called when a controller calls ReportReconcileEnd
+	OnReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error)
 }

--- a/pkg/structuredreporting/events.go
+++ b/pkg/structuredreporting/events.go
@@ -18,11 +18,18 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func ReportReconcileStart(ctx context.Context, u *unstructured.Unstructured) {
 	if listener, ok := GetListenerFromContext(ctx); ok {
 		listener.OnReconcileStart(ctx, u)
+	}
+}
+
+func ReportReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error) {
+	if listener, ok := GetListenerFromContext(ctx); ok {
+		listener.OnReconcileEnd(ctx, u, result, err)
 	}
 }
 


### PR DESCRIPTION
This should avoid a potential (though unlikely) race condition where we catch an object mid-reconcile.
