### PR TITLE
management conflict is not required

### DIFF
--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -437,7 +437,7 @@ func (r *Reconciler) enqueueForImmediateReconciliation(resourceNN types.Namespac
 }
 
 func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resource *dcl.Resource, liveLabels map[string]string) error {
-	conflictPolicy, err := managementconflict.GetManagementConflictPreventionAnnotationValue(resource)
+	conflictPolicy, err := managementconflict.GetManagementConflictPreventionPolicy(resource)
 	if err != nil {
 		return err
 	}
@@ -449,8 +449,7 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, resourc
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("kind '%v' does not support usage of %v='%v'", resource.GroupVersionKind(),
-			managementconflict.FullyQualifiedAnnotation, conflictPolicy)
+		return managementconflict.NewLeasingNotSupportedByKindError(resource.GroupVersionKind())
 	}
 	// Use SoftObtain instead of Obtain so that obtaining the lease ONLY changes the 'labels' value on the local krmResource and does not write the results
 	// to GCP. The reason to do that is to reduce the number of writes to GCP and therefore improve performance and reduce errors.

--- a/pkg/controller/tf/controller.go
+++ b/pkg/controller/tf/controller.go
@@ -510,7 +510,7 @@ func (r *Reconciler) applyChangesForBackwardsCompatibility(ctx context.Context, 
 }
 
 func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, krmResource *krmtotf.Resource, liveState *terraform.InstanceState) error {
-	conflictPolicy, err := managementconflict.GetManagementConflictPreventionAnnotationValue(krmResource)
+	conflictPolicy, err := managementconflict.GetManagementConflictPreventionPolicy(krmResource)
 	if err != nil {
 		return err
 	}
@@ -522,8 +522,7 @@ func (r *Reconciler) obtainResourceLeaseIfNecessary(ctx context.Context, krmReso
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("kind '%v' does not support usage of %v='%v'", krmResource.GroupVersionKind(),
-			managementconflict.FullyQualifiedAnnotation, conflictPolicy)
+		return managementconflict.NewLeasingNotSupportedByKindError(krmResource.GroupVersionKind())
 	}
 	// Use SoftObtain instead of Obtain so that obtaining the lease ONLY changes the 'labels' value on the local krmResource and does not write the results
 	// to GCP. The reason to do that is to reduce the number of writes to GCP and therefore improve performance and reduce errors.

--- a/pkg/managementconflict/annotations_test.go
+++ b/pkg/managementconflict/annotations_test.go
@@ -28,16 +28,16 @@ func TestGetManagementConflictPreventionAnnotationValue(t *testing.T) {
 		ShouldSucceed  bool
 	}{
 		{
-			Name:           "nil annotations should error",
+			Name:           "nil annotations should no longer error",
 			Annotations:    nil,
 			ExpectedPolicy: ManagementConflictPreventionPolicyNone,
-			ShouldSucceed:  false,
+			ShouldSucceed:  true,
 		},
 		{
-			Name:           "missing annotation should error",
+			Name:           "missing annotation should no longer error",
 			Annotations:    make(map[string]string),
 			ExpectedPolicy: ManagementConflictPreventionPolicyNone,
-			ShouldSucceed:  false,
+			ShouldSucceed:  true,
 		},
 		{
 			Name:           "invalid annotation should error",
@@ -56,7 +56,7 @@ func TestGetManagementConflictPreventionAnnotationValue(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			obj := unstructured.Unstructured{}
 			obj.SetAnnotations(tc.Annotations)
-			policy, err := GetManagementConflictPreventionAnnotationValue(&obj)
+			policy, err := GetManagementConflictPreventionPolicy(&obj)
 			if tc.ShouldSucceed != (err == nil) {
 				t.Fatalf("expected success to be '%v', instead got error mismatch: %v", tc.ShouldSucceed, err)
 			}


### PR DESCRIPTION
- **chore: refactor managementconflict logic**
  Put it in its own package so we can better reason about it.
  

- **Make the management-conflict annotation optional**
  There's no reason to enforce the annotation - it is mutable.
  
  Making it optional means one less thing we depend on the webhook for.
  