### PR TITLE
fix: bqreservation not exposing externaRef

### DIFF
--- a/pkg/controller/direct/bigqueryreservation/reservation_controller.go
+++ b/pkg/controller/direct/bigqueryreservation/reservation_controller.go
@@ -209,6 +209,8 @@ func (a *ReservationAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if len(paths) == 0 {
 		log.V(2).Info("no field needs update", "name", a.id.String())
 		status := &krm.BigQueryReservationReservationStatus{}
+		// Update externalRef when acquiring/importing an existing reservation from gcp
+		status.ExternalRef = direct.LazyPtr(a.id.String())
 		status.ObservedState = BigQueryReservationReservationObservedState_FromProto(mapCtx, a.actual)
 		if mapCtx.Err() != nil {
 			return mapCtx.Err()


### PR DESCRIPTION
BigQueryReservationReservation not exposing externalRef

- When creating a new BigQuery reservation using BigQueryReservationReservation KCC, after reconciliation externalRef field is added to k8s object Status.

- When acquiring an existing BigQuery reservation using BigQueryReservationReservation KCC, after reconciliation external field is not added.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
