### PR TITLE
Add mappers for Materializedviewinfo

### DIFF
--- a/pkg/controller/direct/bigtable/mapper_test.go
+++ b/pkg/controller/direct/bigtable/mapper_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigtable
+
+import (
+	"testing"
+
+	gcp "cloud.google.com/go/bigtable"
+	pb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+)
+
+func TestBigtableMaterializedViewInfo_ToBigtableMaterializedView(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		if got := BigtableMaterializedViewInfo_ToBigtableMaterializedView(nil); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("protected maps to true", func(t *testing.T) {
+		in := &gcp.MaterializedViewInfo{
+			Query:              "q",
+			DeletionProtection: gcp.Protected,
+			MaterializedViewID: "mv1",
+		}
+		got := BigtableMaterializedViewInfo_ToBigtableMaterializedView(in)
+		if got == nil {
+			t.Fatalf("unexpected nil result")
+		}
+		if got.Query != in.Query {
+			t.Errorf("Query: got %q, want %q", got.Query, in.Query)
+		}
+		if got.DeletionProtection != true {
+			t.Errorf("DeletionProtection: got %v, want true", got.DeletionProtection)
+		}
+
+		if got.Name != in.MaterializedViewID {
+			t.Errorf("MaterializedViewID: got %v, want %v", got.Name, in.MaterializedViewID)
+		}
+	})
+
+	t.Run("none/unprotected maps to false", func(t *testing.T) {
+		cases := []gcp.DeletionProtection{gcp.None, gcp.Unprotected}
+		for _, c := range cases {
+			in := &gcp.MaterializedViewInfo{
+				Query:              "qq",
+				DeletionProtection: c,
+				MaterializedViewID: "mv2",
+			}
+			got := BigtableMaterializedViewInfo_ToBigtableMaterializedView(in)
+			if got == nil {
+				t.Fatalf("unexpected nil result for case %v", c)
+			}
+			if got.DeletionProtection != false {
+				t.Errorf("case %v: DeletionProtection: got %v, want false", c, got.DeletionProtection)
+			}
+			if got.Name != in.MaterializedViewID {
+				t.Errorf("case %v: MaterializedViewID: got %v, want %v", c, got.Name, in.MaterializedViewID)
+			}
+		}
+	})
+}
+
+func TestBigtableMaterializedView_ToBigtableMaterializedViewInfo(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		if got := BigtableMaterializedView_ToBigtableMaterializedViewInfo(nil); got != nil {
+			t.Fatalf("expected nil, got: %#v", got)
+		}
+	})
+
+	t.Run("DeletionProtection true -> Protected", func(t *testing.T) {
+		in := &pb.MaterializedView{
+			Query:              "pv1",
+			DeletionProtection: true,
+			Name:               "pv1",
+		}
+		got := BigtableMaterializedView_ToBigtableMaterializedViewInfo(in)
+		if got == nil {
+			t.Fatalf("unexpected nil result")
+		}
+		if got.Query != in.Query {
+			t.Errorf("Query mismatch: got %q, want %q", got.Query, in.Query)
+		}
+		if got.DeletionProtection != gcp.Protected {
+			t.Errorf("DeletionProtection mismatch: got %v, want %v", got.DeletionProtection, gcp.Protected)
+		}
+		if got.MaterializedViewID != in.Name {
+			t.Errorf("MaterializedViewID mismatch: got %v, want %v", got.MaterializedViewID, in.Name)
+		}
+	})
+
+	t.Run("DeletionProtection false -> Unprotected", func(t *testing.T) {
+		in := &pb.MaterializedView{
+			Query:              "pv2",
+			DeletionProtection: false,
+			Name:               "pv2",
+		}
+		got := BigtableMaterializedView_ToBigtableMaterializedViewInfo(in)
+		if got == nil {
+			t.Fatalf("unexpected nil result")
+		}
+		if got.Query != in.Query {
+			t.Errorf("Query mismatch: got %q, want %q", got.Query, in.Query)
+		}
+		if got.DeletionProtection != gcp.Unprotected {
+			t.Errorf("DeletionProtection mismatch: got %v, want %v", got.DeletionProtection, gcp.Unprotected)
+		}
+		if got.MaterializedViewID != in.Name {
+			t.Errorf("MaterializedViewID mismatch: got %v, want %v", got.MaterializedViewID, in.Name)
+		}
+	})
+}

--- a/pkg/controller/direct/bigtable/materializedview_mapper.go
+++ b/pkg/controller/direct/bigtable/materializedview_mapper.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +generated:mapper
+// krm.group: bigtable.cnrm.cloud.google.com
+// krm.version: v1beta1
+// proto.service: google.bigtable.admin.v2
+
+package bigtable
+
+import (
+	gcp "cloud.google.com/go/bigtable"
+	pb "cloud.google.com/go/bigtable/admin/apiv2/adminpb"
+)
+
+func BigtableMaterializedViewInfo_ToBigtableMaterializedView(in *gcp.MaterializedViewInfo) *pb.MaterializedView {
+	if in == nil {
+		return nil
+	}
+
+	deletionProtection := false
+	if in.DeletionProtection == gcp.Protected {
+		deletionProtection = true
+	}
+
+	return &pb.MaterializedView{
+		Query:              in.Query,
+		DeletionProtection: deletionProtection,
+		Name:               in.MaterializedViewID,
+	}
+}
+
+func BigtableMaterializedView_ToBigtableMaterializedViewInfo(in *pb.MaterializedView) *gcp.MaterializedViewInfo {
+	if in == nil {
+		return nil
+	}
+
+	deletionProtection := gcp.None
+	if in.DeletionProtection {
+		deletionProtection = gcp.Protected
+	} else {
+		deletionProtection = gcp.Unprotected
+	}
+
+	return &gcp.MaterializedViewInfo{
+		Query:              in.Query,
+		DeletionProtection: deletionProtection,
+		MaterializedViewID: in.Name,
+	}
+}


### PR DESCRIPTION
### BRIEF Change description

We use [`materializedviewinfo`](https://pkg.go.dev/cloud.google.com/go/bigtable#MaterializedViewInfo) to interact with CloudBigtable rather than the `MaterializedView`proto. Add mapper for `materializedviewinfo`.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->
Ran:
```
go test ./pkg/controller/direct/bigtable -run Test -v
```

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
