### PR TITLE
feat: backport alpha for multi-version CRD

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@ pkg/clients/generated/** linguist-generated=true
 **/*.generated.go linguist-generated=true
 
 **/go.sum linguist-generated=true
+
+config/crds/resources/** linguist-generated=true

--- a/apis/storage/v1beta1/anywherecache_types.go
+++ b/apis/storage/v1beta1/anywherecache_types.go
@@ -102,7 +102,7 @@ type StorageAnywhereCacheObservedState struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=gcp,shortName=gcpstorageanywherecache;gcpstorageanywherecaches
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true";"cnrm.cloud.google.com/system=true"
+// +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true";"cnrm.cloud.google.com/system=true";"internal.cloud.google.com/additional-versions=v1alpha1"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date"
 // +kubebuilder:printcolumn:name="Ready",JSONPath=".status.conditions[?(@.type=='Ready')].status",type="string",description="When 'True', the most recent reconcile of the resource succeeded"
 // +kubebuilder:printcolumn:name="Status",JSONPath=".status.conditions[?(@.type=='Ready')].reason",type="string",description="The reason for the value in 'Ready'"

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_storageanywherecaches.storage.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_storageanywherecaches.storage.cnrm.cloud.google.com.yaml
@@ -201,3 +201,181 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'True', the most recent reconcile of the resource succeeded
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: The reason for the value in 'Ready'
+      jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Status
+      type: string
+    - description: The last transition time for the value in 'Status'
+      jsonPath: .status.conditions[?(@.type=='Ready')].lastTransitionTime
+      name: Status Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StorageAnywhereCache is the Schema for the StorageAnywhereCache
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StorageAnywhereCacheSpec defines the desired state of StorageAnywhereCache
+            properties:
+              admissionPolicy:
+                default: admit-on-first-miss
+                description: 'Cache admission policy. Valid values includes: `admit-on-first-miss`
+                  and `admit-on-second-miss`. Defaults to `admit-on-first-miss`.'
+                enum:
+                - admit-on-first-miss
+                - admit-on-second-miss
+                type: string
+              bucketRef:
+                description: Immutable. The reference to bucket where cache needs
+                  to be created.
+                oneOf:
+                - not:
+                    required:
+                    - external
+                  required:
+                  - name
+                - not:
+                    anyOf:
+                    - required:
+                      - name
+                    - required:
+                      - namespace
+                  required:
+                  - external
+                properties:
+                  external:
+                    description: The StorageBucket selfLink, when not managed by Config
+                      Connector.
+                    type: string
+                  name:
+                    description: The `name` field of a `StorageBucket` resource.
+                    type: string
+                  namespace:
+                    description: The `namespace` field of a `StorageBucket` resource.
+                    type: string
+                type: object
+              desiredState:
+                default: running
+                description: The desired state of the cache. Possible values include
+                  "running", "disabled", and "paused". If not specified, the default
+                  value is "running". This field controls the runtime behavior of
+                  the cache. Please note that changes to the `desiredState` are prioritized
+                  over any other updates. For instance, if both the `desiredState`
+                  and `ttl` are updated simultaneously, the state would be updated
+                  first, followed by `ttl`.
+                enum:
+                - running
+                - paused
+                - disabled
+                type: string
+              resourceID:
+                description: The AnywhereCacheID generated via backend, It can be
+                  used by users to manage an existing cache.
+                type: string
+              ttl:
+                default: 86400s
+                description: Cache entry TTL (ranges between 1h to 7d). This is a
+                  cache-level config that defines how long a cache entry can live.
+                  Defaults to "86400s" TTL must be in whole seconds.
+                type: string
+              zone:
+                description: Immutable. The zone in which the cache instance needs
+                  to be created. For example, us-central1-a.
+                type: string
+            required:
+            - bucketRef
+            - zone
+            type: object
+          status:
+            description: StorageAnywhereCacheStatus defines the config connector machine
+              state of StorageAnywhereCache
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the object's current state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              externalRef:
+                description: A unique specifier for the StorageAnywhereCache resource
+                  in GCP.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the generation of the resource
+                  that was most recently observed by the Config Connector controller.
+                  If this is equal to metadata.generation, then that means that the
+                  current reported status reflects the most recent desired state of
+                  the resource.
+                format: int64
+                type: integer
+              observedState:
+                description: ObservedState is the state of the resource as most recently
+                  observed in GCP.
+                properties:
+                  createTime:
+                    description: Output only. Time when Anywhere cache instance is
+                      allocated.
+                    type: string
+                  pendingUpdate:
+                    description: Output only. True if there is an active update operation
+                      against this cache instance. Subsequential update requests will
+                      be rejected if this field is true. Output only.
+                    type: boolean
+                  state:
+                    description: Output only. Cache state including "running", "creating",
+                      "disabled" and "paused".
+                    type: string
+                  updateTime:
+                    description: Output only. Time when Anywhere cache instance is
+                      last updated, including creation.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/dev/tasks/generate-crds
+++ b/dev/tasks/generate-crds
@@ -39,6 +39,7 @@ go run ./scripts/crd-tools delete-field status --dir apis/config/crd/
 go run ./scripts/crd-tools set-annotation cnrm.cloud.google.com/version=0.0.0-dev --dir apis/config/crd/
 go run ./scripts/crd-tools delete-annotation controller-gen.kubebuilder.io/version --dir apis/config/crd/
 go run ./scripts/crd-tools reflow-descriptions --dir apis/config/crd/
+go run ./scripts/crd-tools backport-alpha --dir apis/config/crd/
 
 # Copy generated CRDs to apis/config/crd/
 # The crds directory is generated only as part of the release (currently)

--- a/experiments/promoter/scripts/find_promotion_candidates.sh
+++ b/experiments/promoter/scripts/find_promotion_candidates.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # This script finds KCC Kind names that are ready to be promoted from v1alpha1 to v1beta1.
 #

--- a/pkg/gvks/supportedgvks/gvks_generated.go
+++ b/pkg/gvks/supportedgvks/gvks_generated.go
@@ -5020,6 +5020,16 @@ var SupportedGVKs = map[schema.GroupVersionKind]GVKMetadata{
 	},
 	{
 		Group:   "storage.cnrm.cloud.google.com",
+		Version: "v1alpha1",
+		Kind:    "StorageAnywhereCache",
+	}: {
+		Labels: map[string]string{
+			"cnrm.cloud.google.com/managed-by-kcc": "true",
+			"cnrm.cloud.google.com/system":         "true",
+		},
+	},
+	{
+		Group:   "storage.cnrm.cloud.google.com",
 		Version: "v1beta1",
 		Kind:    "StorageBucketAccessControl",
 	}: {

--- a/scripts/crd-tools/cmd/backport-alpha/backport-alpha.go
+++ b/scripts/crd-tools/cmd/backport-alpha/backport-alpha.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backportalpha
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/pkg/objectvisitor"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func AddCommand(parent *cobra.Command) {
+	var opt Options
+	cmd := &cobra.Command{
+		Use:   "backport-alpha",
+		Short: "Ensures CRDs have a v1alpha1 version if they have a v1beta1 version.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Run(cmd.Context(), opt)
+		},
+	}
+	cmd.Flags().StringVar(&opt.Dir, "dir", "", "Directory to process")
+	parent.AddCommand(cmd)
+}
+
+type Options struct {
+	Dir string
+}
+
+func (o *Options) Validate() error {
+	if o.Dir == "" {
+		return fmt.Errorf("--dir is required")
+	}
+	return nil
+}
+
+type visitor struct {
+}
+
+func (v *visitor) VisitObject(obj *unstructured.Unstructured) error {
+	if obj.GetKind() != "CustomResourceDefinition" {
+		return nil
+	}
+
+	labels := obj.GetLabels()
+	if labels["cnrm.cloud.google.com/tf2crd"] == "true" || labels["cnrm.cloud.google.com/dcl2crd"] == "true" {
+		return nil
+	}
+
+	group, _, err := unstructured.NestedString(obj.Object, "spec", "group")
+	if err != nil {
+		return fmt.Errorf("error getting spec.group: %w", err)
+	}
+	if group == "iam.cnrm.cloud.google.com" {
+		return nil
+	}
+
+	versions, found, err := unstructured.NestedSlice(obj.Object, "spec", "versions")
+	if err != nil {
+		return fmt.Errorf("error getting spec.versions: %w", err)
+	}
+	if !found {
+		return nil
+	}
+
+	hasV1Beta1 := false
+	hasV1Alpha1 := false
+	var v1beta1Spec map[string]interface{}
+
+	for _, version := range versions {
+		versionMap, ok := version.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(versionMap, "name")
+		if name == "v1beta1" {
+			hasV1Beta1 = true
+			v1beta1Spec = versionMap
+		}
+		if name == "v1alpha1" {
+			hasV1Alpha1 = true
+		}
+	}
+
+	if hasV1Beta1 && !hasV1Alpha1 {
+		v1alpha1Spec := make(map[string]interface{})
+		for k, v := range v1beta1Spec {
+			v1alpha1Spec[k] = v
+		}
+
+		v1alpha1Spec["name"] = "v1alpha1"
+		v1alpha1Spec["storage"] = false
+		v1alpha1Spec["served"] = true
+
+		versions = append(versions, v1alpha1Spec)
+		if err := unstructured.SetNestedSlice(obj.Object, versions, "spec", "versions"); err != nil {
+			return fmt.Errorf("error setting spec.versions: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func Run(ctx context.Context, options Options) error {
+	if err := options.Validate(); err != nil {
+		return err
+	}
+
+	visitor := &visitor{}
+	return objectvisitor.VisitObjectsInDirectory(ctx, options.Dir, visitor)
+}

--- a/scripts/crd-tools/main.go
+++ b/scripts/crd-tools/main.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"os"
 
+	backportalpha "github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/backport-alpha"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/deleteannotation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/deletefield"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/reflowdescriptions"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/removedescriptions"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/setannotation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/setfield"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/backport-alpha"
 	"github.com/spf13/cobra"
 )
 

--- a/scripts/crd-tools/main.go
+++ b/scripts/crd-tools/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/removedescriptions"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/setannotation"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/setfield"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/scripts/crd-tools/cmd/backport-alpha"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,7 @@ func run(ctx context.Context) error {
 		Use: "crd-tools",
 	}
 
+	backportalpha.AddCommand(rootCmd)
 	deleteannotation.AddCommand(rootCmd)
 	deletefield.AddCommand(rootCmd)
 	reflowdescriptions.AddCommand(rootCmd)

--- a/tests/apichecks/testdata/exceptions/multi_version_crd_diff/APIGatewayAPI.diff
+++ b/tests/apichecks/testdata/exceptions/multi_version_crd_diff/APIGatewayAPI.diff
@@ -1,0 +1,38 @@
+--- a/v1alpha1
++++ b/v1beta1
+  &v1.JSONSchemaProps{
+  	... // 26 identical fields
+  	AnyOf: nil,
+  	Not:   nil,
+  	Properties: map[string]v1.JSONSchemaProps{
+  		"apiVersion": {Description: "APIVersion defines the versioned schema of this representation o"..., Type: "string"},
+  		"kind":       {Description: "Kind is a string value representing the REST resource this objec"..., Type: "string"},
+  		"metadata":   {Type: "object"},
+  		"spec": {
+  			... // 26 identical fields
+  			AnyOf: nil,
+  			Not:   nil,
+  			Properties: map[string]v1.JSONSchemaProps{
+  				"displayName": {Description: "Optional. Display name.", Type: "string"},
+  				"labels":      {Description: "Optional. Resource labels to represent user-provided metadata. R"..., Type: "object", AdditionalProperties: &{Allows: true, Schema: &{Type: "string"}}},
+  				"managedService": {
+  					... // 41 identical fields
+  					XListType:    nil,
+  					XMapType:     nil,
+- 					XValidations: nil,
++ 					XValidations: v1.ValidationRules{{Rule: "self == oldSelf", Message: "the field is immutable"}},
+  				},
+  				"projectRef": {Description: " Optional. The project that this resource belongs to.", Type: "object", OneOf: {{Required: {"name"}, Not: &{Required: {"external"}}}, {Required: {"external"}, Not: &{AnyOf: {{Required: {"name"}}, {Required: {"namespace"}}}}}}, Properties: {"external": {Description: "The `projectID` field of a project, when not managed by Config C"..., Type: "string"}, "kind": {Description: "The kind of the Project resource; optional but must be `Project`"..., Type: "string"}, "name": {Description: "The `name` field of a `Project` resource.", Type: "string"}, "namespace": {Description: "The `namespace` field of a `Project` resource.", Type: "string"}}, ...},
+  				"resourceID": {Description: "The APIGatewayAPI name. If not given, the metadata.name will be "..., Type: "string"},
+  			},
+  			AdditionalProperties: nil,
+  			PatternProperties:    nil,
+  			... // 13 identical fields
+  		},
+  		"status": {Description: "APIGatewayAPIStatus defines the config connector machine state o"..., Type: "object", Properties: {"conditions": {Description: "Conditions represent the latest available observations of the ob"..., Type: "array", Items: &{Schema: &{Type: "object", Properties: {"lastTransitionTime": {Description: "Last time the condition transitioned from one status to another.", Type: "string"}, "message": {Description: "Human-readable message indicating details about last transition.", Type: "string"}, "reason": {Description: "Unique, one-word, CamelCase reason for the condition's last tran"..., Type: "string"}, "status": {Description: "Status is the status of the condition. Can be True, False, Unknown.", Type: "string"}, ...}}}}, "externalRef": {Description: "A unique specifier for the APIGatewayAPI resource in GCP.", Type: "string"}, "observedGeneration": {Description: "ObservedGeneration is the generation of the resource that was mo"..., Type: "integer", Format: "int64"}, "observedState": {Description: "ObservedState is the state of the resource as most recently obse"..., Type: "object", Properties: {"createTime": {Description: "Created time.", Type: "string"}, "name": {Description: "Resource name of the API. Format: projects/{project}/locations/g"..., Type: "string"}, "state": {Description: " State of the API.", Type: "string"}, "updateTime": {Description: "Updated time.", Type: "string"}}}}},
+  	},
+  	AdditionalProperties: nil,
+  	PatternProperties:    nil,
+  	... // 13 identical fields
+  }
+


### PR DESCRIPTION
This is for multi-version CRD  code review. 

It keeps both Alpha and Beta versions in the CRD, even if we moved the alpha api (so git-diff is simpler) 

I verified those exception CRDs. Backporting the alpha is expected:

1. `ComputeFirewallPolicyRule` has been defaulted to Scifi, no alpha version. 
2. `GKEHubFeatureMembership` has been defaulted to Scifi, no alpha version. 
3. `Logginlogmetrics` has been defaulted to Scifi, no alpha version. 
4. `StorageAnywhereCare` is a pure SciFi. It removes its Alpha  when promoting to Beta. 
 