### PR TITLE
[direct][SpannerInstance] Unmanaged the DefaultBackupScheduleType field if not set

### DIFF
--- a/pkg/controller/direct/spanner/instance_controller.go
+++ b/pkg/controller/direct/spanner/instance_controller.go
@@ -229,7 +229,8 @@ func (a *SpannerInstanceAdapter) Update(ctx context.Context, updateOp *directbas
 		updateMask.Paths = append(updateMask.Paths, "labels")
 	}
 
-	if !reflect.DeepEqual(resource.DefaultBackupScheduleType, a.actual.DefaultBackupScheduleType) {
+	// if defaultBackupScheduleType is not set in spec, the field become unmanaged.
+	if a.desired.Spec.DefaultBackupScheduleType != nil && !reflect.DeepEqual(resource.DefaultBackupScheduleType, a.actual.DefaultBackupScheduleType) {
 		updateMask.Paths = append(updateMask.Paths, "default_backup_schedule_type")
 	}
 

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-autoscaling-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-autoscaling-direct/_http.log
@@ -260,7 +260,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-${uniqueId}
 
 {
-  "fieldMask": "displayName,defaultBackupScheduleType,autoscalingConfig",
+  "fieldMask": "displayName,autoscalingConfig",
   "instance": {
     "autoscalingConfig": {
       "autoscalingLimits": {
@@ -308,6 +308,7 @@ X-Xss-Protection: 0
       },
       "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "Autoscaling Instance Updated",
       "edition": 2,
       "instanceType": 1,
@@ -369,6 +370,7 @@ X-Xss-Protection: 0
       },
       "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "Autoscaling Instance Updated",
       "edition": "ENTERPRISE",
       "instanceType": "PROVISIONED",
@@ -407,6 +409,7 @@ X-Xss-Protection: 0
     },
     "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "Autoscaling Instance Updated",
     "edition": "ENTERPRISE",
     "instanceType": "PROVISIONED",
@@ -459,6 +462,7 @@ X-Xss-Protection: 0
   },
   "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "Autoscaling Instance Updated",
   "edition": 2,
   "instanceType": 1,

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-basic-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-basic-direct/_http.log
@@ -215,7 +215,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
 
 {
-  "fieldMask": "displayName,defaultBackupScheduleType",
+  "fieldMask": "displayName",
   "instance": {
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "displayName": "New Spanner Instance Sample",
@@ -243,6 +243,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "New Spanner Instance Sample",
       "edition": 1,
       "instanceType": 1,
@@ -295,6 +296,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "New Spanner Instance Sample",
       "edition": "STANDARD",
       "instanceType": "PROVISIONED",
@@ -324,6 +326,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "New Spanner Instance Sample",
     "edition": "STANDARD",
     "instanceType": "PROVISIONED",
@@ -367,6 +370,7 @@ X-Xss-Protection: 0
 {
   "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "New Spanner Instance Sample",
   "edition": 1,
   "instanceType": 1,

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-direct/_http.log
@@ -215,7 +215,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
 
 {
-  "fieldMask": "displayName,nodeCount,labels,defaultBackupScheduleType",
+  "fieldMask": "displayName,nodeCount,labels",
   "instance": {
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "displayName": "New Spanner Instance Sample",
@@ -244,6 +244,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "New Spanner Instance Sample",
       "edition": 1,
       "instanceType": 1,
@@ -296,6 +297,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "New Spanner Instance Sample",
       "edition": "STANDARD",
       "instanceType": "PROVISIONED",
@@ -325,6 +327,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "New Spanner Instance Sample",
     "edition": "STANDARD",
     "instanceType": "PROVISIONED",
@@ -368,6 +371,7 @@ X-Xss-Protection: 0
 {
   "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "New Spanner Instance Sample",
   "edition": 1,
   "instanceType": 1,

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-downgrade-edition-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-downgrade-edition-direct/_http.log
@@ -216,7 +216,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
 
 {
-  "fieldMask": "displayName,defaultBackupScheduleType",
+  "fieldMask": "displayName",
   "instance": {
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "displayName": "New Instance Sample",
@@ -245,6 +245,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "New Instance Sample",
       "edition": 2,
       "instanceType": 1,
@@ -297,6 +298,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "New Instance Sample",
       "edition": "ENTERPRISE",
       "instanceType": "PROVISIONED",
@@ -326,6 +328,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "New Instance Sample",
     "edition": "ENTERPRISE",
     "instanceType": "PROVISIONED",
@@ -387,6 +390,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "New Instance Sample",
       "edition": 1,
       "instanceType": 1,
@@ -439,6 +443,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "New Instance Sample",
       "edition": "STANDARD",
       "instanceType": "PROVISIONED",
@@ -468,6 +473,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "New Instance Sample",
     "edition": "STANDARD",
     "instanceType": "PROVISIONED",
@@ -511,6 +517,7 @@ X-Xss-Protection: 0
 {
   "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "New Instance Sample",
   "edition": 1,
   "instanceType": 1,

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-processingunits-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-processingunits-direct/_http.log
@@ -210,7 +210,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-${uniqueId}
 
 {
-  "fieldMask": "displayName,processingUnits,defaultBackupScheduleType",
+  "fieldMask": "displayName,processingUnits",
   "instance": {
     "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
     "displayName": "Spanner Instance Updated",
@@ -238,6 +238,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "Spanner Instance Updated",
       "edition": 1,
       "instanceType": 1,
@@ -289,6 +290,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "Spanner Instance Updated",
       "edition": "STANDARD",
       "instanceType": "PROVISIONED",
@@ -317,6 +319,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "Spanner Instance Updated",
     "edition": "STANDARD",
     "instanceType": "PROVISIONED",
@@ -359,6 +362,7 @@ X-Xss-Protection: 0
 {
   "config": "projects/${projectId}/instanceConfigs/regional-us-central1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "Spanner Instance Updated",
   "edition": 1,
   "instanceType": 1,

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-unset-compute-fields-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-unset-compute-fields-direct/_http.log
@@ -215,7 +215,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
 
 {
-  "fieldMask": "displayName,defaultBackupScheduleType",
+  "fieldMask": "displayName",
   "instance": {
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "displayName": "New spanner Instance Sample",
@@ -244,6 +244,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
       "displayName": "New spanner Instance Sample",
       "edition": 1,
       "instanceType": 1,
@@ -296,6 +297,7 @@ X-Xss-Protection: 0
     "instance": {
       "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
       "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
       "displayName": "New spanner Instance Sample",
       "edition": "STANDARD",
       "instanceType": "PROVISIONED",
@@ -325,6 +327,7 @@ X-Xss-Protection: 0
     "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
     "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
     "displayName": "New spanner Instance Sample",
     "edition": "STANDARD",
     "instanceType": "PROVISIONED",
@@ -368,6 +371,7 @@ X-Xss-Protection: 0
 {
   "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
   "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
   "displayName": "New spanner Instance Sample",
   "edition": 1,
   "instanceType": 1,


### PR DESCRIPTION
### Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
- Fix spanner instance direct controller to ignore `DefaultBackupScheduleType` set by API if not set in spec.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
