### PR TITLE
WIP: include SQLInstance in ratchet tests

### DIFF
--- a/tests/e2e/ratcheting.go
+++ b/tests/e2e/ratcheting.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package e2e
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ShouldTestRereconiliation determines if we "touch" the primary object after we have run the test.
+// This should not cause write operations to GCP (read operations are OK)
+// We would like eventually to turn this on for all objects, but we have to turn on the testing gradually.
+func ShouldTestRereconiliation(t *testing.T, primaryResource *unstructured.Unstructured) bool {
+	gvk := primaryResource.GroupVersionKind()
+
+	switch gvk.GroupKind() {
+	// case schema.GroupKind{Group: "sql.cnrm.cloud.google.com", Kind: "SQLInstance"}:
+	// 	return true
+	}
+
+	switch gvk.Group {
+	case "pubsub.cnrm.cloud.google.com":
+		return true
+	}
+
+	t.Logf("defaulting ShouldTestRereconiliation to false for gvk %v", gvk)
+	return false
+}

--- a/tests/e2e/ratcheting.go
+++ b/tests/e2e/ratcheting.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ShouldTestRereconiliation determines if we "touch" the primary object after we have run the test.
@@ -26,8 +27,8 @@ func ShouldTestRereconiliation(t *testing.T, primaryResource *unstructured.Unstr
 	gvk := primaryResource.GroupVersionKind()
 
 	switch gvk.GroupKind() {
-	// case schema.GroupKind{Group: "sql.cnrm.cloud.google.com", Kind: "SQLInstance"}:
-	// 	return true
+	case schema.GroupKind{Group: "sql.cnrm.cloud.google.com", Kind: "SQLInstance"}:
+		return true
 	}
 
 	switch gvk.Group {

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -376,6 +376,31 @@ func runScenario(ctx context.Context, t *testing.T, testPause bool, fixture reso
 					}
 				}
 
+				if ShouldTestRereconiliation(t, primaryResource) {
+					eventsBefore := h.Events.HTTPEvents
+
+					touchObject(h, primaryResource)
+					// Pause to allow re-reconciliation
+					// (annotations don't change the generation, so we can't wait for observedGeneration)
+					time.Sleep(2 * time.Second)
+
+					eventsAfter := h.Events.HTTPEvents
+
+					h.Events.HTTPEvents = eventsBefore
+
+					for i := len(eventsBefore); i < len(eventsAfter); i++ {
+						event := eventsAfter[i]
+						isReadOnly := false
+						switch event.Request.Method {
+						case "GET":
+							isReadOnly = true
+						}
+						if !isReadOnly {
+							t.Errorf("FAIL: unexpected event during rereconciliation: %v", event)
+						}
+					}
+				}
+
 				if testPause {
 					opt.SkipWaitForDelete = true
 				}


### PR DESCRIPTION
- **tests: introduce test for reconcile being stable**
  Use a GVK-based ratchet to implement this gradually,
  as we expect at least some breakages.
  

- **WIP: include SQLInstance in ratchet tests**
  