### PR TITLE
chore: ensure that make generate does all the generate stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ generate-including-dcl:
 # Generate code
 .PHONY: generate
 generate:
+	dev/tasks/generate-all
 	go generate ./pkg/apis/...
 	make -C operator generate
 	make fmt

--- a/dev/tasks/generate-all
+++ b/dev/tasks/generate-all
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+dev/tasks/generate-types-and-mappers
+# (broken?) dev/tasks/generate-licenses
+dev/tasks/generate-resource-report
+# (needs update?) dev/tasks/generate-ci-cd-jobs
+dev/tasks/generate-github-actions


### PR DESCRIPTION
The LLMs _really_ likes to call `make generate`; make sure
that this target includes all the generation tasks we have.
