### PR TITLE
chore: clean up mapping functions for bigtable

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
@@ -191,7 +191,7 @@ func (v *MapperGenerator) GenerateMappers() error {
 			// TODO: Can we figure out a better way here?
 			switch pbPackage {
 			case "cloud.google.com/go/bigtable/admin/apiv2/adminpb":
-				pbPackage = "google.golang.org/genproto/googleapis/bigtable/admin/v2"
+				// pbPackage = "google.golang.org/genproto/googleapis/bigtable/admin/v2"
 			}
 
 			out.addImport("refs", "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1")

--- a/pkg/controller/direct/bigtable/appprofile_fuzzer.go
+++ b/pkg/controller/direct/bigtable/appprofile_fuzzer.go
@@ -39,11 +39,15 @@ func bigtableAppProfileFuzzer() fuzztesting.KRMFuzzer {
 	f.SpecFields.Insert(".multi_cluster_routing_use_any")
 	f.SpecFields.Insert(".single_cluster_routing")
 	f.SpecFields.Insert(".standard_isolation")
+	f.SpecFields.Insert(".data_boost_isolation_read_only")
 
 	f.UnimplementedFields.Insert(".name") // special field
 	f.UnimplementedFields.Insert(".etag")
-	f.UnimplementedFields.Insert(".priority")                       // deprecated in favor of standard isolation
-	f.UnimplementedFields.Insert(".data_boost_isolation_read_only") // only applies to online serving feature, doesn't support by kcc
+	f.UnimplementedFields.Insert(".priority") // deprecated in favor of standard isolation
+
+	// The default value of `.data_boost_isolation_read_only.compute_billing_owner` is
+	// COMPUTE_BILLING_OWNER_UNSPECIFIED, which does not roundtrip due to our Enum_FromProto implementation.
+	f.UnimplementedFields.Insert(".data_boost_isolation_read_only.compute_billing_owner")
 
 	return f
 }

--- a/pkg/controller/direct/bigtable/mapper.generated.go
+++ b/pkg/controller/direct/bigtable/mapper.generated.go
@@ -180,7 +180,6 @@ func BigtableAppProfileObservedState_FromProto(mapCtx *direct.MapContext, in *pb
 	// MISSING: Name
 	// MISSING: Etag
 	// MISSING: Priority
-	// MISSING: DataBoostIsolationReadOnly
 	return out
 }
 func BigtableAppProfileObservedState_ToProto(mapCtx *direct.MapContext, in *krmv1beta1.BigtableAppProfileObservedState) *pb.AppProfile {
@@ -191,7 +190,6 @@ func BigtableAppProfileObservedState_ToProto(mapCtx *direct.MapContext, in *krmv
 	// MISSING: Name
 	// MISSING: Etag
 	// MISSING: Priority
-	// MISSING: DataBoostIsolationReadOnly
 	return out
 }
 func BigtableAuthorizedViewObservedState_FromProto(mapCtx *direct.MapContext, in *pb.AuthorizedView) *krmv1alpha1.BigtableAuthorizedViewObservedState {


### PR DESCRIPTION
We have a contributor working on a new resource in bigtable API. Let's make sure the generated mapping function file is regenerate-safe.