### PR TITLE
chore: adapt maputil functions to fit mapper-generator 

### DIFF
--- a/pkg/controller/direct/maputils.go
+++ b/pkg/controller/direct/maputils.go
@@ -493,20 +493,6 @@ func UInt64Value_ToProto(mapCtx *MapContext, in *uint64) *wrapperspb.UInt64Value
 	return out
 }
 
-func BytesValue_FromProto(mapCtx *MapContext, in *wrapperspb.BytesValue) []byte {
-	if in == nil {
-		return nil
-	}
-	return in.Value
-}
-
-func BytesValue_ToProto(mapCtx *MapContext, in []byte) *wrapperspb.BytesValue {
-	if in == nil {
-		return nil
-	}
-	return wrapperspb.Bytes(in)
-}
-
 // Convert a number of milliseconds since the Unix epoch to a time.Time.
 // Treat an input of zero specially: convert it to the zero time,
 // rather than the start of the epoch.


### PR DESCRIPTION
### Change description
mapper-generator uses the built-in functions from the maputil, but expect the in and out to be pointers. Without this change, we have to move the functions (if not using pointer) out of the auto-mapper file .


<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
