### PR TITLE
fix: set observedGeneration of ConfigConnectorContext

### DIFF
--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -205,6 +205,7 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 	status := ccc.GetCommonStatus()
 	status.Healthy = false
 	status.Errors = []string{msg}
+	status.ObservedGeneration = ccc.Generation
 	ccc.SetCommonStatus(status)
 	return r.updateConfigConnectorContextStatus(ctx, ccc)
 }
@@ -223,6 +224,7 @@ func (r *Reconciler) handleReconcileSucceeded(ctx context.Context, nn types.Name
 	status := ccc.GetCommonStatus()
 	status.Healthy = true
 	status.Errors = []string{}
+	status.ObservedGeneration = ccc.Generation
 	ccc.SetCommonStatus(status)
 	return r.updateConfigConnectorContextStatus(ctx, ccc)
 }

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller_test.go
@@ -898,12 +898,6 @@ func TestHandleReconcileFailed(t *testing.T) {
 		t.Fatalf("failed to create ConfigConnectorContext: %v", err)
 	}
 
-	// Manually set the observed generation, simulating the declarative reconciler.
-	ccc.Status.ObservedGeneration = 1
-	if err := c.Status().Update(ctx, ccc); err != nil {
-		t.Fatalf("error updating status: %v", err)
-	}
-
 	reconcileErr := fmt.Errorf("reconciliation error")
 	if err := r.handleReconcileFailed(ctx, nn, reconcileErr); err != nil {
 		t.Errorf("error handling failed reconciliation: %v", err)
@@ -959,12 +953,6 @@ func TestHandleReconcileSucceeded(t *testing.T) {
 	testcontroller.EnsureNamespaceExists(c, "foo-ns")
 	if err := c.Create(ctx, ccc); err != nil {
 		t.Fatalf("failed to create ConfigConnectorContext: %v", err)
-	}
-
-	// Manually set the observed generation, simulating the declarative reconciler.
-	ccc.Status.ObservedGeneration = 1
-	if err := c.Status().Update(ctx, ccc); err != nil {
-		t.Fatalf("error updating status: %v", err)
 	}
 
 	if err := r.handleReconcileSucceeded(ctx, nn); err != nil {


### PR DESCRIPTION
### Change description

The ConfigConnectorContext reconciler implements its own status builder logic, so it needs to set the observedGeneration itself.

Note that some of the other controllers also are not properly setting the observedGeneration, but this change is focused on just fixing ConfigConnectorContext.

See:
- https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/v1.133.0/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go#L133 (Empty `BuildStatusImpl`)
- https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/v1.133.0/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go#L182

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
status.observedGeneration is now being set on the ConfigConnectorContext.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

#### Intended Milestone

1.134

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
