### PR TITLE
FirestoreDatabase: fix defaulting

### DIFF
--- a/mockgcp/mockfirestore/database.go
+++ b/mockgcp/mockfirestore/database.go
@@ -223,6 +223,10 @@ func populateDefaultsForDatabase(obj *pb.Database) {
 		obj.DatabaseEdition = pb.Database_STANDARD
 	}
 
+	if obj.DeleteProtectionState == pb.Database_DELETE_PROTECTION_STATE_UNSPECIFIED {
+		obj.DeleteProtectionState = pb.Database_DELETE_PROTECTION_DISABLED
+	}
+
 	if obj.FreeTier == nil {
 		// The first database in each project is free-tier
 		obj.FreeTier = PtrTo(true)

--- a/pkg/controller/direct/firestore/firestoredatabase_defaults.go
+++ b/pkg/controller/direct/firestore/firestoredatabase_defaults.go
@@ -16,7 +16,7 @@ package firestore
 
 import pb "cloud.google.com/go/firestore/apiv1/admin/adminpb"
 
-func ApplyFirestoreDatabaseDefaults(in *pb.Database) {
+func ApplyServerSideDefaults(in *pb.Database) {
 	// Set default values to make sure firestore database is "declarative-friendly".
 	if in.Type == pb.Database_DATABASE_TYPE_UNSPECIFIED {
 		in.Type = pb.Database_FIRESTORE_NATIVE
@@ -26,5 +26,11 @@ func ApplyFirestoreDatabaseDefaults(in *pb.Database) {
 	}
 	if in.DeleteProtectionState == pb.Database_DELETE_PROTECTION_STATE_UNSPECIFIED {
 		in.DeleteProtectionState = pb.Database_DELETE_PROTECTION_DISABLED
+	}
+	if in.ConcurrencyMode == pb.Database_CONCURRENCY_MODE_UNSPECIFIED {
+		in.ConcurrencyMode = pb.Database_PESSIMISTIC
+	}
+	if in.PointInTimeRecoveryEnablement == pb.Database_POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED {
+		in.PointInTimeRecoveryEnablement = pb.Database_POINT_IN_TIME_RECOVERY_DISABLED
 	}
 }

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestoredocument/firestoredocument-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestoredocument/firestoredocument-full/_http.log
@@ -29,8 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
-  "deleteProtectionState": 1,
   "locationId": "us-west2",
   "name": "projects/${projectId}/databases/firestoredatabase-${uniqueId}",
   "type": 1

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestorefield/firestorefield-clearing/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestorefield/firestorefield-clearing/_http.log
@@ -29,8 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
-  "deleteProtectionState": 1,
   "locationId": "us-west2",
   "name": "projects/${projectId}/databases/firestoredatabase-${uniqueId}",
   "type": 1

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestorefield/firestorefield-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1alpha1/firestorefield/firestorefield-minimal/_http.log
@@ -29,8 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
-  "deleteProtectionState": 1,
   "locationId": "us-west2",
   "name": "projects/${projectId}/databases/firestoredatabase-${uniqueId}",
   "type": 1

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoredatabase/firestoredatabase-full/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoredatabase/firestoredatabase-full/_http.log
@@ -29,7 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
   "concurrencyMode": 2,
   "deleteProtectionState": 2,
   "locationId": "us-west2",
@@ -159,7 +158,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: database.name=projects%2F${projectId}%2Fdatabases%2Ffirestoredatabase-${uniqueId}
 
 {
-  "appEngineIntegrationMode": 2,
   "concurrencyMode": 1,
   "deleteProtectionState": 1,
   "locationId": "us-west2",

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoredatabase/firestoredatabase-minimal/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoredatabase/firestoredatabase-minimal/_http.log
@@ -29,8 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
-  "deleteProtectionState": 1,
   "locationId": "us-west2",
   "name": "projects/${projectId}/databases/firestoredatabase-${uniqueId}",
   "type": 1

--- a/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoreindex/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/firestore/v1beta1/firestoreindex/_http.log
@@ -29,8 +29,6 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
 X-Goog-Request-Params: parent=projects%2F${projectId}
 
 {
-  "appEngineIntegrationMode": 2,
-  "deleteProtectionState": 1,
   "locationId": "us-west2",
   "name": "projects/${projectId}/databases/firestoredatabase-${uniqueId}",
   "type": 1


### PR DESCRIPTION
We want to simulate the server-defaulting logic to avoid spurious diffs,
not to send values the users did not specify.
