### PR TITLE
fix: turn off compression for Prometheus metrics to reduce memory usage

### DIFF
--- a/cmd/recorder/main.go
+++ b/cmd/recorder/main.go
@@ -106,7 +106,9 @@ func run(ctx context.Context) error {
 
 	// Expose the registered metrics via HTTP.
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
+		http.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+			DisableCompression: true, // Disable compression to save memory - flate is surprisingly memory hungry
+		}))
 		logging.Fatal(http.ListenAndServe(prometheusScrapeEndpoint, nil), "error registering the Prometheus HTTP handler")
 	}()
 


### PR DESCRIPTION
flate compression used by default in Prometheus metrics handler can consume significant memory.
