### PR TITLE
ci: pin gcloud

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -62,6 +62,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '520.0.0'
       - name: "Run dev/ci/presubmits/test-mockgcp"
         run: |
           ./dev/ci/presubmits/test-mockgcp

--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -65,6 +65,7 @@ jobs:
       - uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '520.0.0'
+          install_components: 'alpha,beta'
       - name: "Run dev/ci/presubmits/test-mockgcp"
         run: |
           ./dev/ci/presubmits/test-mockgcp

--- a/mockgcp/mocknetworkconnectivity/testdata/internalranges/crud/_http.log
+++ b/mockgcp/mocknetworkconnectivity/testdata/internalranges/crud/_http.log
@@ -153,7 +153,6 @@ Connection: keep-alive
 Content-Type: application/json
 
 {
-  "immutable": false,
   "network": "${networkID}",
   "peering": "FOR_SELF",
   "prefixLength": 24,

--- a/mockgcp/mocknetworkconnectivity/testdata/internalranges/crud/_http.log
+++ b/mockgcp/mocknetworkconnectivity/testdata/internalranges/crud/_http.log
@@ -153,6 +153,7 @@ Connection: keep-alive
 Content-Type: application/json
 
 {
+  "immutable": false,
   "network": "${networkID}",
   "peering": "FOR_SELF",
   "prefixLength": 24,


### PR DESCRIPTION
Following up on https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4498#issuecomment-2858595050

It seems without this the HEAD is broken and some PRs on the `immutable` field being absent (!) in some other gcloud version.