### PR TITLE
test: Update runtime field in CloudFunctionsFunction to a supported value

### DIFF
--- a/config/samples/resources/cloudfunctionsfunction/eventtrigger-with-pubsubtopic/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
+++ b/config/samples/resources/cloudfunctionsfunction/eventtrigger-with-pubsubtopic/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
@@ -22,7 +22,10 @@ spec:
     external: "projects/${PROJECT_ID?}"
   description: "A sample cloud function with an event trigger from PubSubTopic and a VPCAccessConnector"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   serviceAccountRef:
     # Replace ${PROJECT_ID?} with your project ID

--- a/config/samples/resources/cloudfunctionsfunction/eventtrigger-with-storagebucket/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
+++ b/config/samples/resources/cloudfunctionsfunction/eventtrigger-with-storagebucket/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
@@ -22,7 +22,10 @@ spec:
     external: "projects/${PROJECT_ID?}"
   description: "A sample cloud function with an event trigger from StorageBucket"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   eventTrigger:

--- a/config/samples/resources/cloudfunctionsfunction/httpstrigger/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
+++ b/config/samples/resources/cloudfunctionsfunction/httpstrigger/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
@@ -21,7 +21,10 @@ spec:
     # Replace ${PROJECT_ID?} with your project ID
     external: "projects/${PROJECT_ID?}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   httpsTrigger:

--- a/config/samples/resources/identityplatformconfig/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
+++ b/config/samples/resources/identityplatformconfig/cloudfunctions_v1beta1_cloudfunctionsfunction.yaml
@@ -18,7 +18,10 @@ metadata:
   name: identityplatformconfig-dep
 spec:
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   sourceArchiveUrl: "gs://aaa-dont-delete-dcl-cloud-functions-testing/http_trigger.zip"
   timeout: "60s"

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/_generated_object_eventfunction.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/_generated_object_eventfunction.golden.yaml
@@ -34,7 +34,10 @@ spec:
     external: projects/${projectId}
   region: us-west2
   resourceID: cloudfunctionsfunction-${uniqueId}
-  runtime: nodejs10
+  # This field needs to be updated per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: nodejs20
   serviceAccountRef:
     external: ${projectId}@appspot.gserviceaccount.com
   sourceRepository:

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/_http.log
@@ -442,7 +442,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
   },
   "maxInstances": 10,
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "serviceAccountEmail": "${projectId}@appspot.gserviceaccount.com",
   "sourceRepository": {
     "url": "https://source.developers.google.com/projects//repos/kcc-cloud-functions/moveable-aliases/main"
@@ -505,7 +505,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "minInstances": 0,
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
   "network": "",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "secretEnvironmentVariables": [],
   "secretVolumes": [],
   "serviceAccountEmail": "${projectId}@appspot.gserviceaccount.com",
@@ -543,7 +543,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "maxInstances": 7,
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "timeout": "120s",
   "vpcConnector": "projects/${projectId}/locations/us-west2/connectors/c-2-${uniqueId}",
   "vpcConnectorEgressSettings": "ALL_TRAFFIC"
@@ -604,7 +604,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "minInstances": 0,
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
   "network": "",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "secretEnvironmentVariables": [],
   "secretVolumes": [],
   "serviceAccountEmail": "${projectId}@appspot.gserviceaccount.com",

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/create.yaml
@@ -22,7 +22,10 @@ spec:
   projectRef:
     external: "projects/${projectId}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   description: "A sample cloud function with an event trigger"
   availableMemoryMb: 128
   serviceAccountRef:

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/eventfunction/update.yaml
@@ -22,7 +22,10 @@ spec:
   projectRef:
     external: "projects/${projectId}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   description: "An updated sample cloud function with an event trigger"
   availableMemoryMb: 256
   serviceAccountRef:

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_generated_object_httpsfunction.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_generated_object_httpsfunction.golden.yaml
@@ -20,7 +20,7 @@ spec:
     external: projects/${projectId}
   region: us-west2
   resourceID: cloudfunctionsfunction-${uniqueId}
-  runtime: nodejs10
+  runtime: nodejs20
   sourceArchiveUrl: gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip
   timeout: 120s
 status:

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_http.log
@@ -27,7 +27,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "managed-by-cnrm": "true"
   },
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "sourceArchiveUrl": "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
 }
 
@@ -77,7 +77,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "minInstances": 0,
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
   "network": "",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "secretEnvironmentVariables": [],
   "secretVolumes": [],
   "serviceAccountEmail": "",
