### PR TITLE
feat: direct iampartialpolicy controller

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -111,6 +111,17 @@ jobs:
       - name: "Run vcr tests"
         run: |
           ./scripts/github-actions/tests-e2e-fixtures-vcr.sh
+  tests-e2e-direct-iam:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run direct iam tests"
+        run: |
+          ./scripts/github-actions/ga-iam-direct-tests.sh
   build-images:
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/apis/iam/v1beta1/policy_types.go
+++ b/apis/iam/v1beta1/policy_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type ResourceReference struct {
@@ -31,6 +32,13 @@ type ResourceReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// The external name of the referenced resource
 	External string `json:"external,omitempty"`
+}
+
+func (r *ResourceReference) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      r.Name,
+		Namespace: r.Namespace,
+	}
 }
 
 type Member string

--- a/apis/iam/v1beta1/register.go
+++ b/apis/iam/v1beta1/register.go
@@ -42,12 +42,12 @@ var (
 		Kind:    reflect.TypeOf(IAMPolicy{}).Name(),
 	}
 
+	IAMPartialPolicyGVK = schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    reflect.TypeOf(IAMPartialPolicy{}).Name(),
+	}
 	// NOT YET
-	// IAMPartialPolicyGVK = schema.GroupVersionKind{
-	// 	Group:   SchemeGroupVersion.Group,
-	// 	Version: SchemeGroupVersion.Version,
-	// 	Kind:    reflect.TypeOf(IAMPartialPolicy{}).Name(),
-	// }
 	// IAMPolicyMemberGVK = schema.GroupVersionKind{
 	// 	Group:   SchemeGroupVersion.Group,
 	// 	Version: SchemeGroupVersion.Version,
@@ -58,5 +58,5 @@ var (
 	// 	Version: SchemeGroupVersion.Version,
 	// 	Kind:    reflect.TypeOf(IAMAuditConfig{}).Name(),
 	// }
-	//IAMAPIVersion = SchemeGroupVersion.String()
+	IAMAPIVersion = SchemeGroupVersion.String()
 )

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -320,9 +320,11 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 
 	var adapter Adapter
 	var adapteErr error
-	if iamModel, ok := r.Reconciler.model.(IAMModel); ok {
-		adapter, adapteErr = iamModel.IAMAdapterForObject(ctx, r.Reconciler.Client, u, r.Reconciler.iamDeps)
-	} else {
+	switch m := r.Reconciler.model.(type) {
+	case IAMModel:
+		adapter, adapteErr = m.IAMAdapterForObject(ctx, r.Reconciler.Client, u, r.Reconciler.iamDeps)
+	default:
+		// The default case handles any other type that implements the base model interface.
 		adapter, adapteErr = r.Reconciler.model.AdapterForObject(ctx, r.Reconciler.Client, u)
 	}
 	if adapteErr != nil {

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -98,7 +98,7 @@ func NewReconciler(mgr manager.Manager, immediateReconcileRequests chan event.Ge
 		},
 		jitterGenerator: deps.JitterGenerator,
 		defaulters:      deps.Defaulters,
-		iamDeps:         deps.AdapterDeps,
+		iamDeps:         deps.IAMAdapterDeps,
 	}
 	return &r, nil
 }
@@ -161,7 +161,7 @@ type Deps struct {
 	ReconcilePredicate predicate.Predicate
 
 	// There are Dependencies for Adapters in particular (not the reconcilers)
-	AdapterDeps *IAMAdapterDeps
+	IAMAdapterDeps *IAMAdapterDeps
 }
 
 // TODO(kcc-team): we want to remove these in the future

