### PR TITLE
refactor: reference new iam "core" apis

### DIFF
--- a/apis/iam/v1beta1/auditconfig_types_test.go
+++ b/apis/iam/v1beta1/auditconfig_types_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStorageIAMAuditConfig(t *testing.T) {
+	key := types.NamespacedName{Name: "foo", Namespace: "default"}
+	testCases := []*IAMAuditConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMAuditConfigSpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Service:           "sampleservice.googleapis.com",
+				AuditLogConfigs: []AuditLogConfig{
+					{
+						LogType:         "DATA_WRITE",
+						ExemptedMembers: []Member{"user:foo", "serviceAccount:bar, group:g, domain:d"},
+					},
+					{
+						LogType:         "DATA_READ",
+						ExemptedMembers: []Member{"projectOwner:po", "projectEditor:pe", "projectViewer:pv"},
+					},
+					{
+						LogType:         "ADMIN_READ",
+						ExemptedMembers: []Member{"allUsers", "allAuthenticatedUsers"},
+					},
+				},
+			},
+			Status: IAMAuditConfigStatus{},
+		},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	for _, created := range testCases {
+		// Test Create
+		fetched := &IAMAuditConfig{}
+		g.Expect(c.Create(context.TODO(), created)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(created))
+
+		// Test Updating the Labels
+		updated := fetched.DeepCopy()
+		updated.Labels = map[string]string{"hello": "world"}
+		g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(updated))
+
+		// Test Delete
+		g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.HaveOccurred())
+	}
+}

--- a/apis/iam/v1beta1/krm_types.go
+++ b/apis/iam/v1beta1/krm_types.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func (ref *ResourceReference) GroupVersionKind() schema.GroupVersionKind {
+	return schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+}
+
+func (ref *ResourceReference) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	ref.APIVersion, ref.Kind = gvk.ToAPIVersionAndKind()
+}
+
+func (ms *MemberSource) Validate() error {
+	v := reflect.ValueOf(ms).Elem()
+	var count int
+	for i := 0; i < v.NumField(); i++ {
+		if !v.Field(i).IsNil() {
+			count++
+		}
+	}
+	if count > 1 {
+		return fmt.Errorf("%d memberFrom refs found. Only one subfield of MemberSource can be set", count)
+	}
+	return nil
+}

--- a/apis/iam/v1beta1/partialpolicy_types_test.go
+++ b/apis/iam/v1beta1/partialpolicy_types_test.go
@@ -1,0 +1,136 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var fakePartialPolicyBindings = []IAMPartialPolicyBinding{
+	{
+		Members: []IAMPartialPolicyMember{
+			{
+				MemberFrom: &MemberSource{
+					ServiceAccountRef: &MemberReference{
+						Namespace: "cnrm-foo",
+						Name:      "cnrm-sa",
+					},
+				},
+			},
+		},
+		Role: "roles/selor",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "user:foo"},
+			{Member: "serviceAccount:bar"},
+		},
+		Role: "roles/foo",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "group:g"},
+			{Member: "domain:d"},
+		},
+		Role: "roles/bar",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "projectOwner:po"},
+			{Member: "projectEditor:pe"},
+			{Member: "projectViewer:pv"},
+		},
+		Role: "roles/bar",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "allUsers"},
+			{Member: "allAuthenticatedUsers"}},
+		Role: "roles/bar",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "user:foo"},
+			{Member: "serviceAccount:bar"},
+		},
+		Role: "projects/test-project/roles/foo",
+	},
+	{
+		Members: []IAMPartialPolicyMember{
+			{Member: "user:foo"},
+			{Member: "serviceAccount:bar"},
+		},
+		Role: "organizations/1234567890/roles/foo",
+	},
+}
+
+func TestStorageIAMPartialPolicy(t *testing.T) {
+	key := types.NamespacedName{Name: "foo", Namespace: "default"}
+	testCases := []*IAMPartialPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPartialPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Organization", Name: "bar"},
+				Bindings:          fakePartialPolicyBindings,
+			},
+			Status: IAMPartialPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPartialPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Folder", Name: "bar"},
+				Bindings:          fakePartialPolicyBindings,
+			},
+			Status: IAMPartialPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPartialPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Bindings:          fakePartialPolicyBindings,
+			},
+			Status: IAMPartialPolicyStatus{},
+		},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	for _, created := range testCases {
+		// Test Create
+		fetched := &IAMPartialPolicy{}
+		g.Expect(c.Create(context.TODO(), created)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(created))
+		g.Expect(fetched.Spec.Bindings[0].Members[0].Member).To(gomega.BeEmpty())
+		g.Expect(fetched.Spec.Bindings[0].Members[0].MemberFrom).NotTo(gomega.BeNil())
+
+		// Test Updating the Labels
+		updated := fetched.DeepCopy()
+		updated.Labels = map[string]string{"hello": "world"}
+		g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(updated))
+
+		// Test Delete
+		g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.HaveOccurred())
+	}
+}

