### PR TITLE
chore: automatically build/update googleapis.pb in scripts

### DIFF
--- a/apis/accesscontextmanager/v1beta1/generate.sh
+++ b/apis/accesscontextmanager/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.identity.accesscontextmanager.v1 \
     --api-version accesscontextmanager.cnrm.cloud.google.com/v1beta1  \

--- a/apis/analytics/v1alpha1/generate.sh
+++ b/apis/analytics/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.analytics.admin.v1beta \
     --api-version "analytics.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/asset/v1beta1/generate.sh
+++ b/apis/asset/v1beta1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.asset.v1 \
     --api-version asset.cnrm.cloud.google.com/v1beta1 \

--- a/apis/assuredworkloads/v1alpha1/generate.sh
+++ b/apis/assuredworkloads/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.assuredworkloads.v1 \
     --api-version "assuredworkloads.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/backupdr/v1alpha1/generate.sh
+++ b/apis/backupdr/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1alpha1 \
@@ -36,4 +38,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/backupdr/
-

--- a/apis/backupdr/v1beta1/generate.sh
+++ b/apis/backupdr/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1beta1 \

--- a/apis/batch/v1alpha1/generate.sh
+++ b/apis/batch/v1alpha1/generate.sh
@@ -21,12 +21,14 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.batch.v1 \
     --api-version "batch.cnrm.cloud.google.com/v1alpha1" \
     --resource BatchJob:Job \
     --resource BatchTask:Task
-    
+
 
 go run . generate-mapper \
     --service google.cloud.batch.v1 \
@@ -36,4 +38,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/batch/
-

--- a/apis/bigquerybiglake/v1alpha1/generate.sh
+++ b/apis/bigquerybiglake/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/bigquerybiglake/v1beta1/generate.sh
+++ b/apis/bigquerybiglake/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1beta1" \

--- a/apis/bigqueryreservation/v1beta1/generate.sh
+++ b/apis/bigqueryreservation/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.bigquery.reservation.v1 \
     --api-version "bigqueryreservation.cnrm.cloud.google.com/v1beta1" \

--- a/apis/bigtable/v1alpha1/generate.sh
+++ b/apis/bigtable/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1alpha1  \
@@ -39,4 +41,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigtable/
-

--- a/apis/bigtable/v1beta1/generate.sh
+++ b/apis/bigtable/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
@@ -36,4 +38,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigtable/
-

--- a/apis/billing/v1alpha1/generate.sh
+++ b/apis/billing/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.billing.v1 \
   --api-version billing.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/certificatemanager/v1alpha1/generate.sh
+++ b/apis/certificatemanager/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/certificatemanager/v1beta1/generate.sh
+++ b/apis/certificatemanager/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1" \

--- a/apis/clouddeploy/v1alpha1/generate.sh
+++ b/apis/clouddeploy/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1alpha1  \
@@ -35,4 +37,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddeploy/
-

--- a/apis/clouddeploy/v1beta1/generate.sh
+++ b/apis/clouddeploy/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1beta1  \
@@ -34,4 +36,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddeploy/
-

--- a/apis/clouddms/v1alpha1/generate.sh
+++ b/apis/clouddms/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.clouddms.v1 \
     --api-version "clouddms.cnrm.cloud.google.com/v1alpha1" \
@@ -36,4 +38,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddms/
-

--- a/apis/cloudquota/v1beta1/generate.sh
+++ b/apis/cloudquota/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.api.cloudquotas.v1beta \
     --api-version cloudquota.cnrm.cloud.google.com/v1beta1 \

--- a/apis/composer/v1beta1/generate.sh
+++ b/apis/composer/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.orchestration.airflow.service.v1 \
     --api-version "composer.cnrm.cloud.google.com/v1beta1" \

--- a/apis/compute/v1beta1/generate.sh
+++ b/apis/compute/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.compute.v1 \
   --api-version compute.cnrm.cloud.google.com/v1beta1  \

--- a/apis/configdelivery/v1alpha1/generate.sh
+++ b/apis/configdelivery/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.configdelivery.v1 \
     --api-version "configdelivery.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/dataflow/v1beta1/generate.sh
+++ b/apis/dataflow/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.dataflow.v1beta3 \
   --api-version dataflow.cnrm.cloud.google.com/v1beta1  \

--- a/apis/dataplex/v1alpha1/generate.sh
+++ b/apis/dataplex/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.dataplex.v1 \
     --api-version "dataplex.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/datastream/v1alpha1/generate.sh
+++ b/apis/datastream/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.datastream.v1 \
     --api-version datastream.cnrm.cloud.google.com/v1alpha1 \

