### PR TITLE
tests: run tracker presubmits too

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -78,7 +78,7 @@ jobs:
 
   tests-gcptracker:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/dev/ci/presubmits/tracker-tests
+++ b/dev/ci/presubmits/tracker-tests
@@ -33,6 +33,6 @@ echo "Running scenario tests for gcptracker..."
 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock RUN_E2E=1 \
   go test -test.count=1 -timeout 600s -v ./tests/e2e -run '^TestE2EScript/scenarios/tracker/tracker-iampartialpolicy$'
 
-echo "Running some fixtures tests for iam tests with the gcptracker..."
+echo "Running fixture and sample iam tests with the gcptracker..."
 export RUN_TESTS='TestAllInSeries/fixtures/iam|TestAllInSeries/fixtures/fullalloydbcluster|TestAllInSeries/fixtures/noteboolinstance-full|TestAllInSeries/samples/alloydbbackup|TestAllInSeries/samples/alloydbcluster|TestAllInSeries/samples/iampartialpolicy|TestAllInSeries/samples/notebookinstance'
 ${REPO_ROOT}/dev/tasks/run-e2e

--- a/dev/ci/presubmits/tracker-tests
+++ b/dev/ci/presubmits/tracker-tests
@@ -26,9 +26,13 @@ export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-en
 # Always write golden output
 export WRITE_GOLDEN_OUTPUT=1
 
-# FG for gcptracker usage
+# Flag gate for gcptracker usage
 export KCC_RECONCILE_FLAG_GATE=USE_DEPENDENCY_TRACKER
 
 echo "Running scenario tests for gcptracker..."
 GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock RUN_E2E=1 \
   go test -test.count=1 -timeout 600s -v ./tests/e2e -run '^TestE2EScript/scenarios/tracker/tracker-iampartialpolicy$'
+
+echo "Running some fixtures tests for iam tests with the gcptracker..."
+export RUN_TESTS='TestAllInSeries/fixtures/iam|TestAllInSeries/fixtures/fullalloydbcluster|TestAllInSeries/fixtures/noteboolinstance-full|TestAllInSeries/samples/alloydbbackup|TestAllInSeries/samples/alloydbcluster|TestAllInSeries/samples/iampartialpolicy|TestAllInSeries/samples/notebookinstance'
+${REPO_ROOT}/dev/tasks/run-e2e

--- a/dev/ci/presubmits/tracker-tests
+++ b/dev/ci/presubmits/tracker-tests
@@ -34,5 +34,5 @@ GOLDEN_REQUEST_CHECKS=1 E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock RUN_E2E=1 \
   go test -test.count=1 -timeout 600s -v ./tests/e2e -run '^TestE2EScript/scenarios/tracker/tracker-iampartialpolicy$'
 
 echo "Running fixture and sample iam tests with the gcptracker..."
-export RUN_TESTS='TestAllInSeries/fixtures/iam|TestAllInSeries/fixtures/fullalloydbcluster|TestAllInSeries/fixtures/noteboolinstance-full|TestAllInSeries/samples/alloydbbackup|TestAllInSeries/samples/alloydbcluster|TestAllInSeries/samples/iampartialpolicy|TestAllInSeries/samples/notebookinstance'
+export RUN_TESTS='TestAllInSeries/samples/iampartialpolicy'
 ${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
Even if we are just starting with the `Project` kind, I am turning on some early testing for our mock/ presubmits tests where the tracker flag gate is on!

As we turn on more of these, I'll revisit how we select the RUN_TESTS var.