### PR TITLE
fix: Set externalRef on acquisition(part 1)

### DIFF
--- a/dev/tools/controllerbuilder/template/controller/controller.go
+++ b/dev/tools/controllerbuilder/template/controller/controller.go
@@ -255,7 +255,11 @@ func (a *{{.ProtoResource}}Adapter) Update(ctx context.Context, updateOp *direct
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
-	status.ExternalRef = direct.LazyPtr(a.id.String())
+    if a.desired.Status.ExternalRef == nil {
+		// If it is the first reconciliation after switching to direct controller,
+		// or is an acquisition with updates, then fill out the ExternalRef.
+	    status.ExternalRef = direct.LazyPtr(a.id.String())
+    }
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 

--- a/tests/e2e/testdata/scenarios/acquisition/bigqueryconnectionconnection/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/acquisition/bigqueryconnectionconnection/_object01.yaml
@@ -24,6 +24,7 @@ status:
     reason: UpToDate
     status: "True"
     type: Ready
+  externalRef: projects/${projectId}/locations/us-central1/connections/test-bqcc-acquisition
   observedGeneration: 1
   observedState:
     cloudResource:

--- a/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct/_object01.yaml
@@ -26,6 +26,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  externalRef: groups/${groupID}
   name: groups/${groupID}
   observedGeneration: 1
   observedState:

--- a/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct2/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct2/_object01.yaml
@@ -26,6 +26,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  externalRef: groups/${groupID}
   name: groups/${groupID}
   observedGeneration: 1
   observedState:

--- a/tests/e2e/testdata/scenarios/acquisition/cloudidentitymembership/cloudidentitymembership-direct/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/acquisition/cloudidentitymembership/cloudidentitymembership-direct/_object02.yaml
@@ -25,6 +25,7 @@ status:
     status: "True"
     type: Ready
   createTime: "1970-01-01T00:00:00Z"
+  externalRef: groups/${groupID}/memberships/${membershipID}
   observedGeneration: 1
   type: USER
   updateTime: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
### Change description

Inspired by #4843, I noticed that `externalRef` is also missing on acquisition([created resource](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/8df3108ee2c0a35fad67695aec114dd62322fb8d/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct/_object00.yaml#L30) vs [acquired resource](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/8df3108ee2c0a35fad67695aec114dd62322fb8d/tests/e2e/testdata/scenarios/acquisition/cloudidentitygroup/cloudidentitygroup-direct/_object01.yaml)). That could potentially cause issues with referenced resources, because our ref resolver is looking for `externalRef`.

1st commit: update controller template
(todo)followup commits: upon approval of 1st commit, add `externalRef` in **all** existing direct controllers

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
