### PR TITLE
chore: make output from dev/tasks/generate-types-and-mappers much shorter

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -143,3 +143,7 @@ When promoting a resource from `v1alpha1` to `v1beta1`, we should keep `krm` as 
 * `docs/ai/add-missing-field.md` describes how to add a missing field, for example when the GCP service adds a new field.
 * `docs/ai/create-crd-for-existing-terraform-resource.md` describes how to create a CRD for an existing terraform resource.
 * `docs/ai/github-workflow.md` describes how to generate github workflows.
+
+# Helpful scripts
+
+* `dev/tasks/generate-types-and-mappers` will regenerate all our generated CRD files and generated mapper code.  It should be run after changing API types.

--- a/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/generatorbase.go
@@ -142,7 +142,7 @@ func (f *generatedFile) Write(addCopyright bool, writeEmptyFiles bool) error {
 		return fmt.Errorf("running goimports on %q: %w", p, err)
 	}
 
-	klog.Infof("writing file %v", p)
+	klog.V(2).Infof("writing file %v", p)
 	if err := os.WriteFile(p, formatted, 0644); err != nil {
 		return fmt.Errorf("writing %q: %w", p, err)
 	}

--- a/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/mappergenerator.go
@@ -226,7 +226,7 @@ func (v *MapperGenerator) GenerateMappers(goImports map[string]string) error {
 	return nil
 }
 func (v *MapperGenerator) writeMapFunctionsForPair(out io.Writer, srcDir string, pair *typePair) {
-	klog.InfoS("writeMapFunctionsForPair", "pair.Proto.FullName", pair.Proto.FullName(), "pair.KRMType.Name", pair.KRMType.Name)
+	klog.V(2).InfoS("writeMapFunctionsForPair", "pair.Proto.FullName", pair.Proto.FullName(), "pair.KRMType.Name", pair.KRMType.Name)
 	msg := pair.Proto
 	pbTypeName := protoNameForType(msg)
 	pbTypeGoImport := v.goPackageForProto(msg.ParentFile())
@@ -291,7 +291,7 @@ func (v *MapperGenerator) writeMapFunctionsForPair(out io.Writer, srcDir string,
 					tokens := strings.SplitN(qualifiedTypeName, ".", 2)
 					if len(tokens) > 1 {
 						alias := v.getGoImportAlias(krmFieldRefs.GoPackage)
-						klog.Infof("getGetImportAlias(%q) => %q", krmFieldRefs.GoPackage, alias)
+						klog.V(2).Infof("getGoImportAlias(%q) => %q", krmFieldRefs.GoPackage, alias)
 						qualifiedTypeName = alias + "." + tokens[1]
 					} else if len(tokens) == 1 {
 						// In same package
@@ -448,7 +448,7 @@ func (v *MapperGenerator) writeMapFunctionsForPair(out io.Writer, srcDir string,
 				}
 
 				if useSliceFromProtoFunction != "" {
-					klog.Infof("Slice_FromProto krmFieldName %v, protoFieldName %v",
+					klog.V(2).Infof("Slice_FromProto krmFieldName %v, protoFieldName %v",
 						krmFieldName,
 						protoFieldName,
 					)
@@ -534,7 +534,7 @@ func (v *MapperGenerator) writeMapFunctionsForPair(out io.Writer, srcDir string,
 		fmt.Fprintf(out, "\treturn out\n")
 		fmt.Fprintf(out, "}\n")
 	} else {
-		klog.Infof("found existing non-generated mapping function %q, won't generate", goTypeName+"_FromProto")
+		klog.V(1).Infof("found existing non-generated mapping function %q, won't generate", goTypeName+"_FromProto")
 	}
 
 	if v.findFuncDeclaration(goTypeName+versionSpecifier+"_ToProto", srcDir, true) == nil {
@@ -885,7 +885,7 @@ func (v *MapperGenerator) writeMapFunctionsForPair(out io.Writer, srcDir string,
 		fmt.Fprintf(out, "\treturn out\n")
 		fmt.Fprintf(out, "}\n")
 	} else {
-		klog.Infof("found existing non-generated mapping function %q, won't generate", goTypeName+"_ToProto")
+		klog.V(1).Infof("found existing non-generated mapping function %q, won't generate", goTypeName+"_ToProto")
 	}
 
 	// Generate ToProto helpers for oneof fields that are not messages

--- a/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
+++ b/dev/tools/controllerbuilder/pkg/codegen/typegenerator.go
@@ -145,7 +145,7 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 			return fmt.Errorf("looking up go type: %w", err)
 		}
 		if goType != nil {
-			klog.Infof("found existing non-generated go type %q, won't generate", goTypeName)
+			klog.V(1).Infof("found existing non-generated go type %q, won't generate", goTypeName)
 			continue
 		}
 
@@ -154,7 +154,7 @@ func (g *TypeGenerator) WriteVisitedMessages() error {
 			return fmt.Errorf("looking up go type by proto tag: %w", err)
 		}
 		if goType != nil {
-			klog.Infof("found existing non-generated go type with proto tag %q, won't generate", msg.FullName())
+			klog.V(1).Infof("found existing non-generated go type with proto tag %q, won't generate", msg.FullName())
 			continue
 		}
 
@@ -186,7 +186,7 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 			return fmt.Errorf("looking up go type: %w", err)
 		}
 		if goType != nil {
-			klog.Infof("found existing non-generated go type %q, won't generate", goTypeName)
+			klog.V(1).Infof("found existing non-generated go type %q, won't generate", goTypeName)
 			continue
 		}
 
@@ -195,7 +195,7 @@ func (g *TypeGenerator) WriteOutputMessages() error {
 			return fmt.Errorf("looking up go type by proto tag: %w", err)
 		}
 		if goType != nil {
-			klog.Infof("found existing non-generated go type with proto tag %q, won't generate", msg.FullName())
+			klog.V(1).Infof("found existing non-generated go type with proto tag %q, won't generate", msg.FullName())
 			continue
 		}
 

--- a/dev/tools/controllerbuilder/pkg/commands/generatecontroller/generatecontrollercommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatecontroller/generatecontrollercommand.go
@@ -25,6 +25,7 @@ import (
 	cctemplate "github.com/GoogleCloudPlatform/k8s-config-connector/dev/tools/controllerbuilder/template/controller"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 type GenerateControllerOptions struct {
@@ -108,7 +109,7 @@ func RunController(ctx context.Context, o *GenerateControllerOptions) error {
 		PackageProtoTag: o.ServiceName,
 	}
 	if scaffolder.RefsFileExist(o.Resource) {
-		fmt.Printf("file %s already exists, skipping\n", scaffolder.PathToRefsFile(o.Resource))
+		klog.V(1).Infof("file %s already exists, skipping\n", scaffolder.PathToRefsFile(o.Resource))
 	} else {
 		err := scaffolder.AddRefsFile(o.Resource)
 		if err != nil {
@@ -116,7 +117,7 @@ func RunController(ctx context.Context, o *GenerateControllerOptions) error {
 		}
 	}
 	if scaffolder.IdentityFileExist(o.Resource) {
-		fmt.Printf("file %s already exists, skipping\n", scaffolder.PathToIdentityFile(o.Resource))
+		klog.V(1).Infof("file %s already exists, skipping\n", scaffolder.PathToIdentityFile(o.Resource))
 	} else {
 		err := scaffolder.AddIdentityFile(o.Resource)
 		if err != nil {

--- a/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
+++ b/dev/tools/controllerbuilder/pkg/commands/generatetypes/generatetypescommand.go
@@ -130,7 +130,7 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 	resourceAnnotations := make([]string, 0, len(o.Resources))
 	for _, resource := range o.Resources {
 		resourceProtoFullName := resource.ProtoMessageFullName(o.ServiceName)
-		log.Info("visiting proto", "name", resourceProtoFullName)
+		log.V(2).Info("visiting proto", "name", resourceProtoFullName)
 		if err := typeGenerator.VisitProto(resourceProtoFullName); err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func RunGenerateCRD(ctx context.Context, o *GenerateCRDOptions) error {
 			log.Info("skipping scaffolding type, refs and identity files", "resource", resource.ProtoName)
 		} else {
 			if scaffolder.TypeFileExists(resource) {
-				fmt.Printf("file %s already exists, skipping\n", scaffolder.PathToTypeFile(resource))
+				klog.V(1).Infof("file %s already exists, skipping\n", scaffolder.PathToTypeFile(resource))
 			} else {
 				err := scaffolder.AddTypeFile(resource)
 				if err != nil {

--- a/dev/tools/controllerbuilder/scaffold/controller.go
+++ b/dev/tools/controllerbuilder/scaffold/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fatih/color"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/imports"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -100,7 +101,7 @@ func (c *ControllerBuilder) GenerateController(cArgs *ccTemplate.ControllerArgs)
 		return err
 	}
 	if _, err := os.Stat(controllerFilePath); err == nil {
-		fmt.Printf("file %s already exists, skipping\n", controllerFilePath)
+		klog.V(1).Infof("file %s already exists, skipping\n", controllerFilePath)
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("unexpected controller file: %w", err)


### PR DESCRIPTION
This otherwise eats LLM context.

Also encourage the LLM to run the script when changing API types.
