### PR TITLE
preview: add in-cluster flag for running in GKE cluster

### DIFF
--- a/experiments/kompanion/cmd/preview/preview_cmd.go
+++ b/experiments/kompanion/cmd/preview/preview_cmd.go
@@ -53,6 +53,7 @@ type PreviewOptions struct {
 	gcpQPS           float64
 	gcpBurst         int
 	namespace        string
+	inCluster        bool
 }
 
 func BuildPreviewCmd() *cobra.Command {
@@ -74,11 +75,15 @@ func BuildPreviewCmd() *cobra.Command {
 	cmd.Flags().Float64VarP(&opts.gcpQPS, "gcpQPS", "q", 5.0, "Maximum qps for GCP API requests, per service. Default to 5.0. Set gcpQPS to 0 to disable rate limiting.")
 	cmd.Flags().IntVarP(&opts.gcpBurst, "gcpBurst", "b", 5, "Maximum burst for GCP API requests, per service. Default to 5. Set gcpQPS to 0 to disable rate limiting.")
 	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace to preview. If not specified, all namespaces will be previewed.")
+	cmd.Flags().BoolVarP(&opts.inCluster, "in-cluster", "", false, "Run in GKE cluster.")
 	return cmd
 }
 
 func getRESTConfig(ctx context.Context, opts *PreviewOptions) (*rest.Config, error) {
 	// TODO: Add rate limiting.
+	if opts.inCluster {
+		return rest.InClusterConfig()
+	}
 	var loadingRules clientcmd.ClientConfigLoader
 	if opts.kubeconfig != "" {
 		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: opts.kubeconfig}


### PR DESCRIPTION
### BRIEF Change description

Add in-cluster flag and update get kube API config when running within a GKE cluster
<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
