### PR TITLE
LoggingLogMetric: fix empty metricDescriptor handling

### DIFF
--- a/mockgcp/mocklogging/logmetric.go
+++ b/mockgcp/mocklogging/logmetric.go
@@ -24,14 +24,15 @@ import (
 	"strings"
 	"time"
 
+	pb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/genproto/googleapis/api"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	pb "cloud.google.com/go/logging/apiv2/loggingpb"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 )
 
@@ -80,6 +81,9 @@ func (s *metricsServiceV2) CreateLogMetric(ctx context.Context, req *pb.CreateLo
 	obj.CreateTime = timestamppb.New(now)
 	obj.UpdateTime = timestamppb.New(now)
 
+	if obj.MetricDescriptor == nil {
+		obj.MetricDescriptor = &metricpb.MetricDescriptor{}
+	}
 	if obj.MetricDescriptor != nil {
 		obj.MetricDescriptor.Description = obj.Description
 	}
@@ -98,6 +102,16 @@ func (s *metricsServiceV2) populateDefaultsForLogMetric(name *logMetricName, obj
 	if obj.MetricDescriptor != nil {
 		obj.MetricDescriptor.Name = fmt.Sprintf("projects/%s/metricDescriptors/logging.googleapis.com/user/%s", name.Project.ID, name.MetricName)
 		obj.MetricDescriptor.Type = fmt.Sprintf("logging.googleapis.com/user/%s", name.MetricName)
+
+		if obj.MetricDescriptor.ValueType == metricpb.MetricDescriptor_VALUE_TYPE_UNSPECIFIED {
+			obj.MetricDescriptor.ValueType = metricpb.MetricDescriptor_INT64
+		}
+		if obj.MetricDescriptor.Unit == "" {
+			obj.MetricDescriptor.Unit = "1"
+		}
+		if obj.MetricDescriptor.MetricKind == metricpb.MetricDescriptor_METRIC_KIND_UNSPECIFIED {
+			obj.MetricDescriptor.MetricKind = metricpb.MetricDescriptor_DELTA
+		}
 	}
 }
 

--- a/pkg/controller/direct/logging/logmetric_controller.go
+++ b/pkg/controller/direct/logging/logmetric_controller.go
@@ -267,11 +267,9 @@ func (a *logMetricAdapter) Update(ctx context.Context, updateOp *directbase.Upda
 			}
 		}
 
-		if !compareMetricDescriptors(a.desired.Spec.MetricDescriptor, a.actual.MetricDescriptor) {
-			if err := validateImmutableFieldsUpdated(a.desired.Spec.MetricDescriptor, a.actual.MetricDescriptor); err != nil {
-				return fmt.Errorf("logMetric update failed: %w", err)
-			}
-			update.MetricDescriptor = convertKCCtoAPIForMetricDescriptor(a.desired.Spec.MetricDescriptor)
+		desired := convertKCCtoAPI(&a.desired.Spec)
+		if !compareMetricDescriptors(desired.MetricDescriptor, a.actual.MetricDescriptor) {
+			update.MetricDescriptor = desired.MetricDescriptor
 		}
 
 		if !reflect.DeepEqual(a.desired.Spec.LabelExtractors, a.actual.LabelExtractors) {

--- a/pkg/controller/direct/logging/utils.go
+++ b/pkg/controller/direct/logging/utils.go
@@ -54,30 +54,8 @@ func getObservedGeneration(u *unstructured.Unstructured) int64 {
 
 // todo acpana: house these somewhere else
 
-func compareMetricDescriptors(kccObj *krm.LogmetricMetricDescriptor, apiObj *api.MetricDescriptor) bool {
-	return reflect.DeepEqual(kccObj, convertAPItoKRM_MetricDescriptor(apiObj))
-}
-
-func validateImmutableFieldsUpdated(kccObj *krm.LogmetricMetricDescriptor, apiObj *api.MetricDescriptor) error {
-	actualMetricDescriptor := convertAPItoKRM_MetricDescriptor(apiObj)
-
-	modified := []string{}
-	if kccObj == nil && apiObj == nil {
-		return nil
-	}
-	if kccObj == nil || apiObj == nil {
-		return fmt.Errorf("cannot make changes to immutable field: metricDescriptor")
-	}
-	if !reflect.DeepEqual(kccObj.MetricKind, actualMetricDescriptor.MetricKind) {
-		modified = append(modified, "metricDescriptor.MetricKind")
-	}
-	if !reflect.DeepEqual(kccObj.ValueType, actualMetricDescriptor.ValueType) {
-		modified = append(modified, "metricDescriptor.ValueType")
-	}
-	if len(modified) != 0 {
-		return fmt.Errorf("cannot make changes to immutable field(s): %v", modified)
-	}
-	return nil
+func compareMetricDescriptors(kccObj *api.MetricDescriptor, actual *api.MetricDescriptor) bool {
+	return reflect.DeepEqual(kccObj, actual)
 }
 
 func convertAPItoKRM_LoggingLogMetric(projectID string, in *api.LogMetric) (*unstructured.Unstructured, error) {

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_generated_export_explicitlogmetric.golden
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_generated_export_explicitlogmetric.golden
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/explicitlogmetric/_http.log
@@ -68,6 +68,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -105,6 +106,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -163,6 +165,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -200,6 +203,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -258,6 +262,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -295,6 +300,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_generated_export_exponentiallogmetric.golden
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_generated_export_exponentiallogmetric.golden
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/exponentiallogmetric/_http.log
@@ -66,6 +66,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -102,6 +103,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -158,6 +160,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -194,6 +197,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -250,6 +254,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -286,6 +291,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_generated_export_logginglogmetric-nometricdescriptor.golden
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_generated_export_logginglogmetric-nometricdescriptor.golden
@@ -1,0 +1,21 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-metricdescriptor-${uniqueId}
+spec:
+  description: Test when metricDescriptor is not specified
+  disabled: false
+  filter: |-
+    severity="ERROR"
+    resource.type="k8s_container"
+    resource.labels.cluster_name="testcluster"
+    resource.labels.namespace_name="testnamespace"
+  metricDescriptor:
+    displayName: ""
+    launchStage: ""
+    metricKind: DELTA
+    unit: "1"
+    valueType: INT64
+  projectRef:
+    external: ${projectId}
+  valueExtractor: ""

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_generated_object_logginglogmetric-nometricdescriptor.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_generated_object_logginglogmetric-nometricdescriptor.golden.yaml
@@ -1,0 +1,35 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: logginglogmetric-metricdescriptor-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  description: Test when metricDescriptor is not specified
+  filter: |-
+    severity="ERROR"
+    resource.type="k8s_container"
+    resource.labels.cluster_name="testcluster"
+    resource.labels.namespace_name="testnamespace"
+  projectRef:
+    external: projects/${projectId}
+  resourceID: logginglogmetric-metricdescriptor-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: Test when metricDescriptor is not specified
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}
+  observedGeneration: 2
+  updateTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/_http.log
@@ -1,0 +1,177 @@
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-metricdescriptor-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Metric logginglogmetric-metricdescriptor-${uniqueId} does not exist.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://logging.googleapis.com/v2/projects/${projectId}/metrics?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "metricDescriptor": {
+    "description": "Test when metricDescriptor is not specified",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-metricdescriptor-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "metricDescriptor": {
+    "description": "Test when metricDescriptor is not specified",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-metricdescriptor-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "metricDescriptor": {
+    "description": "Test when metricDescriptor is not specified",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-metricdescriptor-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "Test when metricDescriptor is not specified",
+  "filter": "severity=\"ERROR\"\nresource.type=\"k8s_container\"\nresource.labels.cluster_name=\"testcluster\"\nresource.labels.namespace_name=\"testnamespace\"",
+  "metricDescriptor": {
+    "description": "Test when metricDescriptor is not specified",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-metricdescriptor-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-metricdescriptor-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-metricdescriptor-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/logging/v1beta1/logginglogmetric/logginglogmetric-nometricdescriptor/create.yaml
@@ -1,0 +1,13 @@
+apiVersion: logging.cnrm.cloud.google.com/v1beta1
+kind: LoggingLogMetric
+metadata:
+  name: logginglogmetric-metricdescriptor-${uniqueId}
+spec:
+  description: "Test when metricDescriptor is not specified"
+  filter: |-
+    severity="ERROR"
+    resource.type="k8s_container"
+    resource.labels.cluster_name="testcluster"
+    resource.labels.namespace_name="testnamespace"
+  projectRef:
+    external: "projects/${projectId}"

--- a/tests/e2e/ratcheting.go
+++ b/tests/e2e/ratcheting.go
@@ -350,7 +350,6 @@ func ShouldTestRereconiliation(t *testing.T, testName string, primaryResource *u
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLink"}:
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogBucket"}:
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogExclusion"}:
-	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogMetric"}:
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogSink"}:
 	case schema.GroupKind{Group: "logging.cnrm.cloud.google.com", Kind: "LoggingLogView"}:
 	case schema.GroupKind{Group: "managedkafka.cnrm.cloud.google.com", Kind: "ManagedKafkaCluster"}:

--- a/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_export0.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_export1.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_http00.log
@@ -89,6 +89,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -136,6 +137,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -215,6 +217,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -262,6 +265,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_custom_diff/value_type/label/_http01.log
@@ -36,6 +36,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -114,6 +115,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -161,6 +163,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_export0.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_export1.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: INT64
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_http00.log
@@ -97,6 +97,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -146,6 +147,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -233,6 +235,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -282,6 +285,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/labels_value_type/_http01.log
@@ -38,6 +38,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -126,6 +127,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -176,6 +178,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_export0.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_export1.yaml
@@ -8,7 +8,7 @@ spec:
       bounds:
       - 1.5
       - 4.5
-  description: a description
+  description: an updated description
   disabled: false
   filter: resource.type=gae_app AND severity<=ERROR
   labelExtractors:
@@ -20,9 +20,9 @@ spec:
       key: testkey
       valueType: STRING
     launchStage: ""
-    metricKind: DELTA
-    unit: ""
-    valueType: DISTRIBUTION
+    metricKind: CUMULATIVE
+    unit: "1"
+    valueType: INT64
   projectRef:
     external: ${projectId}
   valueExtractor: EXTRACT(jsonPayload.response)

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_http00.log
@@ -97,6 +97,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -146,6 +147,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -233,6 +235,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -282,6 +285,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_http01.log
@@ -38,7 +38,146 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+PUT https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey",
+        "valueType": "STRING"
+      }
+    ],
+    "launchStage": "EARLY_ACCESS",
+    "metadata": {
+      "ingestDelay": "1s",
+      "samplePeriod": "1s"
+    },
+    "metricKind": "CUMULATIVE",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "an updated description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "CUMULATIVE",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
+  "name": "logginglogmetric-${uniqueId}",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "valueExtractor": "EXTRACT(jsonPayload.response)"
+}
+
+---
+
+GET https://logging.googleapis.com/v2/projects/${projectId}/metrics/logginglogmetric-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bucketOptions": {
+    "explicitBuckets": {
+      "bounds": [
+        1.5,
+        4.5
+      ]
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "description": "an updated description",
+  "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "labelExtractors": {
+    "testkey": "EXTRACT(jsonPayload.request)"
+  },
+  "metricDescriptor": {
+    "description": "an updated description",
+    "displayName": "a concise name",
+    "labels": [
+      {
+        "description": "a label description",
+        "key": "testkey"
+      }
+    ],
+    "metricKind": "CUMULATIVE",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
   },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z",

--- a/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_immutable_field/metric_kind_and_value_type/_object01.yaml
@@ -39,14 +39,13 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"
-    message: 'Update call failed: error updating: logMetric update failed: cannot
-      make changes to immutable field(s): [metricDescriptor.MetricKind metricDescriptor.ValueType]'
-    reason: UpdateFailed
-    status: "False"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
   metricDescriptor:
-    description: a description
+    description: an updated description
     name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
     type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 3

--- a/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_export0.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_export1.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_http00.log
@@ -68,6 +68,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/lazyreconcile-${uniqueId}",
     "type": "logging.googleapis.com/user/lazyreconcile-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "lazyreconcile-${uniqueId}",
@@ -105,6 +106,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/lazyreconcile-${uniqueId}",
     "type": "logging.googleapis.com/user/lazyreconcile-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "lazyreconcile-${uniqueId}",
@@ -163,6 +165,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/lazyreconcile-${uniqueId}",
     "type": "logging.googleapis.com/user/lazyreconcile-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "lazyreconcile-${uniqueId}",
@@ -200,6 +203,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/lazyreconcile-${uniqueId}",
     "type": "logging.googleapis.com/user/lazyreconcile-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "lazyreconcile-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/llm_lazy_reconcile/_http01.log
@@ -26,6 +26,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/lazyreconcile-${uniqueId}",
     "type": "logging.googleapis.com/user/lazyreconcile-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "lazyreconcile-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export0.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_export1.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http00.log
@@ -94,6 +94,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -141,6 +142,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -225,6 +227,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -272,6 +275,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set-zero/_http01.log
@@ -36,6 +36,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -112,6 +113,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -157,6 +159,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export0.yaml
@@ -6,6 +6,12 @@ spec:
   description: ""
   disabled: false
   filter: resource.type=gae_app AND severity<=ERROR
+  metricDescriptor:
+    displayName: ""
+    launchStage: ""
+    metricKind: DELTA
+    unit: "1"
+    valueType: INT64
   projectRef:
     external: ${projectId}
   valueExtractor: ""

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export1.yaml
@@ -6,6 +6,12 @@ spec:
   description: an e2e test
   disabled: true
   filter: resource.type=gae_app AND severity<=INFO
+  metricDescriptor:
+    displayName: ""
+    launchStage: ""
+    metricKind: DELTA
+    unit: "1"
+    valueType: INT64
   projectRef:
     external: ${projectId}
   valueExtractor: ""

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export2.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_export2.yaml
@@ -6,6 +6,12 @@ spec:
   description: ""
   disabled: false
   filter: resource.type=gae_app AND severity<=INFO
+  metricDescriptor:
+    displayName: ""
+    launchStage: ""
+    metricKind: DELTA
+    unit: "1"
+    valueType: INT64
   projectRef:
     external: ${projectId}
   valueExtractor: ""

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http00.log
@@ -43,6 +43,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -65,6 +72,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -95,6 +109,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -117,6 +138,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http01.log
@@ -14,6 +14,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=ERROR",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -48,6 +55,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -72,6 +87,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http02.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_http02.log
@@ -16,6 +16,14 @@ X-Xss-Protection: 0
   "description": "an e2e test",
   "disabled": true,
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "description": "an e2e test",
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -46,6 +54,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }
@@ -68,6 +83,13 @@ X-Xss-Protection: 0
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
   "filter": "resource.type=gae_app AND severity\u003c=INFO",
+  "metricDescriptor": {
+    "metricKind": "DELTA",
+    "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
+    "valueType": "INT64"
+  },
   "name": "logginglogmetric-${uniqueId}",
   "updateTime": "2024-04-01T12:34:56.123456Z"
 }

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object00.yaml
@@ -1,22 +1,7 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:
   annotations:
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -38,5 +23,8 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 2
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object01.yaml
@@ -1,22 +1,7 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:
   annotations:
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -40,5 +25,9 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    description: an e2e test
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 3
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/basic/_object02.yaml
@@ -1,22 +1,7 @@
-# Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: logging.cnrm.cloud.google.com/v1beta1
 kind: LoggingLogMetric
 metadata:
   annotations:
-    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:
@@ -38,5 +23,8 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  metricDescriptor:
+    name: projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}
+    type: logging.googleapis.com/user/logginglogmetric-${uniqueId}
   observedGeneration: 4
   updateTime: "1970-01-01T00:00:00Z"

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export0.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export1.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export2.yaml
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_export2.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http00.log
@@ -68,6 +68,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -105,6 +106,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -163,6 +165,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -200,6 +203,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http01.log
@@ -26,6 +26,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -110,6 +111,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -157,6 +159,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http02.log
+++ b/tests/e2e/testdata/scenarios/fields/management/logging/logmetric/set_unset/metric_descriptor/_http02.log
@@ -36,6 +36,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -94,6 +95,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -131,6 +133,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_export0.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_export1.yaml
+++ b/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_export1.yaml
@@ -21,7 +21,7 @@ spec:
       valueType: STRING
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_http00.log
+++ b/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_http00.log
@@ -94,6 +94,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -141,6 +142,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -225,6 +227,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -272,6 +275,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_http01.log
+++ b/tests/e2e/testdata/scenarios/fields/mutable_but_unreadable/_http01.log
@@ -36,6 +36,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_export0.yaml
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_export0.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_export3.yaml
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_export3.yaml
@@ -15,7 +15,7 @@ spec:
     displayName: ""
     launchStage: ""
     metricKind: DELTA
-    unit: ""
+    unit: "1"
     valueType: DISTRIBUTION
   projectRef:
     external: ${projectId}

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http00.log
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http00.log
@@ -68,6 +68,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -105,6 +106,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -163,6 +165,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -200,6 +203,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http01.log
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http01.log
@@ -26,6 +26,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http02.log
+++ b/tests/e2e/testdata/scenarios/powertool/logginglogmetric_clear_state_into_spec/_http02.log
@@ -87,6 +87,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",
@@ -124,6 +125,7 @@ X-Xss-Protection: 0
     "metricKind": "DELTA",
     "name": "projects/${projectId}/metricDescriptors/logging.googleapis.com/user/logginglogmetric-${uniqueId}",
     "type": "logging.googleapis.com/user/logginglogmetric-${uniqueId}",
+    "unit": "1",
     "valueType": "DISTRIBUTION"
   },
   "name": "logginglogmetric-${uniqueId}",

--- a/tests/e2e/testdata/scenarios/tracker/tracker-iampartialpolicy/_http03.log
+++ b/tests/e2e/testdata/scenarios/tracker/tracker-iampartialpolicy/_http03.log
@@ -405,3 +405,85 @@ X-Xss-Protection: 0
   "etag": "abcdef0123A=",
   "version": 1
 }
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects/iampartialpolicy-dep-project:getIamPolicy?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "options": {
+    "requestedPolicyVersion": 3
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bindings": [
+    {
+      "members": [
+        "serviceAccount:iampartialpolicy-dep-project@iampartialpolicy-dep-project.iam.gserviceaccount.com"
+      ],
+      "role": "roles/editor"
+    },
+    {
+      "members": [
+        "serviceAccount:iampartialpolicy-dep-project@iampartialpolicy-dep-project.iam.gserviceaccount.com"
+      ],
+      "role": "roles/storage.admin"
+    }
+  ],
+  "etag": "abcdef0123A=",
+  "version": 1
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects/iampartialpolicy-dep-project:getIamPolicy?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "options": {
+    "requestedPolicyVersion": 3
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "bindings": [
+    {
+      "members": [
+        "serviceAccount:iampartialpolicy-dep-project@iampartialpolicy-dep-project.iam.gserviceaccount.com"
+      ],
+      "role": "roles/editor"
+    },
+    {
+      "members": [
+        "serviceAccount:iampartialpolicy-dep-project@iampartialpolicy-dep-project.iam.gserviceaccount.com"
+      ],
+      "role": "roles/storage.admin"
+    }
+  ],
+  "etag": "abcdef0123A=",
+  "version": 1
+}


### PR DESCRIPTION
- **tests: Add test for immutable metricDescriptor**
  Adds a new test case to reproduce a bug where LoggingLogMetric
  resources fail to update when the metricDescriptor is not specified
  in the CRD.
  

- **fix: LoggingLogMetric metricDescriptor**
  

- **mockgcp: more fidelity for LoggingLogMetric**
  

- **tests: add LoggingLogMetric to re-reconiliation test list**
  