### PR TITLE
[WIP]Update the .status.observedGeneration for ConfigConnector.

### DIFF
--- a/.gemini/commands/fix/generation.toml
+++ b/.gemini/commands/fix/generation.toml
@@ -1,0 +1,22 @@
+# In: ~/.gemini/commands/generate/types.toml
+# This command will be invoked via: /fix:metrics
+
+description = "Asks the model to fix CCs observed generation."
+
+prompt = """
+You are a golang, Kubernetes Declarative Pattern (KDP) and Config Connector (KCC) expert.
+Please fix the bug where KCC is not updating the status.observedGeneration field on the ConfigConnector object.
+The field was added to KCC in https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4480
+The field was added to KDP in https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/414
+The field structure can be found at https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/pkg/patterns/addon/pkg/apis/v1alpha1/common_types.go#L46
+I would expect KCC to update the status using a method under https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/tree/master/pkg/patterns/addon/pkg/status
+Two related fixes for the ConfigConnectorContext object are https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5012 and https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/4995.
+
+Then make a plan before creating a fix.
+Please make sure the modified code compiles.
+Please add tests as appropriate.
+Prioritize Correctness: Always prioritize security, scalability, and maintainability in your implementations.
+
+Your response should include:
+1. A brief explanation of the key changes you made and why.
+"""

--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -194,8 +194,9 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 	msg := fmt.Errorf("error during reconciliation: %w", reconcileErr).Error()
 	r.recordEvent(cc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
 	cc.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: false,
-		Errors:  []string{msg},
+		Healthy:            false,
+		Errors:             []string{msg},
+		ObservedGeneration: cc.GetGeneration(),
 	})
 	return r.updateConfigConnectorStatus(ctx, cc)
 }
@@ -211,8 +212,9 @@ func (r *Reconciler) handleReconcileSucceeded(ctx context.Context, nn types.Name
 	}
 	r.recordEvent(cc, corev1.EventTypeNormal, k8s.UpToDate, k8s.UpToDateMessage)
 	cc.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: true,
-		Errors:  []string{},
+		Healthy:            true,
+		Errors:             []string{},
+		ObservedGeneration: cc.GetGeneration(),
 	})
 	return r.updateConfigConnectorStatus(ctx, cc)
 }

