### PR TITLE
chore: clean up sync-crds release step

### DIFF
--- a/dev/tasks/sync-crds-folder.sh
+++ b/dev/tasks/sync-crds-folder.sh
@@ -18,8 +18,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=${1:-1.127.0}  # Default to 1.127.0 if no version provided
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [[ -z "${VERSION:-}" ]]; then
+  echo "VERSION must be set"
+  exit 1
+fi
+
 TARGET_CRD_DIR=${REPO_ROOT}/crds
 TEMP_DIR=$(mktemp -td sync-crds-folder.XXXXXXXX)
 CRDS_FILE=${REPO_ROOT}/operator/channels/packages/configconnector/${VERSION}/crds.yaml
@@ -47,11 +52,12 @@ if [ ! -f "${CRDS_FILE}" ]; then
 fi
 
 # Parse CRDs into individual files
+echo "Splitting manifest ${CRDS_FILE}"
 cd ${REPO_ROOT} && go run -mod=readonly ${REPO_ROOT}/scripts/parse-crds/parse-crds.go \
     -file ${CRDS_FILE} \
     -output-dir ${TEMP_DIR}
 
-
+echo "Writing split files to ${TARGET_CRD_DIR}"
 rm -rf ${TARGET_CRD_DIR}
 mkdir ${TARGET_CRD_DIR}
 for filepath in ${TEMP_DIR}/*.yaml; do

--- a/scripts/parse-crds/parse-crds.go
+++ b/scripts/parse-crds/parse-crds.go
@@ -20,16 +20,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/crd/crdgeneration"
 	kccyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/yaml"
-
-	"github.com/ghodss/yaml" //nolint:depguard
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 const fileMode = 0600
@@ -55,11 +54,11 @@ func run(file, outputDir string) error {
 	if err != nil {
 		return fmt.Errorf("error converting file %v to an absolute path: %w", file, err)
 	}
-	bytes, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("error reading file %v: %w", filePath, err)
 	}
-	yamls, err := kccyaml.SplitYAML(bytes)
+	yamls, err := kccyaml.SplitYAML(b)
 	if err != nil {
 		return fmt.Errorf("error splitting bytes into YAMLs: %w", err)
 	}
@@ -72,7 +71,7 @@ func run(file, outputDir string) error {
 		crds = append(crds, &crd)
 	}
 	for _, crd := range crds {
-		bytes, err := yaml.Marshal(crd)
+		b, err := yaml.Marshal(crd)
 		if err != nil {
 			return fmt.Errorf("error marshalling CRD into bytes: %w", err)
 		}
@@ -81,8 +80,8 @@ func run(file, outputDir string) error {
 			return fmt.Errorf("error determining file name for CRD with GVK %v: %w", crd.GroupVersionKind(), err)
 		}
 		outputPath := filepath.Join(outputDir, outputName)
-		if err := ioutil.WriteFile(outputPath, bytes, fileMode); err != nil {
-			return fmt.Errorf("error writing file %v: %w", outputName, err)
+		if err := os.WriteFile(outputPath, b, fileMode); err != nil {
+			return fmt.Errorf("error writing file %v: %w", outputPath, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
* Require VERSION to be set rather than silently choosing a bad version.
* Modernize the go script
