### PR TITLE
fix: ignore gpu_zonal_redundancy_disabled in RunJob fuzzer

### DIFF
--- a/pkg/controller/direct/run/job_fuzzer.go
+++ b/pkg/controller/direct/run/job_fuzzer.go
@@ -71,6 +71,7 @@ func runJobFuzzer() fuzztesting.KRMFuzzer {
 	f.Unimplemented_NotYetTriaged(".template.template.containers[].startup_probe.http_get")
 	f.Unimplemented_NotYetTriaged(".template.template.containers[].liveness_probe.grpc")
 	f.Unimplemented_NotYetTriaged(".template.template.containers[].liveness_probe.http_get")
+	f.Unimplemented_NotYetTriaged(".template.template.gpu_zonal_redundancy_disabled")
 	f.Unimplemented_NotYetTriaged(".template.template.node_selector")
 	f.Unimplemented_NotYetTriaged(".template.template.volumes[].nfs")
 	f.Unimplemented_NotYetTriaged(".template.template.volumes[].gcs")


### PR DESCRIPTION
- **fix: ignore gpu_zonal_redundancy_disabled in RunJob fuzzer**