--- a/apis/iam/v1beta1/policy_types_test.go
+++ b/apis/iam/v1beta1/policy_types_test.go
@@ -1,0 +1,148 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var fakeBindings = []IAMPolicyBinding{
+	{
+		Members: []Member{"user:foo", "serviceAccount:bar"},
+		Role:    "roles/foo",
+	},
+	{
+		Members: []Member{"group:g", "domain:d"},
+		Role:    "roles/bar",
+	},
+	{
+		Members: []Member{"projectOwner:po", "projectEditor:pe", "projectViewer:pv"},
+		Role:    "roles/bar",
+	},
+	{
+		Members: []Member{"allUsers", "allAuthenticatedUsers"},
+		Role:    "roles/bar",
+	},
+	{
+		Members: []Member{"user:foo", "serviceAccount:bar"},
+		Role:    "projects/test-project/roles/foo",
+	},
+	{
+		Members: []Member{"user:foo", "serviceAccount:bar"},
+		Role:    "organizations/1234567890/roles/foo",
+	},
+}
+
+var fakeAuditConfigs = []IAMPolicyAuditConfig{
+	{
+		Service: "allServices",
+		AuditLogConfigs: []AuditLogConfig{
+			{
+				LogType: "DATA_WRITE",
+			},
+		},
+	},
+	{
+		Service: "sampleservice.googleapis.com",
+		AuditLogConfigs: []AuditLogConfig{
+			{
+				LogType:         "DATA_WRITE",
+				ExemptedMembers: []Member{"user:foo", "serviceAccount:bar, group:g, domain:d"},
+			},
+			{
+				LogType:         "DATA_READ",
+				ExemptedMembers: []Member{"projectOwner:po", "projectEditor:pe", "projectViewer:pv"},
+			},
+			{
+				LogType:         "ADMIN_READ",
+				ExemptedMembers: []Member{"allUsers", "allAuthenticatedUsers"},
+			},
+		},
+	},
+}
+
+func TestStorageIAMPolicy(t *testing.T) {
+	key := types.NamespacedName{Name: "foo", Namespace: "default"}
+	testCases := []*IAMPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Organization", Name: "bar"},
+				Bindings:          fakeBindings,
+			},
+			Status: IAMPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Folder", Name: "bar"},
+				Bindings:          fakeBindings,
+			},
+			Status: IAMPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Bindings:          fakeBindings,
+			},
+			Status: IAMPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Bindings:          fakeBindings,
+				AuditConfigs:      fakeAuditConfigs,
+			},
+			Status: IAMPolicyStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: IAMPolicySpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				AuditConfigs:      fakeAuditConfigs,
+			},
+			Status: IAMPolicyStatus{},
+		},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	for _, created := range testCases {
+		// Test Create
+		fetched := &IAMPolicy{}
+		g.Expect(c.Create(context.TODO(), created)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(created))
+
+		// Test Updating the Labels
+		updated := fetched.DeepCopy()
+		updated.Labels = map[string]string{"hello": "world"}
+		g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(updated))
+
+		// Test Delete
+		g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.HaveOccurred())
+	}
+}

