### PR TITLE
Fix: Correctly determine sample API group for test filtering

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -89,11 +89,7 @@ func TestAllInSeries(t *testing.T) {
 					dummySample := create.LoadSample(t, sampleKey, testgcp.GCPProject{ProjectID: "test-skip", ProjectNumber: 123456789})
 					create.MaybeSkip(t, sampleKey.Name, dummySample.Resources)
 
-					var group string
-					if len(dummySample.Resources) > 0 {
-						group = dummySample.Resources[0].GroupVersionKind().Group
-					}
-
+					group := dummySample.APIGroup
 					skipTestReason := ""
 					if group != "" {
 						if s := os.Getenv("SKIP_TEST_APIGROUP"); s != "" {


### PR DESCRIPTION
The logic for SKIP_TEST_APIGROUP and ONLY_TEST_APIGROUPS was not working reliably because the API group for a sample was
  determined by the first resource in the sample file, which could be a dependency.

  This change fixes the issue by:
   - Introducing an APIGroup field to the Sample and SampleKey structs.
   - Updating ListMatchingSamples to parse the sample files and identify the main resource by matching the resource kind with the sample's directory name.
   - Extracting the apiGroup from the apiVersion of the main resource.
   - Using the new APIGroup field in the E2E test filtering logic.

  This ensures that the test filtering based on API groups works correctly.

### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
