### PR TITLE
Improve the cherry-pick script to make it more debuggable and robust

### DIFF
--- a/dev/tasks/cherry-pick
+++ b/dev/tasks/cherry-pick
@@ -15,7 +15,13 @@ import json
 
 def run(cmd):
     print(f"Running command: {' '.join(cmd)}")
-    return subprocess.run(cmd, check=True, capture_output=True, text=True)
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with exit code {e.returncode}")
+        print(f"Stderr: {e.stderr}")
+        print(f"Stdout: {e.stdout}")
+        raise
 
 
 def main():
@@ -39,9 +45,41 @@ def main():
     github_username = run(["gh", "api", "user", "-q", ".login"]).stdout.strip()
     user_fork = f"https://github.com/{github_username}/k8s-config-connector"
 
+    # Clean up any leftover branches from previous runs
+    print("Cleaning up potentially stale local and remote branches...")
+    try:
+        run(["git", "branch", "-D", branch_name])
+        print(f"Successfully deleted stale local branch '{branch_name}'.")
+    except subprocess.CalledProcessError as e:
+        if "not found" in e.stderr:
+            print(f"Local branch '{branch_name}' did not exist, which is clean. Continuing.")
+        elif "used by worktree" in e.stderr:
+            print(f"Branch '{branch_name}' is locked by an orphaned worktree. Please clean it up manually.")
+            print("Run 'git worktree list' to see orphaned worktrees.")
+            print("Run 'git worktree remove --force <path>' to remove it.")
+            sys.exit(1)
+        else:
+            print(f"An unexpected error occurred while deleting the local branch:")
+            print(f"Stderr: {e.stderr}")
+            raise
+
+    try:
+        run(["git", "push", user_fork, "--delete", branch_name])
+        print(f"Successfully deleted stale remote branch '{branch_name}'.")
+    except subprocess.CalledProcessError as e:
+        if "remote ref does not exist" in e.stderr:
+            print(f"Remote branch '{branch_name}' did not exist, which is clean. Continuing.")
+        else:
+            print(f"An unexpected error occurred while deleting the remote branch:")
+            print(f"Stderr: {e.stderr}")
+            raise
+
     # Create a temporary worktree
-    with tempfile.TemporaryDirectory() as tmpdir:
-        run(["git", "worktree", "add", "-b", branch_name, tmpdir, release_branch])
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # We base the new branch on the upstream branch to ensure it's clean
+        run(["git", "worktree", "add", "-b", branch_name, tmpdir, f"upstream/{release_branch}"])
+        # run(["git", "worktree", "add", "-b", branch_name, tmpdir, release_branch])
         os.chdir(tmpdir)
 
         # Cherry-pick the commits
@@ -55,7 +93,9 @@ def main():
         pr_output = run(["gh", "pr", "create", "--title", pr_title, "--body", pr_body, "--base", release_branch, "--head", f"{github_username}:{branch_name}"]).stdout.strip()
         print(f"Created PR for cherry-pick: {pr_output}")
 
+    finally:
         # Remove the worktree
+        print("Cleaning up worktree...")
         os.chdir(repo_root)
         run(["git", "worktree", "remove", tmpdir, "--force"])
 


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fix the rough edges in the cherry-pick script. It is a bit chatty right now but we can always add --verbose flag in the future.

* Print out detailed exception trace when the script fail.
* Clean up the existing branch and worktree before restart the cherrypicking - a bad state might exist due to previous failures.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
