### PR TITLE
chore: clarify docs on server-generated-id policy

### DIFF
--- a/docs/ai/server-generated-id.md
+++ b/docs/ai/server-generated-id.md
@@ -6,13 +6,14 @@ which is the same field that users can specify if they want to adopt an existing
 However, this makes the field ownership of the spec.resourceID field unclear: did the user specify it, or did KCC write it back?
 
 For greenfield controllers, we are introducing status.externalRef.
-This field will consistently give the GCP resource ID, as well as indicating whether a resource is under KCC control.
+All new controllers should write the identity to status.externalRef,
+so this field will both consistently give the GCP resource ID, as well as indicating whether a resource is under KCC control.
 
 The question is whether we should also write to spec.resourceID.
 To avoid a behavioural change, when moving from terraform to direct, we will write to both status.externalRef _and_ spec.resourceID.
 We want to avoid two problems:
 
-* It should be possible to create a GCP resource with the direct controller and then revert back to the terraform controller (without creating a new GCP resource)
+* It should be possible to create a GCP resource with the direct controller and then revert back to the terraform controller (without creating a new GCP resource).
 
 * Tooling or other controllers should continue to see the resourceID in the existing spec.resourceID field.
 
@@ -21,8 +22,8 @@ the only way we have to solve the user expectations problem is with time (a "dep
 
 Instead, we accept that although we would prefer never to write to spec, we will continue
 to write spec.resourceID for server-generated-id resources that we are migrating from DCL or Terraform to Direct.
-We will not (currently) write to spec for non-server-generated-id resources, nor for greenfield Direct controllers.
-Nor are we intending to "open the door" for writing fields _other_ than spec.resourceID from direct controllers.
+We do not intend to write to spec for non-server-generated-id resources, nor for greenfield Direct controllers (unless there is a very compelling and documented reason).
+This edge case for writing to spec should not be used as an excuse for writing any other spec fields.
 
 We may be able to stop writing spec.resourceID as part of "v1";
 we should start communicating now that status.externalRef is the canonical location for the GCP identity


### PR DESCRIPTION
Make it much crisper and less hedging.
