### PR TITLE
feat: Simplify cookie usage for direct controllers (RunJob as example)

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runjob/runjob-iamserviceaccount/_generated_object_runjob-iamserviceaccount.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runjob/runjob-iamserviceaccount/_generated_object_runjob-iamserviceaccount.golden.yaml
@@ -35,6 +35,7 @@ status:
   createTime: "1970-01-01T00:00:00Z"
   creator: test@google.com
   etag: abcdef123456
+  externalRef: projects/${projectId}/locations/us-central1/jobs/runjob-${uniqueId}
   lastModifiedCookie: normalized-cookie
   lastModifier: test@google.com
   latestCreatedExecution:

--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -256,7 +256,8 @@ func testFixturesInSeries(ctx context.Context, t *testing.T, scenarioOptions Sce
 						"kms.cnrm.cloud.google.com",
 						"orgpolicy.cnrm.cloud.google.com",
 						"firestore.cnrm.cloud.google.com",
-						"tags.cnrm.cloud.google.com":
+						"tags.cnrm.cloud.google.com",
+						"run.cnrm.cloud.google.com":
 						// Use SSA
 
 					default:


### PR DESCRIPTION
### Why we want this change:
The current cookie logic is spread in controller Create/Update, confused Gemini for different scenarios. This logic is less error prone and is much easier to use because it abstracts the cookie part to its own library.  

This PR also fixes 2 issues in RunJob. one is the missing externalRef in update, the other is the lastModifiedCookie is not a md hash (but a plain struct)
<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
