### PR TITLE
chore: update propose release instructions and add presubmits for updating crds/ folder

### DIFF
--- a/.gemini/commands/release/propose-release.json
+++ b/.gemini/commands/release/propose-release.json
@@ -1,0 +1,114 @@
+{
+  "name": "propose-release",
+  "description": "Proposes a new release for KCC by generating manifests, updating CRDs, running tests, and creating a release summary.",
+  "steps": [
+    {
+      "name": "Determine Release Versions",
+      "actions": [
+        {
+          "run": "git tag | sort -V | tail -n 1",
+          "id": "get_stale_version"
+        },
+        {
+          "prompt": {
+            "message": "Enter the new version (e.g., if stale is ${get_stale_version.stdout}, the new version is 1.133.0):",
+            "id": "get_version"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Create Release Branch",
+      "actions": [
+        {
+          "run": "git checkout -b release-${get_version.input}"
+        }
+      ]
+    },
+    {
+      "name": "Propose Tag and Update Manifests",
+      "actions": [
+        {
+          "run": "VERSION=${get_version.input} STALE_VERSION=${get_stale_version.stdout} ./dev/tasks/propose-tag"
+        },
+        {
+          "run": "git add ."
+        },
+        {
+          "run": "git commit -m \"Release ${get_version.input}\""
+        }
+      ]
+    },
+    {
+      "name": "Synchronize CRDs",
+      "actions": [
+        {
+          "run": "VERSION=${get_version.input} ./dev/tasks/sync-crds-folder.sh"
+        },
+        {
+          "run": "git add ."
+        },
+        {
+          "run": "git commit -m \"Update alpha CRDs for Release ${get_version.input}\""
+        }
+      ]
+    },
+    {
+      "name": "Run Unit Tests",
+      "actions": [
+        {
+          "run": "cd operator && go test ./pkg/controllers/...",
+          "id": "unit_tests",
+          "on_failure": "continue"
+        },
+        {
+          "if": "${unit_tests.exit_code} != 0",
+          "steps": [
+            {
+              "name": "Update Golden Files",
+              "actions": [
+                {
+                  "run": "cd operator && WRITE_GOLDEN_OUTPUT=\"true\" go test ./pkg/controllers/..."
+                },
+                {
+                  "run": "git add ."
+                },
+                {
+                  "run": "git commit -m \"Update golden files for operator controllers\""
+                },
+                {
+                  "run": "cd operator && go test ./pkg/controllers/..."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Generate Release Summary",
+      "actions": [
+        {
+          "run": "git log -n 3 --pretty=\"format:%H %s\" > commits.log"
+        },
+        {
+          "prompt": {
+            "message": "Please review commits.log and then create a release-summary.md file with a summary of the changes. Once you are done, type 'ok' to continue.",
+            "id": "create_summary"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Push and Finalize",
+      "actions": [
+        {
+          "run": "git push origin release-${get_version.input}"
+        },
+        {
+          "echo": "Pull request URL: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/new/release-${get_version.input}"
+        }
+      ]
+    }
+  ]
+}

--- a/.gemini/commands/release/propose-release.toml
+++ b/.gemini/commands/release/propose-release.toml
@@ -1,0 +1,12 @@
+
+# In: ~/.gemini/commands/release/propose-release.toml
+# Invoked via: /release:propose-release
+# Gemini custom command docs can be found at https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/commands.md#toml-file-format-v1
+
+
+description = "Proposes a new release candidate."
+
+
+prompt = """
+Follow instructsions @.gemini/commands/release/propose-release.json
+"""

--- a/.github/workflows/presubmit-crds.yaml
+++ b/.github/workflows/presubmit-crds.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/presubmit-crds.yaml
+++ b/.github/workflows/presubmit-crds.yaml
@@ -35,6 +35,4 @@ jobs:
           go-version-file: 'go.mod'
       - name: "Verify CRDs folder is up-to-date"
         run: |
-          LATEST_VERSION=$(ls operator/channels/packages/configconnector/ | sort -V | tail -n 1)
-          echo "Latest version found: ${LATEST_VERSION}"
-          VERSION=${LATEST_VERSION} dev/tasks/verify-crds-folder.sh
+          dev/tasks/verify-crds-folder.sh

--- a/.github/workflows/presubmit-crds.yaml
+++ b/.github/workflows/presubmit-crds.yaml
@@ -1,0 +1,40 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Presubmit CRDs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'crds/**'
+  push:
+    branches: ["master"]
+    paths:
+      - 'crds/**'
+
+jobs:
+  verify-crds-folder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: "Verify CRDs folder is up-to-date"
+        run: |
+          LATEST_VERSION=$(ls operator/channels/packages/configconnector/ | sort -V | tail -n 1)
+          echo "Latest version found: ${LATEST_VERSION}"
+          VERSION=${LATEST_VERSION} dev/tasks/verify-crds-folder.sh

--- a/dev/tasks/verify-crds-folder.sh
+++ b/dev/tasks/verify-crds-folder.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev/tasks/verify-crds-folder.sh
+++ b/dev/tasks/verify-crds-folder.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [[ -z "${VERSION:-}" ]]; then
+  echo "VERSION must be set"
+  exit 1
+
+fi
+
+TARGET_CRD_DIR=${REPO_ROOT}/crds
+TEMP_DIR=$(mktemp -td verify-crds-folder.XXXXXXXX)
+CRDS_FILE=${REPO_ROOT}/operator/channels/packages/configconnector/${VERSION}/crds.yaml
+
+LICENSE_HEADER=$(cat << 'EOF'
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# you may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+EOF
+)
+
+if [ ! -f "${CRDS_FILE}" ]; then
+    echo "Error: CRDs file not found at ${CRDS_FILE}"
+    exit 1
+
+fi
+
+# Parse CRDs into individual files
+echo "Splitting manifest ${CRDS_FILE}"
+cd ${REPO_ROOT} && go run -mod=readonly ${REPO_ROOT}/scripts/parse-crds/parse-crds.go \
+    -file ${CRDS_FILE} \
+    -output-dir ${TEMP_DIR}
+
+echo "Adding license headers to split files"
+for filepath in ${TEMP_DIR}/*.yaml; do
+    filename=$(basename -- ${filepath})
+    TMP_FILE=$(mktemp)
+    echo "${LICENSE_HEADER}" > ${TMP_FILE}
+    echo "" >> ${TMP_FILE} # Add a empty line after the license header
+    cat ${filepath} >> ${TMP_FILE}
+    mv ${TMP_FILE} ${filepath}
+
+done
+
+echo "Verifying ${TARGET_CRD_DIR} is up-to-date"
+if ! diff -r -N ${TARGET_CRD_DIR} ${TEMP_DIR}; then
+    echo "Error: The ${TARGET_CRD_DIR} directory is out of date."
+    echo "Please run 'VERSION=${VERSION} dev/tasks/sync-crds-folder.sh' and commit the changes."
+    exit 1
+
+fi
+
+rm -rf ${TEMP_DIR}

--- a/dev/tasks/verify-crds-folder.sh
+++ b/dev/tasks/verify-crds-folder.sh
@@ -20,9 +20,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 if [[ -z "${VERSION:-}" ]]; then
-  echo "VERSION must be set"
-  exit 1
-
+  VERSION=$(ls operator/channels/packages/configconnector/ | sort -V | tail -n 1)
 fi
 
 TARGET_CRD_DIR=${REPO_ROOT}/crds


### PR DESCRIPTION
### Change description

- Update the prompts for propose release candidate.
- Add a script to verify the CRD updates in the crds/ folder
- Add a presubmit test, that is only triggered when changes are made to the crds/ folder

Fixes #

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