--- a/apis/discoveryengine/v1alpha1/generate.sh
+++ b/apis/discoveryengine/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types --service google.cloud.discoveryengine.v1 --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
   --resource DiscoveryEngineDataStore:DataStore \
   --resource DiscoveryEngineEngine:Engine \
@@ -33,4 +35,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/discoveryengine/
-

--- a/apis/documentai/v1alpha1/generate.sh
+++ b/apis/documentai/v1alpha1/generate.sh
@@ -21,6 +21,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
 
 go run . generate-types \
     --service google.cloud.documentai.v1 \

--- a/apis/documentai/v1beta1/generate.sh
+++ b/apis/documentai/v1beta1/generate.sh
@@ -21,6 +21,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
 
 go run . generate-types \
     --service google.cloud.documentai.v1 \

--- a/apis/edgecontainer/v1alpha1/generate.sh
+++ b/apis/edgecontainer/v1alpha1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1 --resource EdgeContainerMachine:Machine
 
 go run . generate-mapper --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1

--- a/apis/essentialcontacts/v1beta1/generate.sh
+++ b/apis/essentialcontacts/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.essentialcontacts.v1 \
     --api-version "essentialcontacts.cnrm.cloud.google.com/v1beta1" \

--- a/apis/firestore/v1alpha1/generate.sh
+++ b/apis/firestore/v1alpha1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.firestore.admin.v1 \
   --api-version firestore.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/firestore/v1beta1/generate.sh
+++ b/apis/firestore/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.firestore.admin.v1 \
   --api-version firestore.cnrm.cloud.google.com/v1beta1  \

--- a/apis/gkebackup/v1alpha1/generate.sh
+++ b/apis/gkebackup/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.gkebackup.v1  \
     --api-version gkebackup.cnrm.cloud.google.com/v1alpha1 \
@@ -38,4 +40,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/gkebackup/
-

--- a/apis/gkehub/v1beta1/generate.sh
+++ b/apis/gkehub/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.gkehub.v1beta --api-version gkehub.cnrm.cloud.google.com/v1beta1 \
   --resource GKEHubFeatureMembership:MembershipFeatureSpec
@@ -36,4 +38,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/gkehub/
-

--- a/apis/iam/v1alpha1/generate.sh
+++ b/apis/iam/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types  --service google.iam.v2 --api-version iam.cnrm.cloud.google.com/v1alpha1 \
   --resource IAMDenyPolicy:Policy
 
@@ -31,4 +33,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/iam/
-

--- a/apis/logging/v1beta1/generate.sh
+++ b/apis/logging/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.logging.v2 \
     --api-version "logging.cnrm.cloud.google.com/v1beta1" \

--- a/apis/monitoring/v1beta1/generate.sh
+++ b/apis/monitoring/v1beta1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.monitoring.v3 \
   --api-version monitoring.cnrm.cloud.google.com/v1beta1  \

--- a/apis/networkmanagement/v1alpha1/generate.sh
+++ b/apis/networkmanagement/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.networkmanagement.v1 \
   --api-version networkmanagement.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/networksecurity/v1beta1/generate.sh
+++ b/apis/networksecurity/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.networksecurity.v1beta1 \
     --api-version networksecurity.cnrm.cloud.google.com/v1beta1 \

--- a/apis/networkservices/v1alpha1/generate.sh
+++ b/apis/networkservices/v1alpha1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.networkservices.v1 \
     --api-version "networkservices.cnrm.cloud.google.com/v1alpha1" \

--- a/apis/orgpolicy/v1alpha1/generate.sh
+++ b/apis/orgpolicy/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.orgpolicy.v2  \
     --api-version orgpolicy.cnrm.cloud.google.com/v1alpha1 \
@@ -35,4 +37,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/orgpolicy/
-

--- a/apis/orgpolicy/v1beta1/generate.sh
+++ b/apis/orgpolicy/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.orgpolicy.v2  \
     --api-version orgpolicy.cnrm.cloud.google.com/v1beta1 \
@@ -35,4 +37,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/orgpolicy/
-

--- a/apis/pubsub/v1beta1/generate.sh
+++ b/apis/pubsub/v1beta1/generate.sh
@@ -21,6 +21,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
 
 go run . generate-types \
     --service google.pubsub.v1 \

--- a/apis/run/v1beta1/generate.sh
+++ b/apis/run/v1beta1/generate.sh
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.run.v2 \
   --api-version run.cnrm.cloud.google.com/v1beta1 \

