### PR TITLE
tests: don't just update labels in pubsub topic test

### DIFF
--- a/mockgcp/common/fields/impliedfieldmask.go
+++ b/mockgcp/common/fields/impliedfieldmask.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fields
+
+import (
+	"context"
+	"sort"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// ComputeImpliedFieldMask computes the implied field mask when it is omitted.
+// According to AIP 134: this is "equivalent to all fields that are populated (have a non-empty value)."
+// https://google.aip.dev/134
+func ComputeImpliedFieldMask(ctx context.Context, req proto.Message) []string {
+	var fieldMask []string
+	req.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		fieldName := string(fd.Name())
+		fieldMask = append(fieldMask, fieldName)
+		return true
+	})
+	sort.Strings(fieldMask)
+	return fieldMask
+}

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/_generated_object_pubsubtopic.golden.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 2
+  generation: 3
   labels:
     cnrm-test: "true"
     label-one: value-one
@@ -16,6 +16,7 @@ metadata:
   name: pubsubtopic-sample-${uniqueId}
   namespace: ${uniqueId}
 spec:
+  messageRetentionDuration: 3600s
   resourceID: pubsubtopic-sample-${uniqueId}
   schemaSettings:
     encoding: JSON
@@ -28,4 +29,4 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
-  observedGeneration: 2
+  observedGeneration: 3

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/_http.log
@@ -170,6 +170,84 @@ X-Xss-Protection: 0
 
 ---
 
+PATCH https://pubsub.googleapis.com/v1/projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}?alt=json&updateMask=labels%2CmessageRetentionDuration
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "topic": {
+    "labels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true",
+      "newkey": "newval"
+    },
+    "messageRetentionDuration": "3600s",
+    "schemaSettings": {
+      "encoding": "JSON",
+      "schema": "projects/${projectId}/schemas/pubsubschema-${uniqueId}"
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true",
+    "newkey": "newval"
+  },
+  "messageRetentionDuration": "3600s",
+  "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
+  "schemaSettings": {
+    "encoding": "JSON",
+    "schema": "projects/${projectId}/schemas/pubsubschema-${uniqueId}"
+  }
+}
+
+---
+
+GET https://pubsub.googleapis.com/v1/projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true",
+    "newkey": "newval"
+  },
+  "messageRetentionDuration": "3600s",
+  "name": "projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}",
+  "schemaSettings": {
+    "encoding": "JSON",
+    "schema": "projects/${projectId}/schemas/pubsubschema-${uniqueId}"
+  }
+}
+
+---
+
 DELETE https://pubsub.googleapis.com/v1/projects/${projectId}/topics/pubsubtopic-sample-${uniqueId}?alt=json
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}

--- a/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/pubsub/v1beta1/pubsubtopic/pubsubtopic/update.yaml
@@ -26,3 +26,4 @@ spec:
     schemaRef:
       name: pubsubschema-${uniqueId}
     encoding: JSON
+  messageRetentionDuration: 3600s

--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -3160,7 +3160,6 @@
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.retryPolicy.maximumBackoff" is not set in unstructured objects
 [missing_field] crd=pubsubsubscriptions.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.retryPolicy.minimumBackoff" is not set in unstructured objects
 [missing_field] crd=pubsubtopics.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.kmsKeyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=pubsubtopics.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.messageRetentionDuration" is not set in unstructured objects
 [missing_field] crd=pubsubtopics.pubsub.cnrm.cloud.google.com version=v1beta1: field ".spec.messageStoragePolicy.allowedPersistenceRegions[]" is not set in unstructured objects
 [missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.wafSettings.wafFeature" is not set in unstructured objects
 [missing_field] crd=recaptchaenterprisekeys.recaptchaenterprise.cnrm.cloud.google.com version=v1beta1: field ".spec.wafSettings.wafService" is not set in unstructured objects


### PR DESCRIPTION
- **tests: don't just change labels on pubsubtopic test**
  Because changing the labels does not bump observedGeneration,
  the tests do not correctly wait for reconciliation.
  

- **mockgcp: implement implied field mask in pubsub topic**
  