### PR TITLE
[Safer Upgrade] Add namespace mode to preview tool

### DIFF
--- a/experiments/kompanion/cmd/preview/preview_cmd.go
+++ b/experiments/kompanion/cmd/preview/preview_cmd.go
@@ -50,6 +50,7 @@ type PreviewOptions struct {
 	timeout          int
 	reportNamePrefix string
 	fullReport       bool
+	namespace        string
 }
 
 func BuildPreviewCmd() *cobra.Command {
@@ -68,7 +69,7 @@ func BuildPreviewCmd() *cobra.Command {
 	cmd.Flags().IntVarP(&opts.timeout, timeoutFlag, "", 15, "timeout in minutes. Default to 15 minutes.")
 	cmd.Flags().StringVarP(&opts.reportNamePrefix, reportNamePrefixFlag, "", "preview-report", "Prefix for the report name. The tool appends a timestamp to this in the format \"YYYYMMDD-HHMMSS.milliseconds\".")
 	cmd.Flags().BoolVarP(&opts.fullReport, "full-report", "f", false, "Enable verbose logging.")
-
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace to preview. If not specified, all namespaces will be previewed.")
 	return cmd
 }
 
@@ -104,7 +105,7 @@ func RunPreview(ctx context.Context, opts *PreviewOptions) error {
 	}
 	recorder := preview.NewRecorder()
 	klog.Info("Preloading the list of resources to reconcile")
-	if err := recorder.PreloadGKNN(ctx, upstreamRESTConfig); err != nil {
+	if err := recorder.PreloadGKNN(ctx, upstreamRESTConfig, opts.namespace); err != nil {
 		return fmt.Errorf("error preload the list of resources to reconcile: %w", err)
 	}
 	klog.Info("Successfully preload the list of resources to reconcile.")
@@ -116,6 +117,7 @@ func RunPreview(ctx context.Context, opts *PreviewOptions) error {
 		UpstreamRESTConfig:       upstreamRESTConfig,
 		UpstreamGCPAuthorization: authorization,
 		UpstreamGCPHTTPClient:    nil,
+		Namespace:                opts.namespace,
 	})
 	if err != nil {
 		return fmt.Errorf("building preview instance: %v", err)
@@ -151,7 +153,7 @@ func printCapturedObjects(recorder *preview.Recorder, prefix string, full bool) 
 	}
 
 	if full {
-		outputFile := fmt.Sprintf("%s-full-%s", prefix, timestamp)
+		outputFile := fmt.Sprintf("%s-%s-full", prefix, timestamp)
 		if err := recorder.ExportDetailObjectsEvent(outputFile); err != nil {
 			return fmt.Errorf("error writing events: %w", err)
 		}

--- a/pkg/cli/preview/preview.go
+++ b/pkg/cli/preview/preview.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/contexts"
@@ -42,6 +43,10 @@ type PreviewInstance struct {
 	hookGCP  *interceptingGCPClient
 	hookKube *interceptingKubeClient
 	recorder *Recorder
+
+	// Namespace is the namespace of the cluster to preview
+	// If empty, all namespaces are previewed
+	Namespace string
 }
 
 // PreviewInstanceOptions are the options for creating a PreviewInstance.
@@ -57,6 +62,10 @@ type PreviewInstanceOptions struct {
 	// UpstreamGCPHTTPClient is the http client to use when talking to upstream (real) GCP
 	// (Upstream GCP may be mocked in tests)
 	UpstreamGCPHTTPClient *http.Client
+
+	// Namespace is the namespace of the cluster to preview
+	// If empty, all namespaces are previewed
+	Namespace string
 }
 
 // NewPreviewInstance creates a new PreviewInstance.
@@ -79,6 +88,7 @@ func NewPreviewInstance(recorder *Recorder, options PreviewInstanceOptions) (*Pr
 	i.hookGCP = hookGCP
 	i.hookKube = hookKube
 	i.recorder = recorder
+	i.Namespace = options.Namespace
 
 	return i, nil
 }
@@ -120,6 +130,11 @@ func (i *PreviewInstance) Start(ctx context.Context) error {
 	}
 
 	kccConfig := kccmanager.Config{}
+	if i.Namespace != "" {
+		kccConfig.ManagerOptions.Cache.DefaultNamespaces = map[string]cache.Config{
+			i.Namespace: {},
+		}
+	}
 	// Prevent manager from binding to a port to serve prometheus metrics
 	// since creating multiple managers for tests will fail if more than
 	// one manager tries to bind to the same port.
@@ -132,14 +147,11 @@ func (i *PreviewInstance) Start(ctx context.Context) error {
 	// Hook kube
 	kccConfig.ManagerOptions.NewCache = i.hookKube.NewCache
 	kccConfig.ManagerOptions.NewClient = i.hookKube.NewClient
-	kccConfig.ManagerOptions.BaseContext = func() context.Context {
-		return ctx
-	}
+
 	kccConfig.ManagerOptions.MapperProvider = i.hookKube.MapperProvider
 
 	// turn off caching (otherwise we get partial object metadata)
 	nocache.OnlyCacheCCAndCCC(&kccConfig.ManagerOptions)
-
 	// Use an empty restConfig as a failsafe against requests "leaking" to real kube-apiserver
 	restConfig := &rest.Config{}
 

--- a/pkg/cli/preview/preview_test.go
+++ b/pkg/cli/preview/preview_test.go
@@ -139,7 +139,7 @@ spec:
 	upstreamRESTConfig := harness.GetRESTConfig()
 
 	recorder := NewRecorder()
-	if err := recorder.PreloadGKNN(ctx, upstreamRESTConfig); err != nil {
+	if err := recorder.PreloadGKNN(ctx, upstreamRESTConfig, ""); err != nil {
 		t.Fatalf("PreloadGKNN: %v", err)
 	}
 

--- a/pkg/cli/preview/streaming_client.go
+++ b/pkg/cli/preview/streaming_client.go
@@ -123,10 +123,10 @@ func (c *StreamingClient) Get(ctx context.Context, typeInfo *typeInfo, namespace
 }
 
 // List lists the objects for the given type.
-func (c *StreamingClient) List(ctx context.Context, typeInfo *typeInfo, listener ListListener) error {
+func (c *StreamingClient) List(ctx context.Context, typeInfo *typeInfo, namespace string, listener ListListener) error {
 	log := klog.FromContext(ctx)
 
-	u := c.resourceURL(typeInfo.gvr, "", "")
+	u := c.resourceURL(typeInfo.gvr, namespace, "")
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -200,10 +200,10 @@ type WatchListener interface {
 }
 
 // Watch watches the given type.
-func (c *StreamingClient) Watch(ctx context.Context, typeInfo *typeInfo, watchOptions WatchOptions, listener WatchListener) error {
+func (c *StreamingClient) Watch(ctx context.Context, typeInfo *typeInfo, namespace string, watchOptions WatchOptions, listener WatchListener) error {
 	log := klog.FromContext(ctx)
 
-	u := c.resourceURL(typeInfo.gvr, "", "")
+	u := c.resourceURL(typeInfo.gvr, namespace, "")
 
 	q := u.Query()
 	q.Set("watch", "true")

--- a/pkg/cli/preview/streaming_informer.go
+++ b/pkg/cli/preview/streaming_informer.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -35,6 +36,7 @@ import (
 type streamingInformer struct {
 	streamingClient *StreamingClient
 	typeInfo        *typeInfo
+	namespace       string
 	mutex           sync.Mutex
 
 	eventHandlerRegistrations []*eventHandlerRegistration
@@ -82,10 +84,11 @@ func (o *objects) OnWatchAdd(obj Object, eventHandlerRegistrations []*eventHandl
 var _ cache.Informer = &streamingInformer{}
 
 // newStreamingInformer creates a new streaming informer.
-func newStreamingInformer(streamingClient *StreamingClient, typeInfo *typeInfo) (*streamingInformer, error) {
+func newStreamingInformer(streamingClient *StreamingClient, typeInfo *typeInfo, namespace string) (*streamingInformer, error) {
 	s := &streamingInformer{
 		streamingClient: streamingClient,
 		typeInfo:        typeInfo,
+		namespace:       namespace,
 	}
 	s.objects = objects{
 		store: make(map[types.NamespacedName]Object),
@@ -136,7 +139,11 @@ func (i *streamingInformer) runOnce(ctx context.Context) error {
 		ResourceVersion:     listMetadata.ResourceVersion,
 		AllowWatchBookmarks: true,
 	}
-	if err := i.streamingClient.Watch(ctx, i.typeInfo, watchOptions, watchListener); err != nil {
+	namespace := ""
+	if i.typeInfo.Scope == meta.RESTScopeNamespace {
+		namespace = i.namespace
+	}
+	if err := i.streamingClient.Watch(ctx, i.typeInfo, namespace, watchOptions, watchListener); err != nil {
 		return err
 	}
 
@@ -150,7 +157,11 @@ func (i *streamingInformer) doList(ctx context.Context) (*ListMetadata, error) {
 
 	isInInitialList := !i.hasSynced.Load()
 	listListener := &listListener{objects: &i.objects, isInInitialList: isInInitialList, eventHandlerRegistrations: i.eventHandlerRegistrations}
-	if err := i.streamingClient.List(ctx, i.typeInfo, listListener); err != nil {
+	namespace := ""
+	if i.typeInfo.Scope == meta.RESTScopeNamespace {
+		namespace = i.namespace
+	}
+	if err := i.streamingClient.List(ctx, i.typeInfo, namespace, listListener); err != nil {
 		return nil, err
 	}
 	return &listListener.metadata, nil
@@ -287,6 +298,9 @@ func (i *eventHandlerRegistration) HasSynced() bool {
 func (i *streamingInformer) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	if len(opts) != 0 {
 		return fmt.Errorf("options not implemented: %v", opts)
+	}
+	if !i.WaitForCacheSync(ctx) {
+		return fmt.Errorf("streamingInformer WaitForCacheSync failed")
 	}
 
 	i.objects.mutex.Lock()

--- a/pkg/cli/preview/typeinfo.go
+++ b/pkg/cli/preview/typeinfo.go
@@ -38,6 +38,7 @@ type typeInfo struct {
 	factory func() Object
 	gvr     GroupVersionResource
 	gvk     schema.GroupVersionKind
+	Scope   meta.RESTScope
 }
 
 // getTypeInfoForGVK returns the type information for the given GVK.
@@ -111,6 +112,7 @@ func (s *typeStore) getTypeInfo(obj client.Object) (*typeInfo, error) {
 	}
 	typeInfo.gvk = gvk
 	typeInfo.gvr = GroupVersionResource(restMapping.Resource)
+	typeInfo.Scope = restMapping.Scope
 	return typeInfo, nil
 }
 

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -172,8 +172,10 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 		return nil, fmt.Errorf("error validating manager options: BaseContext is unexpectedly set")
 	}
 	opts.BaseContext = func() context.Context {
-		// Log the fields that cause object updates
-		ctx = structuredreporting.ContextWithListener(ctx, &structuredreporting.LogFieldUpdates{})
+		// If listener already exists, do not add another
+		if _, exists := structuredreporting.GetListenerFromContext(ctx); !exists {
+			ctx = structuredreporting.ContextWithListener(ctx, &structuredreporting.LogFieldUpdates{})
+		}
 
 		return ctx
 	}


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Add namespace mode to preview tool

### TEST
```
go run main.go preview

Finish reconciled 7 out of 7 resouces.
Detect 6 good and 1 bad objects.
-----------------------------------------------------------------
Namespace: config-control
GROUP                            KIND              GOOD   BAD
storage.cnrm.cloud.google.com    StorageBucket     1      1
bigquery.cnrm.cloud.google.com   BigQueryTable     1      0
bigquery.cnrm.cloud.google.com   BigQueryDataset   1      0
alloydb.cnrm.cloud.google.com    AlloyDBInstance   1      0
spanner.cnrm.cloud.google.com    SpannerInstance   1      0
-----------------------------------------------------------------
Namespace: test-autopilot
GROUP                       KIND          GOOD   BAD
sql.cnrm.cloud.google.com   SQLInstance   1      0
```

```
go run main.go preview --namespace config-control

Finish reconciled 6 out of 6 resouces.
Detect 5 good and 1 bad objects.
-----------------------------------------------------------------
Namespace: config-control
GROUP                            KIND              GOOD   BAD
spanner.cnrm.cloud.google.com    SpannerInstance   1      0
storage.cnrm.cloud.google.com    StorageBucket     1      1
alloydb.cnrm.cloud.google.com    AlloyDBInstance   1      0
bigquery.cnrm.cloud.google.com   BigQueryDataset   1      0
bigquery.cnrm.cloud.google.com   BigQueryTable     1      0
```

```
go run main.go preview --namespace test-autopilot
Finish reconciled 1 out of 1 resouces.
Detect 1 good and 0 bad objects.
-----------------------------------------------------------------
Namespace: test-autopilot
GROUP                       KIND          GOOD   BAD
sql.cnrm.cloud.google.com   SQLInstance   1      0
```

#### WHY do we need this change?
The tool can be run as a job in GKE cluster. Each job can use its own KSA similar to the real manager in namespaced mode.
#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [x] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
