### PR TITLE
tests: don't run unmanageddetector tests in parallel

### DIFF
--- a/pkg/controller/unmanageddetector/controller_test.go
+++ b/pkg/controller/unmanageddetector/controller_test.go
@@ -47,7 +47,6 @@ var (
 )
 
 func TestReconcile_UnmanagedResource(t *testing.T) {
-	t.Parallel()
 	testID := testvariable.NewUniqueID()
 	client := mgr.GetClient()
 	testcontroller.EnsureNamespaceExistsT(t, client, k8s.SystemNamespace)
@@ -89,7 +88,6 @@ func TestReconcile_UnmanagedResource(t *testing.T) {
 }
 
 func TestReconcile_ManagedResource(t *testing.T) {
-	t.Parallel()
 	testID := testvariable.NewUniqueID()
 	client := mgr.GetClient()
 	testcontroller.EnsureNamespaceExistsT(t, client, k8s.SystemNamespace)


### PR DESCRIPTION
These currently share a kube apiserver,
and check whether a statefulset is running,
but one of them starts the statefulset.
We can't run them in parallel.
