### PR TITLE
tests: avoid duplicate normalization in container cluster

### DIFF
--- a/mockgcp/mockcontainer/normalize.go
+++ b/mockgcp/mockcontainer/normalize.go
@@ -57,7 +57,6 @@ func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcp
 	event.VisitResponseStringValues(func(path string, value string) {
 		switch path {
 		case ".controlPlaneEndpointsConfig.ipEndpointsConfig.publicEndpoint",
-			".endpoint",
 			".privateClusterConfig.publicEndpoint":
 			if isIPv4Address(value) {
 				replacements.ReplaceStringValue(value, "${publicEndpointIPV4}")


### PR DESCRIPTION
.endpoint is sometimes the public IP, sometimes the private IP.

This was causing normalization to fail on private clusters.
