### PR TITLE
tests: wait longer for project creation

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -470,8 +470,8 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 			t.Fatalf("error creating project: %v", err)
 		}
 
-		// Wait for the project to be created, up to 5 seconds.
-		for i := 0; i < 50; i++ {
+		// Wait for the project to be created, up to 10 seconds.
+		for i := 0; i < 100; i++ {
 			if op.Done {
 				break
 			}

--- a/mockgcp/mockgcptests/harness.go
+++ b/mockgcp/mockgcptests/harness.go
@@ -186,7 +186,7 @@ func (t *Harness) Init() {
 			t.Fatalf("error creating project: %v", err)
 		}
 
-		for i := 0; i < 50; i++ {
+		for i := 0; i < 100; i++ {
 			if op.Done {
 				break
 			}


### PR DESCRIPTION
We were observing timeouts at 5 seconds in github actions,
switch to a 10 second timeout.
