### PR TITLE
chore: allow github mcp server read-write mode

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -5,10 +5,7 @@
             "command": "dev/mcp/github-mcp-server",
             "args": [
                 "stdio"
-            ],
-            "env": {
-                "GITHUB_READ_ONLY": "1"
-            }
+            ]
         }
     }
 }

--- a/dev/mcp/github-mcp-server
+++ b/dev/mcp/github-mcp-server
@@ -27,6 +27,12 @@ mkdir -p "${BINDIR}"
 
 MCP_SERVER_PATH="${BINDIR}/github-mcp-server"
 
+if [[ -z "${GITHUB_READ_ONLY:-}" ]]; then
+    GITHUB_READ_ONLY=1
+fi
+export GITHUB_READ_ONLY
+
+
 if [[ ! -f "${MCP_SERVER_PATH}" ]]; then
     mkdir -p .build/mcp/src
     cd .build/mcp/src


### PR DESCRIPTION
If the user sets GITHUB_READ_ONLY=0, allow the github mcp server to
run in read-write mode.  Otherwise, default to read-only mode.
