### PR TITLE
BigtableAppProfile: do not write back ResourceID

### DIFF
--- a/pkg/controller/direct/bigtable/appprofile_controller.go
+++ b/pkg/controller/direct/bigtable/appprofile_controller.go
@@ -201,15 +201,7 @@ func (a *BigtableAppProfileAdapter) Create(ctx context.Context, createOp *direct
 	// }
 	status.ExternalRef = direct.LazyPtr(a.id.String())
 	status.Name = direct.LazyPtr(a.id.String())
-	if err := createOp.UpdateStatus(ctx, status, nil); err != nil {
-		return err
-	}
-
-	// Write resourceID into spec.
-	if err := unstructured.SetNestedField(createOp.GetUnstructured().Object, a.id.ID(), "spec", "resourceID"); err != nil {
-		return fmt.Errorf("error setting spec.resourceID: %w", err)
-	}
-	return nil
+	return createOp.UpdateStatus(ctx, status, nil)
 }
 
 // Update updates the resource in GCP based on `spec` and update the Config Connector object `status` based on the GCP response.

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofile-direct/_generated_object_bigtableappprofile-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofile-direct/_generated_object_bigtableappprofile-direct.golden.yaml
@@ -9,7 +9,7 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 3
+  generation: 2
   labels:
     cnrm-test: "true"
   name: bigtableappprofile-${uniqueId}
@@ -22,7 +22,6 @@ spec:
   - cluster1-${uniqueId}
   - cluster2-${uniqueId}
   multiClusterRoutingUseAny: true
-  resourceID: bigtableappprofile-${uniqueId}
   standardIsolation:
     priority: PRIORITY_LOW
 status:
@@ -34,4 +33,4 @@ status:
     type: Ready
   externalRef: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
   name: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
-  observedGeneration: 3
+  observedGeneration: 2

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofiledataboost-disable-direct/_generated_object_bigtableappprofiledataboost-disable-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofiledataboost-disable-direct/_generated_object_bigtableappprofiledataboost-disable-direct.golden.yaml
@@ -9,7 +9,7 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 3
+  generation: 2
   labels:
     cnrm-test: "true"
   name: bigtableappprofile-${uniqueId}
@@ -18,7 +18,6 @@ spec:
   description: Initial description.
   instanceRef:
     name: profiledep${uniqueId}
-  resourceID: bigtableappprofile-${uniqueId}
   singleClusterRouting:
     allowTransactionalWrites: false
     clusterId: cluster1-${uniqueId}
@@ -33,4 +32,4 @@ status:
     type: Ready
   externalRef: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
   name: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
-  observedGeneration: 3
+  observedGeneration: 2

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofiledataboost-enable-direct/_generated_object_bigtableappprofiledataboost-enable-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1beta1/bigtableappprofile/bigtableappprofiledataboost-enable-direct/_generated_object_bigtableappprofiledataboost-enable-direct.golden.yaml
@@ -9,7 +9,7 @@ metadata:
   finalizers:
   - cnrm.cloud.google.com/finalizer
   - cnrm.cloud.google.com/deletion-defender
-  generation: 3
+  generation: 2
   labels:
     cnrm-test: "true"
   name: bigtableappprofile-${uniqueId}
@@ -20,7 +20,6 @@ spec:
   description: Initial description.
   instanceRef:
     name: profiledep${uniqueId}
-  resourceID: bigtableappprofile-${uniqueId}
   singleClusterRouting:
     allowTransactionalWrites: false
     clusterId: cluster1-${uniqueId}
@@ -33,4 +32,4 @@ status:
     type: Ready
   externalRef: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
   name: projects/${projectId}/instances/profiledep${uniqueId}/appProfiles/bigtableappprofile-${uniqueId}
-  observedGeneration: 3
+  observedGeneration: 2


### PR DESCRIPTION
I asked the original author to "write back resourceID" for backward compatibility, as we are migrating this resource from TF-beta to direct. However, I’ve realized that we no longer want to keep this behavior in the direct controller.

(In 1.132, the controller still defaults to TF controller)