--- a/pkg/controller/direct/directbase/interfaces.go
+++ b/pkg/controller/direct/directbase/interfaces.go
@@ -23,6 +23,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// IAMModel will instantiate the IAM controllers with dependecies to be able to
+// interface with Terraform and DCL based IAM resources.
+type IAMModel interface {
+	IAMAdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured, deps *IAMAdapterDeps) (Adapter, error)
+}
+
 // Model is the entry-point for our per-object reconcilers
 type Model interface {
 	// AdapterForObject builds an operation object for reconciling the object u.

--- a/pkg/controller/direct/iam/iambindings.go
+++ b/pkg/controller/direct/iam/iambindings.go
@@ -1,0 +1,252 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
+)
+
+type MemberIdentityResolver interface {
+	Resolve(v1beta1.Member, *v1beta1.MemberSource, string) (string, error)
+}
+
+type iamBindingKey struct {
+	Role      string
+	Condition v1beta1.IAMCondition
+}
+
+// ComputePartialPolicyWithMergedBindings returns the IAMPartialPolicy that results after the user's intent (as specified by the input
+// IAMPartialPolicy) is merged with the underlying IAM policy (as specified by the input IAMPolicy). This function also resolves all memberFrom
+// fields to member fields and ensures the returned IAMPartialPolicy only contains member fields.
+
+// The status.AllBindings in the returned IAMPartialPolicy reflects a mix of user specified bindings and the existing bindings associated with the GCP resource.
+// The merge strategy takes effect on the member level with {role, condition} tuples as keys.
+// The status.LastAppliedBindings in the returned IAMPartialPolicy reflects a list of canonical bindings that specified by users.
+func ComputePartialPolicyWithMergedBindings(partialPolicy *v1beta1.IAMPartialPolicy, livePolicy *v1beta1.IAMPolicy, resolver MemberIdentityResolver) (*v1beta1.IAMPartialPolicy, error) {
+	desiredPartialPolicy := partialPolicy.DeepCopy()
+	specifiedBindings, err := ConvertIAMPartialBindingsToIAMPolicyBindings(partialPolicy, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("error converting IAMPartialPolicy bindings to IAMPolicy bindings: %w", err)
+	}
+
+	// merge live bindings with user specified bindings
+	mergeBindings := mergeBindingSlices(specifiedBindings, livePolicy.Spec.Bindings)
+	// compute members that users intend to delete per binding
+	toRemove := computeDeletedMembersPerBinding(specifiedBindings, partialPolicy.Status.LastAppliedBindings)
+	// remove deleted members per binding
+	desiredAllBindings := removeMembersPerBinding(mergeBindings, toRemove)
+
+	// record lastAppliedBinding as user specified bindings
+	sortBindingSlice(specifiedBindings)
+	desiredPartialPolicy.Status.LastAppliedBindings = specifiedBindings
+	sortBindingSlice(desiredAllBindings)
+	desiredPartialPolicy.Status.AllBindings = desiredAllBindings
+	return desiredPartialPolicy, nil
+}
+
+// ComputePartialPolicyWithRemainingBindings returns the IAMPartialPolicy that results after the user's last applied bindings (as specified by the input
+// IAMPartialPolicy) are deleted from the underlying IAM Policy (as specified by the input IAMPolicy). This function is intended to be called on IAMPartialPolicy
+// resources deletion.
+//
+// The status.AllBindings in the returned IAMPartialPolicy reflects the remaining bindings that are computed by pruning last applied bindings (bindings managed by KCC)
+// from all the existing bindings from the underlying IAM Policy.
+// The status.LastAppliedBindings in the returned IAMPartialPolicy will be cleared.
+func ComputePartialPolicyWithRemainingBindings(partialPolicy *v1beta1.IAMPartialPolicy, livePolicy *v1beta1.IAMPolicy) *v1beta1.IAMPartialPolicy {
+	desiredPartialPolicy := partialPolicy.DeepCopy()
+	remainingBindings := removeMembersPerBinding(livePolicy.Spec.Bindings, partialPolicy.Status.LastAppliedBindings)
+	// record the remaining bindings as (new) all bindings.
+	sortBindingSlice(remainingBindings)
+	desiredPartialPolicy.Status.AllBindings = remainingBindings
+	// clear last applied bindings
+	desiredPartialPolicy.Status.LastAppliedBindings = make([]v1beta1.IAMPolicyBinding, 0)
+	return desiredPartialPolicy
+}
+
+func ConvertIAMPartialBindingsToIAMPolicyBindings(partialPolicy *v1beta1.IAMPartialPolicy, resolver MemberIdentityResolver) (bindings []v1beta1.IAMPolicyBinding, err error) {
+	res := make([]v1beta1.IAMPolicyBinding, 0)
+	for _, binding := range partialPolicy.Spec.Bindings {
+		convertedBinding, err := toIAMPolicyBinding(binding, resolver, partialPolicy.Namespace)
+		if err != nil {
+			return bindings, fmt.Errorf("error converting IAMPartialPolicy binding to IAMPolicy binding: %w", err)
+		}
+		res = append(res, convertedBinding)
+	}
+	return mergeBindingsWithSameRoleAndCondition(res), nil
+}
+
+func toIAMPolicyBinding(b v1beta1.IAMPartialPolicyBinding, resolver MemberIdentityResolver, defaultNamespace string) (binding v1beta1.IAMPolicyBinding, err error) {
+	members := make([]v1beta1.Member, 0)
+	for _, m := range b.Members {
+		resolvedMember, err := resolver.Resolve(m.Member, m.MemberFrom, defaultNamespace)
+		if err != nil {
+			return binding, fmt.Errorf("error resolving member identity of IAMPartialPolicy binding: %w", err)
+		}
+		members = append(members, v1beta1.Member(resolvedMember))
+	}
+
+	return v1beta1.IAMPolicyBinding{
+		Role:      b.Role,
+		Condition: b.Condition,
+		Members:   members,
+	}, nil
+}
+
+func mergeBindingsWithSameRoleAndCondition(bindings []v1beta1.IAMPolicyBinding) []v1beta1.IAMPolicyBinding {
+	bindingMap := mergeBindings(bindings)
+	mergedBindings := make([]v1beta1.IAMPolicyBinding, 0)
+	for _, v := range bindingMap {
+		if len(v.Members) > 0 {
+			mergedBindings = append(mergedBindings, v)
+		}
+	}
+	return mergedBindings
+}
+
+func mergeBindingSlices(bindingSlice1, bindingSlice2 []v1beta1.IAMPolicyBinding) []v1beta1.IAMPolicyBinding {
+	mergedBindings := make([]v1beta1.IAMPolicyBinding, 0)
+	mergedBindings = append(mergedBindings, bindingSlice1...)
+	mergedBindings = append(mergedBindings, bindingSlice2...)
+	return mergeBindingsWithSameRoleAndCondition(mergedBindings)
+}
+
+func mergeBindings(bindings []v1beta1.IAMPolicyBinding) map[iamBindingKey]v1beta1.IAMPolicyBinding {
+	bindingMap := make(map[iamBindingKey]v1beta1.IAMPolicyBinding)
+	for _, a := range bindings {
+		k := getIamBindingKey(a)
+		b, ok := bindingMap[k]
+		if !ok {
+			bindingMap[k] = *a.DeepCopy()
+			continue
+		}
+		b.Members = mergeMembers(b.Members, a.Members)
+		bindingMap[k] = b
+	}
+	return bindingMap
+}
+
+func computeDeletedMembersPerBinding(bindings, lastAppliedBindings []v1beta1.IAMPolicyBinding) []v1beta1.IAMPolicyBinding {
+	res := make([]v1beta1.IAMPolicyBinding, 0)
+	bindingMap := mergeBindings(bindings)
+	lastAppliedBindingMap := mergeBindings(lastAppliedBindings)
+	for k, a := range lastAppliedBindingMap {
+		b, ok := bindingMap[k]
+		if !ok {
+			res = append(res, *a.DeepCopy())
+			continue
+		}
+		removedMembers := computeDeletedMembers(b.Members, a.Members)
+		if len(removedMembers) > 0 {
+			b.Members = removedMembers
+			res = append(res, b)
+		}
+	}
+	return res
+}
+
+func getIamBindingKey(binding v1beta1.IAMPolicyBinding) iamBindingKey {
+	k := iamBindingKey{}
+	k.Role = binding.Role
+	if binding.Condition != nil {
+		k.Condition = *binding.Condition
+	}
+	return k
+}
+
+func removeMembersPerBinding(bindings, deletedBindings []v1beta1.IAMPolicyBinding) []v1beta1.IAMPolicyBinding {
+	bindingMap := mergeBindings(bindings)
+	for _, a := range deletedBindings {
+		k := getIamBindingKey(a)
+		if b, ok := bindingMap[k]; ok {
+			b.Members = removeDeletedMembers(b.Members, a.Members)
+			bindingMap[k] = b
+		}
+	}
+	res := make([]v1beta1.IAMPolicyBinding, 0)
+	for _, b := range bindingMap {
+		if len(b.Members) > 0 {
+			res = append(res, b)
+		}
+	}
+	return res
+}
+
+func removeDeletedMembers(members, deletedMembers []v1beta1.Member) []v1beta1.Member {
+	memberMap := make(map[v1beta1.Member]bool)
+	for _, m := range deletedMembers {
+		memberMap[m] = true
+	}
+	res := make([]v1beta1.Member, 0)
+	for _, m := range members {
+		if _, ok := memberMap[m]; !ok {
+			res = append(res, m)
+		}
+	}
+	return res
+}
+
+func computeDeletedMembers(members, lastAppliedMembers []v1beta1.Member) []v1beta1.Member {
+	memberMap := make(map[v1beta1.Member]bool)
+	res := make([]v1beta1.Member, 0)
+	for _, m := range members {
+		memberMap[m] = true
+	}
+	for _, m := range lastAppliedMembers {
+		if _, ok := memberMap[m]; !ok {
+			res = append(res, m)
+		}
+	}
+	return res
+}
+
+func mergeMembers(memberSlice1, memberSlice2 []v1beta1.Member) []v1beta1.Member {
+	memberMap := make(map[v1beta1.Member]bool)
+	for _, m := range memberSlice1 {
+		memberMap[m] = true
+	}
+	for _, m := range memberSlice2 {
+		memberMap[m] = true
+	}
+	res := make([]v1beta1.Member, 0)
+	for k := range memberMap {
+		res = append(res, k)
+	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i] < res[j]
+	})
+	return res
+}
+
+func sortBindingSlice(bindings []v1beta1.IAMPolicyBinding) {
+	sort.Slice(bindings, func(i, j int) bool {
+		k1 := getIamBindingKey(bindings[i])
+		k2 := getIamBindingKey(bindings[j])
+		if k1.Role != k2.Role {
+			return k1.Role < k2.Role
+		}
+		if k1.Condition.Title != k2.Condition.Title {
+			return k1.Condition.Title < k2.Condition.Title
+		}
+		if k1.Condition.Description != k2.Condition.Description {
+			return k1.Condition.Description < k2.Condition.Description
+		}
+		if k1.Condition.Expression != k2.Condition.Expression {
+			return k1.Condition.Expression < k2.Condition.Expression
+		}
+		return false
+	})
+}

