### PR TITLE
chore: change misleading log message

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -213,7 +213,7 @@ func waitForReadySingleResource(t *Harness, u *unstructured.Unstructured, timeou
 			return true, nil
 		}
 		if u.Object["status"] == nil {
-			logger.Info("resource does not yet have status", "kind", u.GetKind(), "name", u.GetName(), "troubleshooting", "if you are testing a direct resource and keep seeing this error message, check if you've imported the service in pkg/controller/direct/register/register.go")
+			logger.Info("resource does not yet have status", "kind", u.GetKind(), "name", u.GetName())
 			return false, nil
 		}
 


### PR DESCRIPTION
This error is generic for all GCP create/update failures, but the log suggests to triage a case that rarely happens. 