--- a/apis/servicenetworking/v1alpha1/generate.sh
+++ b/apis/servicenetworking/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service mockgcp.cloud.servicenetworking.v1 \
   --api-version servicenetworking.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/serviceusage/v1beta1/generate.sh
+++ b/apis/serviceusage/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.api.serviceusage.v1beta1 \
   --api-version serviceusage.cnrm.cloud.google.com/v1beta1  \
@@ -35,4 +37,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/serviceusage/
-

--- a/apis/speech/v1alpha1/generate.sh
+++ b/apis/speech/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.speech.v2  \
     --api-version speech.cnrm.cloud.google.com/v1alpha1 \
@@ -37,4 +39,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/speech/
-

--- a/apis/speech/v1beta1/generate.sh
+++ b/apis/speech/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.speech.v2  \
     --api-version speech.cnrm.cloud.google.com/v1beta1 \

--- a/apis/tags/v1alpha1/generate.sh
+++ b/apis/tags/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.resourcemanager.v3 \
   --api-version tags.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/tags/v1beta1/generate.sh
+++ b/apis/tags/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
   --service google.cloud.resourcemanager.v3 \
   --api-version tags.cnrm.cloud.google.com/v1beta1  \

--- a/apis/tpu/v1alpha1/generate.sh
+++ b/apis/tpu/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1     --resource TPUVirtualMachine:Node
 
 go run . generate-mapper     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1
@@ -30,4 +32,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/tpu/
-

--- a/apis/vertexai/v1alpha1/generate.sh
+++ b/apis/vertexai/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1     --resource VertexAIFeaturestore:Featurestore
 
 go run . generate-mapper     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1
@@ -30,4 +32,3 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/vertexai/
-

--- a/apis/vmwareengine/v1alpha1/generate.sh
+++ b/apis/vmwareengine/v1alpha1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1alpha1  \

--- a/apis/vmwareengine/v1beta1/generate.sh
+++ b/apis/vmwareengine/v1beta1/generate.sh
@@ -21,6 +21,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1beta1  \

--- a/dev/tools/controllerbuilder/tasks/init-type
+++ b/dev/tools/controllerbuilder/tasks/init-type
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 if [[ -z "${PROTO:-}" ]]; then
   echo "PROTO must be set. e.g. google.bigtable.admin.v2.Table"
   exit 1

--- a/dev/tools/controllerbuilder/tasks/update-type
+++ b/dev/tools/controllerbuilder/tasks/update-type
@@ -20,6 +20,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 if [[ -z "${PROTO:-}" ]]; then
   echo "PROTO must be set. e.g. google.bigtable.admin.v2.Table"
   exit 1

--- a/dev/tools/controllerbuilder/update.sh
+++ b/dev/tools/controllerbuilder/update.sh
@@ -20,6 +20,8 @@ set -x
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 # example usage of inserting a field
 go run . update-types insert \
     --parent "google.monitoring.dashboard.v1.Dashboard" \

--- a/docs/ai/add-crd-mapper-fuzzer.md
+++ b/docs/ai/add-crd-mapper-fuzzer.md
@@ -31,6 +31,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 # Generate the KCC type structs from the GCP proto definitions
 go run . generate-types \
   --service google.example.api.v1 \

--- a/docs/ai/unify-api-mapper-fuzzer.md
+++ b/docs/ai/unify-api-mapper-fuzzer.md
@@ -26,6 +26,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service google.cloud.myservice.v1 \
     --api-version "myservice.cnrm.cloud.google.com/v1alpha1" \

--- a/experiments/conductor/cmd/runner/crd_generator_commands.go
+++ b/experiments/conductor/cmd/runner/crd_generator_commands.go
@@ -49,6 +49,8 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
+
 go run . generate-types \
     --service <PROTO_PACKAGE> \
     --api-version <CRD_GROUP>/<CRD_VERSION> \

--- a/experiments/conductor/cmd/runner/scripts/crd_mapper_fuzzer/notes.md
+++ b/experiments/conductor/cmd/runner/scripts/crd_mapper_fuzzer/notes.md
@@ -24,6 +24,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
+./generate-proto.sh
 
 go run . generate-types \
     --service google.cloud.filestore.v1 \
@@ -134,4 +135,3 @@ git add pkg/controller/direct/filestore/instance_fuzzer.go
 git add pkg/controller/direct/register/register.go
 git commit -m "FilestoreInstance: create fuzzer"
 ```
-


### PR DESCRIPTION
This is because otherwise the LLM has to figure out how to do. this. The trick here is to make it fast in the no-change case, so we can invoke it everywhere.