### PR TITLE
tests: try unified diff format for e2e tests

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -330,7 +330,7 @@ func createDiffs(t *testing.T, ctx context.Context, fixture resourcefixture.Reso
 	computeDiff := func(oldP, newP string) string {
 		var out bytes.Buffer
 
-		cmd := exec.CommandContext(ctx, "diff", oldP, newP)
+		cmd := exec.CommandContext(ctx, "diff", "-u", oldP, newP)
 		cmd.Stdout = &out
 		cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
It seems to be more readable with fewer "random" values.
