### PR TITLE
tests: reuse normalizer for exported KRM object

### DIFF
--- a/tests/e2e/export.go
+++ b/tests/e2e/export.go
@@ -144,8 +144,9 @@ func exportResource(h *create.Harness, obj *unstructured.Unstructured, expectati
 		}
 	}
 
-	output := h.MustReadFile(outputPath)
-	return string(output)
+	outputBytes := h.MustReadFile(outputPath)
+	output := string(outputBytes)
+	return output
 }
 
 func exportResourceAsUnstructured(h *create.Harness, obj *unstructured.Unstructured) *unstructured.Unstructured {

--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -38,7 +38,14 @@ import (
 
 const PlaceholderTimestamp = "2024-04-01T12:34:56.123456Z"
 
-func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project testgcp.GCPProject, folderID string, uniqueID string) error {
+func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project testgcp.GCPProject, folderID string, uniqueID string) {
+	visitor := buildKRMNormalizer(t, u, project, folderID, uniqueID)
+	if err := visitor.VisitUnstructured(u); err != nil {
+		t.Fatalf("failed to normalize KRM object: %v", err)
+	}
+}
+
+func buildKRMNormalizer(t *testing.T, u *unstructured.Unstructured, project testgcp.GCPProject, folderID string, uniqueID string) *objectWalker {
 	replacements := NewReplacements()
 	findLinksInKRMObject(t, replacements, u)
 
@@ -618,7 +625,7 @@ func normalizeKRMObject(t *testing.T, u *unstructured.Unstructured, project test
 		})
 	}
 
-	return visitor.VisitUnstructured(u)
+	return visitor
 }
 
 func setStringAtPath(m map[string]any, atPath string, newValue string) error {
@@ -1029,9 +1036,7 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 	events.PrettifyJSON(func(requestURL string, obj map[string]any) {
 		u := &unstructured.Unstructured{}
 		u.Object = obj
-		if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
-			t.Fatalf("error from normalizeObject: %v", err)
-		}
+		normalizeKRMObject(t, u, project, folderID, uniqueID)
 	})
 
 	// Apply replacements

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -362,9 +362,7 @@ func TestE2EScript(t *testing.T) {
 							t.Logf("ignoring failure to export resource of gvk %v", exportResource.GroupVersionKind())
 							// t.Errorf("failed to export resource of gvk %v", exportResource.GroupVersionKind())
 						} else {
-							if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
-								t.Fatalf("error from normalizeObject: %v", err)
-							}
+							normalizeKRMObject(t, u, project, folderID, uniqueID)
 							got, err := yaml.Marshal(u)
 							if err != nil {
 								t.Errorf("failed to convert kube object to yaml: %v", err)
@@ -385,9 +383,7 @@ func TestE2EScript(t *testing.T) {
 						if err := h.GetClient().Get(ctx, id, u); err != nil {
 							t.Errorf("failed to get kube object: %v", err)
 						} else {
-							if err := normalizeKRMObject(t, u, project, folderID, uniqueID); err != nil {
-								t.Fatalf("error from normalizeObject: %v", err)
-							}
+							normalizeKRMObject(t, u, project, folderID, uniqueID)
 							got, err := yaml.Marshal(u)
 							if err != nil {
 								t.Errorf("failed to convert kube object to yaml: %v", err)


### PR DESCRIPTION
The object we export from the kube-apiserver has more information
than when we export the object, particularly because we do not export
status.

Reuse the normalizer for the kube-apiserver object, because many
fields will be more easily extracted from the status,
in particular identity fields.
