### PR TITLE
[WIP] Added initial test for storage bucket update issue.

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/_generated_object_storagebucketupdatecustomtimebefore.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/_generated_object_storagebucketupdatecustomtimebefore.golden.yaml
@@ -1,0 +1,48 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "true"
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+    label-one: value-one
+    newkey: newval
+  name: area-uploader-bucket-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  lifecycleRule:
+  - action:
+      type: Delete
+    condition:
+      age: 180
+      withState: ANY
+  - action:
+      type: Delete
+    condition:
+      customTimeBefore: "2025-04-01"
+      withState: ANY
+  location: US
+  resourceID: area-uploader-bucket-${uniqueId}
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  observedGeneration: 3
+  observedState:
+    softDeletePolicy:
+      effectiveTime: "1970-01-01T00:00:00Z"
+      retentionDurationSeconds: 604800
+  selfLink: https://www.googleapis.com/storage/v1/b/area-uploader-bucket-${uniqueId}
+  url: gs://area-uploader-bucket-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/create.yaml
@@ -1,0 +1,25 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "true"
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  name: area-uploader-bucket-${uniqueId}
+spec:
+  lifecycleRule:
+  - action:
+      type: Delete
+    condition:
+      age: 180
+      withState: ANY
+  - action:
+      type: Delete
+    condition:
+      customTimeBefore: "2025-04-01"
+      withState: ANY
+  location: US
+  resourceID: area-uploader-bucket-${uniqueId}
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/storage/v1beta1/storagebucket/storagebucketupdatecustomtimebefore/update.yaml
@@ -1,0 +1,25 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  annotations:
+    cnrm.cloud.google.com/force-destroy: "true"
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+  name: area-uploader-bucket-${uniqueId}
+spec:
+  lifecycleRule:
+  - action:
+      type: Delete
+    condition:
+      age: 180
+      withState: ANY
+  - action:
+      type: Delete
+    condition:
+      customTimeBefore: "2025-04-15"
+      withState: ANY
+  location: US
+  resourceID: area-uploader-bucket-${uniqueId}
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/storage/resource_storage_bucket.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/storage/resource_storage_bucket.go
@@ -1515,6 +1515,14 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
+	if v, ok := m["custom_time_before"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["noncurrent_time_before"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
 	withStateV, withStateOk := m["with_state"]
 	if withStateOk {
 		switch withStateV.(string) {

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/storage/resource_storage_bucket_test.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/storage/resource_storage_bucket_test.go
@@ -1555,6 +1555,14 @@ resource "google_storage_bucket" "bucket" {
   }
   lifecycle_rule {
     action {
+      type = "Delete"
+    }
+    condition {
+      noncurrent_time_before = "2019-01-01"
+    }
+  }
+  lifecycle_rule {
+    action {
       type          = "SetStorageClass"
       storage_class = "NEARLINE"
     }
@@ -1642,6 +1650,14 @@ resource "google_storage_bucket" "bucket" {
     }
     condition {
       custom_time_before = "2019-01-01"
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      noncurrent_time_before = "2019-01-12"
     }
   }
   lifecycle_rule {


### PR DESCRIPTION
StorageBucket is not updating when the update custom time before field in the lifecyclerule changes.

### Change description

StorageBucket is not updating when the update custom time before field in the lifecyclerule changes.
Added a create and update yaml will repros the issue.
After running create you can run `gcloud storage buckets describe gs://area-uploader-bucket`
You will see the storage bucket has not be updated.
However the resource shows the change and has a status of up to date.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
