### PR TITLE
Support adding update.yaml to existing maximal tests in conductor

### DIFF
--- a/experiments/conductor/cmd/runner/controller_commands.go
+++ b/experiments/conductor/cmd/runner/controller_commands.go
@@ -464,7 +464,119 @@ func moveTestToSubDir(ctx context.Context, opts *RunnerOptions, branch Branch, e
 	return changedPaths, nil, nil
 }
 
-const CreateFullTestCreatePrompt string = `Generate a ${TEST_DIR}/create.yaml file for testing a Kubernetes controller.
+const addUpdateInFullTestPrompt string = `Generate an ${TEST_DIR}/update.yaml file for testing a Kubernetes controller by modifying the create.yaml file.
+
+First, read the ${TEST_DIR}/create.yaml file.
+Then modify all the mutable fields to create a valid update scenario.
+Read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the what fields are mutable.
+Replace <pluralized-kind> with the pluralized version of the kind: ${KIND} in the filename.
+
+The file should follow these requirements:
+- Keep the same license header, apiVersion, kind and metadata.name
+- Modify as many fields as possibleb in the spec section to test updates
+- Ensure the changes are valid according to the CRD schema
+- Keep other fields unchanged from create.yaml
+
+Use ReadFile to read the ${TEST_DIR}/create.yaml file.
+Use ReadFile to read the CRD file.
+Use CreateFile to write the YAML content to the ${TEST_DIR}/update.yaml file if it doesn't exist; or overwrite the existing file.
+Respond only with the YAML content, no explanations.`
+
+// addUpdateInFullTest creates update.yaml for test case with given name for the branch.
+func addUpdateInFullTest(ctx context.Context, opts *RunnerOptions, branch Branch, execResults *ExecResults) ([]string, *ExecResults, error) {
+	log.Printf("Adding update.yaml for full test cases in branch %s", branch.Name)
+
+	// Check if we have the required fields
+	if branch.Group == "" {
+		return nil, nil, fmt.Errorf("branch %s is missing Group field", branch.Name)
+	}
+
+	if branch.Kind == "" {
+		return nil, nil, fmt.Errorf("branch %s is missing Kind field", branch.Name)
+	}
+
+	// Default CRD version and group
+	crdVersion := "v1alpha1"
+	if branch.Controller == "terraform-v1beta1" {
+		crdVersion = "v1beta1"
+		log.Printf("This is a TF-based v1beta1 resource")
+	}
+
+	parentDir := filepath.Join(
+		"pkg", "test", "resourcefixture", "testdata", "basic",
+		branch.Group, strings.ToLower(crdVersion),
+		strings.ToLower(branch.Kind),
+	)
+
+	// TODO: Customize the maximal test index.
+	for i := 0; i < 3; i++ {
+		log.Printf("Adding update.yaml to maximal test #%d", i+1)
+
+		// TODO: Customize the max attempt number.
+		for attempt := 0; attempt < 3; attempt++ {
+			log.Printf("Attempt %d to add update.yaml to maximal test #%d", attempt+1, i+1)
+
+			// 1. Check if test case already exists. Skip update.yaml generation if test case and create.yaml doesn't exist.
+			testDir := filepath.Join(
+				parentDir,
+				fmt.Sprintf("%s-%s", strings.ToLower(branch.Kind), opts.testDirSuffix),
+			)
+
+			if i > 0 {
+				testDir = filepath.Join(fmt.Sprintf("%s-%d", testDir, i))
+			}
+			fullTestDir := filepath.Join(opts.branchRepoDir, testDir)
+			_, err := os.Stat(fullTestDir)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return nil, nil, fmt.Errorf("error checking whether test directory %s exists: %w", fullTestDir, err)
+				} else {
+					return nil, nil, fmt.Errorf("cannot generate update.yaml for test case because test directory %s doesn't exist: %w", fullTestDir, err)
+				}
+			}
+			createFilePath := filepath.Join(fullTestDir, "create.yaml")
+			_, err = os.Stat(createFilePath)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return nil, nil, fmt.Errorf("error checking whether create file %s exists: %w", createFilePath, err)
+				} else {
+					return nil, nil, fmt.Errorf("cannot generate update.yaml for test case because create file %s doesn't exist: %w", createFilePath, err)
+				}
+			}
+			updateFilePath := filepath.Join(fullTestDir, "update.yaml")
+			_, err = os.Stat(updateFilePath)
+			if err == nil {
+				log.Printf("no need to generate update.yaml for test case because update file %s already exists", updateFilePath)
+				break
+			}
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, nil, fmt.Errorf("error checking whether update file %s exists: %w", updateFilePath, err)
+			}
+
+			// 2. Generate update.yaml.
+			updatePrompt := strings.ReplaceAll(addUpdateInFullTestPrompt, "${TEST_DIR}", testDir)
+			updatePrompt = strings.ReplaceAll(updatePrompt, "${GROUP}", branch.Group)
+			updatePrompt = strings.ReplaceAll(updatePrompt, "${KIND}", branch.Kind)
+			cfg := CommandConfig{
+				Name:         "Generate Update YAML",
+				Cmd:          "codebot",
+				Args:         []string{"--prompt=/dev/stdin"},
+				Stdin:        strings.NewReader(updatePrompt),
+				WorkDir:      opts.branchRepoDir,
+				RetryBackoff: GenerativeCommandRetryBackoff,
+				MaxAttempts:  2,
+			}
+			_, err = executeCommand(opts, cfg)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to generate update.yaml: %w", err)
+			}
+		}
+	}
+
+	return []string{parentDir}, nil, nil
+}
+
+const createFullTestCreatePrompt string = `Generate a ${TEST_DIR}/create.yaml file for testing a Kubernetes controller.
 
 First, read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the schema.
 Replace <pluralized-kind> with the pluralized version of the kind: ${KIND} in the filename.
