### PR TITLE
chore: free disk space in github actions in more tests

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -59,6 +59,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: dev/tasks/free-disk-space-on-github-actions-runner
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: 'go.mod'
@@ -95,16 +97,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - name: Free up disk space
-        run: |
-          echo "Before cleanup:"
-          df -h /
-          sudo rm -rf /opt/hostedtoolcache/*  # remove pre-installed tool versions
-          sudo rm -rf /usr/share/dotnet
-          sudo docker system prune -af || true
-          echo "After cleanup:"
-          df -h /
       - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: dev/tasks/free-disk-space-on-github-actions-runner
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: 'go.mod'

--- a/dev/tasks/free-disk-space-on-github-actions-runner
+++ b/dev/tasks/free-disk-space-on-github-actions-runner
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# Free up disk space on GitHub Actions runners
+
+if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
+  echo "Not running on GitHub Actions; skipping disk space cleanup (for safety)"
+  exit 1
+fi
+
+
+echo "Before cleanup:"
+df -h /
+
+
+sudo rm -rf /opt/hostedtoolcache/*  # remove pre-installed tool versions
+sudo rm -rf /usr/share/dotnet
+sudo docker system prune -af || true
+
+echo "After cleanup:"
+df -h /


### PR DESCRIPTION
We were seeing test failures in the unit-test test because the disk was full