### PR TITLE
llm-eval: run root Gemini CLI (and config) with different KCC repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,4 +176,4 @@ experiments/mcp/**/__pycache__
 experiments/mcp/**/*.egg-info
 
 # MCP eval
-experiments/mcp-eval/**/__pycache__
+experiments/**/__pycache__/

--- a/experiments/llm-eval/main.py
+++ b/experiments/llm-eval/main.py
@@ -156,7 +156,6 @@ if __name__ == "__main__":
         # --- Run with MCP Disabled ---
         print("\n--- Starting Evaluation with MCP Disabled ---")
         no_mcp_evaluator = MCPEvaluator(gemini_cli_path=args.gemini_cli_path, use_mcp=False, log_path=args.log)
-        no_mcp_evaluator.setup_mcp_config()
         for test in test_cases:
             no_mcp_evaluator.run_test_case(**test)
         no_mcp_results_df = no_mcp_evaluator.generate_report()
@@ -166,23 +165,7 @@ if __name__ == "__main__":
     else:
         # --- Run with MCP Enabled ---
         print("--- Starting Evaluation with MCP Enabled ---")
-        mcp_config = {}
-        if args.config_path:
-            config_path = os.path.expanduser(args.config_path)
-            if not os.path.isabs(config_path):
-                config_path = os.path.join(git_root, config_path)
-            
-            with open(config_path, 'r') as f:
-                mcp_config = json.load(f)
-
-            # Make server directories absolute
-            if "mcp_servers" in mcp_config:
-                for server in mcp_config["mcp_servers"]:
-                    if "directory" in server and not os.path.isabs(server["directory"]):
-                        server["directory"] = os.path.join(git_root, server["directory"])
-        
-        mcp_evaluator = MCPEvaluator(gemini_cli_path=args.gemini_cli_path, use_mcp=True, log_path=args.log)
-        mcp_evaluator.setup_mcp_config(mcp_config)
+        mcp_evaluator = MCPEvaluator(gemini_cli_path=args.gemini_cli_path, use_mcp=True, src_mcp_config_path=args.config_path, log_path=args.log)
         for test in test_cases:
             mcp_evaluator.run_test_case(**test)
         mcp_results_df = mcp_evaluator.generate_report()
@@ -194,7 +177,6 @@ if __name__ == "__main__":
         if not args.task:
             print("\n--- Starting Evaluation with MCP Disabled ---")
             no_mcp_evaluator = MCPEvaluator(gemini_cli_path=args.gemini_cli_path, use_mcp=False, log_path=args.log)
-            no_mcp_evaluator.setup_mcp_config()
             for test in test_cases:
                 no_mcp_evaluator.run_test_case(**test)
             no_mcp_results_df = no_mcp_evaluator.generate_report()

--- a/experiments/llm-eval/tasks/beta-promote/BigQueryReservationReservation-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/BigQueryReservationReservation-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="BigQueryReservationReservation-promote-bigqueryreservation"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/llm-eval/tasks/beta-promote/KMSImportJob-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/KMSImportJob-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="KMSImportJob-promote-kms"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/llm-eval/tasks/beta-promote/LoggingLink-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/LoggingLink-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="LoggingLink-promote-logging"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/llm-eval/tasks/beta-promote/MetastoreBackup-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/MetastoreBackup-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="MetastoreBackup-promote-metastore"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/llm-eval/tasks/beta-promote/MetastoreFederation-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/MetastoreFederation-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="MetastoreFederation-promote-metastore"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/llm-eval/tasks/beta-promote/VMwareEngineExternalAddress-promote/setup.sh
+++ b/experiments/llm-eval/tasks/beta-promote/VMwareEngineExternalAddress-promote/setup.sh
@@ -16,4 +16,7 @@
 set -e
 SUBDIR="VMwareEngineExternalAddress-promote-vmwareengine"
 git clone git@github.com:GoogleCloudPlatform/k8s-config-connector.git $SUBDIR
-echo $SUBDIR
+rm -rf $SUBDIR/.gemini # Avoid using git cloned .gemini.
+
+export MCPWorkDir=${SUBDIR} # placeholder. evaluator runs setup.sh as a temp shell. This env var won't take effect when the shell finishes.
+echo ${MCPWorkDir}

--- a/experiments/mcp/criteria/apis.json
+++ b/experiments/mcp/criteria/apis.json
@@ -28,6 +28,6 @@
       "**Completeness**: The YAML must include all required fields as defined in the CRD.",
       "**Correctness**: User-provided configurations must be placed at the correct paths within the YAML structure.",
       "**Validity**: All values, especially names and labels, must adhere to Kubernetes syntax and naming conventions.",
-      "**Minimalism**: The generated YAML should not include optional fields unless they are explicitly requested or required for a specific configuration.",
+      "**Minimalism**: The generated YAML should not include optional fields unless they are explicitly requested or required for a specific configuration."
     ]
   }

--- a/experiments/mcp/src/run.py
+++ b/experiments/mcp/src/run.py
@@ -15,13 +15,16 @@
 import argparse
 import asyncio
 import os
+import subprocess
 from server import MCPForGKEServer
 
 
 def main():
     KUBE_CONFIG_DEFAULT_LOCATION = os.environ.get('KUBECONFIG', '~/.kube/config')
+    MCPWorkDir = os.environ.get('MCPWorkDir', subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], text=True).strip())
 
-    server = MCPForGKEServer(kubeconfig=KUBE_CONFIG_DEFAULT_LOCATION)
+    print(f"Using MCPWorkDir: {MCPWorkDir}")
+    server = MCPForGKEServer(kubeconfig=KUBE_CONFIG_DEFAULT_LOCATION, absDir=MCPWorkDir)
     server.run(transport='stdio')
 
 


### PR DESCRIPTION
### Change description


The "beta-promote" tasks will git-clone a KCC repo under its own dir. We want Gemini to only consider the codebase in the sub dir repo rather than the root repo and make code changes in sub repo.    


#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
