### PR TITLE
fix: remove unused imports from mapper-generator

### DIFF
--- a/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/pkg/annotations"
+	"golang.org/x/tools/imports"
 	"k8s.io/klog/v2"
 )
 
@@ -123,8 +124,14 @@ func (f *generatedFile) Write(addCopyright bool, writeEmptyFiles bool) error {
 	f.body.WriteTo(&w)
 
 	p := filepath.Join(dir, f.key.FileName)
+	formatted, err := imports.Process(p, w.Bytes(), nil)
+	if err != nil {
+		klog.Errorf("error from goimports processing file %q:\n%s", p, w.String())
+		return fmt.Errorf("running goimports on %q: %w", p, err)
+	}
+
 	klog.Infof("writing file %v", p)
-	if err := os.WriteFile(p, w.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(p, formatted, 0644); err != nil {
 		return fmt.Errorf("writing %q: %w", p, err)
 	}
 


### PR DESCRIPTION
### Change description
Issue found in #5046. Output after this change https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5046/commits/c326e72a5552393c419250e1e18511f9710a63fd
<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
