### PR TITLE
Added docs for running namespace compatability version.

### DIFF
--- a/.gemini/commands/docs/versions.toml
+++ b/.gemini/commands/docs/versions.toml
@@ -1,0 +1,29 @@
+# In: ~/.gemini/commands/docs/versions.toml
+# This command will be invoked via: /docs:versions
+
+description = "Asks the model to generate the docs needed to use version compatability."
+
+prompt = """
+You are a Config Connector and doc writing expert.
+Please write a document explaining how to use the backward compataibility version feature.
+The feature allows a customer to set a desired version for the CNRM in a namespace to operate in.
+The range of such allowed versions for 1.133.0 as example only goes back as far as 1.126.0
+
+Please analyze the following files.
+- @operator/config/crd/bases/core.cnrm.cloud.google.com_configconnectorcontexts.yaml
+
+Please look at the PR https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4898
+
+Please create or update the following files.
+- docs/features/compatabilityversion.md
+
+Your response should include:
+- A table of what versions support what compatability versions.
+- A sample YAML of the type ConfigConnectorContext which highlights the version set to 1.126.0
+
+#### Summary of Changes
+
+- Briefly explain the **purpose** and **nature** of the code changes. What problem is this PR trying
+  to solve?
+- What is the core logic being documented?
+"""

--- a/docs/features/compatabilityversion.md
+++ b/docs/features/compatabilityversion.md
@@ -1,0 +1,53 @@
+# Backward Compatibility Version
+
+The backward compatibility version feature allows you to specify the version of Config Connector that a namespace should align with. This provides a mechanism to opt-out of new features or behavioral changes introduced in newer versions of Config Connector, ensuring stability and a predictable experience during upgrades.
+
+By setting a specific version in the `ConfigConnectorContext` for a namespace, you instruct Config Connector to operate as if it were that older version, but only for the resources within that namespace.
+
+This is particularly useful when you are managing a multi-tenant cluster and want to roll out upgrades incrementally, or if you need to temporarily pin a namespace to an older version to mitigate an issue or a breaking change.
+
+## How it works
+
+You can control this feature by setting the `spec.version` field in the `ConfigConnectorContext` object for a given namespace. When this field is set, the Config Connector controller for that namespace will adapt its behavior to match the specified version.
+
+If the `spec.version` field is not set, the namespace will default to the behavior of the currently installed Config Connector version.
+
+### Example
+
+Here is an example of a `ConfigConnectorContext` resource that pins the namespace to version `1.126.0`:
+
+```yaml
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: your-namespace
+spec:
+  version: "1.126.0"
+  googleServiceAccount: "your-gsa@your-project.iam.gserviceaccount.com"
+```
+
+## Supported Versions
+
+The range of supported backward compatibility versions depends on the version of Config Connector installed. Each version of Config Connector supports a specific range of older versions.
+
+The following table shows an example of the supported compatibility versions for a given installed version of Config Connector.
+
+| Installed KCC Version | Supported Compatibility Versions |
+| --------------------- | -------------------------------- |
+| 1.133.0               | 1.126.0 - 1.133.0                |
+| 1.132.0               | 1.125.0 - 1.132.0                |
+| 1.131.0               | 1.124.0 - 1.131.0                |
+| 1.130.0               | 1.123.0 - 1.130.0                |
+| 1.129.0               | 1.122.0 - 1.129.0                |
+| 1.128.0               | 1.121.0 - 1.128.0                |
+| 1.127.0               | 1.120.0 - 1.127.0                |
+| 1.126.0               | 1.126.0                          |
+
+**Note:** The table above is an example. Please refer to the official release notes for the exact supported version range for your installed version of Config Connector.
+
+## Caveats
+
+- Setting a version outside the supported range will result in an error.
+- This feature should be used as a temporary measure to ensure stability during upgrades, not as a long-term solution to avoid upgrading.
+- While this feature provides backward compatibility, it is always recommended to test your configurations against the latest version of Config Connector in a non-production environment before rolling out upgrades.

