### PR TITLE
chore: modernize unmanageddetector controller & test

### DIFF
--- a/pkg/controller/lifecyclehandler/handler_test.go
+++ b/pkg/controller/lifecyclehandler/handler_test.go
@@ -150,8 +150,8 @@ func TestIsOrphaned(t *testing.T) {
 	h := test.NewKubeHarness(ctx, t)
 	c := h.GetClient()
 
-	h.CreateDummyCRD("test1.cnrm.cloud.google.com", "v1alpha1", "Test1Foo")
-	h.CreateDummyCRD("test1.cnrm.cloud.google.com", "v1alpha1", "Test1Bar")
+	h.CreateDummyCRD(schema.GroupVersionKind{Group: "test1.cnrm.cloud.google.com", Version: "v1alpha1", Kind: "Test1Foo"})
+	h.CreateDummyCRD(schema.GroupVersionKind{Group: "test1.cnrm.cloud.google.com", Version: "v1alpha1", Kind: "Test1Bar"})
 
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -368,10 +368,12 @@ func registerDeletionDefenderController(r *ReconcileRegistration, crd *apiextens
 }
 
 func registerUnmanagedDetectorController(r *ReconcileRegistration, crd *apiextensions.CustomResourceDefinition, _ schema.GroupVersionKind) (k8s.SchemaReferenceUpdater, error) {
+	ctx := context.TODO()
+
 	if _, ok := k8s.IgnoredKindList[crd.Spec.Names.Kind]; ok {
 		return nil, nil
 	}
-	if err := unmanageddetector.Add(r.mgr, crd); err != nil {
+	if err := unmanageddetector.Add(ctx, r.mgr, crd); err != nil {
 		return nil, fmt.Errorf("error registering unmanaged detector controller for '%v': %w", crd.GetName(), err)
 	}
 	return nil, nil

--- a/pkg/controller/unmanageddetector/controller_test.go
+++ b/pkg/controller/unmanageddetector/controller_test.go
@@ -59,7 +59,7 @@ func TestReconcile_UnmanagedResource(t *testing.T) {
 	resource := newTestKindUnstructured(resourceNN)
 	test.EnsureObjectExists(t, resource, client)
 
-	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD)
+	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD.GroupVersionKind())
 	if err != nil {
 		t.Fatal(fmt.Errorf("error creating reconciler: %w", err))
 	}
@@ -103,7 +103,7 @@ func TestReconcile_ManagedResource(t *testing.T) {
 	controller := newControllerUnstructuredForNamespace(resourceNN.Namespace)
 	test.EnsureObjectExists(t, controller, client)
 
-	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD)
+	reconciler, err := unmanageddetector.NewReconciler(mgr, fakeCRD.GroupVersionKind())
 	if err != nil {
 		t.Fatal(fmt.Errorf("error creating reconciler: %w", err))
 	}

--- a/pkg/test/kubeharness.go
+++ b/pkg/test/kubeharness.go
@@ -29,6 +29,7 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -235,21 +236,22 @@ func (h *KubeHarness) EnsureNamespaceExists(name string) {
 }
 
 // CreateDummyCRD registers a CRD so we can create objects in tests
-func (h *KubeHarness) CreateDummyCRD(group, version, kind string) {
+func (h *KubeHarness) CreateDummyCRD(gvk schema.GroupVersionKind) {
 	ctx := h.Ctx
 
-	resource := strings.ToLower(kind) + "s"
+	resource := strings.ToLower(gvk.Kind) + "s" // It's only a test
+
 	crd := &apiextensions.CustomResourceDefinition{}
 	crd.SetGroupVersionKind(apiextensions.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 
-	crd.SetName(resource + "." + group)
-	crd.Spec.Group = group
-	crd.Spec.Names.Kind = kind
+	crd.SetName(resource + "." + gvk.Group)
+	crd.Spec.Group = gvk.Group
+	crd.Spec.Names.Kind = gvk.Kind
 	crd.Spec.Names.Plural = resource
 	crd.Spec.Scope = apiextensions.NamespaceScoped
 
 	crd.Spec.Versions = append(crd.Spec.Versions, apiextensions.CustomResourceDefinitionVersion{
-		Name:    version,
+		Name:    gvk.Version,
 		Served:  true,
 		Storage: true,
 		Schema: &apiextensions.CustomResourceValidation{
@@ -259,10 +261,53 @@ func (h *KubeHarness) CreateDummyCRD(group, version, kind string) {
 					"spec": {
 						Type: "object",
 					},
+					"status": {
+						Type: "object",
+
+						Properties: map[string]apiextensions.JSONSchemaProps{
+							"observedGeneration": {
+								Type:   "integer",
+								Format: "int64",
+							},
+							"conditions": {
+								Type: "array",
+								Items: &apiextensions.JSONSchemaPropsOrArray{
+									Schema: &apiextensions.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensions.JSONSchemaProps{
+											"type": {
+												Type: "string",
+											},
+											"status": {
+												Type: "string",
+											},
+											"lastTransitionTime": {
+												Type:   "string",
+												Format: "date-time",
+											},
+											"reason": {
+												Type: "string",
+											},
+											"message": {
+												Type: "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 	})
+
+	// Enable the status subresource for this CRD. This is needed to allow
+	// UpdateStatus() calls to work on custom resources belonging to this CRD
+	// on the API server.
+	crd.Spec.Versions[0].Subresources = &apiextensions.CustomResourceSubresources{
+		Status: &apiextensions.CustomResourceSubresourceStatus{},
+	}
 
 	if err := h.client.Create(ctx, crd); err != nil {
 		h.Fatalf("error creating crd %v: %v", crd.GroupVersionKind(), err)

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,43 +37,43 @@ const Namespace = "namespace-1"
 
 func FakeCRDs() []*apiextensions.CustomResourceDefinition {
 	return []*apiextensions.CustomResourceDefinition{
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test1.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test1Foo",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test1.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test1Bar",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			// Unique group
 			Group:   "test2.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test2Baz",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test3.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test3UserSpecifiedResourceIDKind",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test3.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test3ServerGeneratedResourceIDKind",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test4.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test4DCLResourceServerGeneratedResourceIDKind",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test4.cnrm.cloud.google.com",
 			Version: "v1alpha1",
 			Kind:    "Test4DCLResourceUserSpecifiedResourceIDKind",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "test5.cnrm.cloud.google.com",
 			Version: "v1beta1",
 			Kind:    "TestKindWithObservedState",
@@ -85,12 +86,12 @@ func FakeCRDs() []*apiextensions.CustomResourceDefinition {
 // hierarchical resources (e.g. "Project")
 func FakeCRDsWithHierarchicalResources() []*apiextensions.CustomResourceDefinition {
 	return append(FakeCRDs(),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "resourcemanager.cnrm.cloud.google.com",
 			Version: "v1beta1",
 			Kind:    "Project",
 		}),
-		CRDForGVK(metav1.GroupVersionKind{
+		CRDForGVK(schema.GroupVersionKind{
 			Group:   "resourcemanager.cnrm.cloud.google.com",
 			Version: "v1beta1",
 			Kind:    "Folder",
@@ -464,7 +465,7 @@ func EnsureObjectExists(t *testing.T, obj *unstructured.Unstructured, c client.C
 	}
 }
 
-func CRDForGVK(gvk metav1.GroupVersionKind) *apiextensions.CustomResourceDefinition {
+func CRDForGVK(gvk schema.GroupVersionKind) *apiextensions.CustomResourceDefinition {
 	singular := strings.ToLower(gvk.Kind)
 	plural := text.Pluralize(singular)
 	preserveUnknownFields := true


### PR DESCRIPTION
- **chore: modernize unmanageddetector test**
  We can use envtest and avoid a lot of the setup complexity.
  