### PR TITLE
preview environment: don't check for duplicate controller names

### DIFF
--- a/pkg/cli/preview/preview.go
+++ b/pkg/cli/preview/preview.go
@@ -126,6 +126,10 @@ func (i *PreviewInstance) Start(ctx context.Context) error {
 	// manager tries to bind to the same port.
 	kccConfig.ManagerOptions.HealthProbeBindAddress = "0"
 
+	// Don't check for duplicate controller names
+	skipNameValidation := true
+	kccConfig.ManagerOptions.Controller.SkipNameValidation = &skipNameValidation
+
 	// Hook kube
 	kccConfig.ManagerOptions.NewCache = i.hookKube.NewCache
 	kccConfig.ManagerOptions.NewClient = i.hookKube.NewClient


### PR DESCRIPTION
It probably isn't a particularly important test in the first place,
given that names are primarily for metrics, but it shouldn't cause
a preview operation to fail.
