### PR TITLE
docs: add release notes for 1.137.0

### DIFF
--- a/docs/releasenotes/release-1.137.md
+++ b/docs/releasenotes/release-1.137.md
@@ -1,0 +1,47 @@
+# Release 1.137.0
+
+*   Special shout-outs to 600lyy, acpana, anhdle-sso, gemmahou, georgecma, justinsb, maqiuyujoyce, shavonz, xiaoweim, yuwenma for their contributions to this release.
+
+## New Beta Resources (Direct Reconciler):
+
+*   `DocumentAIProcessorVersion`
+*   `EssentialContactsContact`
+*   `BigQueryBigLakeTable`
+*   `BackupDRBackupPlan`
+
+## New Alpha Resources (Direct Reconciler):
+
+*   `BigtableMaterializedView`
+
+## New Fields:
+
+*   `BigtableMaterializedView`: Added `spec.sourceTableRef` and `spec.definition`.
+*   `BackupDRBackupPlan`: Added `spec.backupConfig.retentionPeriodDays` and `spec.backupConfig.backupWindow`.
+*   `MemorystoreInstance`: Added support for `MEMCACHE` and `REDIS` instance types.
+
+## Reconciliation Improvements:
+
+*   Enabled opt-in for IAM partial policy management.
+*   Enabled server-side apply for KMS resources.
+*   Improved reconciliation for `BigtableLogicalView` by using deep reflection.
+*   Improved reconciliation for `FirestoreDatabase` with identity pattern and export support.
+*   Improved reconciliation for `RunJob` with export support.
+*   Unified `ComputeTargetTCPProxy` direct API and controller.
+
+## New features:
+
+*   Added a preview command to see the changes that will be applied by Config Connector.
+*   Added resource reconciliation tracking and early termination for the preview manager.
+
+## Bug Fixes:
+
+*   Fixed an issue where `ComputeBackendService` backends were not sorted.
+*   Fixed an issue where `CloudFunctionsFunction` runtime was not a supported value.
+*   Fixed an issue with labels for `BackupDRBackupPlan`.
+*   Fixed an issue with labels for `RunJob`.
+*   Fixed a fuzzing issue for `FirestoreField`.
+*   Fixed an issue with `KMSCryptoKey` import.
+*   Fixed a flakiness issue in the `MonitoringDashboard` fuzzer.
+*   Fixed a flakiness issue in tests.
+*   Fixed an issue with bad labels in tests.
+*   Fixed an issue with etag in direct reconciliation.


### PR DESCRIPTION
### BRIEF Change description

Release notes for 1.137.0

#### WHY do we need this change?

#### Special notes for your reviewer:

Using gemini command `/release:release-notes v1.136.1 v1.137.0` to generate the release notes.

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