--- a/apis/iam/v1beta1/policymember_types_test.go
+++ b/apis/iam/v1beta1/policymember_types_test.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStorageIAMPolicyMember(t *testing.T) {
+	testCases := []*IAMPolicyMember{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo1", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Organization", Name: "bar"},
+				Member:            "serviceAccount:bar",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo2", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Folder", Name: "bar"},
+				Member:            "serviceAccount:bar",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo3", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Member:            "serviceAccount:bar",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo4", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Member:            "allUsers",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo5", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Member:            "allAuthenticatedUsers",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo6", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "StorageBucket", Name: "bar"},
+				Member:            "projectEditor:pe",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo7", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "StorageBucket", Name: "bar"},
+				Member:            "projectOwner:po",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo8", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "StorageBucket", Name: "bar"},
+				Member:            "projectViewer:pv",
+				Role:              "roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo9", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Project", Name: "bar"},
+				Member:            "serviceAccount:bar",
+				Role:              "projects/test-project/roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo10", Namespace: "default"},
+			Spec: IAMPolicyMemberSpec{
+				ResourceReference: ResourceReference{Kind: "Organization", Name: "bar"},
+				Member:            "serviceAccount:bar",
+				Role:              "organizations/1234567890/roles/foo",
+			},
+			Status: IAMPolicyMemberStatus{},
+		},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	for _, created := range testCases {
+		// Test Create
+		fetched := &IAMPolicyMember{}
+		g.Expect(c.Create(context.TODO(), created)).NotTo(gomega.HaveOccurred())
+
+		key := types.NamespacedName{Name: created.Name, Namespace: created.Namespace}
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(created))
+
+		// Test Updating the Labels
+		updated := fetched.DeepCopy()
+		updated.Labels = map[string]string{"hello": "world"}
+		g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+
+		g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(fetched).To(gomega.Equal(updated))
+
+		// Test Delete
+		g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.HaveOccurred())
+	}
+}

--- a/apis/iam/v1beta1/register.go
+++ b/apis/iam/v1beta1/register.go
@@ -47,16 +47,15 @@ var (
 		Version: SchemeGroupVersion.Version,
 		Kind:    reflect.TypeOf(IAMPartialPolicy{}).Name(),
 	}
-	// NOT YET
-	// IAMPolicyMemberGVK = schema.GroupVersionKind{
-	// 	Group:   SchemeGroupVersion.Group,
-	// 	Version: SchemeGroupVersion.Version,
-	// 	Kind:    reflect.TypeOf(IAMPolicyMember{}).Name(),
-	// }
-	// IAMAuditConfigGVK = schema.GroupVersionKind{
-	// 	Group:   SchemeGroupVersion.Group,
-	// 	Version: SchemeGroupVersion.Version,
-	// 	Kind:    reflect.TypeOf(IAMAuditConfig{}).Name(),
-	// }
+	IAMPolicyMemberGVK = schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    reflect.TypeOf(IAMPolicyMember{}).Name(),
+	}
+	IAMAuditConfigGVK = schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    reflect.TypeOf(IAMAuditConfig{}).Name(),
+	}
 	IAMAPIVersion = SchemeGroupVersion.String()
 )

--- a/apis/iam/v1beta1/suite_test.go
+++ b/apis/iam/v1beta1/suite_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var cfg *rest.Config
+var c client.Client
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths:        []string{repo.GetCRDsPath()},
+		ControlPlaneStartTimeout: time.Minute,
+		ControlPlaneStopTimeout:  time.Minute,
+	}
+
+	err := SchemeBuilder.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if cfg, err = t.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
+		log.Fatal(err)
+	}
+
+	code := m.Run()
+	if err := t.Stop(); err != nil {
+		log.Printf("unable to stop test runner: %v", err)
+	}
+	os.Exit(code)
+}

