### PR TITLE
Add reconciler type and gcp update field masks to recorder

### DIFF
--- a/pkg/cli/preview/intercepting_gcp_client.go
+++ b/pkg/cli/preview/intercepting_gcp_client.go
@@ -33,9 +33,9 @@ import (
 
 // BlockedGCPError is an error that occurs when a GCP API call is blocked.
 type BlockedGCPError struct {
-	Method string
-	URL    string
-	Body   string
+	Method     string
+	URL        string
+	Body       string
 	UpdateMask []string
 }
 

--- a/pkg/cli/preview/recorder.go
+++ b/pkg/cli/preview/recorder.go
@@ -194,8 +194,8 @@ func (r *Recorder) recordReconcileStart(ctx context.Context, u *unstructured.Uns
 
 	info := r.getObjectInfo(gknn)
 	info.events = append(info.events, event{
-		eventType: EventTypeReconcileStart,
-		object:    u.DeepCopy(),
+		eventType:      EventTypeReconcileStart,
+		object:         u.DeepCopy(),
 		reconcilerType: t,
 	})
 }
@@ -210,8 +210,8 @@ func (r *Recorder) recordReconcileEnd(ctx context.Context, u *unstructured.Unstr
 
 	info := r.getObjectInfo(gknn)
 	info.events = append(info.events, event{
-		eventType: EventTypeReconcileEnd,
-		object:    u.DeepCopy(),
+		eventType:      EventTypeReconcileEnd,
+		object:         u.DeepCopy(),
 		reconcilerType: t,
 	})
 	r.reconcileTrackerMutex.Lock()


### PR DESCRIPTION
### BRIEF Change description
Add reconciler type to recorder ReconcileStart and ReconcileEnd
Add update fields mask if available for GCP action
<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
