### PR TITLE
Add direct ServiceIdentity controller, opt-in except for magic gserviceaccount P4SA

### DIFF
--- a/apis/common/projects/mapper.go
+++ b/apis/common/projects/mapper.go
@@ -1,0 +1,58 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+)
+
+type ProjectMapper struct {
+	client *resourcemanager.ProjectsClient
+}
+
+func NewProjectMapper(client *resourcemanager.ProjectsClient) *ProjectMapper {
+	return &ProjectMapper{
+		client: client,
+	}
+}
+
+func (m *ProjectMapper) ReplaceProjectNumberWithID(ctx context.Context, projectID string) (string, error) {
+	if _, err := strconv.ParseInt(projectID, 10, 64); err != nil {
+		// Not a project number, no need to map
+		return projectID, nil
+	}
+
+	req := &resourcemanagerpb.GetProjectRequest{
+		Name: "projects/" + projectID,
+	}
+	project, err := m.client.GetProject(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("error getting project %q: %w", req.Name, err)
+	}
+	return project.ProjectId, nil
+}
+
+func (m *ProjectMapper) LookupProjectNumber(ctx context.Context, projectID string) (int64, error) {
+	// Check if the project number is already a valid integer
+	// If not, we need to look it up
+	projectNumber, err := strconv.ParseInt(projectID, 10, 64)
+	if err != nil {
+		req := &resourcemanagerpb.GetProjectRequest{
+			Name: "projects/" + projectID,
+		}
+		project, err := m.client.GetProject(ctx, req)
+		if err != nil {
+			return 0, fmt.Errorf("error getting project %q: %w", req.Name, err)
+		}
+		n, err := strconv.ParseInt(strings.TrimPrefix(project.Name, "projects/"), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("error parsing project number for %q: %w", project.Name, err)
+		}
+		projectNumber = n
+	}
+	return projectNumber, nil
+}

--- a/apis/refs/v1beta1/computerefs.go
+++ b/apis/refs/v1beta1/computerefs.go
@@ -20,8 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
-	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -74,7 +73,7 @@ func ParseComputeNetworkID(external string) (*ComputeNetworkID, error) {
 }
 
 // ConvertToProjectNumber converts the external reference to use a project number.
