### PR TITLE
Add MaterializedView to MockGCP

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -903,6 +903,7 @@ func MaybeSkip(t *testing.T, name string, resources []*unstructured.Unstructured
 			case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableInstance"}:
 			case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableTable"}:
 			case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableLogicalView"}:
+			case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableMaterializedView"}:
 
 			case schema.GroupKind{Group: "cloudfunctions.cnrm.cloud.google.com", Kind: "CloudFunctionsFunction"}:
 			case schema.GroupKind{Group: "cloudids.cnrm.cloud.google.com", Kind: "CloudIDSEndpoint"}:

--- a/mockgcp/mockbigtable/materializedview.go
+++ b/mockgcp/mockbigtable/materializedview.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +tool:mockgcp-support
+// proto.service: google.bigtable.admin.v2.BigtableInstanceAdmin
+// proto.message: google.bigtable.admin.v2.MaterializedView
+
+package mockbigtable
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/pkg/storage"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	// Note: we use the "real" proto (not mockgcp), because the client uses GRPC.
+	pb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+)
+
+func (s *instanceAdminServer) GetMaterializedView(ctx context.Context, req *pb.GetMaterializedViewRequest) (*pb.MaterializedView, error) {
+	name, err := s.parseMaterializedViewName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.MaterializedView{}
+	if err := s.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "%v not found", name)
+		}
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func (s *instanceAdminServer) CreateMaterializedView(ctx context.Context, req *pb.CreateMaterializedViewRequest) (*longrunningpb.Operation, error) {
+	reqName := req.Parent + "/materializedViews/" + req.MaterializedViewId
+	name, err := s.parseMaterializedViewName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := ProtoClone(req.MaterializedView)
+	obj.Name = fqn
+	obj.Etag = "abcdef0123A="
+
+	if err := s.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	metadata := &pb.CreateMaterializedViewMetadata{
+		StartTime:       timestamppb.Now(),
+		OriginalRequest: req,
+	}
+	zone := "us-west1-a"
+	prefix := fmt.Sprintf("operations/%s/locations/%s", name.String(), zone)
+
+	return s.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.New(time.Now().Add(5 * time.Minute))
+		return obj, nil
+	})
+
+}
+
+func (s *instanceAdminServer) UpdateMaterializedView(ctx context.Context, req *pb.UpdateMaterializedViewRequest) (*longrunningpb.Operation, error) {
+	name, err := s.parseMaterializedViewName(req.GetMaterializedView().GetName())
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	existing := &pb.MaterializedView{}
+	if err := s.storage.Get(ctx, fqn, existing); err != nil {
+		return nil, err
+	}
+
+	updated := ProtoClone(existing)
+
+	// Required. The set of fields to update.
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "update_mask must be provided")
+	}
+
+	for _, path := range paths {
+		switch path {
+		case "query":
+			// Query is immutable. Ignore.
+			continue
+		case "deletion_protection":
+			updated.DeletionProtection = req.MaterializedView.DeletionProtection
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not valid", path)
+		}
+	}
+
+	if err := s.storage.Update(ctx, fqn, updated); err != nil {
+		return nil, err
+	}
+
+	zone := "us-west1-a"
+	prefix := fmt.Sprintf("operations/%s/locations/%s", name.String(), zone)
+
+	metadata := &pb.UpdateMaterializedViewMetadata{
+		StartTime:       timestamppb.Now(),
+		OriginalRequest: req,
+		EndTime:         timestamppb.New(time.Now().Add(5 * time.Minute)),
+	}
+	return s.operations.DoneLRO(ctx, prefix, metadata, updated)
+}
+
+func (s *instanceAdminServer) ListMaterializedViews(ctx context.Context, req *pb.ListMaterializedViewsRequest) (*pb.ListMaterializedViewsResponse, error) {
+	instanceName, err := s.parseInstanceName(req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+
+	materializedView, err := s.listMaterializedViewsForInstance(ctx, instanceName)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &pb.ListMaterializedViewsResponse{}
+	response.MaterializedViews = materializedView
+
+	return response, nil
+}
+
+func (s *instanceAdminServer) listMaterializedViewsForInstance(ctx context.Context, instanceName *instanceName) ([]*pb.MaterializedView, error) {
+	if instanceName.InstanceName == "-" {
+		return nil, fmt.Errorf("mock does not implement ListMaterializedViews for wildcard instances")
+	}
+
+	var response []*pb.MaterializedView
+
+	findKind := (&pb.MaterializedView{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, findKind, storage.ListOptions{
+		Prefix: instanceName.String() + "/materializedViews/",
+	}, func(obj proto.Message) error {
+		materializedView := obj.(*pb.MaterializedView)
+		response = append(response, materializedView)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(response, func(i, j int) bool {
+		return response[i].Name < response[j].Name
+	})
+
+	return response, nil
+}
+
+func (s *instanceAdminServer) DeleteMaterializedView(ctx context.Context, req *pb.DeleteMaterializedViewRequest) (*emptypb.Empty, error) {
+	name, err := s.parseMaterializedViewName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	deleted := &pb.MaterializedView{}
+	if err := s.storage.Delete(ctx, fqn, deleted); err != nil {
+		return nil, err
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+type materializedViewName struct {
+	instanceName
+	MaterializedView string
+}
+
+func (n *materializedViewName) String() string {
+	return fmt.Sprintf("projects/%s/instances/%s/materializedViews/%s", n.Project.ID, n.InstanceName, n.MaterializedView)
+}
+
+// parseMaterializedViewName parses a string into a materializedViewName.
+// The expected form is `projects/*/instances/*/materializedViews/*`.
+func (s *instanceAdminServer) parseMaterializedViewName(name string) (*materializedViewName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 6 && tokens[0] == "projects" && tokens[2] == "instances" && tokens[4] == "materializedViews" {
+		instanceName, err := s.parseInstanceName(strings.Join(tokens[0:4], "/"))
+		if err != nil {
+			return nil, err
+		}
+
+		name := &materializedViewName{
+			instanceName:     *instanceName,
+			MaterializedView: tokens[5],
+		}
+
+		return name, nil
+	}
+
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+}

--- a/mockgcp/mockbigtable/testdata/materializedview/crud/script.yaml
+++ b/mockgcp/mockbigtable/testdata/materializedview/crud/script.yaml
@@ -1,0 +1,18 @@
+# Test for `gcloud bigtable materialized-views`
+# Create resources
+- exec: gcloud bigtable instances create test-instance-${uniqueId} --display-name=test-instance --cluster-config=id=test-cluster-${uniqueId},zone=us-west1-a
+- exec: gcloud bigtable tables create test-table --instance=test-instance-${uniqueId} --column-families="family1,family2"
+
+- exec: gcloud bigtable materialized-views create test-materialized-view-${uniqueId} --instance=test-instance-${uniqueId} --query="SELECT _key, COUNT(*) as count from test-table group by _key;" --deletion-protection=true
+- exec: gcloud bigtable materialized-views describe test-materialized-view-${uniqueId} --instance=test-instance-${uniqueId}
+
+# Change deletion protection
+- exec: gcloud bigtable materialized-views update test-materialized-view-${uniqueId} --instance=test-instance-${uniqueId} --deletion-protection=false
+- exec: gcloud bigtable materialized-views describe test-materialized-view-${uniqueId} --instance=test-instance-${uniqueId}
+
+- exec: gcloud bigtable materialized-views list --instance=test-instance-${uniqueId}
+
+# Delete resources
+- exec: gcloud bigtable materialized-views delete test-materialized-view-${uniqueId} --instance=test-instance-${uniqueId} --quiet
+- exec: gcloud bigtable tables delete test-table --instance=test-instance-${uniqueId} --quiet
+- exec: gcloud bigtable instances delete test-instance-${uniqueId} --quiet

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/create.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigtable.cnrm.cloud.google.com/v1alpha1
+kind: BigtableMaterializedView
+metadata:
+  name: mv-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/ignore-warnings: "true"
+spec:
+  # resourceId: mv-${uniqueId}
+  instanceRef:
+    name: mvdep${uniqueId}
+  query: "SELECT _key, COUNT(*) as count from test-table group by _key;"
+  deletionProtection: true

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/dependencies.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+kind: BigtableInstance
+metadata:
+  name: mvdep${uniqueId}
+spec:
+  displayName: BigtableSampleMV
+  cluster:
+  - clusterId: cluster1-${uniqueId}
+    zone: us-west1-a
+    numNodes: 1
+---
+apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+kind: BigtableTable
+metadata:
+  name: test-table
+spec:
+  columnFamily:
+  - family: family1
+  - family: family2
+  instanceRef:
+    name: mvdep${uniqueId}
+  splitKeys:
+  - a

--- a/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/bigtable/v1alpha1/bigtablematerializedview/update.yaml
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: bigtable.cnrm.cloud.google.com/v1alpha1
+kind: BigtableMaterializedView
+metadata:
+  name: mv-${uniqueId}
+  annotations:
+    cnrm.cloud.google.com/ignore-warnings: "true"
+spec:
+  instanceRef:
+    name: mvdep${uniqueId}
+  deletionProtection: false

--- a/tests/e2e/ratcheting.go
+++ b/tests/e2e/ratcheting.go
@@ -120,6 +120,7 @@ func ShouldTestRereconiliation(t *testing.T, testName string, primaryResource *u
 	case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableGCPolicy"}:
 	case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableInstance"}:
 	case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableLogicalView"}:
+	case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableMaterializedView"}:
 	case schema.GroupKind{Group: "bigtable.cnrm.cloud.google.com", Kind: "BigtableTable"}:
 	case schema.GroupKind{Group: "billingbudgets.cnrm.cloud.google.com", Kind: "BillingBudgetsBudget"}:
 	case schema.GroupKind{Group: "binaryauthorization.cnrm.cloud.google.com", Kind: "BinaryAuthorizationAttestor"}:


### PR DESCRIPTION
### BRIEF Change description

Adding mockgcp tests for new MaterializedView APIs. New APIs will be added in a following PR

Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
