### PR TITLE
Decide default model during runtime

### DIFF
--- a/dev/tools/controllerbuilder/cmd/ctf/main.go
+++ b/dev/tools/controllerbuilder/cmd/ctf/main.go
@@ -42,7 +42,17 @@ func main() {
 func run(ctx context.Context) error {
 
 	var options llm.Options
-	options.InitDefaults()
+
+	llmClient, err := options.NewLLMClient(ctx)
+	if err != nil {
+		return fmt.Errorf("initializing LLM: %w", err)
+	}
+	defer llmClient.Close()
+
+	err = options.InitDefaultsWithLatestModelIfUnset(ctx, llmClient)
+	if err != nil {
+		return fmt.Errorf("initializing defaults: %w", err)
+	}
 
 	scenario := ""
 	flag.StringVar(&scenario, "scenario", scenario, "scenario to run")
@@ -120,12 +130,6 @@ func run(ctx context.Context) error {
 	if buildResults.ExitCode == 0 {
 		return fmt.Errorf("expected build error from scenario, but got no error")
 	}
-
-	llmClient, err := options.NewLLMClient(ctx)
-	if err != nil {
-		return fmt.Errorf("initializing LLM: %w", err)
-	}
-	defer llmClient.Close()
 
 	u := ui.NewTerminalUI()
 

--- a/dev/tools/controllerbuilder/pkg/llm/options.go
+++ b/dev/tools/controllerbuilder/pkg/llm/options.go
@@ -46,8 +46,9 @@ func (o *Options) InitDefaults() {
 
 func (o *Options) InitDefaultsWithLatestModelIfUnset(ctx context.Context, llmClient gollm.Client) error {
 	model := os.Getenv("LLM_MODEL")
-	if model == "" {
 
+	modelNameSubString := "gemini-2.5-pro"
+	if model == "" {
 		models, err := llmClient.ListModels(ctx)
 		if err != nil {
 			return fmt.Errorf("listing models: %w", err)
@@ -56,11 +57,15 @@ func (o *Options) InitDefaultsWithLatestModelIfUnset(ctx context.Context, llmCli
 		for _, m := range models {
 			// There are many old or experimental models in the list.
 			// Let's use the first `gemini-2.5-pro` model for now.
-			if strings.Contains(m, "gemini-2.5-pro") {
+			if strings.Contains(m, modelNameSubString) {
 				model = m
 				break
 			}
 		}
+	}
+	if model == "" {
+		klog.Errorf("No model containing %q in name found", modelNameSubString)
+		return fmt.Errorf("cannot find model containing %q in name", modelNameSubString)
 	}
 
 	klog.Infof("Using model %v", model)


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 

For example: "Fixes #858"
-->
Our default Gemini model is no longer supported (again). Supported the function to determine the model during runtime instead of hard-coding the default one.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
