### PR TITLE
WIP: more reusable wait for object

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -1140,7 +1140,11 @@ func (h *Harness) waitForCRDReady(obj client.Object) {
 			logger.Info("Error getting resource", "kind", kind, "id", id, "error", err)
 			return false, err
 		}
-		objectStatus := dynamic.GetObjectStatus(h.T, u)
+		objectStatus, err := dynamic.GetObjectStatus(u)
+		if err != nil {
+			logger.Info("Error getting object status", "kind", kind, "id", id, "error", err)
+			return false, err
+		}
 		// CRDs do not have observedGeneration
 		for _, condition := range objectStatus.Conditions {
 			if condition.Type == "Established" && condition.Status == "True" {

--- a/mockgcp/mockgcptests/e2e_test.go
+++ b/mockgcp/mockgcptests/e2e_test.go
@@ -65,7 +65,7 @@ func TestScripts(t *testing.T) {
 
 			uniqueID := fmt.Sprintf("%x", time.Now().UnixNano())
 
-			h := NewHarness(t)
+			h := NewHarness(ctx, t)
 			h.Init()
 
 			project := h.Project

--- a/pkg/cli/preview/localmode_kube.go
+++ b/pkg/cli/preview/localmode_kube.go
@@ -1,0 +1,279 @@
+package preview
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// LocalModeKube is a client that implements the KubeClient interface,
+// but runs against a static set of objects stored in memory.
+type LocalModeKube struct {
+	objectsByGK map[GroupKind]*objectsOfKind
+
+	resourceVersion int64
+}
+
+// NewLocalModeKube creates a new LocalModeClient.
+func NewLocalModeKube() *LocalModeKube {
+	return &LocalModeKube{
+		objectsByGK: make(map[GroupKind]*objectsOfKind),
+	}
+}
+
+func (k *LocalModeKube) typeInfoForObject(obj client.Object) (*typeInfo, error) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		gvk := u.GroupVersionKind()
+		if gvk.Empty() {
+			return nil, fmt.Errorf("unstructured object has no group version kind: %v", obj)
+		}
+		gvr := GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: gvk.Kind + "s",
+		}
+		return &typeInfo{gvk: gvk, gvr: gvr}, nil
+	}
+	return nil, fmt.Errorf("unsupported object type: %T", obj)
+}
+
+func (k *LocalModeKube) BuildRESTMapper() meta.RESTMapper {
+	return &localModeRESTMapper{
+		kube: k,
+	}
+}
+
+type localModeRESTMapper struct {
+	kube *LocalModeKube
+}
+
+var _ meta.RESTMapper = &localModeRESTMapper{}
+
+func (m *localModeRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, fmt.Errorf("KindFor not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, fmt.Errorf("KindsFor not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	switch gk {
+	case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:
+		return &meta.RESTMapping{
+			GroupVersionKind: schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
+			Resource:         schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+			Scope:            meta.RESTScopeRoot,
+		}, nil
+	case schema.GroupKind{Group: "", Kind: "Namespace"}:
+		return &meta.RESTMapping{
+			GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+			Scope:            meta.RESTScopeRoot,
+		}, nil
+	}
+
+	crds := m.kube.objectsByGK[GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}]
+	for _, crd := range crds.objects {
+		u, ok := crd.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(u.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(u.Object, "spec", "names", "kind")
+		resource, _, _ := unstructured.NestedString(u.Object, "spec", "names", "plural")
+		scopeName, _, _ := unstructured.NestedString(u.Object, "spec", "scope")
+		version := versions[0]
+
+		if group == "" || kind == "" || resource == "" || scopeName == "" {
+			return nil, fmt.Errorf("invalid CRD: %s", crd.GetName())
+		}
+
+		var scope meta.RESTScope
+		switch scopeName {
+		case "Namespaced":
+			scope = meta.RESTScopeNamespace
+		case "Cluster":
+			scope = meta.RESTScopeRoot
+		default:
+			return nil, fmt.Errorf("unknown scope: %s", scopeName)
+		}
+
+		if group == gk.Group && kind == gk.Kind {
+			return &meta.RESTMapping{
+				GroupVersionKind: schema.GroupVersionKind{Group: group, Version: version, Kind: kind},
+				Resource:         schema.GroupVersionResource{Group: group, Version: version, Resource: resource},
+				Scope:            scope,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("RESTMapping not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, fmt.Errorf("ResourceFor not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, fmt.Errorf("ResourcesFor not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("RESTMappings not implemented by localModeRESTMapper")
+}
+
+func (m *localModeRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	return "", fmt.Errorf("ResourceSingularizer not implemented by localModeRESTMapper")
+}
+
+type objectsOfKind struct {
+	groupKind GroupKind
+	objects   map[NamespacedName]Object
+}
+
+type NamespacedName struct {
+	Namespace string
+	Name      string
+}
+
+func (c *LocalModeKube) AddObject(obj *unstructured.Unstructured) {
+	gk := GroupKind{
+		Group: obj.GroupVersionKind().Group,
+		Kind:  obj.GroupVersionKind().Kind,
+	}
+	nn := NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+	objs := c.objectsByGK[gk]
+	if objs == nil {
+		objs = &objectsOfKind{
+			groupKind: gk,
+			objects:   make(map[NamespacedName]Object),
+		}
+		c.objectsByGK[gk] = objs
+	}
+	c.resourceVersion++
+	objs.objects[nn] = obj
+}
+
+type localModeKubeClient struct {
+	kube *LocalModeKube
+}
+
+var _ KubeClient = &localModeKubeClient{}
+
+func (k *LocalModeKube) BuildKubeClient() KubeClient {
+	return &localModeKubeClient{
+		kube: k,
+	}
+}
+
+// Get implements the KubeClient interface.
+func (c *localModeKubeClient) Get(ctx context.Context, typeInfo *typeInfo, namespace, name string, dest Object) error {
+	gk := typeInfo.GroupKind()
+	objects, found := c.kube.objectsByGK[gk]
+	if !found {
+		return fmt.Errorf("no objects found for group kind %s", gk)
+	}
+	nn := NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	object, ok := objects.objects[nn]
+	if !ok {
+		id := name
+		if namespace != "" {
+			id = namespace + "/" + id
+		}
+		return apierrors.NewNotFound(typeInfo.GroupResource(), id)
+	}
+	return typeInfo.CopyObjectInto(object, dest)
+}
+
+// List implements the KubeClient interface.
+func (c *localModeKubeClient) List(ctx context.Context, typeInfo *typeInfo, listener ListListener) error {
+	gk := typeInfo.GroupKind()
+
+	metadata := ListMetadata{
+		APIVersion:      typeInfo.gvk.GroupVersion().String(),
+		Kind:            typeInfo.gvk.Kind,
+		ResourceVersion: strconv.FormatInt(c.kube.resourceVersion, 10),
+	}
+
+	listener.OnListBegin(metadata)
+
+	objects, found := c.kube.objectsByGK[gk]
+	if found {
+		for _, object := range objects.objects {
+			listener.OnListObject(object)
+		}
+	}
+
+	listener.OnListEnd()
+	return nil
+}
+
+// Watch implements the KubeClient interface.
+func (c *localModeKubeClient) Watch(ctx context.Context, typeInfo *typeInfo, watchOptions WatchOptions, listener WatchListener) error {
+	if watchOptions.ResourceVersion == "" {
+		return fmt.Errorf("resource version empty not supported in local mode")
+	}
+	if watchOptions.ResourceVersion == "0" {
+		return fmt.Errorf("resource version empty not supported in local mode")
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type localModeControllerRuntimeClient struct {
+	kube *LocalModeKube
+}
+
+var _ client.Reader = &localModeControllerRuntimeClient{}
+
+func (k *LocalModeKube) BuildControllerRuntimeClient() client.Reader {
+	return &localModeControllerRuntimeClient{
+		kube: k,
+	}
+}
+
+// Get implements the KubeClient interface.
+func (c *localModeControllerRuntimeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if len(opts) != 0 {
+		return fmt.Errorf("local mode does not support get options")
+	}
+	typeInfo, err := c.kube.typeInfoForObject(obj)
+	if err != nil {
+		return err
+	}
+	gk := typeInfo.GroupKind()
+	objects, found := c.kube.objectsByGK[gk]
+	if !found {
+		return fmt.Errorf("no objects found for group kind %s", gk)
+	}
+	nn := NamespacedName{
+		Namespace: key.Namespace,
+		Name:      key.Name,
+	}
+	object, ok := objects.objects[nn]
+	if !ok {
+		id := key.Name
+		if key.Namespace != "" {
+			id = key.Namespace + "/" + id
+		}
+		return apierrors.NewNotFound(typeInfo.GroupResource(), id)
+	}
+	return typeInfo.CopyObjectInto(object, obj)
+}
+
+// List implements the KubeClient interface.
+func (c *localModeControllerRuntimeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return fmt.Errorf("local mode does not support list")
+}

--- a/pkg/cli/preview/preview_test.go
+++ b/pkg/cli/preview/preview_test.go
@@ -125,10 +125,19 @@ spec:
 
 	timeoutAt := time.Now().Add(2 * time.Minute)
 	for {
+		// Wait for the object to be reconciled
 		if len(recorder.objects) > 0 {
-			// Object has reconciled
-			// TODO: I guess we _might_ catch the reconcileStart event but not the kubeAction/gcpAction ... so maybe we need a reconcileEnd event?
-			break
+			hasReconciled := make(map[GKNN]bool)
+			for gknn, obj := range recorder.objects {
+				for _, event := range obj.events {
+					if event.eventType == EventTypeReconcileEnd {
+						hasReconciled[gknn] = true
+					}
+				}
+			}
+			if len(hasReconciled) > 0 {
+				break
+			}
 		}
 		if time.Now().After(timeoutAt) {
 			t.Fatalf("did not see captured object in recorder")

--- a/pkg/cli/preview/recorder.go
+++ b/pkg/cli/preview/recorder.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // GKNN is the canonical identity for a kube object; it is short for Group-Kind-Namespaced-Name
@@ -70,6 +71,7 @@ type EventType string
 
 const (
 	EventTypeReconcileStart EventType = "reconcileStart"
+	EventTypeReconcileEnd   EventType = "reconcileEnd"
 	EventTypeDiff           EventType = "diff"
 	EventTypeKubeAction     EventType = "kubeAction"
 	EventTypeGCPAction      EventType = "gcpAction"
@@ -123,6 +125,11 @@ func (l *structuredReportingListener) OnReconcileStart(ctx context.Context, u *u
 	l.recorder.recordReconcileStart(ctx, u)
 }
 
+// OnReconcileEnd is called by the structured reporting subsystem when a reconcile ends.
+func (l *structuredReportingListener) OnReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error) {
+	l.recorder.recordReconcileEnd(ctx, u, result, err)
+}
+
 // OnDiff is called by the structured reporting subsystem when a diff occurs.
 func (l *structuredReportingListener) OnDiff(ctx context.Context, diff *structuredreporting.Diff) {
 	l.recorder.recordDiff(ctx, diff)
@@ -165,6 +172,19 @@ func (r *Recorder) recordReconcileStart(ctx context.Context, u *unstructured.Uns
 	info.events = append(info.events, event{
 		eventType: EventTypeReconcileStart,
 		object:    u.DeepCopy(),
+	})
+}
+
+// recordReconcileEnd captures the reconcile end into our recorder.
+func (r *Recorder) recordReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error) {
+	gknn := gknnFromUnstructured(u)
+
+	info := r.getObjectInfo(gknn)
+	info.events = append(info.events, event{
+		eventType: EventTypeReconcileEnd,
+		object:    u.DeepCopy(),
+		result:    result,
+		err:       err,
 	})
 }
 

--- a/pkg/cli/preview/streaming_client.go
+++ b/pkg/cli/preview/streaming_client.go
@@ -51,6 +51,18 @@ type GroupVersionResource struct {
 	Resource string
 }
 
+// GroupKind is a group and kind.
+type GroupKind struct {
+	Group string
+	Kind  string
+}
+
+type KubeClient interface {
+	Get(ctx context.Context, typeInfo *typeInfo, namespace, name string, dest Object) error
+	List(ctx context.Context, typeInfo *typeInfo, listener ListListener) error
+	Watch(ctx context.Context, typeInfo *typeInfo, watchOptions WatchOptions, listener WatchListener) error
+}
+
 // NewStreamingClient creates a new StreamingClient.
 func NewStreamingClient(opt ClientOptions) *StreamingClient {
 	return &StreamingClient{

--- a/pkg/cli/preview/typeinfo.go
+++ b/pkg/cli/preview/typeinfo.go
@@ -15,6 +15,7 @@
 package preview
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -117,4 +118,22 @@ func (s *typeStore) getTypeInfo(obj client.Object) (*typeInfo, error) {
 // GroupResource returns the group and resource for the type info.
 func (t *typeInfo) GroupResource() schema.GroupResource {
 	return schema.GroupResource{Group: t.gvr.Group, Resource: t.gvr.Resource}
+}
+
+// GroupKind returns the group and kind for the type info.
+func (t *typeInfo) GroupKind() GroupKind {
+	return GroupKind{Group: t.gvk.Group, Kind: t.gvk.Kind}
+}
+
+// CopyObjectInto copies the object into the given object.
+func (t *typeInfo) CopyObjectInto(src Object, dest Object) error {
+	// TODO: How do we want to copy objects?
+	b, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("error copying %T: %w", src, err)
+	}
+	if err := json.Unmarshal(b, dest); err != nil {
+		return fmt.Errorf("error copying %T: %w", src, err)
+	}
+	return nil
 }

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -180,6 +180,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (res 
 	}
 
 	structuredreporting.ReportReconcileStart(ctx, u)
+	defer structuredreporting.ReportReconcileEnd(ctx, u, res, err)
 
 	skip, err := resourceactuation.ShouldSkip(u)
 	if err != nil {

--- a/pkg/structuredreporting/context.go
+++ b/pkg/structuredreporting/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type contextKey string
@@ -53,4 +54,6 @@ type Listener interface {
 	OnDiff(ctx context.Context, diffs *Diff)
 	// OnReconcileStart is called when a controller calls ReportReconcileStart
 	OnReconcileStart(ctx context.Context, u *unstructured.Unstructured)
+	// OnReconcileEnd is called when a controller calls ReportReconcileEnd
+	OnReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error)
 }

--- a/pkg/structuredreporting/events.go
+++ b/pkg/structuredreporting/events.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func ReportReconcileStart(ctx context.Context, u *unstructured.Unstructured) {

--- a/pkg/structuredreporting/events.go
+++ b/pkg/structuredreporting/events.go
@@ -26,6 +26,12 @@ func ReportReconcileStart(ctx context.Context, u *unstructured.Unstructured) {
 	}
 }
 
+func ReportReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error) {
+	if listener, ok := GetListenerFromContext(ctx); ok {
+		listener.OnReconcileEnd(ctx, u, result, err)
+	}
+}
+
 func ReportError(ctx context.Context, err error, args ...any) {
 	if listener, ok := GetListenerFromContext(ctx); ok {
 		listener.OnError(ctx, err, args...)

--- a/pkg/test/controller/condition.go
+++ b/pkg/test/controller/condition.go
@@ -35,7 +35,10 @@ func AssertReadyCondition(t *testing.T, object runtime.Object, minObservedGenera
 	}
 	objectID := gvk.Kind + ":" + accessor.GetName()
 
-	objectStatus := dynamic.GetObjectStatus(t, object)
+	objectStatus, err := dynamic.GetObjectStatus(object)
+	if err != nil {
+		t.Fatalf("error getting object status: %v", err)
+	}
 	if objectStatus.ObservedGeneration == nil {
 		t.Fatalf("resource %v does not yet have status.observedGeneration", objectID)
 	}

--- a/pkg/test/kubeharness.go
+++ b/pkg/test/kubeharness.go
@@ -202,7 +202,11 @@ func (h *KubeHarness) waitForCRDReady(obj client.Object) {
 			logger.Info("Error getting resource", "kind", kind, "id", id, "error", err)
 			return false, err
 		}
-		objectStatus := dynamic.GetObjectStatus(h.T, u)
+		objectStatus, err := dynamic.GetObjectStatus(u)
+		if err != nil {
+			logger.Info("Error getting object status", "kind", kind, "id", id, "error", err)
+			return false, err
+		}
 		// CRDs do not have observedGeneration
 		for _, condition := range objectStatus.Conditions {
 			if condition.Type == "Established" && condition.Status == "True" {


### PR DESCRIPTION
- **preview mode: introduce reconcile end event**
  This should avoid a potential (though unlikely) race condition where we catch an object mid-reconcile.
  

- **WIP: run preview in local-apiserver mode**
  

- **WIP: more reusable wait for object**
  