### PR TITLE
Change trigger on release tag creation workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,8 +19,6 @@ on:
     branches:
       - master
       - 'release-*'
-    paths:
-      - 'version/VERSION'
 
 jobs:
   tag-release:
@@ -34,10 +32,20 @@ jobs:
         with:
           # We need to fetch all tags to see if the tag already exists.
           fetch-depth: 0
+      # Check if version/VERSION was changed
+      - name: "Check for version change"
+        id: check_version
+        run: |
+          # Compare the list of changed files between the last two commits
+          if git diff --name-only HEAD~1 HEAD | grep -q "version/VERSION"; then
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          fi
       - name: "Set git user"
+        if: steps.check_version.outputs.version_changed == 'true'
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions Release Tagger"
       - name: "Run tag script"
+        if: steps.check_version.outputs.version_changed == 'true'
         run: |
           ./dev/tasks/auto-tag-on-version-update.sh


### PR DESCRIPTION
### BRIEF Change description

The workflow did not get triggered when we merge release PRs. For example [Release PR 137](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5433), and [Github Action Tag Release](https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/workflows/tag-release.yml) did not get triggered. 

I suspect it is related to this long standing Github issue: https://github.com/orgs/community/discussions/57830. When too many files are changes in one PR, the `paths` fails to check all the file change path to match to the workflow and trigger the necessary workflow.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
