### PR TITLE
chore: remove redundant codebot functions to avoid dead end

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codebot/tool_find_in_workspace.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/tool_find_in_workspace.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func init() {
-	RegisterTool(&FindInWorkspace{})
-}
+// func init() {
+// 	RegisterTool(&FindInWorkspace{})
+// }
 
 type FindInWorkspace struct {
 	FindText string `json:"find_text"`

--- a/dev/tools/controllerbuilder/pkg/codebot/tool_list_files.go
+++ b/dev/tools/controllerbuilder/pkg/codebot/tool_list_files.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func init() {
-	RegisterTool(&ListFilesInWorkspace{})
-}
+// func init() {
+// 	RegisterTool(&ListFilesInWorkspace{})
+// }
 
 type ListFilesInWorkspace struct {
 	FindFileName string `json:"find_file_name"`


### PR DESCRIPTION
These two functions introduce dead end in the new model. Basically without those functions LLM can find a way to list files or find files in workspace. But these functions seem to have higher priority that overrides and forces the model to call them, and terminate the codebot loop on self-resolving problems. For example, using "list all files" to walk a large directory exceeds the token limit and terminates the codebot directly, while LLM itself could try to run other cmd (via run_cmd function) to find the answer.