@@ -487,7 +599,7 @@ Use ReadFile to read the CRD file.
 Use CreateFile to write the YAML content to the ${TEST_DIR}/create.yaml file if it doesn't exist; or overwrite the existing file.
 Respond only with the YAML content, no explanations.`
 
-const CreateFullTestUpdatePrompt string = `Generate an ${TEST_DIR}/update.yaml file for testing a Kubernetes controller by modifying the create.yaml file.
+const createFullTestUpdatePrompt string = `Generate an ${TEST_DIR}/update.yaml file for testing a Kubernetes controller by modifying the create.yaml file.
 
 First, read the ${TEST_DIR}/create.yaml file that was just generated.
 Then modify all the mutable fields to create a valid update scenario.
@@ -505,7 +617,7 @@ Use ReadFile to read the CRD file.
 Use CreateFile to write the YAML content to the ${TEST_DIR}/update.yaml file if it doesn't exist; or overwrite the existing file.
 Respond only with the YAML content, no explanations.`
 
-const CreateFullTestDependenciesPrompt string = `Generate a ${TEST_DIR}/dependencies.yaml file based on the information in the ${TEST_DIR}/create.yaml file and the ${TEST_DIR}/update.yaml.
+const createFullTestDependenciesPrompt string = `Generate a ${TEST_DIR}/dependencies.yaml file based on the information in the ${TEST_DIR}/create.yaml file and the ${TEST_DIR}/update.yaml.
 
 First, read the ${TEST_DIR}/create.yaml and ${TEST_DIR}/update.yaml file that was just generated.
 If any spec field name ends with "Ref", or if any field value ends with "${uniqueId}", then read the CRD file at config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_<pluralized-kind>.${GROUP}.cnrm.cloud.google.com.yaml to understand the schema.
