### PR TITLE
fix the commit on which the release branch was created on

### DIFF
--- a/dev/tasks/auto-tag-on-version-update.sh
+++ b/dev/tasks/auto-tag-on-version-update.sh
@@ -41,7 +41,43 @@ echo "Tag v$VERSION does not exist. Proceeding."
 # We tag the end of the release PR (which includes 3 commits), not just the first commit that bumped the version.
 # We assume this script runs on the tip of the release branch/PR.
 COMMIT_HASH=$(git rev-parse HEAD)
+if [ -z "${COMMIT_HASH}" ]; then
+  echo "ERROR: Could not determine commit hash."
+  exit 1
+fi
 echo "Using HEAD as commit to tag: ${COMMIT_HASH}"
+
+# 4. Verify the commit messages of the last 3 commits.
+# Expected order (oldest to newest):
+# 1. Release <VERSION>
+# 2. Update alpha CRDs for Release <VERSION>
+# 3. Update golden files for operator controllers
+
+# HEAD~2 (First commit)
+MSG_FIRST=$(git log --format=%s -n 1 HEAD~2)
+EXPECTED_FIRST="Release ${VERSION}"
+if [ "${MSG_FIRST}" != "${EXPECTED_FIRST}" ]; then
+  echo "ERROR: HEAD~2 commit message '${MSG_FIRST}' does not match expected '${EXPECTED_FIRST}'"
+  exit 1
+fi
+
+# HEAD~1 (Second commit)
+MSG_SECOND=$(git log --format=%s -n 1 HEAD~1)
+EXPECTED_SECOND="Update alpha CRDs for Release ${VERSION}"
+if [ "${MSG_SECOND}" != "${EXPECTED_SECOND}" ]; then
+  echo "ERROR: HEAD~1 commit message '${MSG_SECOND}' does not match expected '${EXPECTED_SECOND}'"
+  exit 1
+fi
+
+# HEAD (Third commit)
+MSG_THIRD=$(git log --format=%s -n 1 HEAD)
+EXPECTED_THIRD="Update golden files for operator controllers"
+if [ "${MSG_THIRD}" != "${EXPECTED_THIRD}" ]; then
+  echo "ERROR: HEAD commit message '${MSG_THIRD}' does not match expected '${EXPECTED_THIRD}'"
+  exit 1
+fi
+
+echo "Verified last 3 commit messages match release pattern."
 
 # 4. Verify the version in the file at the target commit matches the version from HEAD.
 # This ensures we're tagging the right commit.


### PR DESCRIPTION
### BRIEF Change description

Include all three commits related to release to create the release branch.

#### WHY do we need this change?

The issue was spotted on the 140 release and we cherry picked the two remaining commits: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5790

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
