### PR TITLE
Add BigtableMaterializedView Mapper

### DIFF
--- a/pkg/controller/direct/bigtable/mapper.generated.go
+++ b/pkg/controller/direct/bigtable/mapper.generated.go
@@ -161,6 +161,26 @@ func BigtableLogicalViewObservedState_ToProto(mapCtx *direct.MapContext, in *krm
 		return nil
 	}
 	out := &pb.LogicalView{}
+	// MISSING: Name
+	// MISSING: Etag
+	// MISSING: DeletionProtection
+	return out
+}
+func BigtableMaterializedViewObservedState_FromProto(mapCtx *direct.MapContext, in *pb.MaterializedView) *krmv1alpha1.BigtableMaterializedViewObservedState {
+	if in == nil {
+		return nil
+	}
+	out := &krmv1alpha1.BigtableMaterializedViewObservedState{}
+	// MISSING: Name
+	// MISSING: Etag
+	return out
+}
+func BigtableMaterializedViewObservedState_ToProto(mapCtx *direct.MapContext, in *krmv1alpha1.BigtableMaterializedViewObservedState) *pb.MaterializedView {
+	if in == nil {
+		return nil
+	}
+	out := &pb.MaterializedView{}
+	// MISSING: Name
 	// MISSING: Etag
 	return out
 }

--- a/pkg/controller/direct/bigtable/materializedview_mapper.go
+++ b/pkg/controller/direct/bigtable/materializedview_mapper.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +generated:mapper
+// krm.group: bigtable.cnrm.cloud.google.com
+// krm.version: v1beta1
+// proto.service: google.bigtable.admin.v2
+
+package bigtable
+
+import (
+	pb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+	krmv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/bigtable/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+)
+
+func BigtableMaterializedViewSpec_FromProto(mapCtx *direct.MapContext, in *pb.MaterializedView) *krmv1alpha1.BigtableMaterializedViewSpec {
+	if in == nil {
+		return nil
+	}
+	out := &krmv1alpha1.BigtableMaterializedViewSpec{}
+	_, resourceID, _ := krmv1alpha1.ParseMaterializedViewExternal(in.Name)
+	out.ResourceID = &resourceID
+	out.Query = &in.Query
+
+	out.DeletionProtection = &in.DeletionProtection
+	return out
+}
+
+func BigtableMaterializedViewSpec_ToProto(mapCtx *direct.MapContext, in *krmv1alpha1.BigtableMaterializedViewSpec) *pb.MaterializedView {
+	if in == nil {
+		return nil
+	}
+	out := &pb.MaterializedView{
+		Query:              *in.Query,
+		DeletionProtection: *in.DeletionProtection,
+	}
+	return out
+}


### PR DESCRIPTION
### BRIEF Change description

[[STEP 3](docs/develop-resources/scenarios/new-resource.md)] Adding mapper for BigtableMaterializedView.

New materialized view APIs were added in #5282. 

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
