### PR TITLE
tests: re-use re-reconciliation ratchet for SSA

### DIFF
--- a/tests/e2e/ratcheting.go
+++ b/tests/e2e/ratcheting.go
@@ -24,6 +24,9 @@ import (
 // ShouldTestRereconiliation determines if we "touch" the primary object after we have run the test.
 // This should not cause write operations to GCP (read operations are OK)
 // We would like eventually to turn this on for all objects, but we have to turn on the testing gradually.
+//
+// Note that we also use this "ratchet" list to determine whether to use SSA for creates in unified_test.go,
+// so new resources must pass the re-reconciliation test from the start.
 func ShouldTestRereconiliation(t *testing.T, testName string, primaryResource *unstructured.Unstructured) bool {
 	gvk := primaryResource.GroupVersionKind()
 

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -259,8 +259,13 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, scenarioOptions Sce
 						// Use SSA
 
 					default:
-						t.Logf("not yet using SSA for create of resources in group %q", group)
-						opt.DoNotUseServerSideApplyForCreate = true
+						// Share the rereconiliation ratchet, rather than introducing a second long list
+						if ShouldTestRereconiliation(t, fixture.Name, primaryResource) {
+							opt.DoNotUseServerSideApplyForCreate = false
+						} else {
+							t.Logf("not yet using SSA for create of resources in group %q", group)
+							opt.DoNotUseServerSideApplyForCreate = true
+						}
 					}
 
 					return primaryResource, opt


### PR DESCRIPTION
This is easier than maintaining two separate lists.
