### PR TITLE
FirestoreDocument: fix numeric precision handling

### DIFF
--- a/pkg/controller/direct/firestore/firestoredocument_mappers.go
+++ b/pkg/controller/direct/firestore/firestoredocument_mappers.go
@@ -15,7 +15,11 @@
 package firestore
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 
 	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/firestore/v1alpha1"
@@ -35,14 +39,126 @@ func FirestoreDocumentSpec_v1alpha1_FromProto(mapCtx *direct.MapContext, in *pb.
 	for k, v := range in.Fields {
 		outV := Field_FromProto(mapCtx, v)
 
-		j, err := json.Marshal(outV)
+		j, err := toJSON(outV)
 		if err != nil {
-			return nil
+			mapCtx.Errorf("failed to marshal field %q=%q in FirestoreDocument: %v", k, outV, err)
+			continue
 		}
-		out.Fields[k] = apiextensionsv1.JSON{Raw: j}
+		out.Fields[k] = j
 	}
 
 	return out
+}
+
+// toJSON converts a Go value to an apiextensionsv1.JSON representation,
+// taking care to preserve integer and float types to avoid type conversion issues,
+// even when nested in an array or map.
+func toJSON(in any) (apiextensionsv1.JSON, error) {
+	var buffer bytes.Buffer
+
+	render := in
+	switch in := in.(type) {
+	case []any:
+		arr := make([]apiextensionsv1.JSON, 0, len(in))
+		for _, elem := range in {
+			v, err := toJSON(elem)
+			if err != nil {
+				return apiextensionsv1.JSON{}, err
+			}
+			arr = append(arr, v)
+		}
+		render = arr
+		// Fall-through
+
+	case map[string]any:
+		m := make(map[string]apiextensionsv1.JSON)
+		for k, elem := range in {
+			v, err := toJSON(elem)
+			if err != nil {
+				return apiextensionsv1.JSON{}, err
+			}
+			m[k] = v
+		}
+		render = m
+		// Fall-through
+
+	case int, int32, int64:
+		// As a special case, we want to avoid encoding int64 as a float in JSON,
+		// because this causes type conversions.
+		// So we manually format it as a string.
+		s := fmt.Sprintf("%d", in)
+		return apiextensionsv1.JSON{Raw: []byte(s)}, nil
+	case float32, float64:
+		// Force float to be formatted with scientific notation (%e),
+		// so we don't convert back to int accidentally.
+		s := fmt.Sprintf("%v", in)
+		if !strings.ContainsAny(s, "eE.") {
+			s += ".0"
+		}
+		return apiextensionsv1.JSON{Raw: []byte(s)}, nil
+
+	default:
+		// Fall-through
+	}
+
+	encoder := json.NewEncoder(&buffer)
+	if err := encoder.Encode(render); err != nil {
+		return apiextensionsv1.JSON{}, err
+	}
+	return apiextensionsv1.JSON{Raw: buffer.Bytes()}, nil
+}
+
+// fromJSON converts an apiextensionsv1.JSON representation to a Go value,
+// taking care to preserve integer and float types to avoid type conversion issues,
+// even when nested in an array or map.
+func fromJSON(in []byte) (any, error) {
+	var wrappedValue any
+	decoder := json.NewDecoder(bytes.NewReader(in))
+	decoder.UseNumber()
+	if err := decoder.Decode(&wrappedValue); err != nil {
+		return nil, err
+	}
+
+	// Recursively unwrap json.Number to int64 or float64 as appropriate.
+	var errs []error
+	var unwrapJSONValue func(any) any
+	unwrapJSONValue = func(v any) any {
+		switch v := v.(type) {
+		case json.Number:
+			if strings.ContainsAny(v.String(), "Ee.") {
+				// Parse as float64
+				if f, err := v.Float64(); err == nil {
+					return f
+				} else {
+					errs = append(errs, fmt.Errorf("failed to parse json.Number %q as float64: %w", v.String(), err))
+				}
+			} else {
+				// Parse as int64
+				if f, err := v.Int64(); err == nil {
+					return f
+				} else {
+					errs = append(errs, fmt.Errorf("failed to parse json.Number %q as int64: %w", v.String(), err))
+				}
+			}
+			return nil
+		case []any:
+			arr := make([]any, len(v))
+			for i, elem := range v {
+				arr[i] = unwrapJSONValue(elem)
+			}
+			return arr
+		case map[string]any:
+			m := make(map[string]any, len(v))
+			for k, elem := range v {
+				m[k] = unwrapJSONValue(elem)
+			}
+			return m
+		default:
+			return v
+		}
+	}
+
+	return unwrapJSONValue(wrappedValue), errors.Join(errs...)
 }
 
 func Field_FromProto(mapCtx *direct.MapContext, in *pb.Value) any {
@@ -104,8 +220,8 @@ func FirestoreDocumentSpec_v1alpha1_ToProto(mapCtx *direct.MapContext, in *krm.F
 			continue
 		}
 
-		var wrappedValue any
-		if err := json.Unmarshal(v.Raw, &wrappedValue); err != nil {
+		wrappedValue, err := fromJSON(v.Raw)
+		if err != nil {
 			mapCtx.Errorf("failed to unmarshal JSON field in FirestoreDocument: %v", err)
 			out.Fields[k] = &pb.Value{ValueType: &pb.Value_NullValue{}}
 			continue

--- a/pkg/controller/direct/firestore/firestoredocument_test.go
+++ b/pkg/controller/direct/firestore/firestoredocument_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+// There are some difficult FirestoreDocument field values which we want to test specially
+func TestSpecialRoundTripDocumentValues(t *testing.T) {
+	grid := []struct {
+		Name         string
+		ExpectedJSON string
+		Value        *pb.Value
+	}{
+		{
+			Name:         "Integer and Float are preserved",
+			ExpectedJSON: `{"databaseRef":{},"fields":{"specialValues":[100.0,100]}}`,
+			Value: &pb.Value{
+				ValueType: &pb.Value_ArrayValue{
+					ArrayValue: &pb.ArrayValue{
+						Values: []*pb.Value{
+							{
+								// 100.0 would normally be converted to an integer in JSON
+								ValueType: &pb.Value_DoubleValue{DoubleValue: 100.0},
+							},
+							{
+								// The same value as an integer
+								ValueType: &pb.Value_IntegerValue{IntegerValue: 100},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:         "Large Integer and Float",
+			ExpectedJSON: `{"databaseRef":{},"fields":{"specialValues":[5903169270288737330,5.903169270288737e+18]}}`,
+			Value: &pb.Value{
+				ValueType: &pb.Value_ArrayValue{
+					ArrayValue: &pb.ArrayValue{
+						Values: []*pb.Value{
+							{
+								// This value is large and would normally be converted to a float in JSON
+								ValueType: &pb.Value_IntegerValue{IntegerValue: 5903169270288737330},
+							},
+							{
+								// The same value as a float
+								ValueType: &pb.Value_DoubleValue{DoubleValue: 5.903169270288737e+18},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:         "Empty array",
+			ExpectedJSON: `{"databaseRef":{},"fields":{"specialValues":[]}}`,
+			Value: &pb.Value{
+				ValueType: &pb.Value_ArrayValue{
+					ArrayValue: &pb.ArrayValue{
+						Values: []*pb.Value{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.Name, func(t *testing.T) {
+			inputProto := &pb.Document{
+				Fields: map[string]*pb.Value{
+					"specialValues": g.Value,
+				},
+			}
+
+			// Proto -> KRM
+			mapCtx := &direct.MapContext{}
+			inputKRM := FirestoreDocumentSpec_v1alpha1_FromProto(mapCtx, inputProto)
+			if mapCtx.Err() != nil {
+				t.Fatalf("unexpected error mapping from proto: %v", mapCtx.Err())
+			}
+
+			// Verify expected JSON representation
+			jsonData, err := json.Marshal(inputKRM)
+			if err != nil {
+				t.Fatalf("unexpected error marshalling to JSON: %v", err)
+			}
+
+			if diff := cmp.Diff(g.ExpectedJSON, string(jsonData)); diff != "" {
+				t.Errorf("JSON representation mismatch (-want +got):\n%s", diff)
+			}
+
+			// // JSON -> KRM
+			// var outputKRM krm.FirestoreDocumentSpec
+			// if err := json.Unmarshal(jsonData, &outputKRM); err != nil {
+			// 	t.Fatalf("unexpected error unmarshalling from JSON: %v", err)
+			// }
+
+			// if diff := cmp.Diff(inputKRM, outputKRM); diff != "" {
+			// 	t.Errorf("KRM round-trip mismatch (-want +got):\n%s", diff)
+			// }
+
+			// KRM -> Proto
+			mapCtx = &direct.MapContext{}
+			outputProto := FirestoreDocumentSpec_v1alpha1_ToProto(mapCtx, inputKRM)
+			if mapCtx.Err() != nil {
+				t.Fatalf("unexpected error mapping to proto: %v", mapCtx.Err())
+			}
+
+			// Verify round-trip
+			if diff := cmp.Diff(inputProto, outputProto, protocmp.Transform()); diff != "" {
+				t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The fuzzer found an issue where large integers were being converted to floats
and losing precision. This change improves the handling of numeric types during
the mapping process to preserve integer precision.