@@ -103,7 +103,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
     "cnrm-test": "true",
     "managed-by-cnrm": "true"
   },
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "timeout": "120s",
   "vpcConnectorEgressSettings": "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"
 }
@@ -154,7 +154,7 @@ Grpc-Metadata-Content-Type: application/grpc
   "minInstances": 0,
   "name": "projects/${projectId}/locations/us-west2/functions/cloudfunctionsfunction-${uniqueId}",
   "network": "",
-  "runtime": "nodejs10",
+  "runtime": "nodejs20",
   "secretEnvironmentVariables": [],
   "secretVolumes": [],
   "serviceAccountEmail": "",

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_vcr_cassettes/nontf.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/_vcr_cassettes/nontf.yaml
@@ -125,7 +125,7 @@ interactions:
       host: cloudfunctions.googleapis.com
       remote_addr: ""
       request_uri: ""
-      body: '{"entryPoint":"helloGET","httpsTrigger":{"securityLevel":"SECURE_OPTIONAL"},"labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"name":"projects/example-project/locations/us-west2/functions/cloudfunctionsfunction-1xnjudyudz13f","runtime":"nodejs10","sourceArchiveUrl":"gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"}'
+      body: '{"entryPoint":"helloGET","httpsTrigger":{"securityLevel":"SECURE_OPTIONAL"},"labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"name":"projects/example-project/locations/us-west2/functions/cloudfunctionsfunction-1xnjudyudz13f","runtime":"nodejs20","sourceArchiveUrl":"gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"}'
       form: {}
       headers:
         Content-Type:
@@ -159,7 +159,7 @@ interactions:
                 "cnrm-test": "true",
                 "managed-by-cnrm": "true"
               },
-              "runtime": "nodejs10"
+              "runtime": "nodejs20"
             },
             "versionId": "1",
             "updateTime": "2024-04-25T01:20:32Z"
@@ -216,7 +216,7 @@ interactions:
                 "cnrm-test": "true",
                 "managed-by-cnrm": "true"
               },
-              "runtime": "nodejs10"
+              "runtime": "nodejs20"
             },
             "versionId": "1",
             "updateTime": "2024-04-25T01:21:42Z",
@@ -244,7 +244,7 @@ interactions:
               "cnrm-test": "true",
               "managed-by-cnrm": "true"
             },
-            "runtime": "nodejs10",
+            "runtime": "nodejs20",
             "ingressSettings": "ALLOW_ALL",
             "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
             "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -303,7 +303,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -361,7 +361,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -419,7 +419,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -477,7 +477,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -535,7 +535,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -593,7 +593,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -651,7 +651,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -709,7 +709,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -767,7 +767,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
           "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -791,7 +791,7 @@ interactions:
       host: cloudfunctions.googleapis.com
       remote_addr: ""
       request_uri: ""
-      body: '{"availableMemoryMb":256,"ingressSettings":"ALLOW_ALL","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"runtime":"nodejs10","timeout":"120s"}'
+      body: '{"availableMemoryMb":256,"ingressSettings":"ALLOW_ALL","labels":{"cnrm-test":"true","managed-by-cnrm":"true"},"runtime":"nodejs20","timeout":"120s"}'
       form: {}
       headers:
         Content-Type:
@@ -832,7 +832,7 @@ interactions:
                 "cnrm-test": "true",
                 "managed-by-cnrm": "true"
               },
-              "runtime": "nodejs10",
+              "runtime": "nodejs20",
               "ingressSettings": "ALLOW_ALL",
               "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
               "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -901,7 +901,7 @@ interactions:
                 "cnrm-test": "true",
                 "managed-by-cnrm": "true"
               },
-              "runtime": "nodejs10",
+              "runtime": "nodejs20",
               "ingressSettings": "ALLOW_ALL",
               "buildId": "5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
               "buildName": "projects/123456789/locations/us-west2/builds/5aeba6a2-b6fa-4219-a634-e24cd84f86d9",
@@ -934,7 +934,7 @@ interactions:
               "cnrm-test": "true",
               "managed-by-cnrm": "true"
             },
-            "runtime": "nodejs10",
+            "runtime": "nodejs20",
             "ingressSettings": "ALLOW_ALL",
             "buildId": "68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
             "buildName": "projects/123456789/locations/us-west2/builds/68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
@@ -993,7 +993,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
           "buildName": "projects/123456789/locations/us-west2/builds/68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
@@ -1051,7 +1051,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
           "buildName": "projects/123456789/locations/us-west2/builds/68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
