### PR TITLE
update scripts to create patch release tag

### DIFF
--- a/dev/tasks/auto-tag-on-version-update.sh
+++ b/dev/tasks/auto-tag-on-version-update.sh
@@ -37,13 +37,53 @@ if [ "$(git tag -l "v${VERSION}")" ]; then
 fi
 echo "Tag v$VERSION does not exist. Proceeding."
 
-# 3. Find the commit that last modified the VERSION file. This is the commit we will tag.
-COMMIT_HASH=$(git log -1 --pretty=format:%H "${VERSION_FILE}")
-if [ -z "$COMMIT_HASH" ]; then
-  echo "ERROR: Could not find a commit for ${VERSION_FILE}."
+# 3. Use the current commit (HEAD) as the tag target.
+# We tag the end of the release PR (which includes 3 commits), not just the first commit that bumped the version.
+# We assume this script runs on the tip of the release branch/PR.
+COMMIT_HASH=$(git rev-parse HEAD)
+if [ -z "${COMMIT_HASH}" ]; then
+  echo "ERROR: Could not determine commit hash."
   exit 1
 fi
-echo "Found commit to tag: ${COMMIT_HASH}"
+echo "Using HEAD as commit to tag: ${COMMIT_HASH}"
+
+# 4. Verify the commit messages match the release pattern.
+# We expect the sequence (oldest to newest):
+# 1. Release <VERSION>
+# 2. Update alpha CRDs for Release <VERSION>
+# 3. (Optional) Update golden files for operator controllers
+
+# We start checking from HEAD and work backwards.
+CURRENT_REF="HEAD"
+
+# Check for Optional commit 3: Golden files
+MSG=$(git log --format=%s -n 1 "${CURRENT_REF}")
+EXPECTED_GOLDEN="Update golden files for operator controllers"
+if [ "${MSG}" = "${EXPECTED_GOLDEN}" ]; then
+  echo "Found golden files update commit at ${CURRENT_REF}."
+  CURRENT_REF="${CURRENT_REF}~1"
+  MSG=$(git log --format=%s -n 1 "${CURRENT_REF}")
+else
+  echo "Optional golden files update commit not found. Proceeding..."
+fi
+
+# Check for Required commit 2: Alpha CRDs
+EXPECTED_CRDS="Update alpha CRDs for Release ${VERSION}"
+if [ "${MSG}" = "${EXPECTED_CRDS}" ]; then
+  echo "Found alpha CRDs update commit at ${CURRENT_REF}."
+  CURRENT_REF="${CURRENT_REF}~1"
+  MSG=$(git log --format=%s -n 1 "${CURRENT_REF}")
+fi
+
+# Check for Required commit 1: Release version
+EXPECTED_RELEASE="Release ${VERSION}"
+if [ "${MSG}" != "${EXPECTED_RELEASE}" ]; then
+  echo "ERROR: Expected commit message '${EXPECTED_RELEASE}' at ${CURRENT_REF} (derived from HEAD), but found '${MSG}'"
+  echo "The release PR must typically start with a 'Release ${VERSION}' commit, optionally followed by CRD updates and/or golden file updates."
+  exit 1
+fi
+
+echo "Verified commit messages match release pattern."
 
 # 4. Verify the version in the file at the target commit matches the version from HEAD.
 # This ensures we're tagging the right commit.


### PR DESCRIPTION
### BRIEF Change description

Fix the script to pick out the correct commit for patch release to create release tag.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
