### PR TITLE
chore: replace references to generated client with canonical packages

### DIFF
--- a/apis/alloydb/v1beta1/util.go
+++ b/apis/alloydb/v1beta1/util.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
 
 	corev1 "k8s.io/api/core/v1"

--- a/apis/apikeys/v1alpha1/apikey_type.go
+++ b/apis/apikeys/v1alpha1/apikey_type.go
@@ -17,7 +17,7 @@ package v1alpha1
 import (
 	"reflect"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"

--- a/apis/apikeys/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apikeys/v1alpha1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@
 package v1alpha1
 
 import (
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/certificatemanager/v1alpha1/certificateissuanceconfig_types.go
+++ b/apis/certificatemanager/v1alpha1/certificateissuanceconfig_types.go
@@ -17,7 +17,7 @@ package v1alpha1
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/parent"
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/certificatemanager/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/certificatemanager/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/parent"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/certificatemanager/v1beta1/dnsauthorization_types.go
+++ b/apis/certificatemanager/v1beta1/dnsauthorization_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/certificatemanager/v1beta1/zz_generated.deepcopy.go
+++ b/apis/certificatemanager/v1beta1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@
 package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/cloudbuild/v1alpha1/workerpool_types.go
+++ b/apis/cloudbuild/v1alpha1/workerpool_types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	computev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/compute/v1beta1"
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/cloudbuild/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cloudbuild/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ package v1alpha1
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/datacatalog/v1beta1/policytag_types.go
+++ b/apis/datacatalog/v1beta1/policytag_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/datacatalog/v1beta1/taxonomy_types.go
+++ b/apis/datacatalog/v1beta1/taxonomy_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/datacatalog/v1beta1/zz_generated.deepcopy.go
+++ b/apis/datacatalog/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ package v1beta1
 
 import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/dataform/v1alpha1/repository_types.go
+++ b/apis/dataform/v1alpha1/repository_types.go
@@ -16,7 +16,7 @@ package v1alpha1
 
 import (
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/dataform/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/dataform/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ package v1alpha1
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/dataform/v1beta1/repository_types.go
+++ b/apis/dataform/v1beta1/repository_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	refv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/dataform/v1beta1/zz_generated.deepcopy.go
+++ b/apis/dataform/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ package v1beta1
 
 import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/gkehub/v1beta1/featuremembership_types.go
+++ b/apis/gkehub/v1beta1/featuremembership_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/gkehub/v1beta1/zz_generated.deepcopy.go
+++ b/apis/gkehub/v1beta1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ package v1beta1
 
 import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/kms/v1beta1/keyring_types.go
+++ b/apis/kms/v1beta1/keyring_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/apis/kms/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kms/v1beta1/zz_generated.deepcopy.go
@@ -23,7 +23,6 @@ import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	k8sv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1beta1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -833,7 +832,7 @@ func (in *KMSKeyRingStatus) DeepCopyInto(out *KMSKeyRingStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]k8sv1alpha1.Condition, len(*in))
+		*out = make([]v1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
 	if in.ObservedGeneration != nil {

--- a/apis/logging/v1beta1/logmetric_types.go
+++ b/apis/logging/v1beta1/logmetric_types.go
@@ -16,7 +16,10 @@ package v1beta1
 
 import (
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
+
+	derprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -137,7 +140,7 @@ type LoggingLogMetricSpec struct {
 	// If empty, then the Log Metric is considered a non-Bucket Log Metric.
 	/* Only `external` field is supported to configure the reference for now. */
 	// +optional
-	LoggingLogBucketRef *v1alpha1.ResourceRef `json:"loggingLogBucketRef,omitempty"`
+	LoggingLogBucketRef *derprecatedrefs.ResourceRef `json:"loggingLogBucketRef,omitempty"`
 
 	/* Optional. The `bucket_options` are required when the logs-based metric is using a DISTRIBUTION value type and it describes the bucket boundaries used to create a histogram of the extracted values. */
 	// +optional

--- a/apis/logging/v1beta1/zz_generated.deepcopy.go
+++ b/apis/logging/v1beta1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/parent"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -181,7 +182,7 @@ func (in *LoggingLogMetricStatus) DeepCopyInto(out *LoggingLogMetricStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1alpha1.Condition, len(*in))
+		*out = make([]k8sv1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
 	if in.CreateTime != nil {

--- a/apis/monitoring/v1beta1/dashboard_types.go
+++ b/apis/monitoring/v1beta1/dashboard_types.go
@@ -16,8 +16,10 @@ package v1beta1
 
 import (
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	deprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 )
 
 var MonitoringDashboardGVK = GroupVersion.WithKind("MonitoringDashboard")
@@ -640,7 +642,7 @@ type LogsPanel struct {
 	Filter *string `json:"filter,omitempty"`
 
 	// The names of logging resources to collect logs for.
-	ResourceNames []v1alpha1.ResourceRef `json:"resourceNames,omitempty"`
+	ResourceNames []deprecatedrefs.ResourceRef `json:"resourceNames,omitempty"`
 }
 
 // +kcc:spec:proto=google.monitoring.dashboard.v1.Dashboard

--- a/apis/monitoring/v1beta1/notificationchannel_types.go
+++ b/apis/monitoring/v1beta1/notificationchannel_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	refsv1beta1secret "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/monitoring/v1beta1/zz_generated.deepcopy.go
+++ b/apis/monitoring/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/parent"
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
+	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -523,7 +524,7 @@ func (in *MonitoringDashboardStatus) DeepCopyInto(out *MonitoringDashboardStatus
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1alpha1.Condition, len(*in))
+		*out = make([]k8sv1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
 	if in.Etag != nil {
@@ -664,7 +665,7 @@ func (in *MonitoringNotificationChannelStatus) DeepCopyInto(out *MonitoringNotif
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1alpha1.Condition, len(*in))
+		*out = make([]k8sv1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
 	if in.Name != nil {

--- a/apis/refs/v1beta1/folderref.go
+++ b/apis/refs/v1beta1/folderref.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 )
 
 // FolderRef represents the Folder that this resource belongs to.
@@ -46,7 +46,7 @@ type FolderRef struct {
 }
 
 // AsFolderRef converts a generic ResourceRef into a FolderRef.
-func AsFolderRef(in *v1alpha1.ResourceRef) *FolderRef {
+func AsFolderRef(in *deprecatedrefs.ResourceRef) *FolderRef {
 	if in == nil {
 		return nil
 	}

--- a/apis/refs/v1beta1/organizationref.go
+++ b/apis/refs/v1beta1/organizationref.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 )
 
 // OrganizationRef represents the Organization that this resource belongs to.
@@ -33,7 +33,7 @@ type OrganizationRef struct {
 }
 
 // AsOrganizationRef converts a generic ResourceRef into a OrganizationRef.
-func AsOrganizationRef(in *v1alpha1.ResourceRef) *OrganizationRef {
+func AsOrganizationRef(in *deprecatedrefs.ResourceRef) *OrganizationRef {
 	if in == nil {
 		return nil
 	}

--- a/apis/refs/v1beta1/projectref.go
+++ b/apis/refs/v1beta1/projectref.go
@@ -20,12 +20,13 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/identity"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 )
 
 var ProjectGVK = schema.GroupVersionKind{
@@ -67,7 +68,7 @@ func (r *ProjectRef) SetExternal(ref string) {
 }
 
 // AsProjectRef converts a generic ResourceRef into a ProjectRef
-func AsProjectRef(in *v1alpha1.ResourceRef) *ProjectRef {
+func AsProjectRef(in *deprecatedrefs.ResourceRef) *ProjectRef {
 	if in == nil {
 		return nil
 	}

--- a/apis/refs/v1beta1/secret/legacy.go
+++ b/apis/refs/v1beta1/secret/legacy.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deprecatedrefs "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 )
 
 // +kubebuilder:object:generate:=true
@@ -41,10 +42,10 @@ type Legacy struct {
 type LegacyValueFrom struct {
 	/* Reference to a value with the given key in the given Secret in the resource's namespace. */
 	// +optional
-	SecretKeyRef *v1alpha1.SecretKeyRef `json:"secretKeyRef,omitempty"`
+	SecretKeyRef *deprecatedrefs.SecretKeyRef `json:"secretKeyRef,omitempty"`
 }
 
-func NormalizedLegacySecret(ctx context.Context, r *v1alpha1.SecretKeyRef, reader client.Reader, otherNamespace string) ([]byte, error) {
+func NormalizedLegacySecret(ctx context.Context, r *deprecatedrefs.SecretKeyRef, reader client.Reader, otherNamespace string) ([]byte, error) {
 	if r == nil {
 		return nil, nil
 	}

--- a/apis/secretmanager/v1beta1/secretversion_types.go
+++ b/apis/secretmanager/v1beta1/secretversion_types.go
@@ -16,7 +16,7 @@ package v1beta1
 
 import (
 	refsv1beta1secret "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
+++ b/apis/secretmanager/v1beta1/zz_generated.deepcopy.go
@@ -23,7 +23,6 @@ import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
-	k8sv1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -751,7 +750,7 @@ func (in *SecretManagerSecretVersionStatus) DeepCopyInto(out *SecretManagerSecre
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]k8sv1alpha1.Condition, len(*in))
+		*out = make([]v1alpha1.Condition, len(*in))
 		copy(*out, *in)
 	}
 	if in.ObservedGeneration != nil {

--- a/apis/sql/v1beta1/instance_types.go
+++ b/apis/sql/v1beta1/instance_types.go
@@ -23,7 +23,7 @@ import (
 
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	refsv1beta1secret "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"

--- a/apis/sql/v1beta1/zz_generated.deepcopy.go
+++ b/apis/sql/v1beta1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ import (
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1/secret"
 	storagev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/storage/v1beta1"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
This is not a huge problem in itself, but the ones where we are using
not-standard Ref types are more concerning.  These are now imported
as "deprecatedrefs" to make it clear that these are not the preferred
way to do things.
