### PR TITLE
chore: fix Makefile to compile kustomize itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ GOLANGCI_LINT_VERSION := v2.7.1
 # multi-stage builds (https://github.com/moby/moby/issues/38132)
 DOCKER_BUILD := DOCKER_BUILDKIT=1 docker build
 
+KUSTOMIZE=go run sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
+
 CRD_OUTPUT_TMP := config/crds/tmp
 CRD_OUTPUT_STAGING := config/crds/tmp/staging
 CRD_OUTPUT_FINAL := config/crds/resources
@@ -78,8 +80,8 @@ manifests: generate
 	# add kustomize patches on all CRDs
 	mkdir config/crds/resources
 	cp config/crds/kustomization.yaml kustomization.yaml
-	kustomize edit add resource config/crds/tmp_resources/*.yaml
-	kustomize build -o config/crds/resources
+	$(KUSTOMIZE) edit add resource config/crds/tmp_resources/*.yaml
+	$(KUSTOMIZE) build -o config/crds/resources
 	rm -rf config/crds/tmp_resources
 	rm kustomization.yaml
 
@@ -216,7 +218,7 @@ CONTROLLER_GEN=docker run --rm -v $(shell pwd):/wkdir kcc-tooling controller-gen
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
 deploy: manifests install
-	kustomize build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
+	$(KUSTOMIZE) build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
 # Install CRDs into a cluster
 .PHONY: install
@@ -227,13 +229,13 @@ install: manifests
 # faster than "make deploy". It is useful if you only want to quickly apply code change in controller
 .PHONY: deploy-controller
 deploy-controller: docker-build docker-push
-	kustomize build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
+	$(KUSTOMIZE) build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
 # Deploy controller only, this will skip CRD install in the configured K8s and usually runs much
 # faster than "make deploy". It is useful if you only want to quickly apply code change in controller
 .PHONY: deploy-controller-autopilot
 deploy-controller-autopilot: docker-build docker-push
-	kustomize build config/installbundle/releases/scopes/cluster/autopilot-withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
+	$(KUSTOMIZE) build config/installbundle/releases/scopes/cluster/autopilot-withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
 # Generate CRD go clients
 .PHONY: generate-go-client
@@ -319,25 +321,25 @@ operator-manager-bin:
 all-manifests: crd-manifests rbac-manifests build-operator-manifests
 	cp config/installbundle/release-manifests/crds.yaml config/installbundle/release-manifests/standard/crds.yaml
 	cp config/installbundle/release-manifests/rbac.yaml config/installbundle/release-manifests/standard/rbac.yaml
-	kustomize build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
+	$(KUSTOMIZE) build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
 	cp config/installbundle/release-manifests/crds.yaml config/installbundle/release-manifests/autopilot/crds.yaml
 	cp config/installbundle/release-manifests/rbac.yaml config/installbundle/release-manifests/autopilot/rbac.yaml
-	kustomize build config/installbundle/release-manifests/autopilot -o config/installbundle/release-manifests/autopilot/manifests.yaml
+	$(KUSTOMIZE) build config/installbundle/release-manifests/autopilot -o config/installbundle/release-manifests/autopilot/manifests.yaml
 
 
 # Build kcc manifests for standard GKE clusters
 .PHONY: config-connector-manifests-standard
 config-connector-manifests-standard: build-operator-manifests
-	kustomize build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
+	$(KUSTOMIZE) build config/installbundle/release-manifests/standard -o config/installbundle/release-manifests/standard/manifests.yaml
 
 # Build kcc manifests for autopilot clusters
 .PHONY: config-connector-manifests-autopilot
 config-connector-manifests-autopilot: build-operator-manifests
-	kustomize build config/installbundle/release-manifests/autopilot -o config/installbundle/release-manifests/autopilot/manifests.yaml
+	$(KUSTOMIZE) build config/installbundle/release-manifests/autopilot -o config/installbundle/release-manifests/autopilot/manifests.yaml
 
 .PHONY: build-operator-manifests
 build-operator-manifests:
-	go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 crd paths="./operator/pkg/apis/..." output:crd:artifacts:config=operator/config/crd/bases	
+	go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 crd paths="./operator/pkg/apis/..." output:crd:artifacts:config=operator/config/crd/bases
 	make -C operator docker-build
 
 .PHONY: push-operator-manifest
@@ -354,14 +356,14 @@ clean-release-manifests:
 	rm config/installbundle/release-manifests/autopilot/manifests.yaml
 
 .PHONY: deploy-kcc-standard
-deploy-kcc-standard: docker-build docker-push config-connector-manifests-standard push-operator-manifest 
+deploy-kcc-standard: docker-build docker-push config-connector-manifests-standard push-operator-manifest
 	kubectl apply -f config/installbundle/release-manifests/standard/manifests.yaml ${CONTEXT_FLAG}
-	kustomize build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
+	$(KUSTOMIZE) build config/installbundle/releases/scopes/cluster/withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
 .PHONY: deploy-kcc-autopilot
 deploy-kcc-autopilot: docker-build docker-push config-connector-manifests-autopilot push-operator-manifest
 	kubectl apply -f config/installbundle/release-manifests/autopilot/manifests.yaml ${CONTEXT_FLAG}
-	kustomize build config/installbundle/releases/scopes/cluster/autopilot-withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
+	$(KUSTOMIZE) build config/installbundle/releases/scopes/cluster/autopilot-withworkloadidentity | sed -e 's/$${PROJECT_ID?}/${PROJECT_ID}/g'| kubectl apply -f - ${CONTEXT_FLAG}
 
 .PHONY: powertool-tests
 powertool-tests:
@@ -397,4 +399,4 @@ generate-types:
 	cd dev/tools/controllerbuilder && \
 	./generate-proto.sh && \
 	find config -name "*.yaml" -type f | xargs -I {} go run . generate-types --config {}
-	dev/tasks/fix-gofmt 
+	dev/tasks/fix-gofmt

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -17,6 +17,7 @@ PROJECT_ID ?= $(shell gcloud config get-value project)
 SHORT_SHA := $(shell git rev-parse --short=7 HEAD)
 OPERATOR_IMG ?= gcr.io/${PROJECT_ID}/cnrm/operator:${SHORT_SHA}
 
+KUSTOMIZE=go run sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
 
 # enable multi-versions feature for CRDs
 CRD_OPTIONS ?= "crd"
@@ -65,12 +66,12 @@ generate:
 # Install CRDs into a cluster
 .PHONY: install
 install: manifests
-	kustomize build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
 # Uninstall CRDs from a cluster
 .PHONY: uninstall
 uninstall: manifests
-	kustomize build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 # Build the docker image
 .PHONY: docker-build
@@ -91,12 +92,12 @@ docker-push:
 # Note: run docker-build first to generate config/manager/manager_image_patch.yaml
 .PHONY: deploy
 deploy: manifests  # docker-build, docker-push also required, but not explicit to speed up deploy
-	kustomize build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Destroy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: destroy
 destroy: manifests
-	kustomize build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 # Upgrade KCC core manifest
 .PHONY: upgrade-kcc
@@ -111,4 +112,3 @@ upgrade-kcc-local:
 	cd ${REPO_ROOT}/operator; go run scripts/update-kcc-manifest/main.go --version=local
 	cd ${REPO_ROOT}/operator; go run scripts/copy-dependency-manifests/main.go
 	make -C ${REPO_ROOT}/operator manifests
-


### PR DESCRIPTION
This avoids having to preinstall kustomize binary, which may not be present
or may be the wrong version.
