### PR TITLE
refactor: configurable poll intervals

### DIFF
--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -187,18 +187,18 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 	}
 	rd.DependencyTracker = gcpwatch.NewDependencyTracker(fetcher)
 
-	pollInterval := 10 * time.Minute
-	if interval := os.Getenv("DEPENDENCY_TRACKER_POLL_INTERVAL"); interval != "" {
+	pollInterval := gcpwatch.DefaultPollInterval
+	if interval := os.Getenv("TEST_DEPENDENCY_TRACKER_POLL_INTERVAL"); interval != "" {
 		intInterval, err := strconv.Atoi(interval)
 		if err != nil {
-			return nil, fmt.Errorf("parsing DEPENDENCY_TRACKER_POLL_INTERVAL: %w", err)
+			return nil, fmt.Errorf("parsing TEST_DEPENDENCY_TRACKER_POLL_INTERVAL: %w", err)
 		}
 		pollInterval = time.Duration(intInterval) * time.Second
 	}
 	go func() {
 		rd.DependencyTracker.PollForever(ctx, &gcpwatch.PollConfig{
-			InitialDelay: time.Second,
-			MinInterval:  time.Second,
+			InitialDelay: gcpwatch.DefaultInitialDelay,
+			MinInterval:  gcpwatch.DefaultMinInterval,
 			PollInterval: pollInterval,
 		})
 	}()

--- a/pkg/gcpwatch/tracker.go
+++ b/pkg/gcpwatch/tracker.go
@@ -25,6 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+const (
+	DefaultPollInterval = 10 * time.Minute
+	DefaultMinInterval  = time.Second
+	DefaultInitialDelay = time.Second
+)
+
 type DependencyTracker struct {
 	fetcher Fetcher
 

--- a/pkg/gcpwatch/tracker.go
+++ b/pkg/gcpwatch/tracker.go
@@ -96,21 +96,27 @@ func NewDependencyTracker(fetcher Fetcher) *DependencyTracker {
 	return tracker
 }
 
-func (t *DependencyTracker) PollForever(ctx context.Context, initialDelay time.Duration, minInterval time.Duration) {
-	nextPoll := time.Now().Add(initialDelay)
+type PollConfig struct {
+	InitialDelay time.Duration
+	MinInterval  time.Duration
+	PollInterval time.Duration
+}
+
+func (t *DependencyTracker) PollForever(ctx context.Context, pc *PollConfig) {
+	nextPoll := time.Now().Add(pc.InitialDelay)
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 
-		// todo acpana jitter and configurable interval
-		time.Sleep(10 * time.Minute)
+		// todo acpana jitter
+		time.Sleep(pc.PollInterval)
 
 		if time.Now().Before(nextPoll) {
 			continue
 		}
 
-		nextPoll = time.Now().Add(minInterval)
+		nextPoll = time.Now().Add(pc.MinInterval)
 
 		if err := t.pollOnce(ctx); err != nil {
 			klog.Warningf("error during drift-correction polling: %v", err)


### PR DESCRIPTION
Might be temporary but I think we will start using a configurable interval, especially in dynamic tests (postsubmits) soon! Can also configure the jitter to reflect current behavior. Still TBD how we are going to handle the reconcile annotation.