### PR TITLE
fix: don't replace namespaced with tagKeyID/tagValueID

### DIFF
--- a/mockgcp/mockresourcemanager/normalize.go
+++ b/mockgcp/mockresourcemanager/normalize.go
@@ -48,7 +48,11 @@ func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcp
 		}
 	}
 	if len(tokens) == 2 && tokens[0] == "tagValues" {
-		replacements.ReplaceStringValue(tokens[1], "${tagValueID}")
+		if name == "namespaced" {
+			// This is actually a search operation: https://cloud.google.com/resource-manager/reference/rest/v3/tagValues/getNamespaced
+		} else {
+			replacements.ReplaceStringValue(tokens[1], "${tagValueID}")
+		}
 	}
 	if len(tokens) == 2 && tokens[0] == "tagBindings" {
 		replacements.ReplaceStringValue(tokens[1], "${tagBindingID}")


### PR DESCRIPTION
Both of these have URL paths for a search operation that looks
like a GET operation, which we need to special case to avoid
replacing the "namespaced" value with a placeholder.
