### PR TITLE
fix: update test output for dashboard replacement

### DIFF
--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboard-toplist/_generated_export_monitoringdashboard-toplist.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboard-toplist/_generated_export_monitoringdashboard-toplist.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   displayName: Example with TopList
   mosaicLayout:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboard-toplist/_generated_object_monitoringdashboard-toplist.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboard-toplist/_generated_object_monitoringdashboard-toplist.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   displayName: Example with TopList
@@ -37,7 +37,7 @@ spec:
       width: 24
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref1/_generated_export_monitoringdashboardalertpolicyref1.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref1/_generated_export_monitoringdashboardalertpolicyref1.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   columnLayout:
     columns:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref1/_generated_object_monitoringdashboardalertpolicyref1.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref1/_generated_object_monitoringdashboardalertpolicyref1.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   columnLayout:
@@ -141,7 +141,7 @@ spec:
   displayName: monitoringdashboard-full
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref2/_generated_export_monitoringdashboardalertpolicyref2.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref2/_generated_export_monitoringdashboardalertpolicyref2.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   columnLayout:
     columns:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref2/_generated_object_monitoringdashboardalertpolicyref2.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardalertpolicyref2/_generated_object_monitoringdashboardalertpolicyref2.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   columnLayout:
@@ -141,7 +141,7 @@ spec:
   displayName: monitoringdashboard-full
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_generated_export_monitoringdashboardbasic.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_generated_export_monitoringdashboardbasic.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   columnLayout:
     columns:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_generated_object_monitoringdashboardbasic.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardbasic/_generated_object_monitoringdashboardbasic.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 3
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   columnLayout:
@@ -51,7 +51,7 @@ spec:
   displayName: monitoringdashboard-updated
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_generated_export_monitoringdashboardfull.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_generated_export_monitoringdashboardfull.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   columnLayout:
     columns:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_generated_object_monitoringdashboardfull.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardfull/_generated_object_monitoringdashboardfull.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   columnLayout:
@@ -141,7 +141,7 @@ spec:
   displayName: monitoringdashboard-full
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardmosaiclayout/_generated_export_monitoringdashboardmosaiclayout.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardmosaiclayout/_generated_export_monitoringdashboardmosaiclayout.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboardmosaiclayout-${uniqueId}
+  name: ${dashboardID}
 spec:
   displayName: monitoringdashboard-mosaiclayout
   mosaicLayout:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardmosaiclayout/_generated_object_monitoringdashboardmosaiclayout.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardmosaiclayout/_generated_object_monitoringdashboardmosaiclayout.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 2
   labels:
     cnrm-test: "true"
-  name: monitoringdashboardmosaiclayout-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   displayName: monitoringdashboard-mosaiclayout
@@ -48,7 +48,7 @@ spec:
       yPos: 2
   projectRef:
     external: ${projectId}
-  resourceID: monitoringdashboardmosaiclayout-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardprojectref/_generated_export_monitoringdashboardprojectref.golden
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardprojectref/_generated_export_monitoringdashboardprojectref.golden
@@ -1,7 +1,7 @@
 apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
 kind: MonitoringDashboard
 metadata:
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
 spec:
   columnLayout:
     columns:

--- a/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardprojectref/_generated_object_monitoringdashboardprojectref.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/monitoring/v1beta1/monitoringdashboard/monitoringdashboardprojectref/_generated_object_monitoringdashboardprojectref.golden.yaml
@@ -7,7 +7,7 @@ metadata:
   generation: 3
   labels:
     cnrm-test: "true"
-  name: monitoringdashboard-${uniqueId}
+  name: ${dashboardID}
   namespace: ${uniqueId}
 spec:
   columnLayout:
@@ -51,7 +51,7 @@ spec:
   displayName: monitoringdashboard updated
   projectRef:
     name: otherproject
-  resourceID: monitoringdashboard-${uniqueId}
+  resourceID: ${dashboardID}
 status:
   conditions:
   - lastTransitionTime: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
Looks like some PRs crossed again, this updates the test output
for replacing dashboardID.
