### PR TITLE
[SpannerInstance] Support full instanceConfig URI

### DIFF
--- a/pkg/controller/direct/spanner/spannerinstace_mapper.go
+++ b/pkg/controller/direct/spanner/spannerinstace_mapper.go
@@ -15,8 +15,6 @@
 package spanner
 
 import (
-	"strings"
-
 	pb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/spanner/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
@@ -70,12 +68,12 @@ func State_FromProto(mapCtx *direct.MapContext, in *pb.Instance) *string {
 	return direct.Enum_FromProto(mapCtx, in.GetState())
 }
 
-func SpannerInstanceSpec_FromProto(mapCtx *direct.MapContext, in *pb.Instance, configPrefix string) *krm.SpannerInstanceSpec {
+func SpannerInstanceSpec_FromProto(mapCtx *direct.MapContext, in *pb.Instance) *krm.SpannerInstanceSpec {
 	if in == nil {
 		return nil
 	}
 	out := &krm.SpannerInstanceSpec{}
-	out.Config = strings.TrimPrefix(in.GetConfig(), configPrefix)
+	out.Config = in.GetConfig()
 	out.DisplayName = in.GetDisplayName()
 	out.Labels = in.Labels
 	out.ProcessingUnits = direct.LazyPtr(in.GetProcessingUnits())
@@ -86,12 +84,12 @@ func SpannerInstanceSpec_FromProto(mapCtx *direct.MapContext, in *pb.Instance, c
 	return out
 }
 
-func SpannerInstanceSpec_ToProto(mapCtx *direct.MapContext, in *krm.SpannerInstanceSpec, configPrefix string) *pb.Instance {
+func SpannerInstanceSpec_ToProto(mapCtx *direct.MapContext, in *krm.SpannerInstanceSpec) *pb.Instance {
 	if in == nil {
 		return nil
 	}
 	out := &pb.Instance{}
-	out.Config = configPrefix + in.Config
+	out.Config = in.Config
 	out.DisplayName = in.DisplayName
 	out.NodeCount = direct.ValueOf(in.NumNodes)
 	out.ProcessingUnits = direct.ValueOf(in.ProcessingUnits)

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/_generated_object_spannerinstance-full-instanceconfig-direct.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/_generated_object_spannerinstance-full-instanceconfig-direct.golden.yaml
@@ -1,0 +1,32 @@
+apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+kind: SpannerInstance
+metadata:
+  annotations:
+    alpha.cnrm.cloud.google.com/reconciler: direct
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+    label-one: value-one
+  name: spannerinstance-sample-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  config: projects/${projectId}/instanceConfigs/regional-us-west1
+  displayName: New Spanner Instance Sample
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/${projectId}/instances/spannerinstance-sample-${uniqueId}
+  observedGeneration: 2
+  observedState:
+    numNodes: 1
+    processingUnits: 1000
+  state: READY

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/_http.log
@@ -1,0 +1,413 @@
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "message": "Instance not found: projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://spanner.googleapis.com/v1/projects/${projectId}/instances?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}
+
+{
+  "instance": {
+    "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+    "displayName": "Spanner Instance Sample",
+    "labels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+    "nodeCount": 1
+  },
+  "instanceId": "spannerinstance-sample-${uniqueId}",
+  "parent": "projects/${projectId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.CreateInstanceMetadata",
+    "instance": {
+      "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+      "defaultBackupScheduleType": 2,
+      "displayName": "Spanner Instance Sample",
+      "edition": 1,
+      "instanceType": 1,
+      "labels": {
+        "cnrm-test": "true",
+        "label-one": "value-one",
+        "managed-by-cnrm": "true"
+      },
+      "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+      "nodeCount": 1,
+      "processingUnits": 1000,
+      "replicaComputeCapacity": [
+        {
+          "nodeCount": 1,
+          "replicaSelection": {
+            "location": "us-west1"
+          }
+        }
+      ],
+      "state": 2
+    },
+    "startTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}"
+}
+
+---
+
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.CreateInstanceMetadata",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "expectedFulfillmentPeriod": "FULFILLMENT_PERIOD_NORMAL",
+    "instance": {
+      "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+      "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
+      "displayName": "Spanner Instance Sample",
+      "edition": "STANDARD",
+      "instanceType": "PROVISIONED",
+      "labels": {
+        "cnrm-test": "true",
+        "label-one": "value-one",
+        "managed-by-cnrm": "true"
+      },
+      "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+      "nodeCount": 1,
+      "processingUnits": 1000,
+      "replicaComputeCapacity": [
+        {
+          "nodeCount": 1,
+          "replicaSelection": {
+            "location": "us-west1"
+          }
+        }
+      ],
+      "state": "READY",
+      "updateTime": "2024-04-01T12:34:56.123456Z"
+    },
+    "startTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
+    "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
+    "displayName": "Spanner Instance Sample",
+    "edition": "STANDARD",
+    "instanceType": "PROVISIONED",
+    "labels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+    "nodeCount": 1,
+    "processingUnits": 1000,
+    "replicaComputeCapacity": [
+      {
+        "nodeCount": 1,
+        "replicaSelection": {
+          "location": "us-west1"
+        }
+      }
+    ],
+    "state": "READY",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
+  "displayName": "Spanner Instance Sample",
+  "edition": 1,
+  "instanceType": 1,
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+  "nodeCount": 1,
+  "processingUnits": 1000,
+  "replicaComputeCapacity": [
+    {
+      "nodeCount": 1,
+      "replicaSelection": {
+        "location": "us-west1"
+      }
+    }
+  ],
+  "state": 2,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: instance.name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
+
+{
+  "fieldMask": "displayName",
+  "instance": {
+    "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+    "displayName": "New Spanner Instance Sample",
+    "labels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "metadata": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.UpdateInstanceMetadata",
+    "instance": {
+      "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+      "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": 2,
+      "displayName": "New Spanner Instance Sample",
+      "edition": 1,
+      "instanceType": 1,
+      "labels": {
+        "cnrm-test": "true",
+        "label-one": "value-one",
+        "managed-by-cnrm": "true"
+      },
+      "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+      "nodeCount": 1,
+      "processingUnits": 1000,
+      "replicaComputeCapacity": [
+        {
+          "nodeCount": 1,
+          "replicaSelection": {
+            "location": "us-west1"
+          }
+        }
+      ],
+      "state": 2,
+      "updateTime": "2024-04-01T12:34:56.123456Z"
+    },
+    "startTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}"
+}
+
+---
+
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}%2Foperations%2F${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.UpdateInstanceMetadata",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "expectedFulfillmentPeriod": "FULFILLMENT_PERIOD_NORMAL",
+    "instance": {
+      "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+      "createTime": "2024-04-01T12:34:56.123456Z",
+      "defaultBackupScheduleType": "AUTOMATIC",
+      "displayName": "New Spanner Instance Sample",
+      "edition": "STANDARD",
+      "instanceType": "PROVISIONED",
+      "labels": {
+        "cnrm-test": "true",
+        "label-one": "value-one",
+        "managed-by-cnrm": "true"
+      },
+      "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+      "nodeCount": 1,
+      "processingUnits": 1000,
+      "replicaComputeCapacity": [
+        {
+          "nodeCount": 1,
+          "replicaSelection": {
+            "location": "us-west1"
+          }
+        }
+      ],
+      "state": "READY",
+      "updateTime": "2024-04-01T12:34:56.123456Z"
+    },
+    "startTime": "2024-04-01T12:34:56.123456Z"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.spanner.admin.instance.v1.Instance",
+    "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "defaultBackupScheduleType": "AUTOMATIC",
+    "displayName": "New Spanner Instance Sample",
+    "edition": "STANDARD",
+    "instanceType": "PROVISIONED",
+    "labels": {
+      "cnrm-test": "true",
+      "label-one": "value-one",
+      "managed-by-cnrm": "true"
+    },
+    "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+    "nodeCount": 1,
+    "processingUnits": 1000,
+    "replicaComputeCapacity": [
+      {
+        "nodeCount": 1,
+        "replicaSelection": {
+          "location": "us-west1"
+        }
+      }
+    ],
+    "state": "READY",
+    "updateTime": "2024-04-01T12:34:56.123456Z"
+  }
+}
+
+---
+
+GET https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "config": "projects/${projectId}/instanceConfigs/regional-us-west1",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "defaultBackupScheduleType": 2,
+  "displayName": "New Spanner Instance Sample",
+  "edition": 1,
+  "instanceType": 1,
+  "labels": {
+    "cnrm-test": "true",
+    "label-one": "value-one",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectId}/instances/spannerinstance-sample-${uniqueId}",
+  "nodeCount": 1,
+  "processingUnits": 1000,
+  "replicaComputeCapacity": [
+    {
+      "nodeCount": 1,
+      "replicaSelection": {
+        "location": "us-west1"
+      }
+    }
+  ],
+  "state": 2,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+DELETE https://spanner.googleapis.com/v1/projects/${projectId}/instances/spannerinstance-sample-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Finstances%2Fspannerinstance-sample-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/create.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+kind: SpannerInstance
+metadata:
+  labels:
+    label-one: "value-one"
+  name: spannerinstance-sample-${uniqueId}
+  annotations:
+    alpha.cnrm.cloud.google.com/reconciler: "direct"
+spec:
+  config: projects/${projectId}/instanceConfigs/regional-us-west1
+  displayName: Spanner Instance Sample

--- a/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/spanner/v1beta1/spannerinstance/spannerinstance-full-instanceconfig-direct/update.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+kind: SpannerInstance
+metadata:
+  labels:
+    label-one: "value-one"
+  name: spannerinstance-sample-${uniqueId}
+  annotations:
+    alpha.cnrm.cloud.google.com/reconciler: "direct"
+spec:
+  config: projects/${projectId}/instanceConfigs/regional-us-west1
+  displayName: New Spanner Instance Sample


### PR DESCRIPTION
Without this, customers cannot migrate from TF reconciler to direct reconciler (and by extension, cannot use backup type, and new API fields).

This will support the same semantic behaviour that the TF reconciler had.

### BRIEF Change description

Supports `projects/$PROJECT/instanceConfigs/$CONFIG` full URI in SpannerInstance's `config` field.

Fixes #5478

#### WHY do we need this change?

This keeps backwards compatability and has an upgrade path for TF reconciler to Direct reconciler.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
Support `projects/$PROJECT/instanceConfigs/$CONFIG` full URI in SpannerInstance's `config` field.
```

### Tests you have done

Used 1.137.0, direct reconciler, and pass config: `projects/xyz/instanceConfigs/xyz`, failed. Updated controller with this change, and it worked.

```
cjmoberg@iglooze:~/k8s-config-connector$ go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests spannerinstance
{"severity":"info","timestamp":"2025-10-21T11:34:57.646-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/deny-unknown-fields"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.646-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/iam-validation"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.647-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/iam-defaulter"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.647-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/container-annotation-handler"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.655-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/management-conflict-annotation-defaulter"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.655-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/generic-defaulter"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/resource-validation"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/state-into-spec-validation"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.webhook","msg":"Starting webhook server"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.webhook","msg":"Serving webhook server","host":"127.0.0.1","port":33237}
{"severity":"info","timestamp":"2025-10-21T11:34:57.656-0700","logger":"controller-runtime.certwatcher","msg":"Starting certificate poll+watcher","interval":"10s"}
=== RUN   TestAll
{"severity":"info","timestamp":"2025-10-21T11:34:59.667-0700","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"severity":"info","timestamp":"2025-10-21T11:34:59.667-0700","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"severity":"info","timestamp":"2025-10-21T11:34:59.667-0700","msg":"Starting EventSource","controller":"registration-controller","source":"kind source: *v1.CustomResourceDefinition"}
{"severity":"info","timestamp":"2025-10-21T11:34:59.667-0700","msg":"Starting EventSource","controller":"deletion-defender-registration-controller","source":"kind source: *v1.CustomResourceDefinition"}
=== RUN   TestAll/spannerinstance
=== PAUSE TestAll/spannerinstance
=== CONT  TestAll/spannerinstance
--- PASS: TestAll (2.01s)
    --- PASS: TestAll/spannerinstance (0.00s)
PASS
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
