### PR TITLE
fix: filter sample by service 

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -407,7 +407,7 @@ func ListMatchingSamples(t *testing.T, regex *regexp.Regexp) []SampleKey {
 
 						if strings.HasSuffix(apiGroup, ".cnrm.cloud.google.com") {
 							service := strings.TrimSuffix(apiGroup, ".cnrm.cloud.google.com")
-							if strings.Contains(path, "/"+service+"/") {
+							if strings.Contains(path, service) {
 								shouldPrepend = true
 							}
 						}


### PR DESCRIPTION
### Change description

https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4826/files splits the presubmit sample checks by api groups.

It determines if a filepath is relevant to a api group by checking if the filepath contains the group name. This is based on the documented sample requirement "Files should be named `<service>_<api-version>_<kind>.yaml`. For example,
`pubsub_v1alpha2_pubsubtopic.yaml`." in README.Samples.md

 
<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
