### PR TITLE
Backport functionality from #5547 onto release 1.134

### DIFF
--- a/dev/ci/presubmits/tests-e2e-samples-unclassified
+++ b/dev/ci/presubmits/tests-e2e-samples-unclassified
@@ -22,7 +22,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 SKIP_TEST_APIGROUPS=(
     "alloydb.cnrm.cloud.google.com"

--- a/dev/ci/presubmits/tests-gcptracker
+++ b/dev/ci/presubmits/tests-gcptracker
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 # Always write golden output
 export WRITE_GOLDEN_OUTPUT=1

--- a/dev/ci/presubmits/tests-scenarios-acquisition
+++ b/dev/ci/presubmits/tests-scenarios-acquisition
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 export RUN_TESTS=TestE2EScript/scenarios/acquisition
 export TEST_TIMEOUT=600s

--- a/dev/ci/presubmits/tests-scenarios-gkehubfeaturemembership
+++ b/dev/ci/presubmits/tests-scenarios-gkehubfeaturemembership
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 export RUN_TESTS=TestE2EScript/scenarios/gkehubfeaturemembership
 export TEST_TIMEOUT=600s

--- a/dev/ci/presubmits/tests-scenarios-powertool
+++ b/dev/ci/presubmits/tests-scenarios-powertool
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 export RUN_TESTS=TestE2EScript/scenarios/powertool
 export TEST_TIMEOUT=600s

--- a/dev/ci/presubmits/tests-scenarios-unclassified
+++ b/dev/ci/presubmits/tests-scenarios-unclassified
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 export RUN_TESTS=TestE2EScript/scenarios
 export SKIP_TESTS="TestE2EScript/scenarios/sql/unmanage-edition|TestE2EScript/scenarios/acquisition|TestE2EScript/scenarios/powertool|TestE2EScript/scenarios/gkehubfeaturemembership|TestE2EScript/scenarios/iam/iampartialpolicy"

--- a/dev/tasks/run-e2e
+++ b/dev/tasks/run-e2e
@@ -22,7 +22,7 @@ cd ${REPO_ROOT}
 
 if [[ -z "${KUBEBUILDER_ASSETS:-}" ]]; then
   echo "Downloading envtest assets..."
-  export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+  export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 fi
 
 if [[ -n "${KCC_USE_DIRECT_RECONCILERS:-}" ]]; then

--- a/dev/tasks/turbo-e2e
+++ b/dev/tasks/turbo-e2e
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}
 dev/tasks/list-tests | xargs -I {} mkdir -p "testlogs/{}"
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 echo "Prebuilding e2e tests"
 export PREBUILT_TEST_BINARY=${REPO_ROOT}/.build/tests-e2e

--- a/dev/tasks/warm-devcontainer
+++ b/dev/tasks/warm-devcontainer
@@ -18,7 +18,7 @@ echo "Downloading go modules"
 go mod download
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 echo "Building binaries"
 go build ./cmd/...

--- a/docs/ai/github-workflow.md
+++ b/docs/ai/github-workflow.md
@@ -48,7 +48,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 echo "Running fixtures in tests/e2e for storage..."
 

--- a/experiments/compositions/composition/Makefile
+++ b/experiments/compositions/composition/Makefile
@@ -256,7 +256,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) $(GOPREFIX) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) $(GOPREFIX) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
 
 ###### ----------- include other make targets

--- a/experiments/compositions/facade/Makefile
+++ b/experiments/compositions/facade/Makefile
@@ -176,4 +176,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22

--- a/experiments/kubectl-plan/dev/tasks/run-tests
+++ b/experiments/kubectl-plan/dev/tasks/run-tests
@@ -20,7 +20,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/experiments/kubectl-plan/
 
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 WRITE_GOLDEN_OUTPUT=1 \
 go test ./... -v

--- a/hack/record-gcp
+++ b/hack/record-gcp
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 rm -rf $(pwd)/artifactz/realgcp
 

--- a/scripts/github-actions/ga-unit-test.sh
+++ b/scripts/github-actions/ga-unit-test.sh
@@ -21,7 +21,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 echo "Downloading envtest assets..."
-export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 
 source ${REPO_ROOT}/scripts/shared-vars-public.sh
 source ${REPO_ROOT}/scripts/fetch_ext_bins.sh && \


### PR DESCRIPTION
- **chore: ping envtest to release-0.22**

This is a backport of the functionality in #5547 , needed because envtest broke at head.

This is not a clean cherry-pick, so rewriting dependency.