-func (ref *ComputeNetworkRef) ConvertToProjectNumber(ctx context.Context, projectsClient *resourcemanager.ProjectsClient) error {
+func (ref *ComputeNetworkRef) ConvertToProjectNumber(ctx context.Context, projectMapper *projects.ProjectMapper) error {
 	if ref == nil {
 		return nil
 	}
@@ -84,24 +83,12 @@ func (ref *ComputeNetworkRef) ConvertToProjectNumber(ctx context.Context, projec
 		return err
 	}
 
-	// Check if the project number is already a valid integer
-	// If not, we need to look it up
-	projectNumber, err := strconv.ParseInt(id.Project, 10, 64)
+	projectNumber, err := projectMapper.LookupProjectNumber(ctx, id.Project)
 	if err != nil {
-		req := &resourcemanagerpb.GetProjectRequest{
-			Name: "projects/" + id.Project,
-		}
-		project, err := projectsClient.GetProject(ctx, req)
-		if err != nil {
-			return fmt.Errorf("error getting project %q: %w", req.Name, err)
-		}
-		n, err := strconv.ParseInt(strings.TrimPrefix(project.Name, "projects/"), 10, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing project number for %q: %w", project.Name, err)
-		}
-		projectNumber = n
+		return fmt.Errorf("error looking up project number for project %q: %w", id.Project, err)
 	}
 	id.Project = strconv.FormatInt(projectNumber, 10)
+
 	ref.External = id.String()
 	return nil
 }

--- a/apis/refs/v1beta1/projectref.go
+++ b/apis/refs/v1beta1/projectref.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/identity"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -55,6 +56,25 @@ func AsProjectRef(in *v1alpha1.ResourceRef) *ProjectRef {
 
 type Project struct {
 	ProjectID string
+}
+
+var _ identity.Identity = &Project{}
+
+func (p *Project) String() string {
+	return "projects/" + p.ProjectID
+}
+
+func (p *Project) FromExternal(ref string) error {
+	tokens := strings.Split(ref, "/")
+	if len(tokens) == 1 {
+		p.ProjectID = tokens[0]
+		return nil
+	}
+	if len(tokens) == 2 && tokens[0] == "projects" {
+		p.ProjectID = tokens[1]
+		return nil
+	}
+	return fmt.Errorf("unknown format for project %q (use projects/{projectId})", ref)
 }
 
 // ResolveProjectFromAnnotation resolves the projectID to use for a resource,
@@ -167,4 +187,17 @@ func ResolveProjectID(ctx context.Context, reader client.Reader, obj *unstructur
 	}
 
 	return "", fmt.Errorf("cannot find project id for %v %v/%v", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+}
+
+func (r *ProjectRef) Normalize(ctx context.Context, reader client.Reader, defaultNamespace string) error {
+	// No status.externalRef, so can't use default method
+	// return Normalize(ctx, reader, r, defaultNamespace)
+
+	project, err := ResolveProject(ctx, reader, defaultNamespace, r)
+	if err != nil {
+		return err
+	}
+
+	r.External = "projects/" + project.ProjectID
+	return nil
 }

--- a/dev/ci/presubmits/tests-e2e-direct-optin
+++ b/dev/ci/presubmits/tests-e2e-direct-optin
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+export ONLY_TEST_KINDS=ServiceIdentity
+export KCC_USE_DIRECT_RECONCILERS=ServiceIdentity
+
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/pkg/config/controllerconfig.go
+++ b/pkg/config/controllerconfig.go
@@ -15,8 +15,12 @@
 package config
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
+	cloudresourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -45,6 +49,25 @@ type ControllerConfig struct {
 	// GCPTokenSource mints OAuth2 tokens to be passed with GCP API calls,
 	// allowing use of a non-default OAuth2 identity
 	GCPTokenSource oauth2.TokenSource
+
+	// ProjectMapper maps between project ids and numbers
+	ProjectMapper *projects.ProjectMapper
+}
+
+func (c *ControllerConfig) Init(ctx context.Context) error {
+	if c.ProjectMapper == nil {
+		opts, err := c.RESTClientOptions()
+		if err != nil {
+			return err
+		}
+
+		projectsClient, err := cloudresourcemanager.NewProjectsRESTClient(ctx, opts...)
+		if err != nil {
+			return fmt.Errorf("building cloudresourcemanager client: %w", err)
+		}
+		c.ProjectMapper = projects.NewProjectMapper(projectsClient)
+	}
+	return nil
 }
 
 func (c *ControllerConfig) RESTClientOptions() ([]option.ClientOption, error) {

--- a/pkg/controller/direct/registry/registry.go
+++ b/pkg/controller/direct/registry/registry.go
@@ -36,7 +36,9 @@ type registration struct {
 	gvk     schema.GroupVersionKind
 	factory ModelFactoryFunc
 	model   directbase.Model
-	rg      predicate.ReconcileGate
+
+	// reconcileGate is a condition, we will reconcile only objects matching the specified condition
+	reconcileGate predicate.ReconcileGate
 }
 
 type ModelFactoryFunc func(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error)
@@ -51,7 +53,7 @@ func GetModel(gk schema.GroupKind) (directbase.Model, error) {
 
 func GetReconcileGate(gk schema.GroupKind) predicate.ReconcileGate {
 	registration := singleton.registrations[gk]
-	return registration.rg
+	return registration.reconcileGate
 }
 
 func PreferredGVK(gk schema.GroupKind) (schema.GroupVersionKind, bool) {
@@ -97,14 +99,14 @@ func RegisterModel(gvk schema.GroupVersionKind, modelFn ModelFactoryFunc) {
 	RegisterModelWithReconcileGate(gvk, modelFn, rg)
 }
 
-func RegisterModelWithReconcileGate(gvk schema.GroupVersionKind, modelFn ModelFactoryFunc, rg predicate.ReconcileGate) {
+func RegisterModelWithReconcileGate(gvk schema.GroupVersionKind, modelFn ModelFactoryFunc, reconcileGate predicate.ReconcileGate) {
 	if singleton.registrations == nil {
 		singleton.registrations = make(map[schema.GroupKind]*registration)
 	}
 	singleton.registrations[gvk.GroupKind()] = &registration{
-		gvk:     gvk,
-		factory: modelFn,
-		rg:      rg,
+		gvk:           gvk,
+		factory:       modelFn,
+		reconcileGate: reconcileGate,
 	}
 }
 

--- a/pkg/controller/direct/secretmanager/secret_controller.go
+++ b/pkg/controller/direct/secretmanager/secret_controller.go
@@ -44,8 +44,8 @@ const (
 )
 
 func init() {
-	rg := &SecretReconcileGate{}
-	registry.RegisterModelWithReconcileGate(krm.SecretManagerSecretGVK, NewModel, rg)
+	reconcileGate := &SecretReconcileGate{}
+	registry.RegisterModelWithReconcileGate(krm.SecretManagerSecretGVK, NewModel, reconcileGate)
 }
 
 type SecretReconcileGate struct {

--- a/pkg/controller/direct/serviceusage/client.go
+++ b/pkg/controller/direct/serviceusage/client.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:controller-client
+// proto.service: google.api.serviceusage.v1beta1.ServiceUsage
+
+package serviceusage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	v1beta1 "google.golang.org/api/serviceusage/v1beta1"
+)
+
+type gcpClient struct {
+	config config.ControllerConfig
+}
+
+func newGCPClient(ctx context.Context, config *config.ControllerConfig) (*gcpClient, error) {
+	gcpClient := &gcpClient{
+		config: *config,
+	}
+	return gcpClient, nil
+}
+
+func (m *gcpClient) newV1Beta1Client(ctx context.Context) (*v1beta1.APIService, error) {
+	opts, err := m.config.RESTClientOptions()
+	if err != nil {
+		return nil, err
+	}
+	client, err := v1beta1.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("building serviceusage v1beta1 client: %w", err)
+	}
+	return client, err
+}

--- a/pkg/controller/direct/serviceusage/serviceidentity_controller.go
+++ b/pkg/controller/direct/serviceusage/serviceidentity_controller.go
@@ -26,11 +26,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/serviceusage/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	kccpredicate "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/predicate"
 
 	gcp "google.golang.org/api/serviceusage/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,8 +41,38 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// How long to wait for an LRO to complete
+const operationPollTimeout = 5 * time.Minute
+
+// GoogleApisServiceAgent was historically used by multiple services, but for more granular permission control we moved to P4SAs instead.
+// MIGs were tricky to move though, and so instead of switching to a P4SA, they adopted the GoogleApisServiceAgent as their P4SA
+// We still want to support this though, so we recognize this "magic value"
+const GoogleApisServiceAgent = "cloudservices.gserviceaccount.com"
+
 func init() {
-	registry.RegisterModel(krm.ServiceIdentityGVK, NewServiceIdentityModel)
+	reconcileGate := &SecretReconcileGate{}
+	registry.RegisterModelWithReconcileGate(krm.ServiceIdentityGVK, NewServiceIdentityModel, reconcileGate)
+}
+
+type SecretReconcileGate struct {
+	optIn kccpredicate.OptInToDirectReconciliation
+}
+
+var _ kccpredicate.ReconcileGate = &SecretReconcileGate{}
+
+func (r *SecretReconcileGate) ShouldReconcile(o *unstructured.Unstructured) bool {
+	if r.optIn.ShouldReconcile(o) {
+		return true
+	}
+	obj := &krm.ServiceIdentity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(o.Object, &obj); err != nil {
+		return false
+	}
+	serviceName := direct.ValueOf(obj.Spec.ResourceID)
+	if serviceName == "" {
+		serviceName = obj.GetName()
+	}
+	return serviceName == GoogleApisServiceAgent
 }
 
 func NewServiceIdentityModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
@@ -74,9 +106,10 @@ func (m *serviceIdentityModel) AdapterForObject(ctx context.Context, reader clie
 		return nil, err
 	}
 	return &serviceIdentityAdapter{
-		gcpBeta: gcpBeta,
-		id:      id.(*krm.ServiceIdentityIdentity),
-		desired: obj,
+		gcpBeta:       gcpBeta,
+		id:            id.(*krm.ServiceIdentityIdentity),
+		desired:       obj,
+		projectMapper: m.config.ProjectMapper,
 	}, nil
 }
 
@@ -86,7 +119,9 @@ func (m *serviceIdentityModel) AdapterForURL(ctx context.Context, url string) (d
 }
 
 type serviceIdentityAdapter struct {
-	gcpBeta *gcp.APIService
+	projectMapper *projects.ProjectMapper
+	gcpBeta       *gcp.APIService
+
 	id      *krm.ServiceIdentityIdentity
 	desired *krm.ServiceIdentity
 	actual  *gcp.ServiceIdentity // This will be populated from status or after generation
@@ -122,55 +157,68 @@ func (a *serviceIdentityAdapter) Create(ctx context.Context, createOp *directbas
 	fqn := a.id.String()
 	log.V(2).Info("generating service identity", "fqn", fqn)
 
-	//   - parent: Name of the consumer and service to generate an identity for. The
-	//     `GenerateServiceIdentity` methods currently support projects, folders,
-	//     organizations. Example parents would be:
-	//     `projects/123/services/example.googleapis.com`
-	//     `folders/123/services/example.googleapis.com`
-	//     `organizations/123/services/example.googleapis.com`.
-
-	op, err := a.gcpBeta.Services.GenerateServiceIdentity(fqn).Context(ctx).Do()
-	if err != nil {
-		return fmt.Errorf("generating service identity for %q: %w", fqn, err)
-	}
-
-	var serviceIdentity *gcp.GoogleApiServiceusageV1beta1ServiceIdentity
-	for {
-		if op.Done {
-			klog.Warningf("RESPONSE IS %v", string(op.Response))
-			klog.Warningf("FULL OPERATION IS %v", op)
-			identity := &gcp.GoogleApiServiceusageV1beta1ServiceIdentity{}
-			if err := json.Unmarshal(op.Response, identity); err != nil {
-				return fmt.Errorf("error parsing response: %w", err)
-			}
-			serviceIdentity = identity
-			break
-		}
-		time.Sleep(2 * time.Second)
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		op, err = a.gcpBeta.Operations.Get(op.Name).Context(ctx).Do()
-		if err != nil {
-			return fmt.Errorf("waiting for service identity generation for %q: %w", fqn, err)
-		}
-	}
-
-	log.V(2).Info("successfully generated service identity", "fqn", fqn, "identity.email", serviceIdentity.Email, "identity.uniqueId", serviceIdentity.UniqueId)
-
-	// It really doesn't seem worthwhile to use the mapper here
-
 	status := &krm.ServiceIdentityStatus{}
+	if a.id.Service == GoogleApisServiceAgent {
+		// Special case: the MIG "P4SA" (which is also the "Google APIs Service Agent")
+		// Format is always <projectNumber>@cloudservices.gserviceaccount.com
 
-	// observedState := krm.ServiceIdentityObservedState{
-	// 	Email:    direct.ValueOf(serviceIdentity.Email),
-	// 	UniqueID: direct.ValueOf(serviceIdentity.UniqueId),
-	// }
+		projectNumber, err := a.projectMapper.LookupProjectNumber(ctx, a.id.ParentID.ProjectID)
+		if err != nil {
+			return fmt.Errorf("looking up project number for %q: %w", a.id.ParentID.ProjectID, err)
+		}
+		email := fmt.Sprintf("%d@cloudservices.gserviceaccount.com", projectNumber)
+		status.Email = &email
+	} else {
+		//   - parent: Name of the consumer and service to generate an identity for. The
+		//     `GenerateServiceIdentity` methods currently support projects, folders,
+		//     organizations. Example parents would be:
+		//     `projects/123/services/example.googleapis.com`
+		//     `folders/123/services/example.googleapis.com`
+		//     `organizations/123/services/example.googleapis.com`.
 
-	// status.ObservedState = &observedState
+		op, err := a.gcpBeta.Services.GenerateServiceIdentity(fqn).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("generating service identity for %q: %w", fqn, err)
+		}
 
-	status.Email = direct.LazyPtr(serviceIdentity.Email)
-	// status.UniqueID = direct.LazyPtr(serviceIdentity.UniqueId)
+		var serviceIdentity *gcp.GoogleApiServiceusageV1beta1ServiceIdentity
+		start := time.Now()
+		for {
+			if op.Done {
+				identity := &gcp.GoogleApiServiceusageV1beta1ServiceIdentity{}
+				if err := json.Unmarshal(op.Response, identity); err != nil {
+					return fmt.Errorf("error parsing response: %w", err)
+				}
+				serviceIdentity = identity
+				break
+			}
+			if time.Since(start) > operationPollTimeout {
+				return fmt.Errorf("timed out waiting for service identity generation for %q", fqn)
+			}
+			time.Sleep(2 * time.Second)
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			op, err = a.gcpBeta.Operations.Get(op.Name).Context(ctx).Do()
+			if err != nil {
+				return fmt.Errorf("waiting for service identity generation for %q: %w", fqn, err)
+			}
+		}
+
+		log.V(2).Info("successfully generated service identity", "fqn", fqn, "identity.email", serviceIdentity.Email, "identity.uniqueId", serviceIdentity.UniqueId)
+
+		// It really doesn't seem worthwhile to use the mapper here
+
+		// observedState := krm.ServiceIdentityObservedState{
+		// 	Email:    direct.ValueOf(serviceIdentity.Email),
+		// 	UniqueID: direct.ValueOf(serviceIdentity.UniqueId),
+		// }
+
+		// status.ObservedState = &observedState
+
+		status.Email = direct.LazyPtr(serviceIdentity.Email)
+		// status.UniqueID = direct.LazyPtr(serviceIdentity.UniqueId)
+	}
 
 	// status.ExternalRef = direct.LazyPtr(parent)
 	return createOp.UpdateStatus(ctx, status, nil)

--- a/pkg/controller/direct/serviceusage/serviceidentity_controller.go
+++ b/pkg/controller/direct/serviceusage/serviceidentity_controller.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:controller
+// proto.service: google.api.serviceusage.v1beta1.ServiceUsage
+// proto.message: google.api.serviceusage.v1beta1.ServiceIdentity
+// crd.type: ServiceIdentity
+// crd.version: v1beta1
+
+package serviceusage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/serviceusage/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+
+	gcp "google.golang.org/api/serviceusage/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	registry.RegisterModel(krm.ServiceIdentityGVK, NewServiceIdentityModel)
+}
+
+func NewServiceIdentityModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &serviceIdentityModel{config: *config}, nil
+}
+
+var _ directbase.Model = &serviceIdentityModel{}
+
+type serviceIdentityModel struct {
+	config config.ControllerConfig
+}
+
+func (m *serviceIdentityModel) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	obj := &krm.ServiceIdentity{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	id, err := obj.GetIdentity(ctx, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get ServiceUsage GCP client
+	gcpClient, err := newGCPClient(ctx, &m.config)
+	if err != nil {
+		return nil, err
+	}
+	gcpBeta, err := gcpClient.newV1Beta1Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &serviceIdentityAdapter{
+		gcpBeta: gcpBeta,
+		id:      id.(*krm.ServiceIdentityIdentity),
+		desired: obj,
+	}, nil
+}
+
+func (m *serviceIdentityModel) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// This resource type does not have a direct GETtable URL in the traditional sense.
+	return nil, nil
+}
+
+type serviceIdentityAdapter struct {
+	gcpBeta *gcp.APIService
+	id      *krm.ServiceIdentityIdentity
+	desired *krm.ServiceIdentity
+	actual  *gcp.ServiceIdentity // This will be populated from status or after generation
+}
+
+var _ directbase.Adapter = &serviceIdentityAdapter{}
+
+// Find determines if the service identity has already been generated and recorded.
+func (a *serviceIdentityAdapter) Find(ctx context.Context) (bool, error) {
+	log := klog.FromContext(ctx)
+
+	// If status fields are populated, we consider the identity "found"
+	// as its details are known to KCC.
+	email := direct.ValueOf(a.desired.Status.Email)
+	uniqueID := ""   //direct.ValueOf(a.desired.Status.UniqueID)
+	if email != "" { // && uniqueID != "" {
+		log.V(2).Info("service identity found in KRM status", "email", email)
+		a.actual = &gcp.ServiceIdentity{
+			Email:    email,
+			UniqueId: uniqueID,
+		}
+		return true, nil
+	}
+
+	log.V(2).Info("service identity not yet recorded in KRM status, needs generation")
+	return false, nil
+}
+
+// Create generates the service identity using the GenerateServiceIdentity RPC.
+func (a *serviceIdentityAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+
+	fqn := a.id.String()
+	log.V(2).Info("generating service identity", "fqn", fqn)
+
+	//   - parent: Name of the consumer and service to generate an identity for. The
+	//     `GenerateServiceIdentity` methods currently support projects, folders,
+	//     organizations. Example parents would be:
+	//     `projects/123/services/example.googleapis.com`
+	//     `folders/123/services/example.googleapis.com`
+	//     `organizations/123/services/example.googleapis.com`.
+
+	op, err := a.gcpBeta.Services.GenerateServiceIdentity(fqn).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("generating service identity for %q: %w", fqn, err)
+	}
+
+	var serviceIdentity *gcp.GoogleApiServiceusageV1beta1ServiceIdentity
+	for {
+		if op.Done {
+			klog.Warningf("RESPONSE IS %v", string(op.Response))
+			klog.Warningf("FULL OPERATION IS %v", op)
+			identity := &gcp.GoogleApiServiceusageV1beta1ServiceIdentity{}
+			if err := json.Unmarshal(op.Response, identity); err != nil {
+				return fmt.Errorf("error parsing response: %w", err)
+			}
+			serviceIdentity = identity
+			break
+		}
+		time.Sleep(2 * time.Second)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		op, err = a.gcpBeta.Operations.Get(op.Name).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("waiting for service identity generation for %q: %w", fqn, err)
+		}
+	}
+
+	log.V(2).Info("successfully generated service identity", "fqn", fqn, "identity.email", serviceIdentity.Email, "identity.uniqueId", serviceIdentity.UniqueId)
+
+	// It really doesn't seem worthwhile to use the mapper here
+
+	status := &krm.ServiceIdentityStatus{}
+
+	// observedState := krm.ServiceIdentityObservedState{
+	// 	Email:    direct.ValueOf(serviceIdentity.Email),
+	// 	UniqueID: direct.ValueOf(serviceIdentity.UniqueId),
+	// }
+
+	// status.ObservedState = &observedState
+
+	status.Email = direct.LazyPtr(serviceIdentity.Email)
+	// status.UniqueID = direct.LazyPtr(serviceIdentity.UniqueId)
+
+	// status.ExternalRef = direct.LazyPtr(parent)
+	return createOp.UpdateStatus(ctx, status, nil)
+}
+
+// Update for ServiceIdentity is a no-op as it should only be called when we already have a service identity.
+func (a *serviceIdentityAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := klog.FromContext(ctx)
+
+	fqn := a.id.String()
+	log.V(2).Info("update is a no-op for ServiceIdentity", "fqn", fqn)
+
+	return nil
+}
+
+// Export is not meaningful for ServiceIdentity as it has no configurable spec from the GCP resource.
+func (a *serviceIdentityAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	return nil, fmt.Errorf("export not implemented")
+}
+
+// Delete is a no-op for ServiceIdentity as they are managed by GCP with the service.
+func (a *serviceIdentityAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := klog.FromContext(ctx)
+	fqn := a.id.String()
+	log.V(2).Info("delete is a no-op for ServiceIdentity", "parent", fqn)
+	return true, nil // Indicate successful (no-op) deletion
+}

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -166,6 +166,10 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 		controllerConfig.GCPTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cfg.GCPAccessToken})
 	}
 
