### PR TITLE
feat(compute): add provisionedThroughput field to ComputeInstanceTemplate

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeinstancetemplates.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeinstancetemplates.compute.cnrm.cloud.google.com.yaml
@@ -190,6 +190,12 @@ spec:
                         120,000. For more details, see the [Extreme persistent disk
                         documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
                       type: integer
+                    provisionedThroughput:
+                      description: Immutable. Indicates how much throughput to provision
+                        for the disk. This sets the number of throughput mb per second
+                        that the disk can handle. Values must be greater than or equal
+                        to 1.
+                      type: integer
                     resourcePolicies:
                       items:
                         oneOf:

--- a/pkg/clients/generated/apis/compute/v1beta1/computeinstancetemplate_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeinstancetemplate_types.go
@@ -121,6 +121,10 @@ type InstancetemplateDisk struct {
 	// +optional
 	ProvisionedIops *int64 `json:"provisionedIops,omitempty"`
 
+	/* Immutable. Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle. Values must be greater than or equal to 1. */
+	// +optional
+	ProvisionedThroughput *int64 `json:"provisionedThroughput,omitempty"`
+
 	// +optional
 	ResourcePolicies []v1alpha1.ResourceRef `json:"resourcePolicies,omitempty"`
 

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_instance_template.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_instance_template.go
@@ -171,6 +171,14 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
 						},
 
+						"provisioned_throughput": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle. Values must be greater than or equal to 1.`,
+						},
+
 						"source_image": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -1110,7 +1118,7 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 		}
 		if v, ok := d.GetOk(prefix + ".source"); ok {
 			disk.Source = v.(string)
-			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "provisioned_iops", "source_image", "source_snapshot", "labels"}
+			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "provisioned_iops", "provisioned_throughput", "source_image", "source_snapshot", "labels"}
 			for _, conflict := range conflicts {
 				if _, ok := d.GetOk(prefix + "." + conflict); ok {
 					return nil, fmt.Errorf("Cannot use `source` with any of the fields in %s", conflicts)
@@ -1132,6 +1140,9 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 			}
 			if v, ok := d.GetOk(prefix + ".provisioned_iops"); ok {
 				disk.InitializeParams.ProvisionedIops = int64(v.(int))
+			}
+			if v, ok := d.GetOk(prefix + ".provisioned_throughput"); ok {
+				disk.InitializeParams.ProvisionedThroughput = int64(v.(int))
 			}
 
 			disk.InitializeParams.Labels = tpgresource.ExpandStringMap(d, prefix+".labels")
@@ -1330,12 +1341,13 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 }
 
 type diskCharacteristics struct {
-	mode            string
-	diskType        string
-	diskSizeGb      string
-	autoDelete      bool
-	sourceImage     string
-	provisionedIops string
+	mode                  string
+	diskType              string
+	diskSizeGb            string
+	autoDelete            bool
+	sourceImage           string
+	provisionedIops       string
+	provisionedThroughput string
 }
 
 func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
@@ -1371,6 +1383,12 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 		dc.provisionedIops = fmt.Sprintf("%v", v)
 	}
 
+	if v := m["provisioned_throughput"]; v != nil {
+		// Terraform and GCP return ints as different types (int vs int64), so just
+		// use strings to compare for simplicity.
+		dc.provisionedThroughput = fmt.Sprintf("%v", v)
+	}
+
 	return dc
 }
 
@@ -1394,6 +1412,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		}
 		diskMap["disk_type"] = disk.InitializeParams.DiskType
 		diskMap["provisioned_iops"] = disk.InitializeParams.ProvisionedIops
+		diskMap["provisioned_throughput"] = disk.InitializeParams.ProvisionedThroughput
 		diskMap["disk_name"] = disk.InitializeParams.DiskName
 		diskMap["labels"] = disk.InitializeParams.Labels
 		// The API does not return a disk size value for scratch disks. They are largely only one size,


### PR DESCRIPTION
## Summary
- Add support for the `provisionedThroughput` field in ComputeInstanceTemplate disk configuration
- This field allows users to specify disk throughput in MB/s when using `initializeParams`
- Particularly useful for Hyperdisk types (Hyperdisk Extreme, Hyperdisk Balanced)

## Changes
- **TF Provider**: Add `provisioned_throughput` schema field and handling in `buildDisks()`, `flattenDisk()`, and `diskCharacteristicsFromMap()`
- **CRD**: Add `provisionedThroughput` field to disk spec
- **Go Types**: Add `ProvisionedThroughput *int64` to `InstancetemplateDisk` struct

## Scenario Followed
This change follows the **"Missing Fields"** scenario from [`docs/archive/README.ChangingTerraform.md`](docs/archive/README.ChangingTerraform.md):
> Missing Fields: Implementing fields recently introduced in TPG v5 or the underlying GCP API but absent in the current subtree.

## Reference
- [GCP REST API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates) documents `provisionedThroughput` in `properties.disks[].initializeParams`
- Upstream TF provider added this field in [hashicorp/terraform-provider-google#19852](https://github.com/hashicorp/terraform-provider-google/pull/19852)

## Test plan
- [ ] Verify CRD schema includes the new field
- [ ] Verify Go types compile correctly
- [ ] Verify TF provider code compiles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)