### PR TITLE
chore: fix controllerbuilder to write empty files

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
@@ -51,10 +51,10 @@ func (g *generatorBase) Errorf(msg string, args ...any) {
 }
 
 type generatedFile struct {
-	baseDir     string
-	key         generatedFileKey
-	packageName string
-	body        bytes.Buffer
+	baseDir   string
+	key       generatedFileKey
+	goPackage string
+	body      bytes.Buffer
 
 	fileAnnotation *annotations.FileAnnotation
 
@@ -82,8 +82,8 @@ func (f *generatedFile) addImport(alias string, pkgName string) {
 	f.imports[pkgName] = alias
 }
 
-func (f *generatedFile) Write(addCopyright bool) error {
-	if f.body.Len() == 0 {
+func (f *generatedFile) Write(addCopyright bool, writeEmptyFiles bool) error {
+	if f.body.Len() == 0 && !writeEmptyFiles {
 		return nil
 	}
 
@@ -104,8 +104,8 @@ func (f *generatedFile) Write(addCopyright bool) error {
 		fmt.Fprintf(&w, "%s\n", s)
 	}
 
-	if f.packageName != "" {
-		fmt.Fprintf(&w, "package %s\n", f.packageName)
+	if f.goPackage != "" {
+		fmt.Fprintf(&w, "package %s\n", f.goPackage)
 		fmt.Fprintf(&w, "\n")
 	}
 
@@ -131,9 +131,9 @@ func (f *generatedFile) Write(addCopyright bool) error {
 	return nil
 }
 
-func (g *generatorBase) WriteFiles(addCopyright bool) error {
+func (g *generatorBase) WriteFiles(addCopyright bool, writeEmptyFiles bool) error {
 	for _, f := range g.generatedFiles {
-		if err := f.Write(addCopyright); err != nil {
+		if err := f.Write(addCopyright, writeEmptyFiles); err != nil {
 			return err
 		}
 	}

--- a/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
@@ -191,7 +191,7 @@ func (v *MapperGenerator) GenerateMappers() error {
 			FileName:  "mapper.generated.go",
 		}
 		out := v.getOutputFile(k)
-		out.packageName = lastGoComponent(goPackage)
+		out.goPackage = lastGoComponent(goPackage)
 
 		out.fileAnnotation = v.generatedFileAnnotation
 

--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -129,13 +128,13 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 			continue
 		}
 
-		krmVersion := filepath.Base(g.goPackage)
-
 		k := generatedFileKey{
 			GoPackage: g.goPackage,
 			FileName:  "types.generated.go",
 		}
 		out := g.getOutputFile(k)
+
+		out.goPackage = lastGoComponent(g.goPackage)
 
 		out.fileAnnotation = g.generatedFileAnnotation
 
@@ -159,8 +158,6 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 			continue
 		}
 
-		out.packageName = krmVersion
-
 		WriteMessage(&out.body, msg)
 	}
 	return errors.Join(g.errors...)
@@ -173,13 +170,12 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 			continue
 		}
 
-		krmVersion := filepath.Base(g.goPackage)
-
 		k := generatedFileKey{
 			GoPackage: g.goPackage,
 			FileName:  "types.generated.go",
 		}
 		out := g.getOutputFile(k)
+		out.goPackage = lastGoComponent(g.goPackage)
 
 		out.fileAnnotation = g.generatedFileAnnotation
 
@@ -202,8 +198,6 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 			klog.Infof("found existing non-generated go type with proto tag %q, won't generate", msg.FullName())
 			continue
 		}
-
-		out.packageName = krmVersion
 
 		WriteOutputMessage(&out.body, msgDetails)
 	}

--- a/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatemapper/generatemappercommand.go
@@ -149,7 +149,8 @@ func RunGenerateMapper(ctx context.Context, o *GenerateMapperOptions) error {
 	}
 
 	addCopyright := true
-	if err := mapperGenerator.WriteFiles(addCopyright); err != nil {
+	writeEmptyFiles := true
+	if err := mapperGenerator.WriteFiles(addCopyright, writeEmptyFiles); err != nil {
 		return err
 	}
 

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -185,7 +185,8 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 	}
 
 	addCopyright := true
-	if err := typeGenerator.WriteFiles(addCopyright); err != nil {
+	writeEmptyFiles := true
+	if err := typeGenerator.WriteFiles(addCopyright, writeEmptyFiles); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Otherwise when we had no generated types left, we were leaving the old file behind.