@@ -570,7 +682,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 
 	// TODO: Customize the max attempt number.
 	for attempt := 0; attempt < 3; attempt++ {
-		log.Printf("Attempt %d to ensure full coverage", attempt+1)
+		log.Printf("Generating maximal test #%d to ensure full coverage", attempt+1)
 		// 1. Identify missing fields for target resource.
 		//
 		// Run TestCRDFieldPresenceInTests for two times:
@@ -641,7 +753,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 
 		// 3. Generate testdata.
 		// Use codebot to generate the initial create.yaml content.
-		createPrompt := strings.ReplaceAll(CreateFullTestCreatePrompt, "${TEST_DIR}", testDir)
+		createPrompt := strings.ReplaceAll(createFullTestCreatePrompt, "${TEST_DIR}", testDir)
 		createPrompt = strings.ReplaceAll(createPrompt, "${GROUP}", branch.Group)
 		createPrompt = strings.ReplaceAll(createPrompt, "${KIND}", branch.Kind)
 		createPrompt = strings.ReplaceAll(createPrompt, "${CURRENT_YEAR}", fmt.Sprintf("%d", currentYear))
@@ -663,7 +775,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 		}
 
 		// Use codebot to generate the update.yaml content by modifying create.yaml
-		updatePrompt := strings.ReplaceAll(CreateFullTestUpdatePrompt, "${TEST_DIR}", testDir)
+		updatePrompt := strings.ReplaceAll(createFullTestUpdatePrompt, "${TEST_DIR}", testDir)
 		updatePrompt = strings.ReplaceAll(updatePrompt, "${GROUP}", branch.Group)
 		updatePrompt = strings.ReplaceAll(updatePrompt, "${KIND}", branch.Kind)
 		cfg = CommandConfig{
@@ -673,6 +785,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 			Stdin:        strings.NewReader(updatePrompt),
 			WorkDir:      opts.branchRepoDir,
 			RetryBackoff: GenerativeCommandRetryBackoff,
+			MaxAttempts:  2,
 		}
 		_, err = executeCommand(opts, cfg)
 		if err != nil {
@@ -680,7 +793,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 		}
 
 		// Use codebot to generate the dependencies.yaml content based on create.yaml and update.yaml.
-		dependenciesPrompt := strings.ReplaceAll(CreateFullTestDependenciesPrompt, "${TEST_DIR}", testDir)
+		dependenciesPrompt := strings.ReplaceAll(createFullTestDependenciesPrompt, "${TEST_DIR}", testDir)
 		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${GROUP}", branch.Group)
 		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${KIND}", branch.Kind)
 		dependenciesPrompt = strings.ReplaceAll(dependenciesPrompt, "${CURRENT_YEAR}", fmt.Sprintf("%d", currentYear))
@@ -691,6 +804,7 @@ func createFullCoverageTest(ctx context.Context, opts *RunnerOptions, branch Bra
 			Stdin:        strings.NewReader(dependenciesPrompt),
 			WorkDir:      opts.branchRepoDir,
 			RetryBackoff: GenerativeCommandRetryBackoff,
+			MaxAttempts:  2,
 		}
 		_, err = executeCommand(opts, cfg)
 		if err != nil {

--- a/experiments/conductor/cmd/runner/github_commands.go
+++ b/experiments/conductor/cmd/runner/github_commands.go
@@ -63,6 +63,7 @@ const (
 	COMMIT_MSG_51A = "{{kind}}: Move existing test to subdirectory before creating maximal test"
 	COMMIT_MSG_51B = "{{kind}}: Create maximal test"
 	COMMIT_MSG_51C = "{{kind}}: Enable test with mockgcp"
+	COMMIT_MSG_52  = "{{kind}}: Add update step to existing maximal tests"
 )
 
 var REGEX_MSG_9A = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_9A))
@@ -103,6 +104,7 @@ var REGEX_MSG_48 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_48))
 var REGEX_MSG_50 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_50))
 var REGEX_MSG_51A = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_51A))
 var REGEX_MSG_51 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_51B, COMMIT_MSG_51C))
