### PR TITLE
fix: Prevent redundant patchRule request for ComputeFirewallPolicyRule when no changes

### DIFF
--- a/pkg/controller/direct/compute/firewallpolicyrule_controller.go
+++ b/pkg/controller/direct/compute/firewallpolicyrule_controller.go
@@ -221,6 +221,10 @@ func (a *firewallPolicyRuleAdapter) Update(ctx context.Context, updateOp *direct
 		// See API doc: https://cloud.google.com/compute/docs/reference/rest/v1/firewallPolicies/patchRule#query-parameters
 		firewallPolicyRule.Priority = nil
 
+		// Cleanup previously assigned values to output-only fields.
+		firewallPolicyRule.Kind = nil
+		firewallPolicyRule.RuleTupleCount = nil
+
 		updateReq := &computepb.PatchRuleFirewallPolicyRequest{
 			FirewallPolicyRuleResource: firewallPolicyRule,
 			FirewallPolicy:             a.id.Parent().FirewallPolicy,

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-egress-full-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-egress-full-direct/_http.log
@@ -803,7 +803,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
 {
   "action": "allow",
   "direction": "EGRESS",
-  "kind": "compute#firewallPolicyRule",
   "match": {
     "destAddressGroups": [
       "organizations/${organizationID}/locations/global/addressGroups/testnetworksecurityaddressgroup-2"
@@ -833,7 +832,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
       "10.100.0.2/32"
     ]
   },
-  "ruleTupleCount": 4,
   "targetResources": [
     "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
   ],

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-ingress-full-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-ingress-full-direct/_http.log
@@ -803,7 +803,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
 {
   "action": "allow",
   "direction": "INGRESS",
-  "kind": "compute#firewallPolicyRule",
   "match": {
     "destIpRanges": [
       "10.100.0.2/32"
@@ -833,7 +832,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
       "iplist-tor-exit-nodes"
     ]
   },
-  "ruleTupleCount": 4,
   "targetResources": [
     "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
   ],

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-minimal-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computefirewallpolicyrule/computefirewallpolicyrule-minimal-direct/_http.log
@@ -323,7 +323,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
 {
   "action": "allow",
   "direction": "INGRESS",
-  "kind": "compute#firewallPolicyRule",
   "match": {
     "layer4Configs": [
       {
@@ -333,8 +332,7 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
     "srcIpRanges": [
       "10.100.0.1/32"
     ]
-  },
-  "ruleTupleCount": 2
+  }
 }
 
 200 OK

--- a/tests/e2e/testdata/scenarios/computefirewallpolicyrule/update/_http02.log
+++ b/tests/e2e/testdata/scenarios/computefirewallpolicyrule/update/_http02.log
@@ -42,7 +42,6 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
 {
   "action": "allow",
   "direction": "INGRESS",
-  "kind": "compute#firewallPolicyRule",
   "match": {
     "layer4Configs": [
       {
@@ -52,8 +51,7 @@ X-Goog-Request-Params: firewall_policy=${firewallPolicyID}
     "srcIpRanges": [
       "10.100.0.1/32"
     ]
-  },
-  "ruleTupleCount": 2
+  }
 }
 
 200 OK


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Commit 1: Fixed the 'noupdate' test to force a re-reconciliation even when the resource is unchanged. The test now correctly identifies the bug by showing that patchRule is being triggered unnecessarily.

Commit 2: Fixed the direct controller update logic and re-ran the "noupdate" test. No patchRule request logged.
a) Removed the `priority` field after calling `common.CompareProtoMessage` to prevent it from being flagged as a diff unexpectedly.
b) Handled output-only fields to avoid unnecessary diffs caused by a known limitation in the `common.CompareProtoMessage` method: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/4455

#### WHY do we need this change?
To address a Cx issue(BestBuy)

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[PR https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/5931]: Prevent redundant patchRule request for ComputeFirewallPolicyRule when no changes.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
