### PR TITLE
fix: use autopilot-manager config

### DIFF
--- a/config/installbundle/release-manifests/autopilot/kustomization.yaml
+++ b/config/installbundle/release-manifests/autopilot/kustomization.yaml
@@ -20,4 +20,4 @@ commonAnnotations:
 resources:
   - ../../../../operator/config/rbac
   - ../../../../operator/config/crd
-  - ../../../../operator/config/manager
+  - ../../../../operator/config/autopilot-manager


### PR DESCRIPTION
I hope I am using the right terminology but this kustomization patch is not using the right resource for autopilot clusters. Hence we don't pick up the right `local-repo` flag.