+var REGEX_MSG_52 = regexp.MustCompile(convertCommitMsgToRegex(COMMIT_MSG_52))
 
 func skipPost21A(msg string) bool {
 	return REGEX_MSG_21A.MatchString(msg)

--- a/experiments/conductor/cmd/runner/runner.go
+++ b/experiments/conductor/cmd/runner/runner.go
@@ -84,6 +84,7 @@ conductor runner --branch-repo=/usr/local/google/home/wfender/go/src/github.com/
 	cmdRunAndFixGoldenMockOutput    = 48
 	cmdMoveExistingTest             = 50
 	cmdCreateFullTest               = 51
+	cmdAddUpdateInFullTest          = 52
 
 	typeScriptYaml = "scriptyaml"
 	typeHttpLog    = "httplog"
@@ -180,7 +181,7 @@ func (opts *RunnerOptions) validateAndDefaultFlags() error {
 	case "":
 		// When the handle local change option is unset, each command will handle it differently.
 		switch opts.command {
-		case cmdCreateFullTest:
+		case cmdCreateFullTest, cmdAddUpdateInFullTest:
 			opts.handleLocalChange = handleLocalChangeOptionCommit
 		default:
 			opts.handleLocalChange = handleLocalChangeOptionCleanUp
@@ -198,7 +199,7 @@ func (opts *RunnerOptions) validateAndDefaultFlags() error {
 			cmdRunAndFixGoldenRealGCPOutput, cmdCaptureGoldenMockOutput,
 			cmdRunAndFixGoldenMockOutput:
 			opts.testDirSuffix = "minimal"
-		case cmdCreateFullTest:
+		case cmdCreateFullTest, cmdAddUpdateInFullTest:
 			opts.testDirSuffix = "full"
 		}
 	} else {
@@ -491,6 +492,10 @@ func RunRunner(ctx context.Context, opts *RunnerOptions) error {
 			{Fn: createFullCoverageTest, CommitMsgTemplate: COMMIT_MSG_51B, CommitOptional: true},
 			{Fn: updateTestHarness, CommitMsgTemplate: COMMIT_MSG_51C, CommitOptional: true},
 		})
+	case cmdAddUpdateInFullTest: // 52
+		processBranches(ctx, opts, REGEX_MSG_52, branches.Branches, "Add update step to existing maximal tests", []BranchProcessor{
+			{Fn: addUpdateInFullTest, CommitMsgTemplate: COMMIT_MSG_52, AttemptsOnNoChange: 0, CommitOptional: true},
+		})
 	default:
 		log.Fatalf("unrecognized command: %d", opts.command)
 	}
@@ -535,7 +540,8 @@ func printHelp() {
 	log.Println("\t47 - [Controller] Capture golden logs for mock GCP tests for each branch")
 	log.Println("\t48 - [Controller] Run and Fix mock GCP tests for each branch")
 	log.Println("\t50 - [Test] Move test data to subdirectory if the test files are directly under <version>/<kind> directory for each branch")
-	log.Println("\t51 - [Test] Create a maximal test for each branch")
+	log.Println("\t51 - [Test] Create maximal tests for each branch")
+	log.Println("\t52 - [Test] Add the update step to existing maximal tests for each branch")
 }
 
 func checkRepoDir(ctx context.Context, opts *RunnerOptions, branches Branches) {

--- a/experiments/conductor/cmd/runner/utilities.go
+++ b/experiments/conductor/cmd/runner/utilities.go
@@ -66,6 +66,7 @@ var commandMap = map[int64]string{
 	cmdRunAndFixGoldenMockOutput:    "runandfixgoldenmockoutput",
 	cmdMoveExistingTest:             "moveexistingtest",
 	cmdCreateFullTest:               "createfulltest",
+	cmdAddUpdateInFullTest:          "addupdateinfulltest",
 }
 
 type exitBash func()


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->

Add a command in conductor to only generate update.yaml when it doesn't exist in the generated maximal test cases.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