--- a/pkg/controller/direct/iam/iambindings_test.go
+++ b/pkg/controller/direct/iam/iambindings_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/direct/iam/iambindings_test.go
+++ b/pkg/controller/direct/iam/iambindings_test.go
@@ -1,0 +1,1116 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iam"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// mockIdentityResolver helps to resolve referenced member identity
+type mockIdentityResolver struct{}
+
+func (t *mockIdentityResolver) Resolve(member iamv1beta1.Member, memberFrom *iamv1beta1.MemberSource, _ string) (string, error) {
+	if member != "" {
+		return string(member), nil
+	}
+
+	if memberFrom.ServiceAccountRef != nil {
+		if memberFrom.ServiceAccountRef.Namespace == "cnrm-foo" && memberFrom.ServiceAccountRef.Name == "cnrm-sa" {
+			return "serviceAccount:foo@domain.com", nil
+		}
+	}
+	panic(fmt.Errorf("memberFrom is not mocked"))
+}
+
+func TestComputePartialPolicyWithMergedBindings(t *testing.T) {
+	condition1 := newIAMCondition("test-iam-condition1")
+	condition2 := newIAMCondition("test-iam-condition2")
+	tests := []struct {
+		name          string
+		partialPolicy *iamv1beta1.IAMPartialPolicy
+		livePolicy    *iamv1beta1.IAMPolicy
+		mergedPolicy  *iamv1beta1.IAMPartialPolicy
+	}{
+		{
+			name: "empty partial policy with empty live policy",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings:         []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+		},
+		{
+			name: "empty partial policy with non-empty live policy",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no existing bindings from live policy",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge bindings with different {role, condition} tuples",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									// Resolves to "serviceAccount:foo@domain.com",
+									MemberFrom: &iamv1beta1.MemberSource{
+										ServiceAccountRef: &iamv1beta1.MemberReference{
+											Namespace: "cnrm-foo",
+											Name:      "cnrm-sa",
+										},
+									},
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									// Resolves to "serviceAccount:foo@domain.com",
+									MemberFrom: &iamv1beta1.MemberSource{
+										ServiceAccountRef: &iamv1beta1.MemberReference{
+											Namespace: "cnrm-foo",
+											Name:      "cnrm-sa",
+										},
+									},
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge members with same {role, condition} tuples",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"serviceAccount:foo@domain.com",
+								"user:foo@example.com",
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+								"user:user2@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge members from multiple entries with same {role, condition} tuples in the same binding slice",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user3@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user3@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user1@example.com",
+								},
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:user2@example.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"serviceAccount:foo@domain.com",
+								"user:user1@example.com",
+								"user:user2@example.com",
+								"user:user3@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"user:user2@example.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"serviceAccount:foo@domain.com",
+								"user:foo@example.com",
+								"user:user1@example.com",
+								"user:user2@example.com",
+								"user:user3@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition2,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+								"user:user1@example.com",
+								"user:user2@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty member arrays",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:    "roles/viewer",
+							Members: []iamv1beta1.IAMPartialPolicyMember{},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+								{
+									Member: "serviceAccount:foo@domain.com",
+								},
+							},
+						},
+						{
+							Role:    "roles/viewer",
+							Members: []iamv1beta1.IAMPartialPolicyMember{},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "remove partial managed bindings from spec compared to lastAppliedBindings",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{
+					Bindings: []iamv1beta1.IAMPartialPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.IAMPartialPolicyMember{
+								{
+									Member: "user:foo@example.com",
+								},
+							},
+						},
+					},
+				},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+							},
+						},
+					},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "remove all managed bindings from spec compared to lastAppliedBindings",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+						{
+							Role: "roles/viewer",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "remove all bindings",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:foo@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:bar@example.com",
+							},
+						},
+					},
+				},
+			},
+			mergedPolicy: &iamv1beta1.IAMPartialPolicy{
+				Spec: iamv1beta1.IAMPartialPolicySpec{},
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings:         []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resolver := mockIdentityResolver{}
+			res, err := iam.ComputePartialPolicyWithMergedBindings(tc.partialPolicy, tc.livePolicy, &resolver)
+			if err != nil {
+				t.Fatalf("error when computing partial policy with merged bindings: %v", err)
+			}
+			if !reflect.DeepEqual(res, tc.mergedPolicy) {
+				t.Fatalf("unexpected merged policy diff (-want +got): \n%v", cmp.Diff(tc.mergedPolicy, res))
+			}
+		})
+	}
+}
+
+func TestComputePartialPolicyWithRemainingBindings(t *testing.T) {
+	condition1 := newIAMCondition("test-iam-condition1")
+	tests := []struct {
+		name          string
+		partialPolicy *iamv1beta1.IAMPartialPolicy
+		livePolicy    *iamv1beta1.IAMPolicy
+		remaining     *iamv1beta1.IAMPartialPolicy
+	}{
+		{
+			name: "remove previously managed bindings",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+			remaining: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no previously managed bindings to remove",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+			remaining: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+								"serviceAccount:foo@domain.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all bindings are removed",
+			partialPolicy: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						// roles that are removed out of band
+						// and KCC hasn't drift-corrected yet before deletion.
+						{
+							Role: "roles/viewer",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+					},
+				},
+			},
+			livePolicy: &iamv1beta1.IAMPolicy{
+				Spec: iamv1beta1.IAMPolicySpec{
+					Bindings: []iamv1beta1.IAMPolicyBinding{
+						{
+							Role: "roles/editor",
+							Members: []iamv1beta1.Member{
+								"user:user2@example.com",
+							},
+						},
+						{
+							Role:      "roles/editor",
+							Condition: condition1,
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+						{
+							Role: "roles/owner",
+							Members: []iamv1beta1.Member{
+								"user:user1@example.com",
+							},
+						},
+					},
+				},
+			},
+			remaining: &iamv1beta1.IAMPartialPolicy{
+				Status: iamv1beta1.IAMPartialPolicyStatus{
+					LastAppliedBindings: []iamv1beta1.IAMPolicyBinding{},
+					AllBindings:         []iamv1beta1.IAMPolicyBinding{},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := iam.ComputePartialPolicyWithRemainingBindings(tc.partialPolicy, tc.livePolicy)
+			if !reflect.DeepEqual(res, tc.remaining) {
+				t.Fatalf("unexpected merged policy diff (-want +got): \n%v", cmp.Diff(tc.remaining, res))
+			}
+		})
+	}
+}
+
+func newIAMCondition(title string) *iamv1beta1.IAMCondition {
+	return &iamv1beta1.IAMCondition{
+		Title:       title,
+		Description: "Test IAM Condition",
+		Expression:  "request.time < timestamp(\"2020-01-01T00:00:00Z\")",
+	}
+}

