### PR TITLE
chore: fix a few gofmt / addlicense issues

### DIFF
--- a/config/tests/samples/create/contents_test.go
+++ b/config/tests/samples/create/contents_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package create
 
 import (

--- a/experiments/kompanion/cmd/lint/result.go
+++ b/experiments/kompanion/cmd/lint/result.go
@@ -25,7 +25,6 @@ type Result struct {
 	resources map[string]map[string][]string
 }
 
-
 func (r *Result) Print() {
 	log.Println("Following Resources should include `cnrm.cloud.google.com/deletion-policy: abandon` annotation")
 	r.lock.Lock()

--- a/experiments/kompanion/cmd/preview/preview_cmd.go
+++ b/experiments/kompanion/cmd/preview/preview_cmd.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	kubeconfigFlag     = "kubeconfig"
-	timeoutFlag        = "timeout"
+	kubeconfigFlag = "kubeconfig"
+	timeoutFlag    = "timeout"
 
 	reportNamePrefixFlag = "report-prefix"
 	defaultScope         = "https://www.googleapis.com/auth/cloud-platform"

--- a/experiments/kompanion/pkg/utils/utils.go
+++ b/experiments/kompanion/pkg/utils/utils.go
@@ -79,7 +79,7 @@ func GetResources(discoveryClient discovery.DiscoveryInterface, resources []sche
 }
 
 func GetResourcesWithKindFilter(discoveryClient discovery.DiscoveryInterface, resources []schema.GroupVersionResource, kinds map[string]bool) ([]schema.GroupVersionResource, error) {
-		apiResourceLists, err := discoveryClient.ServerPreferredResources()
+	apiResourceLists, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get preferred resources: %w", err)
 	}


### PR DESCRIPTION
These escaped our machinery, but they were flagged by the ap tool.
