### PR TITLE
chore: Remove redundant managed-by-cnrm label

### DIFF
--- a/pkg/controller/direct/compute/forwardingrule/forwardingrule_controller.go
+++ b/pkg/controller/direct/compute/forwardingrule/forwardingrule_controller.go
@@ -106,8 +106,7 @@ func (m *forwardingRuleModel) AdapterForObject(ctx context.Context, reader clien
 	// Get location
 	location := obj.Spec.Location
 
-	// Set label managed-by-cnrm: true
-	obj.ObjectMeta.Labels["managed-by-cnrm"] = "true"
+	
 
 	// Handle TF default values
 	if obj.Spec.LoadBalancingScheme == nil {


### PR DESCRIPTION
The managed-by-cnrm label is already added by the common
labeling function. This change removes the redundant addition
in the forwardingrule controller.
