### PR TITLE
Added a command to find missing label sanitization.

### DIFF
--- a/.gemini/commands/fix/findlabels.toml
+++ b/.gemini/commands/fix/findlabels.toml
@@ -1,0 +1,16 @@
+# In: ~/.gemini/commands/fix/findlabels.toml
+# This command will be invoked via: /fix:findlabels
+
+description = "Asks the model to find direct controllers not sanitizing labels."
+
+prompt = """
+You are a golang, Google Cloud and Config Connector (KCC) expert.
+Please find the set of resources whose Direct Controllers do not use the NewGCPLabelsFromK8sLabels method to sanitize their labels.
+An example of Pull Request which added the sanitization to a Direct Controller is https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4981.
+
+Then make a plan before finding the resources.
+Prioritize Correctness.
+
+Your response should include:
+1. The name of the resource and the direct controller file missing the call to NewGCPLabelsFromK8sLabels.
+"""

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -44,6 +44,21 @@ as the trigger for watching that namespace, and also allows configuration of thi
 
 We often abbreviate ConfigConnectorContext to CCC or "triple-C".
 
+# Resources and Controllers
+
+Each resource is represented by a file under config/crds/resources.
+You can extract the name of the resource by running `cat <file> | yq '.spec.names.kind'` on the file.
+
+Terraform (TF) controllers are represented by files under scripts/resource-autogen/generated/servicemappings.
+If a resource can be found in `cat <file> | yq '.spec.resources.[] | .kind'` then it has a Terraform controller.
+If the config/crds/resources file containing the resource name has the following annotation in it `cat <file> | yq '.metadata.labels."cnrm.cloud.google.com/tf2crd"'` the the Terraform controller is the default controller for that resource.
+
+DCL controllers are supported and the default if the config/crds/resources file containing the resource name has the following annotation in it `cat <file> | yq '.metadata.labels."cnrm.cloud.google.com/dcl2crd"'`.
+
+Direct controllers can be found under pkg/controller/direct.
+The controller will have a file name ending in '_controller.go'.
+The controller will call RegisterModel using a KRM containing the resource name and ending in GVK.
+
 # Options
 
 We have an emerging pattern for configuring options.  The "state-into-spec" option was an early option to demonstrate the pattern.


### PR DESCRIPTION
### Change description

Added hints in GEMINI.md for classifying controller types. Added a custom command to find direct controllers which are missing the call to do label sanitization.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