@@ -1109,7 +1109,7 @@ interactions:
             "cnrm-test": "true",
             "managed-by-cnrm": "true"
           },
-          "runtime": "nodejs10",
+          "runtime": "nodejs20",
           "ingressSettings": "ALLOW_ALL",
           "buildId": "68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",
           "buildName": "projects/123456789/locations/us-west2/builds/68a7d30b-fc3f-404d-a4a5-1e4b63ec71c1",

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/create.yaml
@@ -20,7 +20,10 @@ spec:
   projectRef:
     external: "projects/${projectId}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   httpsTrigger:

--- a/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/cloudfunctions/v1beta1/cloudfunctionsfunction/httpsfunction/update.yaml
@@ -20,7 +20,10 @@ spec:
   projectRef:
     external: "projects/${projectId}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   timeout: "120s"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudfunctioncomputeregionnetworkendpointgroup/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudfunctioncomputeregionnetworkendpointgroup/dependencies.yaml
@@ -20,6 +20,9 @@ spec:
   projectRef:
     external: "projects/${projectId}"
   region: us-central1
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
   runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"

--- a/pkg/test/resourcefixture/testdata/basic/identityplatform/v1beta1/identityplatformconfig/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/identityplatform/v1beta1/identityplatformconfig/dependencies.yaml
@@ -27,7 +27,10 @@ metadata:
   name: cloudfunctionsfunction-1-${uniqueId}
 spec:
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   timeout: "60s"
@@ -45,7 +48,10 @@ metadata:
   name: cloudfunctionsfunction-2-${uniqueId}
 spec:
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   timeout: "60s"

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudfunctions/cloudfunctionsfunction.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/cloudfunctions/cloudfunctionsfunction.md
@@ -750,7 +750,10 @@ spec:
     external: "projects/${PROJECT_ID?}"
   description: "A sample cloud function with an event trigger from PubSubTopic and a VPCAccessConnector"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   serviceAccountRef:
     # Replace ${PROJECT_ID?} with your project ID
@@ -830,7 +833,10 @@ spec:
     external: "projects/${PROJECT_ID?}"
   description: "A sample cloud function with an event trigger from StorageBucket"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   eventTrigger:
@@ -882,7 +888,10 @@ spec:
     # Replace ${PROJECT_ID?} with your project ID
     external: "projects/${PROJECT_ID?}"
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   httpsTrigger:

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeregionnetworkendpointgroup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeregionnetworkendpointgroup.md
@@ -528,7 +528,10 @@ spec:
     # Replace ${PROJECT_ID?} with your project ID
     external: "projects/${PROJECT_ID?}"
   region: us-west1
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   sourceArchiveUrl: "gs://config-connector-samples/cloudfunctionsfunction/http_trigger.zip"
   entryPoint: "helloGET"
   httpsTrigger:

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformconfig.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/identityplatform/identityplatformconfig.md
@@ -1559,7 +1559,10 @@ metadata:
   name: identityplatformconfig-dep
 spec:
   region: "us-west2"
-  runtime: "nodejs10"
+  # This field needs to be updated to a supported 1st gen version per the service team
+  # support schedule: https://cloud.google.com/functions/docs/runtime-support#support_schedule
+  # Deprecated runtime version will cause googleapis error
+  runtime: "nodejs20"
   availableMemoryMb: 128
   sourceArchiveUrl: "gs://aaa-dont-delete-dcl-cloud-functions-testing/http_trigger.zip"
   timeout: "60s"


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Update runtime field in CloudFunctionsFunction to a supported value according to https://cloud.google.com/functions/docs/runtime-support#support_schedule 

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done
`eventfunction` is still disabled due to permission issue: https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/80ac6a127ad02a9c94c5572a51778d26969566c3/pkg/test/constants/constants.go#L31

go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests httpsfunction  -timeout 900s

--- PASS: TestCreateNoChangeUpdateDelete (0.13s)
    --- PASS: TestCreateNoChangeUpdateDelete/cloudfunctions (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/cloudfunctions/basic-httpsfunction (348.33s)
PASS

go test -v -tags=integration ./pkg/controller/dynamic/ -test.run TestCreateNoChangeUpdateDelete -run-tests cloudfunctioncomputeregionnetworkendpointgroup  -timeout 900s

--- PASS: TestCreateNoChangeUpdateDelete (0.14s)
    --- PASS: TestCreateNoChangeUpdateDelete/compute (0.00s)
        --- PASS: TestCreateNoChangeUpdateDelete/compute/basic-cloudfunctioncomputeregionnetworkendpointgroup (196.40s)
PASS



- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