+	if err := controllerConfig.Init(ctx); err != nil {
+		return nil, err
+	}
+
 	// Initialize direct controllers
 	if err := registry.Init(ctx, controllerConfig); err != nil {
 		return nil, err

--- a/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/_generated_object_serviceidentity-gserviceaccount.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/_generated_object_serviceidentity-gserviceaccount.golden.yaml
@@ -1,0 +1,26 @@
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 1
+  labels:
+    cnrm-test: "true"
+  name: example
+  namespace: ${uniqueId}
+spec:
+  projectRef:
+    external: ${projectId}
+  resourceID: cloudservices.gserviceaccount.com
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  email: ${projectNumber}@cloudservices.gserviceaccount.com
+  observedGeneration: 1

--- a/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/_http.log
@@ -1,0 +1,22 @@
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectNumber}",
+  "projectId": "${projectId}",
+  "state": 1
+}

--- a/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/serviceusage/v1beta1/serviceidentity/serviceidentity-gserviceaccount/create.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: ServiceIdentity
+metadata:
+  name: example
+spec:
+  projectRef:
+    external: ${projectId}
+  resourceID: cloudservices.gserviceaccount.com

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -91,6 +91,9 @@ func TestAllInSeries(t *testing.T) {
 					if s := os.Getenv("ONLY_TEST_APIGROUPS"); s != "" {
 						t.Skipf("skipping test because cannot determine group for samples, with ONLY_TEST_APIGROUPS=%s", s)
 					}
+					if s := os.Getenv("ONLY_TEST_KINDS"); s != "" {
+						t.Skipf("skipping test because cannot determine group for samples, with ONLY_TEST_KINDS=%s", s)
+					}
 
 					// Record the CRDs we will use, for faster testing
 					keepCRDs := map[schema.GroupKind]bool{}
@@ -175,6 +178,12 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, testPause bool, can
 				groups := strings.Split(s, ",")
 				if !slice.StringSliceContains(groups, group) {
 					skipTestReason = fmt.Sprintf("skipping test %s because group %q did not match ONLY_TEST_APIGROUPS=%s", fixture.Name, group, s)
+				}
+			}
+			if s := os.Getenv("ONLY_TEST_KINDS"); s != "" {
+				kinds := strings.Split(s, ",")
+				if !slice.StringSliceContains(kinds, fixture.GVK.Kind) {
+					skipTestReason = fmt.Sprintf("skipping test %s because group %q did not match ONLY_TEST_KINDS=%s", fixture.Name, fixture.GVK.Kind, s)
 				}
 			}
 			// TODO(b/259496928): Randomize the resource names for parallel execution when/if needed.


### PR DESCRIPTION
* feat: Add optin direct ServiceIdentity controller

Create an opt-in ServiceIdentity controller

*  e2e: add tests for direct types

Add testing of direct controllers alongside legacy controllers

*  chore: create shared project number/id mapper

Refactor the project id resolver into shared code

* ServiceIdentity: support cloudservices.gserviceaccount.com

Recognize the special-case MIG P4SA, force it to direct with a reconcile gate