### PR TITLE
feat: set GOMEMLIMIT for KCC operator and controller manager

### DIFF
--- a/config/installbundle/components/manager/base/manager.yaml
+++ b/config/installbundle/components/manager/base/manager.yaml
@@ -62,6 +62,9 @@ spec:
         ports:
         # Port used for readiness probe
         - containerPort: 23232
+        env:
+          - name: GOMEMLIMIT
+            value: 460MiB # Set to ~90% of the 512Mi limit
         resources:
           limits:
             memory: 512Mi

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -63,6 +63,9 @@ spec:
         image: operator:latest
         imagePullPolicy: Always
         name: manager
+        env:
+        - name: GOMEMLIMIT
+          value: 900MiB # Set to ~90% of the 1Gi limit
         resources:
           limits:
             memory: 1Gi


### PR DESCRIPTION
It is generally recommended to set `GOMEMLIMIT` to help with OOM kills.
