### PR TITLE
fix: Set Observed Generation for ConfigConnector

### DIFF
--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -194,10 +194,11 @@ func (r *Reconciler) handleReconcileFailed(ctx context.Context, nn types.Namespa
 	}
 	msg := fmt.Errorf("error during reconciliation: %w", reconcileErr).Error()
 	r.recordEvent(cc, corev1.EventTypeWarning, k8s.UpdateFailed, msg)
-	cc.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: false,
-		Errors:  []string{msg},
-	})
+	status := cc.GetCommonStatus()
+	status.Healthy = false
+	status.Errors = []string{msg}
+	status.ObservedGeneration = cc.Generation
+	cc.SetCommonStatus(status)
 	return r.updateConfigConnectorStatus(ctx, cc)
 }
 
@@ -211,10 +212,11 @@ func (r *Reconciler) handleReconcileSucceeded(ctx context.Context, nn types.Name
 		return fmt.Errorf("error getting ConfigConnector object %v: %w", nn.Name, err)
 	}
 	r.recordEvent(cc, corev1.EventTypeNormal, k8s.UpToDate, k8s.UpToDateMessage)
-	cc.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: true,
-		Errors:  []string{},
-	})
+	status := cc.GetCommonStatus()
+	status.Healthy = true
+	status.Errors = []string{}
+	status.ObservedGeneration = cc.Generation
+	cc.SetCommonStatus(status)
 	return r.updateConfigConnectorStatus(ctx, cc)
 }
 

--- a/operator/pkg/controllers/configconnector/configconnector_controller_test.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller_test.go
@@ -99,6 +99,9 @@ func TestHandleReconcileFailed(t *testing.T) {
 	} else if errMsg := status.Errors[0]; errMsg != expectedErrMsg {
 		t.Errorf("unexpected error in status.errors: got '%v', want '%v'", errMsg, expectedErrMsg)
 	}
+	if status.ObservedGeneration != tc.cc.Generation {
+		t.Errorf("unexpected observed generation: got %v, want %v", status.ObservedGeneration, tc.cc.Generation)
+	}
 }
 
 func TestHandleReconcileSucceeded(t *testing.T) {
@@ -149,6 +152,9 @@ func TestHandleReconcileSucceeded(t *testing.T) {
 	}
 	if len(status.Errors) != 0 {
 		t.Errorf("unexpected number of errors in status.errors: got %v errors, want 0 errors. Got the errors: %v", len(status.Errors), status.Errors)
+	}
+	if status.ObservedGeneration != tc.cc.Generation {
+		t.Errorf("unexpected observed generation: got %v, want %v", status.ObservedGeneration, tc.cc.Generation)
 	}
 }
 


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fix error: "ConfigConnector generation is 1, but latest observed generation is 0"

Similar to #5083, set status.observedGeneration of ConfigConnector and update unit test.
Gemini CLI command: /fix:metrics ConfigConnector

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[PR#5507](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5507)
Update .status.observedGeneration in ConfigConnector object.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

1.138

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