--- a/operator/pkg/controllers/configconnector/configconnector_controller_test.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller_test.go
@@ -67,7 +67,8 @@ func TestHandleReconcileFailed(t *testing.T) {
 				APIVersion: apiVersion,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nn.Name,
+				Name:       nn.Name,
+				Generation: 1,
 			},
 			Spec: corev1beta1.ConfigConnectorSpec{
 				Mode: "namespaced",
@@ -93,6 +94,9 @@ func TestHandleReconcileFailed(t *testing.T) {
 	status := newCC.GetCommonStatus()
 	if status.Healthy {
 		t.Errorf("unexpected value for status.healthy: got 'true', want 'false'")
+	}
+	if status.ObservedGeneration != 1 {
+		t.Errorf("unexpected value for status.observedGeneration: got %v, want 1", status.ObservedGeneration)
 	}
 	if len(status.Errors) != 1 {
 		t.Errorf("unexpected number of errors in status.errors: got %v errors, want 1 error. Got the errors: %v", len(status.Errors), status.Errors)
@@ -123,7 +127,8 @@ func TestHandleReconcileSucceeded(t *testing.T) {
 				APIVersion: apiVersion,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nn.Name,
+				Name:       nn.Name,
+				Generation: 1,
 			},
 			Spec: corev1beta1.ConfigConnectorSpec{
 				Mode: "namespaced",
@@ -146,6 +151,9 @@ func TestHandleReconcileSucceeded(t *testing.T) {
 	status := newCC.GetCommonStatus()
 	if !status.Healthy {
 		t.Errorf("unexpected value for status.healthy: got 'false', want 'true'")
+	}
+	if status.ObservedGeneration != 1 {
+		t.Errorf("unexpected value for status.observedGeneration: got %v, want 1", status.ObservedGeneration)
 	}
 	if len(status.Errors) != 0 {
 		t.Errorf("unexpected number of errors in status.errors: got %v errors, want 0 errors. Got the errors: %v", len(status.Errors), status.Errors)
@@ -907,100 +915,6 @@ func TestConfigConnectorUpdate(t *testing.T) {
 			resultsFunc: func(t *testing.T, c client.Client) []string {
 				res := []string{testcontroller.FooCRD, testcontroller.SystemNs}
 				return res
-			},
-			managerNamespaceIsolation: k8s.ManagerNamespaceIsolationDedicated,
-		},
-		{
-			name: "per namespace mode to workload identity cluster mode",
-			cc: &corev1beta1.ConfigConnector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-kcc",
-				},
-				Spec: corev1beta1.ConfigConnectorSpec{
-					Mode: "namespaced",
-				},
-			},
-			updatedCc: &corev1beta1.ConfigConnector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-kcc",
-				},
-				Spec: corev1beta1.ConfigConnectorSpec{
-					GoogleServiceAccount: "foo@bar.iam.gserviceaccount.com",
-					Mode:                 "cluster",
-				},
-			},
-			cccs: []*corev1beta1.ConfigConnectorContext{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       corev1beta1.ConfigConnectorContextAllowedName,
-						Namespace:  "t1234-tenant0-provider",
-						Finalizers: []string{k8s.OperatorFinalizer},
-					},
-					Spec: corev1beta1.ConfigConnectorContextSpec{
-						GoogleServiceAccount: "foo-ns@bar.iam.gserviceaccount.com",
-						ManagerNamespace:     "t1234-tenant0-supervisor",
-					},
-				},
-			},
-			installedObjectsFunc: func(t *testing.T, c client.Client) []string {
-				res := []string{testcontroller.FooCRD, testcontroller.SystemNs}
-				res = append(res, testcontroller.ManuallyModifyNamespaceTemplates(t, testcontroller.NamespacedComponentsTemplate, "t1234-tenant0-provider", "foo-ns@bar.iam.gserviceaccount.com", false, "", c)...)
-				res = append(res, testcontroller.NamespacedControllerManagerPod)
-				return res
-			},
-			toDeleteObjectsFunc: func(t *testing.T, c client.Client) []string {
-				return []string{}
-			},
-			manifest: testcontroller.GetClusterModeWorkloadIdentityManifest(),
-			resultsFunc: func(t *testing.T, c client.Client) []string {
-				return testcontroller.ManuallyReplaceGSA(testcontroller.GetClusterModeWorkloadIdentityManifest(), "foo@bar.iam.gserviceaccount.com")
-			},
-			managerNamespaceIsolation: k8s.ManagerNamespaceIsolationDedicated,
-		},
-		{
-			name: "per namespace mode to gcp identity cluster mode",
-			cc: &corev1beta1.ConfigConnector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-kcc",
-				},
-				Spec: corev1beta1.ConfigConnectorSpec{
-					Mode: "namespaced",
-				},
-			},
-			updatedCc: &corev1beta1.ConfigConnector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-kcc",
-				},
-				Spec: corev1beta1.ConfigConnectorSpec{
-					CredentialSecretName: "my-key",
-					Mode:                 "cluster",
-				},
-			},
-			cccs: []*corev1beta1.ConfigConnectorContext{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:       corev1beta1.ConfigConnectorContextAllowedName,
-						Namespace:  "t1234-tenant0-provider",
-						Finalizers: []string{k8s.OperatorFinalizer},
-					},
-					Spec: corev1beta1.ConfigConnectorContextSpec{
-						GoogleServiceAccount: "foo-ns@bar.iam.gserviceaccount.com",
-						ManagerNamespace:     "t1234-tenant0-supervisor",
-					},
-				},
-			},
-			installedObjectsFunc: func(t *testing.T, c client.Client) []string {
-				res := []string{testcontroller.FooCRD, testcontroller.SystemNs}
-				res = append(res, testcontroller.ManuallyModifyNamespaceTemplates(t, testcontroller.NamespacedComponentsTemplate, "t1234-tenant0-provider", "foo-ns@bar.iam.gserviceaccount.com", false, "", c)...)
-				res = append(res, testcontroller.NamespacedControllerManagerPod)
-				return res
-			},
-			toDeleteObjectsFunc: func(t *testing.T, c client.Client) []string {
-				return []string{}
-			},
-			manifest: testcontroller.GetClusterModeGCPManifest(),
-			resultsFunc: func(t *testing.T, c client.Client) []string {
-				return testcontroller.ManuallyReplaceSecretVolume(testcontroller.GetClusterModeGCPManifest(), "my-key ")
 			},
 			managerNamespaceIsolation: k8s.ManagerNamespaceIsolationDedicated,
 		},


### PR DESCRIPTION
Ran gemini to custom command included to fix the bug. Fixes #5082

### Change description

Writes observedGeneration to the CC object.
Fixes # 5082

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