--- a/docs/features/compatabilityversion.md
+++ b/docs/features/compatabilityversion.md
@@ -2,15 +2,15 @@
 
 The backward compatibility version feature allows you to specify the version of Config Connector that a namespace should align with. This provides a mechanism to opt-out of new features or behavioral changes introduced in newer versions of Config Connector, ensuring stability and a predictable experience during upgrades.
 
-By setting a specific version in the `ConfigConnectorContext` for a namespace, you instruct Config Connector to operate as if it were that older version, but only for the resources within that namespace.
+By setting a specific version in the `ConfigConnectorContext` for a namespace, you instruct Config Connector to operate at that older version, but only for the resources within that namespace.
 
 This is particularly useful when you are managing a multi-tenant cluster and want to roll out upgrades incrementally, or if you need to temporarily pin a namespace to an older version to mitigate an issue or a breaking change.
 
 ## How it works
 
-You can control this feature by setting the `spec.version` field in the `ConfigConnectorContext` object for a given namespace. When this field is set, the Config Connector controller for that namespace will adapt its behavior to match the specified version.
+You can control this feature by setting the `spec.version` field in the `ConfigConnectorContext` object for a given namespace. When this field is set, the Config Connector controller for that namespace will run the cnrm operator at the specified version.
 
-If the `spec.version` field is not set, the namespace will default to the behavior of the currently installed Config Connector version.
+If the `spec.version` field is not set, the namespace will default to the currently installed Config Connector version.
 
 ### Example
 
@@ -36,13 +36,13 @@ The following table shows an example of the supported compatibility versions for
 | Installed KCC Version | Supported Compatibility Versions |
 | --------------------- | -------------------------------- |
 | 1.133.0               | 1.126.0 - 1.133.0                |
-| 1.132.0               | 1.125.0 - 1.132.0                |
-| 1.131.0               | 1.124.0 - 1.131.0                |
-| 1.130.0               | 1.123.0 - 1.130.0                |
-| 1.129.0               | 1.122.0 - 1.129.0                |
-| 1.128.0               | 1.121.0 - 1.128.0                |
-| 1.127.0               | 1.120.0 - 1.127.0                |
-| 1.126.0               | 1.126.0                          |
+| 1.132.0               | 1.126.0 - 1.132.0                |
+| 1.131.0               | 1.129.2 - 1.131.0                |
+| 1.130.0               | 1.128.0 - 1.130.0                |
+| 1.129.0               | 1.127.0 - 1.129.0                |
+| 1.128.0               | 1.126.0 - 1.128.0                |
+| 1.127.0               | 1.125.0 - 1.127.0                |
+| 1.126.0               | 1.124.0 - 1.126.0                         |
 
 **Note:** The table above is an example. Please refer to the official release notes for the exact supported version range for your installed version of Config Connector.
 


### PR DESCRIPTION
### Change description

Summary of Changes
    
      This change introduces a backward compatibility feature in Config Connector. It allows platform administrators to pin a specific namespace to an older,
      supported version of Config Connector. This is crucial for large, multi-tenant environments where different teams may have different sensitivities to
      upgrades. It allows for a more controlled and gradual rollout of new Config Connector versions, reducing the risk of breaking changes affecting all
      users simultaneously. The core purpose is to enhance stability and provide more granular control over the upgrade process.
    
      The core logic being documented is the new spec.version field within the ConfigConnectorContext custom resource. This field accepts a specific Config
      Connector version string (e.g., "1.126.0"). When this field is set, the Config Connector controllers operating on that namespace will emulate the
      behavior of the specified version, ensuring that resources within that namespace are managed according to the logic of that older version. The
      documentation clarifies how to use this field, provides a sample YAML configuration, and includes a table illustrating the window of supported backward


#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [X] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
Added docs for running namespace compatability version.
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
