### PR TITLE
Adding container resource CRD documentation.

### DIFF
--- a/.gemini/commands/docs/memory.toml
+++ b/.gemini/commands/docs/memory.toml
@@ -1,0 +1,26 @@
+# In: ~/.gemini/commands/docs/versions.toml
+# This command will be invoked via: /docs:versions
+
+description = "Asks the model to generate the docs needed to use version compatability."
+
+prompt = """
+You are a Config Connector and doc writing expert.
+Please write a document explaining how to configure more memory or CPU for a KCC pod.
+Background for this feature can be found at https://cloud.google.com/config-connector/docs/how-to/customizing-container-resources
+You should explain how to use both ControllerResource and NamespacedControllerResource.
+Please detail all the configuration options.
+Please detail which pods can be configured this way.
+
+Please create or update the following files.
+- docs/features/containerresource.md
+
+Your response should include:
+- A table of which pods support this.
+- A sample YAML of the configuration types with a full example of configurations.
+
+#### Summary of Changes
+
+- Briefly explain the **purpose** and **nature** of the code changes. What problem is this PR trying
+  to solve?
+- What is the core logic being documented?
+"""

--- a/docs/features/containerresource.md
+++ b/docs/features/containerresource.md
@@ -1,0 +1,121 @@
+# Customizing Container Resources
+
+You can customize the CPU and memory resource requests and limits for Config Connector pods. You can also customize the number of replicas for the `cnrm-webhook-manager`.
+
+There are two ways to configure container resources, depending on whether you are running Config Connector in cluster mode or namespaced mode.
+
+- **Cluster Mode:** Use a `ControllerResource` object to configure resources for all Config Connector pods in the cluster.
+- **Namespaced Mode:** Use a `NamespacedControllerResource` object to configure resources for Config Connector pods in a specific namespace.
+
+## Configurable Pods and Containers
+
+The following table lists the pods and containers that can be configured.
+
+| Pod                      | Container Name      |
+| ------------------------ | ------------------- |
+| `cnrm-controller-manager`| `manager`           |
+| `cnrm-webhook-manager`   | `webhook`           |
+| `cnrm-deletion-defender` | `deletiondefender`  |
+| `cnrm-recorder`          | `recorder`          |
+| `cnrm-unmanaged-detector`| `unmanageddetector` |
+| `prom-to-sd`             | `prom-to-sd`        |
+
+## Configuring Resources in Cluster Mode
+
+To customize resources in cluster mode, create a `ControllerResource` object. The `metadata.name` of the `ControllerResource` object must match the name of the pod you are configuring.
+
+### Example: Customizing `cnrm-controller-manager`
+
+The following example shows how to customize the CPU and memory for the `manager` container in the `cnrm-controller-manager` pod.
+
+```yaml
+apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+kind: ControllerResource
+metadata:
+  name: cnrm-controller-manager
+spec:
+  containers:
+    - name: manager
+      resources:
+        limits:
+          cpu: 200m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+```
+
+### Example: Customizing `cnrm-webhook-manager` and Replicas
+
+The following example shows how to customize the memory for the `webhook` container in the `cnrm-webhook-manager` pod and set the number of replicas to 4.
+
+```yaml
+apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+kind: ControllerResource
+metadata:
+  name: cnrm-webhook-manager
+spec:
+  replicas: 4
+  containers:
+    - name: webhook
+      resources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 256Mi
+```
+
+## Configuring Resources in Namespaced Mode
+
+To customize resources in namespaced mode, create a `NamespacedControllerResource` object. The `metadata.name` of the `NamespacedControllerResource` object must match the name of the pod you are configuring, and the `metadata.namespace` must match the namespace of the Config Connector installation.
+
+### Example: Customizing `cnrm-controller-manager` in a specific namespace
+
+The following example shows how to customize the CPU and memory for the `manager` container in the `cnrm-controller-manager` pod in the `config-control` namespace.
+
+```yaml
+apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+kind: NamespacedControllerResource
+metadata:
+  name: cnrm-controller-manager # name should not contain the namespace ID suffix
+  namespace: config-control
+spec:
+  containers:
+    - name: manager
+      resources:
+        limits:
+          cpu: 200m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+```
+
+## Configuration Options
+
+### ControllerResourceSpec
+
+| Field      | Description                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `containers` | A list of containers whose resource requirements to be customized.                                                                     |
+| `replicas`   | The number of desired replicas of the config connector controller. This field takes effect only if the controller name is "cnrm-webhook-manager". |
+
+### NamespacedControllerResourceSpec
+
+| Field      | Description                                                                                                                            |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `containers` | A list of containers whose resource requirements to be customized.                                                                     |
+
+### ContainerResourceSpec
+
+| Field       | Description                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| `name`      | The name of the container whose resource requirements will be customized. |
+| `resources` | Specifies the resource customization of this container.                  |
+
+### ResourceRequirements
+
+| Field      | Description                                                                                                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limits`   | Describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/                                                     |
+| `requests` | Describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. |


### PR DESCRIPTION
### Change description

This PR introduces documentation on customizing KCC pod container resources. It explains using
  ControllerResource and NamespacedControllerResource to manage CPU, memory, and replicas for KCC controllers.
  The document covers configurable pods, YAML examples for cluster and namespace scopes, and all configuration
  options, fulfilling the need for clear feature documentation. The docs/features/containerresource.md file has
  been created, and the task is now complete.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