--- a/pkg/cli/cmd/bulkexport/iamresource/iamresource.go
+++ b/pkg/cli/cmd/bulkexport/iamresource/iamresource.go
@@ -17,7 +17,7 @@ package iamresource
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/deepcopy"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/cli/cmd/bulkexport/iamresource/iamresource_test.go
+++ b/pkg/cli/cmd/bulkexport/iamresource/iamresource_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/cmd/bulkexport/iamresource"
 	testyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/yaml"
 )

--- a/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
+++ b/pkg/cli/cmd/bulkexport/singleresourceiamclient/singleresourceiamclient.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/deepcopy"

--- a/pkg/cli/stream/unstructuredresource_iampolicystream.go
+++ b/pkg/cli/stream/unstructuredresource_iampolicystream.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/cmd/bulkexport/iamresource"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 

--- a/pkg/cli/stream/unstructuredresource_iampolicystream_test.go
+++ b/pkg/cli/stream/unstructuredresource_iampolicystream_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/cli/stream"
 	testyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/yaml"
 

--- a/pkg/controller/direct/iam.go
+++ b/pkg/controller/direct/iam.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/iam/apiv1/iampb"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controller/direct/iam/mappings.go
+++ b/pkg/controller/direct/iam/mappings.go
@@ -20,8 +20,7 @@ import (
 	"cloud.google.com/go/iam/apiv1/iampb"
 	expr "google.golang.org/genproto/googleapis/type/expr"
 
-	newiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
-	oldiamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
@@ -32,7 +31,7 @@ const (
 	DataRead           = "DATA_READ"
 )
 
-func IAMPolicySpec_ToProto(_ *direct.MapContext, in *oldiamv1beta1.IAMPolicySpec) *iampb.Policy {
+func IAMPolicySpec_ToProto(_ *direct.MapContext, in *krm.IAMPolicySpec) *iampb.Policy {
 	if in == nil {
 		return nil
 	}
@@ -98,29 +97,29 @@ func IAMPolicySpec_ToProto(_ *direct.MapContext, in *oldiamv1beta1.IAMPolicySpec
 	return protoPolicy
 }
 
-func IAMPolicySpec_FromProto(_ *direct.MapContext, in *iampb.Policy) *newiamv1beta1.IAMPolicySpec {
+func IAMPolicySpec_FromProto(_ *direct.MapContext, in *iampb.Policy) *krm.IAMPolicySpec {
 	if in == nil {
 		return nil
 	}
 
-	out := &newiamv1beta1.IAMPolicySpec{
+	out := &krm.IAMPolicySpec{
 		Etag: string(in.Etag),
 	}
 
 	// Map Bindings from Proto to KRM
 	if len(in.Bindings) > 0 {
-		out.Bindings = make([]newiamv1beta1.IAMPolicyBinding, 0, len(in.Bindings))
+		out.Bindings = make([]krm.IAMPolicyBinding, 0, len(in.Bindings))
 		for _, pbBinding := range in.Bindings {
-			binding := newiamv1beta1.IAMPolicyBinding{
+			binding := krm.IAMPolicyBinding{
 				Role:    pbBinding.Role,
-				Members: make([]newiamv1beta1.Member, len(pbBinding.Members)),
+				Members: make([]krm.Member, len(pbBinding.Members)),
 			}
 			for i, member := range pbBinding.Members {
-				binding.Members[i] = newiamv1beta1.Member(member)
+				binding.Members[i] = krm.Member(member)
 			}
 
 			if pbBinding.Condition != nil {
-				binding.Condition = &newiamv1beta1.IAMCondition{
+				binding.Condition = &krm.IAMCondition{
 					Expression:  pbBinding.Condition.Expression,
 					Title:       pbBinding.Condition.Title,
 					Description: pbBinding.Condition.Description,
@@ -132,24 +131,24 @@ func IAMPolicySpec_FromProto(_ *direct.MapContext, in *iampb.Policy) *newiamv1be
 
 	// Map AuditConfigs from Proto to KRM
 	if len(in.AuditConfigs) > 0 {
-		out.AuditConfigs = make([]newiamv1beta1.IAMPolicyAuditConfig, 0, len(in.AuditConfigs))
+		out.AuditConfigs = make([]krm.IAMPolicyAuditConfig, 0, len(in.AuditConfigs))
 		for _, pbAuditConfig := range in.AuditConfigs {
-			ac := newiamv1beta1.IAMPolicyAuditConfig{
+			ac := krm.IAMPolicyAuditConfig{
 				Service: pbAuditConfig.Service,
 			}
 
 			if len(pbAuditConfig.AuditLogConfigs) > 0 {
-				ac.AuditLogConfigs = make([]newiamv1beta1.AuditLogConfig, 0, len(pbAuditConfig.AuditLogConfigs))
+				ac.AuditLogConfigs = make([]krm.AuditLogConfig, 0, len(pbAuditConfig.AuditLogConfigs))
 				for _, pbAlc := range pbAuditConfig.AuditLogConfigs {
 					logTypeString := mapProtoLogTypeToKRM(pbAlc.LogType)
 
-					alc := newiamv1beta1.AuditLogConfig{
+					alc := krm.AuditLogConfig{
 						LogType: logTypeString,
 					}
 					if len(pbAlc.ExemptedMembers) > 0 {
-						alc.ExemptedMembers = make([]newiamv1beta1.Member, len(pbAlc.ExemptedMembers))
+						alc.ExemptedMembers = make([]krm.Member, len(pbAlc.ExemptedMembers))
 						for i, em := range pbAlc.ExemptedMembers {
-							alc.ExemptedMembers[i] = newiamv1beta1.Member(em)
+							alc.ExemptedMembers[i] = krm.Member(em)
 						}
 					}
 					ac.AuditLogConfigs = append(ac.AuditLogConfigs, alc)

--- a/pkg/controller/direct/registry/references.go
+++ b/pkg/controller/direct/registry/references.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/kccstate"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller_integration_test.go
@@ -25,8 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/auditconfig"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
@@ -57,14 +56,14 @@ var (
 func TestReconcileIAMAuditConfigResourceLevelCreate(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -76,14 +75,14 @@ func TestReconcileIAMAuditConfigResourceLevelCreate(t *testing.T) {
 func TestReconcileIAMAuditConfigResourceLevelCreateWithSISMerge(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -101,14 +100,14 @@ func TestReconcileIAMAuditConfigResourceLevelCreateWithExternalRef(t *testing.T)
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -155,7 +154,7 @@ func testReconcileResourceLevelCreate(ctx context.Context, t *testing.T, mgr man
 func TestReconcileIAMAuditConfigResourceLevelUpdate(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
@@ -167,7 +166,7 @@ func TestReconcileIAMAuditConfigResourceLevelUpdate(t *testing.T) {
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -184,7 +183,7 @@ func TestReconcileIAMAuditConfigResourceLevelUpdateWithExternalRef(t *testing.T)
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
@@ -196,7 +195,7 @@ func TestReconcileIAMAuditConfigResourceLevelUpdateWithExternalRef(t *testing.T)
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -252,14 +251,14 @@ func testReconcileResourceLevelUpdate(ctx context.Context, t *testing.T, mgr man
 func TestReconcileIAMAuditConfigResourceLevelNoChanges(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -274,14 +273,14 @@ func TestReconcileIAMAuditConfigResourceLevelNoChangesWithExternalRef(t *testing
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -335,14 +334,14 @@ func testReconcileResourceLevelNoChanges(ctx context.Context, t *testing.T, mgr 
 func TestReconcileIAMAuditConfigResourceLevelDelete(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -357,14 +356,14 @@ func TestReconcileIAMAuditConfigResourceLevelDeleteWithExternalRef(t *testing.T)
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -405,7 +404,7 @@ func testReconcileResourceLevelDelete(ctx context.Context, t *testing.T, mgr man
 	if err != nil {
 		t.Fatalf("expected audit config to exist in GCP, but got error: %v", err)
 	}
-	testk8s.RemoveDeletionDefenderFinalizer(t, k8sAuditConfig, v1beta1.IAMAuditConfigGVK, kubeClient)
+	testk8s.RemoveDeletionDefenderFinalizer(t, k8sAuditConfig, iamv1beta1.IAMAuditConfigGVK, kubeClient)
 	reconcileIAMAuditConfig(ctx, t, reconciler, k8sAuditConfig, expectedReconcileResult, nil)
 	if _, err := tfIamClient.GetAuditConfig(ctx, k8sAuditConfig); !errors.Is(err, kcciamclient.ErrNotFound) {
 		t.Fatalf("unexpected error value: got '%v', want '%v'", err, kcciamclient.ErrNotFound)
@@ -413,20 +412,20 @@ func testReconcileResourceLevelDelete(ctx context.Context, t *testing.T, mgr man
 	if err := kubeClient.Get(ctx, k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err == nil || !apierrors.IsNotFound(err) {
 		t.Fatalf("unexpected error value: %v", err)
 	}
-	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.Deleted)
+	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.Deleted)
 }
 
 func TestReconcileIAMAuditConfigResourceLevelDeleteParentFirst(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -441,14 +440,14 @@ func TestReconcileIAMAuditConfigResourceLevelDeleteParentFirstWithExternalRef(t 
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -493,25 +492,25 @@ func testReconcileResourceLevelDeleteParentFirst(ctx context.Context, t *testing
 	if err := kubeClient.Delete(ctx, k8sAuditConfig); err != nil {
 		t.Fatalf("error deleting k8s resource: %v", err)
 	}
-	testk8s.RemoveDeletionDefenderFinalizer(t, k8sAuditConfig, v1beta1.IAMAuditConfigGVK, kubeClient)
+	testk8s.RemoveDeletionDefenderFinalizer(t, k8sAuditConfig, iamv1beta1.IAMAuditConfigGVK, kubeClient)
 	reconcileIAMAuditConfig(ctx, t, reconciler, k8sAuditConfig, expectedReconcileResult, nil)
 	if err := kubeClient.Get(ctx, k8s.GetNamespacedName(k8sAuditConfig), k8sAuditConfig); err == nil || !apierrors.IsNotFound(err) {
 		t.Fatalf("unexpected error value: %v", err)
 	}
-	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.Deleted)
+	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.Deleted)
 }
 
 func TestReconcileIAMAuditConfigResourceLevelAcquire(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -526,14 +525,14 @@ func TestReconcileIAMAuditConfigResourceLevelAcquireWithExternalRef(t *testing.T
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return testiam.ShouldRunWithAuditConfigs(fixture) && testiam.ShouldRunWithExternalRef(fixture)
 	}
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		auditLogConfigs := []iamv1beta1.AuditLogConfig{
 			{
 				LogType: "DATA_WRITE",
 			},
 			{
 				LogType:         "DATA_READ",
-				ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sAuditConfig := newIAMAuditConfigFixture(t, refResource, resourceRef, "allServices", auditLogConfigs)
@@ -567,7 +566,7 @@ func testReconcileResourceLevelAcquire(ctx context.Context, t *testing.T, mgr ma
 		t.Fatalf("unexpected error getting k8s resource: %v", err)
 	}
 	testcontroller.AssertReadyCondition(t, k8sAuditConfig, preReconcileGeneration)
-	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, v1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
+	testcontroller.AssertEventRecordedForObjectMetaAndKind(t, kubeClient, iamv1beta1.IAMAuditConfigGVK.Kind, &k8sAuditConfig.ObjectMeta, k8s.UpToDate)
 	assertObservedGenerationEquals(t, k8sAuditConfig, preReconcileGeneration)
 }
 

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller_test.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller_test.go
@@ -17,7 +17,7 @@ package auditconfig
 import (
 	"testing"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 

--- a/pkg/controller/iam/iamclient/dcliamclient.go
+++ b/pkg/controller/iam/iamclient/dcliamclient.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/extension"

--- a/pkg/controller/iam/iamclient/dcliamclient_test.go
+++ b/pkg/controller/iam/iamclient/dcliamclient_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 
 	dcliam "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/iam"
 	dclunstruct "github.com/GoogleCloudPlatform/declarative-resource-client-library/unstructured"

--- a/pkg/controller/iam/iamclient/externalonly.go
+++ b/pkg/controller/iam/iamclient/externalonly.go
@@ -17,8 +17,8 @@ package iamclient
 import (
 	"fmt"
 
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gvks/externalonlygvks"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/controller/iam/iamclient/helpers.go
+++ b/pkg/controller/iam/iamclient/helpers.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	bigqueryconnection "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigqueryconnection/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/controller/iam/iamclient/iamclient.go
+++ b/pkg/controller/iam/iamclient/iamclient.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"

--- a/pkg/controller/iam/iamclient/iamclient_integration_test.go
+++ b/pkg/controller/iam/iamclient/iamclient_integration_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	dclmetadata "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/schema/dclschemaloader"

--- a/pkg/controller/iam/iamclient/tfiamclient.go
+++ b/pkg/controller/iam/iamclient/tfiamclient.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	corekccv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/core/v1alpha1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gvks/externalonlygvks"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/krmtotf"

--- a/pkg/controller/iam/partialpolicy/bindings.go
+++ b/pkg/controller/iam/partialpolicy/bindings.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 )
 
 type MemberIdentityResolver interface {

--- a/pkg/controller/iam/partialpolicy/bindings_test.go
+++ b/pkg/controller/iam/partialpolicy/bindings_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/partialpolicy"
 
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller.go
@@ -21,9 +21,9 @@ import (
 	"reflect"
 	"time"
 
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/kccstate"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"

--- a/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
+++ b/pkg/controller/iam/partialpolicy/iampartialpolicy_controller_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/partialpolicy"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/clientconfig"

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/kccstate"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"

--- a/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
+++ b/pkg/controller/iam/policy/iampolicy_controller_integration_test.go
@@ -25,8 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/clientconfig"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/conversion"
@@ -57,21 +56,21 @@ var (
 	expectedReconcileResult = reconcile.Result{RequeueAfter: k8s.MeanReconcileReenqueuePeriod}
 )
 
-var resourceLevelIAMPolicyTestFunc = func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+var resourceLevelIAMPolicyTestFunc = func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 	bindings := []iamv1beta1.IAMPolicyBinding{
 		{
 			Role:    rc.CreateBindingRole,
-			Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+			Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 		},
 	}
 	newBindings := []iamv1beta1.IAMPolicyBinding{
 		{
 			Role:    rc.CreateBindingRole,
-			Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+			Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 		},
 		{
 			Role:    rc.UpdateBindingRole,
-			Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+			Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 		},
 	}
 	k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -104,21 +103,21 @@ func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithSISMerge(
 	shouldRun := func(fixture resourcefixture.ResourceFixture) bool {
 		return fixture.GVK.Kind == "PubSubTopic"
 	}
-	var resourceLevelIAMPolicyTestFunc = func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	var resourceLevelIAMPolicyTestFunc = func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		newBindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 			{
 				Role:    rc.UpdateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -154,11 +153,11 @@ func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithExternalR
 func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithAuditConfigs(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		auditConfigs := []iamv1beta1.IAMPolicyAuditConfig{
@@ -167,7 +166,7 @@ func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithAuditConf
 				AuditLogConfigs: []iamv1beta1.AuditLogConfig{
 					{
 						LogType:         "ADMIN_READ",
-						ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+						ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 					},
 				},
 			},
@@ -181,7 +180,7 @@ func TestReconcileIAMPolicyResourceLevelCreateNoChangesUpdateDeleteWithAuditConf
 					},
 					{
 						LogType:         "ADMIN_READ",
-						ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+						ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 					},
 				},
 			},
@@ -283,11 +282,11 @@ func testReconcileResourceLevelNoChanges(ctx context.Context, t *testing.T, kube
 func TestReconcileIAMPolicyResourceLevelDeleteParentFirst(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -299,11 +298,11 @@ func TestReconcileIAMPolicyResourceLevelDeleteParentFirst(t *testing.T) {
 func TestReconcileIAMPolicyResourceLevelDeleteParentFirstWithExternalRef(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -376,11 +375,11 @@ func testReconcileResourceLevelDeleteParentFirst(ctx context.Context, t *testing
 func TestReconcileIAMPolicyResourceLevelAcquire(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -392,11 +391,11 @@ func TestReconcileIAMPolicyResourceLevelAcquire(t *testing.T) {
 func TestReconcileIAMPolicyResourceLevelAcquireWithExternalRef(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		k8sPolicy := newIAMPolicyFixture(t, refResource, resourceRef, bindings, nil)
@@ -408,11 +407,11 @@ func TestReconcileIAMPolicyResourceLevelAcquireWithExternalRef(t *testing.T) {
 func TestReconcileIAMPolicyResourceLevelAcquireWithAuditConfigs(t *testing.T) {
 	ctx := context.TODO()
 
-	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef v1beta1.ResourceReference) {
+	testFunc := func(ctx context.Context, t *testing.T, _ string, mgr manager.Manager, rc testiam.IAMResourceContext, refResource *unstructured.Unstructured, resourceRef iamv1beta1.ResourceReference) {
 		bindings := []iamv1beta1.IAMPolicyBinding{
 			{
 				Role:    rc.CreateBindingRole,
-				Members: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+				Members: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 			},
 		}
 		auditConfigs := []iamv1beta1.IAMPolicyAuditConfig{
@@ -421,7 +420,7 @@ func TestReconcileIAMPolicyResourceLevelAcquireWithAuditConfigs(t *testing.T) {
 				AuditLogConfigs: []iamv1beta1.AuditLogConfig{
 					{
 						LogType:         "ADMIN_READ",
-						ExemptedMembers: []v1beta1.Member{v1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
+						ExemptedMembers: []iamv1beta1.Member{iamv1beta1.Member(testgcp.GetIAMPolicyBindingMember(t))},
 					},
 				},
 			},

--- a/pkg/controller/iam/policy/iampolicy_controller_test.go
+++ b/pkg/controller/iam/policy/iampolicy_controller_test.go
@@ -17,7 +17,7 @@ package policy
 import (
 	"testing"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	opcorev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/kccstate"
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	kontroller "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"

--- a/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	kcciamclient "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/iamclient"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/iam/policymember"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/clientconfig"

--- a/pkg/controller/iam/policymember/iampolicymember_controller_test.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller_test.go
@@ -17,7 +17,7 @@ package policymember
 import (
 	"testing"
 
-	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	iamv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	condition "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 

--- a/pkg/gcpwatch/tracker.go
+++ b/pkg/gcpwatch/tracker.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/test/iam/comparison.go
+++ b/pkg/test/iam/comparison.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/pkg/test/iam/resource.go
+++ b/pkg/test/iam/resource.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/extension"
 	dclmetadata "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/metadata"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/dcl/schema/dclschemaloader"

--- a/pkg/test/iam/resource_level_test_runner.go
+++ b/pkg/test/iam/resource_level_test_runner.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/iam/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/iam/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture"
 	testrunner "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/runner"
 


### PR DESCRIPTION
This is a minimal change from https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4731 that compiles! 

Basically reference the new IAM api location. Next PRs will remove the location of the old ones.