### PR TITLE
chore: include signal in context-cancellation error

### DIFF
--- a/cmd/deletiondefender/main.go
+++ b/cmd/deletiondefender/main.go
@@ -22,6 +22,7 @@ import (
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -37,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	// Ensure built-in types are registered.
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
@@ -46,7 +46,7 @@ import (
 var logger = crlog.Log.WithName("setup")
 
 func main() {
-	stop := signals.SetupSignalHandler()
+	ctx := contexts.SetupSignalHandler()
 
 	var enablePprof bool
 	var pprofPort int
@@ -123,5 +123,5 @@ func main() {
 	log.Println("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(stop))
+	log.Fatal(mgr.Start(ctx))
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	controllermetrics "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/metrics"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/ratelimiter"
@@ -40,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	// Ensure built-in types are registered.
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
@@ -49,9 +49,7 @@ import (
 var logger = crlog.Log.WithName("setup")
 
 func main() {
-	ctx := context.Background()
-
-	stop := signals.SetupSignalHandler()
+	ctx := contexts.SetupSignalHandler()
 
 	var (
 		prometheusScrapeEndpoint string
@@ -142,7 +140,7 @@ func main() {
 	logger.Info("Starting the Cmd.")
 
 	// Start the Cmd
-	logging.Fatal(mgr.Start(stop), "error during manager execution.")
+	logging.Fatal(mgr.Start(ctx), "error during manager execution.")
 }
 
 func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string) (manager.Manager, error) {

--- a/cmd/unmanageddetector/main.go
+++ b/cmd/unmanageddetector/main.go
@@ -21,6 +21,7 @@ import (
 	_ "net/http/pprof" // Needed to allow pprof server to accept requests
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -36,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	// Ensure built-in types are registered.
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
@@ -45,7 +45,7 @@ import (
 var logger = log.Log.WithName("setup")
 
 func main() {
-	stop := signals.SetupSignalHandler()
+	ctx := contexts.SetupSignalHandler()
 
 	var enablePprof bool
 	var pprofPort int
@@ -125,5 +125,5 @@ func main() {
 	logger.Info("Starting the Cmd.")
 
 	// Start the Cmd
-	logging.Fatal(mgr.Start(stop), "error during manager execution")
+	logging.Fatal(mgr.Start(ctx), "error during manager execution")
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcp/profiler"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/logging"
@@ -42,7 +43,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	// Ensure built-in types are registered.
@@ -52,7 +52,7 @@ import (
 var logger = crlog.Log.WithName("setup")
 
 func main() {
-	stop := signals.SetupSignalHandler()
+	ctx := contexts.SetupSignalHandler()
 
 	var enablePprof bool
 	var pprofPort int
@@ -160,7 +160,7 @@ func main() {
 	log.Printf("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(stop))
+	log.Fatal(mgr.Start(ctx))
 }
 
 func waitForHTTPServerToAcceptRequests(host string, port int, timeout time.Duration) error {

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/registration"
@@ -34,7 +35,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	// Register direct controllers
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
@@ -235,7 +235,7 @@ var testDisabledList = map[string]bool{
 }
 
 func TestAll(t *testing.T) {
-	ctx, ctxCancel := context.WithCancel(signals.SetupSignalHandler())
+	ctx, ctxCancel := context.WithCancel(contexts.SetupSignalHandler())
 	t.Cleanup(func() {
 		ctxCancel()
 	})

--- a/pkg/cli/preview/preview.go
+++ b/pkg/cli/preview/preview.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/kccmanager/nocache"
@@ -183,7 +184,7 @@ func (i *PreviewInstance) Start(ctx context.Context) error {
 
 	if err := mgr.Start(ctx); err != nil {
 		// We expect an error when the context is canceled
-		if ctx.Err() == context.Canceled {
+		if contexts.IsContextCanceledErr(err) {
 			return nil
 		}
 		return fmt.Errorf("starting controllers: %w", err)

--- a/pkg/contexts/signal.go
+++ b/pkg/contexts/signal.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contexts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+// which is canceled on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+//
+// This code is a variant of the code from controller-runtime/pkg/signals, modified to use
+// context.WithCancelCause so that the reason for cancellation can be propagated.
+// This allows callers to distinguish between normal cancellation and cancellation
+// due to termination signals.
+func SetupSignalHandler() context.Context {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		sig := <-c
+		cancel(fmt.Errorf("received termination signal %s: %w", sig, context.Canceled))
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return ctx
+}
+
+// IsContextCanceledErr checks whether the given error is caused by context cancellation.
+func IsContextCanceledErr(err error) bool {
+	return err != nil && errors.Is(err, context.Canceled)
+}

--- a/pkg/contexts/signal_test.go
+++ b/pkg/contexts/signal_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contexts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsContextCanceledErr(t *testing.T) {
+	err := fmt.Errorf("operation failed: %w", context.Canceled)
+	if !IsContextCanceledErr(err) {
+		t.Errorf("Expected IsContextCanceledErr to return true, got false")
+	}
+
+	nonCanceledErr := errors.New("some other error")
+	if IsContextCanceledErr(nonCanceledErr) {
+		t.Errorf("Expected IsContextCanceledErr to return false, got true")
+	}
+}


### PR DESCRIPTION
When the context is cancelled, it is helpful to have the error
indicate that the cancellation was due to a signal.

This change introduces new signal handling utilities
which record the signal that caused the context cancellation.