--- a/pkg/controller/direct/iam/mappings.go
+++ b/pkg/controller/direct/iam/mappings.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"strings"
+
+	"cloud.google.com/go/iam/apiv1/iampb"
+	expr "google.golang.org/genproto/googleapis/type/expr"
+
+	newiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
+	oldiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+const (
+	LogTypeUnspecified = "LOG_TYPE_UNSPECIFIED"
+	AdminRead          = "ADMIN_READ"
+	DataWrite          = "DATA_WRITE"
+	DataRead           = "DATA_READ"
+)
+
+func IAMPolicySpec_ToProto(_ *direct.MapContext, in *oldiamv1beta1.IAMPolicySpec) *iampb.Policy {
+	if in == nil {
+		return nil
+	}
+
+	protoPolicy := &iampb.Policy{
+		// Default to version 3, which supports conditions.
+		// IAM Server should downgrade to supported versions
+		Version: 3,
+		//Etag: spec.Etag, NOT YET
+	}
+
+	// Map Bindings
+	if len(in.Bindings) > 0 {
+		protoPolicy.Bindings = make([]*iampb.Binding, 0, len(in.Bindings))
+		for _, b := range in.Bindings {
+			pbBinding := &iampb.Binding{
+				Role:    b.Role,
+				Members: make([]string, len(b.Members)),
+			}
+			for i, member := range b.Members {
+				pbBinding.Members[i] = string(member)
+			}
+
+			if b.Condition != nil {
+				pbBinding.Condition = &expr.Expr{
+					Expression:  b.Condition.Expression,
+					Title:       b.Condition.Title,
+					Description: b.Condition.Description,
+					// Location: NOT yet, would beed adapter/ id for this; current types don't hold this information
+				}
+			}
+			protoPolicy.Bindings = append(protoPolicy.Bindings, pbBinding)
+		}
+	}
+
+	// Map AuditConfigs
+	if len(in.AuditConfigs) > 0 {
+		protoPolicy.AuditConfigs = make([]*iampb.AuditConfig, 0, len(in.AuditConfigs))
+		for _, ac := range in.AuditConfigs {
+			pbAuditConfig := &iampb.AuditConfig{
+				Service: ac.Service,
+			}
+
+			if len(ac.AuditLogConfigs) > 0 {
+				pbAuditConfig.AuditLogConfigs = make([]*iampb.AuditLogConfig, 0, len(ac.AuditLogConfigs))
+				for _, alc := range ac.AuditLogConfigs {
+					pbAlc := &iampb.AuditLogConfig{
+						LogType: mapV1Beta1LogTypeToProto(alc.LogType),
+					}
+					if len(alc.ExemptedMembers) > 0 {
+						pbAlc.ExemptedMembers = make([]string, len(alc.ExemptedMembers))
+						for i, em := range alc.ExemptedMembers {
+							pbAlc.ExemptedMembers[i] = string(em)
+						}
+					}
+					pbAuditConfig.AuditLogConfigs = append(pbAuditConfig.AuditLogConfigs, pbAlc)
+				}
+			}
+			protoPolicy.AuditConfigs = append(protoPolicy.AuditConfigs, pbAuditConfig)
+		}
+	}
+
+	return protoPolicy
+}
+
+func IAMPolicySpec_FromProto(_ *direct.MapContext, in *iampb.Policy) *newiamv1beta1.IAMPolicySpec {
+	if in == nil {
+		return nil
+	}
+
+	out := &newiamv1beta1.IAMPolicySpec{
+		Etag: string(in.Etag),
+	}
+
+	// Map Bindings from Proto to KRM
+	if len(in.Bindings) > 0 {
+		out.Bindings = make([]newiamv1beta1.IAMPolicyBinding, 0, len(in.Bindings))
+		for _, pbBinding := range in.Bindings {
+			binding := newiamv1beta1.IAMPolicyBinding{
+				Role:    pbBinding.Role,
+				Members: make([]newiamv1beta1.Member, len(pbBinding.Members)),
+			}
+			for i, member := range pbBinding.Members {
+				binding.Members[i] = newiamv1beta1.Member(member)
+			}
+
+			if pbBinding.Condition != nil {
+				binding.Condition = &newiamv1beta1.IAMCondition{
+					Expression:  pbBinding.Condition.Expression,
+					Title:       pbBinding.Condition.Title,
+					Description: pbBinding.Condition.Description,
+				}
+			}
+			out.Bindings = append(out.Bindings, binding)
+		}
+	}
+
+	// Map AuditConfigs from Proto to KRM
+	if len(in.AuditConfigs) > 0 {
+		out.AuditConfigs = make([]newiamv1beta1.IAMPolicyAuditConfig, 0, len(in.AuditConfigs))
+		for _, pbAuditConfig := range in.AuditConfigs {
+			ac := newiamv1beta1.IAMPolicyAuditConfig{
+				Service: pbAuditConfig.Service,
+			}
+
+			if len(pbAuditConfig.AuditLogConfigs) > 0 {
+				ac.AuditLogConfigs = make([]newiamv1beta1.AuditLogConfig, 0, len(pbAuditConfig.AuditLogConfigs))
+				for _, pbAlc := range pbAuditConfig.AuditLogConfigs {
+					logTypeString := mapProtoLogTypeToKRM(pbAlc.LogType)
+
+					alc := newiamv1beta1.AuditLogConfig{
+						LogType: logTypeString,
+					}
+					if len(pbAlc.ExemptedMembers) > 0 {
+						alc.ExemptedMembers = make([]newiamv1beta1.Member, len(pbAlc.ExemptedMembers))
+						for i, em := range pbAlc.ExemptedMembers {
+							alc.ExemptedMembers[i] = newiamv1beta1.Member(em)
+						}
+					}
+					ac.AuditLogConfigs = append(ac.AuditLogConfigs, alc)
+				}
+			}
+			out.AuditConfigs = append(out.AuditConfigs, ac)
+		}
+	}
+
+	return out
+}
+
+// mapV1Beta1LogTypeToProto converts a string log type from v1beta1
+// to the pb.AuditLogConfig_LogType enum (which is a wrapped int).
+func mapV1Beta1LogTypeToProto(logTypeString string) iampb.AuditLogConfig_LogType {
+	switch strings.ToUpper(logTypeString) {
+	case LogTypeUnspecified:
+		return iampb.AuditLogConfig_LOG_TYPE_UNSPECIFIED
+	case AdminRead:
+		return iampb.AuditLogConfig_ADMIN_READ
+	case DataWrite:
+		return iampb.AuditLogConfig_DATA_WRITE
+	case DataRead:
+		return iampb.AuditLogConfig_DATA_READ
+	default:
+		return iampb.AuditLogConfig_LOG_TYPE_UNSPECIFIED
+	}
+}
+
+func mapProtoLogTypeToKRM(logTypeEnum iampb.AuditLogConfig_LogType) string {
+	switch logTypeEnum {
+	case iampb.AuditLogConfig_LOG_TYPE_UNSPECIFIED:
+		return LogTypeUnspecified
+	case iampb.AuditLogConfig_ADMIN_READ:
+		return AdminRead
+	case iampb.AuditLogConfig_DATA_WRITE:
+		return DataWrite
+	case iampb.AuditLogConfig_DATA_READ:
+		return DataRead
+	default:
+		return LogTypeUnspecified
+	}
+}

