### PR TITLE
chore: Move backupplan reference resolver out of adaptor

### DIFF
--- a/pkg/controller/direct/backupdr/backupplan_resolverefs.go
+++ b/pkg/controller/direct/backupdr/backupplan_resolverefs.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupdr
+
+import (
+	"context"
+	"fmt"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/backupdr/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResolveBackupDRBackupPlanRefs(ctx context.Context, reader client.Reader, obj *krm.BackupDRBackupPlan) error {
+	// resolve required reference fields
+	if obj.Spec.BackupVaultRef != nil {
+		if _, err := obj.Spec.BackupVaultRef.NormalizedExternal(ctx, reader, obj.GetNamespace()); err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("spec.backupVaultRef is required")
+	}
+	return nil
+}


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Deletion of BackupPlan shouldn't require resolving its BackupVault dependency. Move the resolver out of the Adaptor to unblock deletion.

Related to this  https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5313#discussion_r2417815936
Similar fix applied in ComputeForwardingRule: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/2758

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done
Delete BackupVault before BackupPlan:
before:
```
"reference BackupDRBackupVault 3m26kpmd6inwhgi/backupdrbackupvault-minimal-3m26kpmd6inwhgi is not found"
```

after: deletion succeeded

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
