### PR TITLE
increase the subtest timeout, and Update release notes for AnywhereCache resource

### DIFF
--- a/dev/ci/periodics/_create_project_and_run_e2e
+++ b/dev/ci/periodics/_create_project_and_run_e2e
@@ -32,7 +32,13 @@ EXIT_CODE=0
 dev/tasks/create-test-project
 trap dev/tasks/cleanup-test-resources EXIT
 
-TEST_TIMEOUT=240m dev/tasks/run-e2e || EXIT_CODE=$?
+# If there doesn't exist a TEST_TIMEOUT from the service, keep it 240m
+if [[ -z "${TEST_TIMEOUT:-}" ]]; then
+  TEST_TIMEOUT=240m
+fi
+echo "Using TEST_TIMEOUT=${TEST_TIMEOUT}"
+
+dev/tasks/run-e2e || EXIT_CODE=$?
 
 if [[ -n "${ARTIFACTS:-}" ]]; then
   # Capture our source tree, which includes golden output

--- a/dev/ci/periodics/e2e-service-storage
+++ b/dev/ci/periodics/e2e-service-storage
@@ -21,5 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
 export ONLY_TEST_APIGROUPS=storage.cnrm.cloud.google.com
+export SUBTEST_TIMEOUT_E2E=280m
+export TEST_TIMEOUT = 280M
 
 dev/ci/periodics/_create_project_and_run_e2e

--- a/docs/releasenotes/release-1.133.md
+++ b/docs/releasenotes/release-1.133.md
@@ -24,6 +24,8 @@ for the future release **
 
 ## New Beta Resources (Direct Reconciler):
 
+*   `StorageAnywhereCache`
+
 *   [`SAMPLE_BigQueryConnectionConnection`](https://cloud.google.com/config-connector/docs/reference/resource-docs/bigqueryconnection/bigqueryconnectionconnection)
     (This is a sample, your actual release note should not contain `SAMPLE_`,
     otherwise it will be deleted)

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -610,8 +610,15 @@ func isOperationDone(s string) bool {
 
 // addTestTimeout will ensure the test fails if not completed before timeout
 func addTestTimeout(ctx context.Context, t *testing.T, timeout time.Duration, name string) context.Context {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
 
+	if name == "storageanywherecache" || name == "storageanywherecache-base" || name == "storageanywherecache-full" {
+		// Special timeouts for anywherecache resource when target is real
+		if targetGCP := os.Getenv("E2E_GCP_TARGET"); targetGCP == "real" {
+			timeout = 4 * time.Hour
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	done := false
 	timedOut := false
 	t.Cleanup(func() {

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -611,10 +611,15 @@ func isOperationDone(s string) bool {
 // addTestTimeout will ensure the test fails if not completed before timeout
 func addTestTimeout(ctx context.Context, t *testing.T, timeout time.Duration, name string) context.Context {
 
-	if name == "storageanywherecache" || name == "storageanywherecache-base" || name == "storageanywherecache-full" {
-		// Special timeouts for anywherecache resource when target is real
-		if targetGCP := os.Getenv("E2E_GCP_TARGET"); targetGCP == "real" {
-			timeout = 4 * time.Hour
+	if targetGCP := os.Getenv("E2E_GCP_TARGET"); targetGCP == "real" {
+		// If the target is real, check if SUBTEST_TIMEOUT_E2E is present set
+		// accordingly, or fallback to original timeouts if there's any error.
+
+		if subtestTimeoutE2EStr := os.Getenv("SUBTEST_TIMEOUT_E2E"); subtestTimeoutE2EStr != "" {
+			parsedTimeout, err := time.ParseDuration(subtestTimeoutE2EStr)
+			if err == nil {
+				timeout = parsedTimeout
+			}
 		}
 	}
 


### PR DESCRIPTION
1. Increase the subtest timeout for anywherecache resource.
2. Update release notes for AnywhereCache resource