--- a/pkg/controller/direct/iam/partialpolicy_controller.go
+++ b/pkg/controller/direct/iam/partialpolicy_controller.go
@@ -1,0 +1,402 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"cloud.google.com/go/iam/apiv1/iampb"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	newiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
+	oldiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	"github.com/go-logr/logr"
+)
+
+const (
+	iamPartialPolicyControllerName = "iampartialpolicy-controller"
+)
+
+func init() {
+	registry.RegisterModel(newiamv1beta1.IAMPartialPolicyGVK, NewIAMPartialPolicyModel)
+}
+
+func NewIAMPartialPolicyModel(ctx context.Context, config *config.ControllerConfig) (directbase.Model, error) {
+	return &modelIAMPartialPolicy{config: *config}, nil
+}
+
+var _ directbase.Model = &modelIAMPartialPolicy{}
+
+type modelIAMPartialPolicy struct {
+	config config.ControllerConfig
+}
+
+func validateDeps(deps *directbase.IAMAdapterDeps) error {
+	if deps == nil {
+		return fmt.Errorf("IAMAdapterDeps is nil")
+	}
+
+	if deps.KubeClient == nil {
+		return fmt.Errorf("KubeClient is nil")
+	}
+	if deps.ControllerDeps == nil {
+		return fmt.Errorf("ControllerDeps is nil")
+	}
+
+	if deps.ControllerDeps.TfProvider == nil {
+		return fmt.Errorf("TfProvider is nil")
+	}
+	if deps.ControllerDeps.TfLoader == nil {
+		return fmt.Errorf("TfLoader is nil")
+	}
+	if deps.ControllerDeps.DclConverter == nil {
+		return fmt.Errorf("DclConverter is nil")
+	}
+
+	return nil
+}
+func (m *modelIAMPartialPolicy) IAMAdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured, deps *directbase.IAMAdapterDeps) (directbase.Adapter, error) {
+	obj := &newiamv1beta1.IAMPartialPolicy{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &obj); err != nil {
+		return nil, fmt.Errorf("error converting to %T: %w", obj, err)
+	}
+
+	if err := validateDeps(deps); err != nil {
+		return nil, fmt.Errorf("error validating dependencies: %w", err)
+	}
+
+	iamClient := kcciamclient.New(deps.ControllerDeps.TfProvider, deps.ControllerDeps.TfLoader, deps.KubeClient, deps.ControllerDeps.DclConverter, deps.ControllerDeps.DclConfig)
+	return &IAMPartialPolicyAdapter{
+		iamClient: iamClient,
+		desired:   obj,
+	}, nil
+}
+
+func (m *modelIAMPartialPolicy) AdapterForObject(ctx context.Context, reader client.Reader, u *unstructured.Unstructured) (directbase.Adapter, error) {
+	return nil, fmt.Errorf("AdapterForObject not supported for IAMPartialPolicy, call IAMAdapterForObject")
+}
+
+func (m *modelIAMPartialPolicy) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
+	// IAMPartialPolicy is not identified or managed via a direct GCP URL in the same way
+	// other resources are.
+	return nil, fmt.Errorf("AdapterForURL not supported for IAMPartialPolicy")
+}
+
+type IAMPartialPolicyAdapter struct {
+	iamClient                      *kcciamclient.IAMClient
+	desired                        *newiamv1beta1.IAMPartialPolicy
+	actualReferencedResourcePolicy *iampb.Policy
+}
+
+var _ directbase.Adapter = &IAMPartialPolicyAdapter{}
+
+func getLogger(ctx context.Context) logr.Logger {
+	return klog.FromContext(ctx).WithName(iamPartialPolicyControllerName).WithValues("controllerType", "direct")
+}
+
+func (a *IAMPartialPolicyAdapter) Find(ctx context.Context) (bool, error) {
+	log := getLogger(ctx)
+	log.V(2).Info("getting IAM policy for resource", "kind", a.desired.Spec.ResourceReference.Kind, "name", a.desired.Spec.ResourceReference.Name, "namespace", a.desired.Spec.ResourceReference.Namespace, "external", a.desired.Spec.ResourceReference.External)
+	mapCtx := &direct.MapContext{}
+
+	iamPolicySkeleton := ToOldIAMPolicySkeleton(a.desired)
+	oldKRMPolicy, err := a.iamClient.GetPolicy(ctx, iamPolicySkeleton)
+	if err != nil {
+		if apierrors.IsNotFound(err) || k8s.IsReferenceNotFoundError(err) {
+			log.V(2).Info("IAM policy not found or underlying resource not found", "resource", k8s.GetNamespacedName(a.desired))
+			return false, nil
+		}
+		return false, fmt.Errorf("getting IAM policy for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+
+	a.actualReferencedResourcePolicy = IAMPolicySpec_ToProto(mapCtx, &oldKRMPolicy.Spec)
+	return true, nil
+}
+
+// IAMMemberIdentityResolver helps to resolve referenced member identity
+type IAMMemberIdentityResolver struct {
+	Iamclient *kcciamclient.IAMClient
+	Ctx       context.Context
+}
+
+func (t IAMMemberIdentityResolver) Resolve(member newiamv1beta1.Member, memberFrom *newiamv1beta1.MemberSource, defaultNamespace string) (string, error) {
+	oldMember := oldiamv1beta1.Member(member)
+	var oldMemberFrom *oldiamv1beta1.MemberSource
+	if memberFrom != nil {
+		oldMemberFrom = &oldiamv1beta1.MemberSource{}
+		if memberFrom.BigQueryConnectionConnectionRef != nil {
+			oldMemberFrom.BigQueryConnectionConnectionRef = memberFrom.BigQueryConnectionConnectionRef
+		}
+		if memberFrom.ServiceAccountRef != nil {
+			oldMemberFrom.ServiceAccountRef = &oldiamv1beta1.MemberReference{
+				Name:      memberFrom.ServiceAccountRef.Name,
+				Namespace: memberFrom.ServiceAccountRef.Namespace,
+			}
+		}
+		if memberFrom.LogSinkRef != nil {
+			oldMemberFrom.LogSinkRef = &oldiamv1beta1.MemberReference{
+				Name:      memberFrom.LogSinkRef.Name,
+				Namespace: memberFrom.LogSinkRef.Namespace,
+			}
+		}
+		if memberFrom.SQLInstanceRef != nil {
+			oldMemberFrom.SQLInstanceRef = &oldiamv1beta1.MemberReference{
+				Name:      memberFrom.SQLInstanceRef.Name,
+				Namespace: memberFrom.SQLInstanceRef.Namespace,
+			}
+		}
+		if memberFrom.ServiceIdentityRef != nil {
+			oldMemberFrom.ServiceIdentityRef = &oldiamv1beta1.MemberReference{
+				Name:      memberFrom.ServiceIdentityRef.Name,
+				Namespace: memberFrom.ServiceIdentityRef.Namespace,
+			}
+		}
+
+	}
+
+	return kcciamclient.ResolveMemberIdentity(t.Ctx, oldMember, oldMemberFrom, defaultNamespace, t.Iamclient.TFIAMClient)
+}
+
+func (a *IAMPartialPolicyAdapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := getLogger(ctx)
+	log.V(2).Info("creating/applying IAMPartialPolicy", "name", k8s.GetNamespacedName(a.desired))
+
+	var livePolicyForMerge *newiamv1beta1.IAMPolicy
+
+	// If the policy truly doesn't exist, livePolicyForMerge should be an empty IAMPolicy struct
+	// for ComputePartialPolicyWithMergedBindings to work correctly.
+	if a.actualReferencedResourcePolicy == nil {
+		livePolicyForMerge = &newiamv1beta1.IAMPolicy{}
+	} else {
+		// todo acpana round trip ?
+		livePolicyForMerge = ToNewIAMPolicySkeleton(a.desired)
+	}
+
+	resolver := IAMMemberIdentityResolver{Iamclient: a.iamClient, Ctx: ctx}
+	desiredPartialPolicyWithStatus, err := ComputePartialPolicyWithMergedBindings(a.desired, livePolicyForMerge, resolver)
+	if err != nil {
+		return fmt.Errorf("computing partial policy for create for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+
+	finalPolicyToSet := toDesiredPolicy(desiredPartialPolicyWithStatus, livePolicyForMerge)
+
+	_, err = a.iamClient.SetPolicy(ctx, finalPolicyToSet)
+	if err != nil {
+		return fmt.Errorf("setting IAM policy for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+
+	log.V(2).Info("successfully applied IAMPartialPolicy for create", "name", k8s.GetNamespacedName(a.desired))
+
+	// Update KRM status
+	newKRMStatus := newiamv1beta1.IAMPartialPolicyStatus{
+		ObservedGeneration:  a.desired.GetGeneration(),
+		LastAppliedBindings: desiredPartialPolicyWithStatus.Status.LastAppliedBindings,
+		AllBindings:         desiredPartialPolicyWithStatus.Status.AllBindings,
+	}
+	readyCondition := k8s.NewCustomReadyCondition(corev1.ConditionTrue, k8s.UpToDate, k8s.UpToDateMessage)
+	if err := createOp.UpdateStatus(ctx, &newKRMStatus, &readyCondition); err != nil {
+		return fmt.Errorf("updating status for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+	return nil
+}
+
+func (a *IAMPartialPolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
+	log := getLogger(ctx)
+	log.V(2).Info("updating/applying IAMPartialPolicy", "name", k8s.GetNamespacedName(a.desired))
+	mapCtx := &direct.MapContext{}
+
+	if a.actualReferencedResourcePolicy == nil {
+		return fmt.Errorf("no IAM policy found for referenced resource %s during update for IAMPartialPolicy %v; requeueing for Find", a.desired.Spec.ResourceReference.GetNamespacedName(), k8s.GetNamespacedName(a.desired))
+	}
+
+	livePolicyForMerge := &newiamv1beta1.IAMPolicy{}
+	livePolicyForMerge.Spec = *IAMPolicySpec_FromProto(mapCtx, a.actualReferencedResourcePolicy)
+
+	resolver := IAMMemberIdentityResolver{Iamclient: a.iamClient, Ctx: ctx}
+
+	desiredPartialPolicyWithStatus, err := ComputePartialPolicyWithMergedBindings(a.desired, livePolicyForMerge, resolver)
+	if err != nil {
+		return fmt.Errorf("computing partial policy for update for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+
+	finalPolicyToSet := toDesiredPolicy(desiredPartialPolicyWithStatus, livePolicyForMerge)
+
+	// todo acpana better comparison, etag?
+	gcpUpdateNeeded := !reflect.DeepEqual(livePolicyForMerge.Spec.Bindings, finalPolicyToSet.Spec.Bindings) ||
+		!reflect.DeepEqual(livePolicyForMerge.Spec.AuditConfigs, finalPolicyToSet.Spec.AuditConfigs)
+
+	if gcpUpdateNeeded {
+		log.V(2).Info("GCP IAM policy change detected, calling SetPolicy", "name", k8s.GetNamespacedName(a.desired))
+		_, err = a.iamClient.SetPolicy(ctx, finalPolicyToSet)
+		if err != nil {
+			return fmt.Errorf("setting IAM policy for %v: %w", k8s.GetNamespacedName(a.desired), err)
+		}
+		log.V(2).Info("successfully applied IAMPartialPolicy for update", "name", k8s.GetNamespacedName(a.desired))
+	} else {
+		log.V(2).Info("no change in GCP IAM policy needed", "name", k8s.GetNamespacedName(a.desired))
+	}
+
+	// Always update KRM status to reflect observed generation and latest computed bindings,
+	// even if GCP didn't change, as spec or other KRM details might have.
+	newKRMStatus := newiamv1beta1.IAMPartialPolicyStatus{
+		ObservedGeneration:  a.desired.GetGeneration(),
+		LastAppliedBindings: desiredPartialPolicyWithStatus.Status.LastAppliedBindings,
+		AllBindings:         desiredPartialPolicyWithStatus.Status.AllBindings,
+	}
+	readyCondition := k8s.NewCustomReadyCondition(corev1.ConditionTrue, k8s.UpToDate, k8s.UpToDateMessage)
+	if err := updateOp.UpdateStatus(ctx, &newKRMStatus, &readyCondition); err != nil {
+		return fmt.Errorf("updating status for %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+	return nil
+}
+
+func (a *IAMPartialPolicyAdapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperation) (bool, error) {
+	log := getLogger(ctx)
+	log.V(2).Info("deleting/finalizing IAMPartialPolicy", "name", k8s.GetNamespacedName(a.desired))
+	mapCtx := &direct.MapContext{}
+
+	if a.actualReferencedResourcePolicy == nil {
+		// If the policy or resource is already gone, there's nothing to prune from GCP.
+		log.V(2).Info("actual policy not found during delete, assuming already gone or no-op needed for GCP", "name", k8s.GetNamespacedName(a.desired))
+		return true, nil
+	}
+	livePolicyForPruning := &newiamv1beta1.IAMPolicy{}
+	livePolicyForPruning.Spec = direct.ValueOf(IAMPolicySpec_FromProto(mapCtx, a.actualReferencedResourcePolicy))
+
+	desiredPartialPolicyWithRemainingStatus := ComputePartialPolicyWithRemainingBindings(a.desired, livePolicyForPruning)
+	finalPolicyToSet := toDesiredPolicy(desiredPartialPolicyWithRemainingStatus, livePolicyForPruning)
+
+	_, err := a.iamClient.SetPolicy(ctx, finalPolicyToSet)
+	if err != nil {
+		if apierrors.IsNotFound(err) || k8s.IsReferenceNotFoundError(err) {
+			log.V(2).Info("IAM policy or underlying resource not found during SetPolicy for deletion, treated as success", "name", k8s.GetNamespacedName(a.desired))
+			return true, nil // Policy/resource gone, so our bindings are effectively removed
+		}
+		return false, fmt.Errorf("setting IAM policy for deletion of %v: %w", k8s.GetNamespacedName(a.desired), err)
+	}
+
+	log.V(2).Info("successfully deleted IAMPartialPolicy", "name", k8s.GetNamespacedName(a.desired))
+	return true, nil
+}
+
+func (a *IAMPartialPolicyAdapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+// ToNewIAMPolicySkeleton creates an IAMPolicy struct with ObjectMeta and resource reference
+// copied from the partial policy. The skeleton struct can be passed to IAMClient.GetPolicy()
+// to fetch the live IAM policy.
+func ToNewIAMPolicySkeleton(p *newiamv1beta1.IAMPartialPolicy) *newiamv1beta1.IAMPolicy {
+	res := &newiamv1beta1.IAMPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       newiamv1beta1.IAMPolicyGVK.Kind,
+			APIVersion: newiamv1beta1.IAMAPIVersion,
+		},
+	}
+
+	res.ObjectMeta = *p.ObjectMeta.DeepCopy()
+	res.Spec.ResourceReference.APIVersion = p.Spec.ResourceReference.APIVersion
+	res.Spec.ResourceReference.Kind = p.Spec.ResourceReference.Kind
+	res.Spec.ResourceReference.Name = p.Spec.ResourceReference.Name
+	res.Spec.ResourceReference.Namespace = p.Spec.ResourceReference.Namespace
+	res.Spec.ResourceReference.External = p.Spec.ResourceReference.External
+
+	return res
+}
+
+// old style v1beta1 Policy representation for the IAM Client
+func ToOldIAMPolicySkeleton(p *newiamv1beta1.IAMPartialPolicy) *oldiamv1beta1.IAMPolicy {
+	res := &oldiamv1beta1.IAMPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       newiamv1beta1.IAMPolicyGVK.Kind,
+			APIVersion: newiamv1beta1.IAMAPIVersion,
+		},
+	}
+
+	res.ObjectMeta = *p.ObjectMeta.DeepCopy()
+	res.Spec.ResourceReference.APIVersion = p.Spec.ResourceReference.APIVersion
+	res.Spec.ResourceReference.Kind = p.Spec.ResourceReference.Kind
+	res.Spec.ResourceReference.Name = p.Spec.ResourceReference.Name
+	res.Spec.ResourceReference.Namespace = p.Spec.ResourceReference.Namespace
+	res.Spec.ResourceReference.External = p.Spec.ResourceReference.External
+
+	return res
+}
+
+func toDesiredPolicy(desiredPartialPolicy *newiamv1beta1.IAMPartialPolicy, livePolicy *newiamv1beta1.IAMPolicy) *oldiamv1beta1.IAMPolicy {
+	desiredPolicy := ToOldIAMPolicySkeleton(desiredPartialPolicy)
+
+	if len(desiredPartialPolicy.Status.AllBindings) > 0 {
+		desiredPolicy.Spec.Bindings = make([]oldiamv1beta1.IAMPolicyBinding, len(desiredPartialPolicy.Status.AllBindings))
+		for i, binding := range desiredPartialPolicy.Status.AllBindings {
+			desiredPolicy.Spec.Bindings[i] = oldiamv1beta1.IAMPolicyBinding{
+				Role: binding.Role,
+			}
+			desiredPolicy.Spec.Bindings[i].Members = make([]oldiamv1beta1.Member, len(binding.Members))
+			for j, member := range binding.Members {
+				desiredPolicy.Spec.Bindings[i].Members[j] = oldiamv1beta1.Member(member)
+			}
+			if binding.Condition != nil {
+				desiredPolicy.Spec.Bindings[i].Condition = &oldiamv1beta1.IAMCondition{
+					Description: binding.Condition.Description,
+					Expression:  binding.Condition.Expression,
+					Title:       binding.Condition.Title,
+				}
+			}
+		}
+	}
+	// Carry the current etag from read to support concurrent read-modify-write operations from multiple systems.
+	// SetPolicy will fail if the policy has been modified by other actors since the controller retrieved it.
+	desiredPolicy.Spec.Etag = livePolicy.Spec.Etag
+	// Preserve the audit configs if any.
+	if len(livePolicy.Spec.AuditConfigs) > 0 {
+		desiredPolicy.Spec.AuditConfigs = make([]oldiamv1beta1.IAMPolicyAuditConfig, len(livePolicy.Spec.AuditConfigs))
+		for i, auditConfig := range livePolicy.Spec.AuditConfigs {
+			desiredPolicy.Spec.AuditConfigs[i] = oldiamv1beta1.IAMPolicyAuditConfig{
+				Service: auditConfig.Service,
+			}
+			if len(auditConfig.AuditLogConfigs) > 0 {
+				desiredPolicy.Spec.AuditConfigs[i].AuditLogConfigs = make([]oldiamv1beta1.AuditLogConfig, len(auditConfig.AuditLogConfigs))
+				for j, auditLogConfig := range auditConfig.AuditLogConfigs {
+					desiredPolicy.Spec.AuditConfigs[i].AuditLogConfigs[j] = oldiamv1beta1.AuditLogConfig{
+						LogType: auditLogConfig.LogType,
+					}
+					if len(auditLogConfig.ExemptedMembers) > 0 {
+						desiredPolicy.Spec.AuditConfigs[i].AuditLogConfigs[j].ExemptedMembers = make([]oldiamv1beta1.Member, len(auditLogConfig.ExemptedMembers))
+						for k, member := range auditLogConfig.ExemptedMembers {
+							desiredPolicy.Spec.AuditConfigs[i].AuditLogConfigs[j].ExemptedMembers[k] = oldiamv1beta1.Member(member)
+						}
+					}
+				}
+			}
+		}
+	}
+	return desiredPolicy
+}

--- a/pkg/controller/direct/iam/partialpolicy_controller.go
+++ b/pkg/controller/direct/iam/partialpolicy_controller.go
@@ -104,9 +104,10 @@ func (m *modelIAMPartialPolicy) AdapterForObject(ctx context.Context, reader cli
 }
 
 func (m *modelIAMPartialPolicy) AdapterForURL(ctx context.Context, url string) (directbase.Adapter, error) {
-	// IAMPartialPolicy is not identified or managed via a direct GCP URL in the same way
-	// other resources are.
-	return nil, fmt.Errorf("AdapterForURL not supported for IAMPartialPolicy")
+	// // IAMPartialPolicy is not identified or managed via a direct GCP URL in the same way
+	// // other resources are.
+	// return nil, fmt.Errorf("AdapterForURL not supported for IAMPartialPolicy")
+	return nil, nil
 }
 
 type IAMPartialPolicyAdapter struct {

--- a/pkg/controller/direct/register/register.go
+++ b/pkg/controller/direct/register/register.go
@@ -56,6 +56,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/firestore"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/gkebackup"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/gkehub"
+	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iam"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/iap"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/kms"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/kms/autokeyconfig"

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -268,7 +268,7 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 				JitterGenerator: r.jitterGenerator,
 				Defaulters:      r.defaulters,
 				// for iam controllers
-				AdapterDeps: &directbase.IAMAdapterDeps{
+				IAMAdapterDeps: &directbase.IAMAdapterDeps{
 					KubeClient: r.Client,
 					ControllerDeps: &controller.Deps{
 						TfProvider:   r.provider,
@@ -343,7 +343,7 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 				ReconcilePredicate: useDirectReconcilerPredicate,
 
 				// for iam controllers
-				AdapterDeps: &directbase.IAMAdapterDeps{
+				IAMAdapterDeps: &directbase.IAMAdapterDeps{
 					KubeClient: r.Client,
 					ControllerDeps: &controller.Deps{
 						TfProvider:   r.provider,

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/config"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	dclcontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
@@ -332,6 +333,15 @@ func (r *TestReconciler) newReconcilerForObject(u *unstructured.Unstructured) re
 		deps := directbase.Deps{
 			Defaulters:      defaulters,
 			JitterGenerator: jg,
+			AdapterDeps: &directbase.IAMAdapterDeps{
+				KubeClient: r.mgr.GetClient(),
+				ControllerDeps: &controller.Deps{
+					TfProvider:   r.provider,
+					TfLoader:     r.smLoader,
+					DclConfig:    r.dclConfig,
+					DclConverter: r.dclConverter,
+				},
+			},
 		}
 		reconciler, err := directbase.NewReconciler(r.mgr, immediateReconcileRequests, resourceWatcherRoutines, gvk, model, deps)
 		if err != nil {

--- a/pkg/test/controller/reconciler/testreconciler.go
+++ b/pkg/test/controller/reconciler/testreconciler.go
@@ -333,7 +333,7 @@ func (r *TestReconciler) newReconcilerForObject(u *unstructured.Unstructured) re
 		deps := directbase.Deps{
 			Defaulters:      defaulters,
 			JitterGenerator: jg,
-			AdapterDeps: &directbase.IAMAdapterDeps{
+			IAMAdapterDeps: &directbase.IAMAdapterDeps{
 				KubeClient: r.mgr.GetClient(),
 				ControllerDeps: &controller.Deps{
 					TfProvider:   r.provider,

--- a/scripts/github-actions/ga-iam-direct-tests.sh
+++ b/scripts/github-actions/ga-iam-direct-tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/
+
+APIGROUPS=(
+    "iam.cnrm.cloud.google.com"
+)
+
+export KCC_USE_DIRECT_RECONCILERS="IAMPartialPolicy"
+
+# Running direct tests
+export ONLY_TEST_APIGROUPS=$(IFS=,; echo "${APIGROUPS[*]}")
+${REPO_ROOT}/dev/tasks/run-e2e
+
+# Running direct and tracker tests
+export KCC_RECONCILE_FLAG_GATE=USE_DEPENDENCY_TRACKER
+unset ONLY_TEST_APIGROUPS
+
+echo "Running fixture and sample iam tests with the gcptracker..."
+export RUN_TESTS='TestAllInSeries/samples/iampartialpolicy'
+${REPO_ROOT}/dev/tasks/run-e2e


### PR DESCRIPTION
This converts the iampartialpolicy controller to the new direct approach.

NOTE: this controller is not turned on so no changes to existing IAM handling are made.

Follow ups

* fuzzer test (will come out as a separate PR)
* export using THIS direct approach https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/4667