### PR TITLE
chore: tweak prompt tool to force correct copyright year

### DIFF
--- a/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt_test.go
+++ b/dev/tools/controllerbuilder/pkg/commands/exportcsv/prompt_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exportcsv
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestFixupCopyrights tests the fixupCopyrights function.
+func TestFixupCopyrights(t *testing.T) {
+	input := `// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foo
+
+func Bar() {...
+`
+
+	got := fixupCopyrights(input, 2024)
+	want := `// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foo
+
+func Bar() {...
+`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("fixupCopyrights() diff (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
It seems easier to just do this as a simple replacement at the end,
rather than trying to rewrite the inputs.
