### PR TITLE
fix: Don't mark Kind default in TagBinding ParentRef

### DIFF
--- a/apis/tags/v1beta1/tagbinding_parentref.go
+++ b/apis/tags/v1beta1/tagbinding_parentref.go
@@ -29,10 +29,9 @@ import (
 // ParentRef is a reference to a parent resource.
 // +kcc:ref=Project;StorageBucket
 type TagsTagBindingParentRef struct {
-	// Kind of the referent.
+	// Kind to which we are binding the tag.  Defaults to Project if not specified.
 	// +optional
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=Project
 	Kind string `json:"kind,omitempty"`
 
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_tagslocationtagbindings.tags.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_tagslocationtagbindings.tags.cnrm.cloud.google.com.yaml
@@ -87,8 +87,8 @@ spec:
                       where {{value}} is the `number` field of a `Project` resource.'
                     type: string
                   kind:
-                    default: Project
-                    description: Kind of the referent.
+                    description: Kind to which we are binding the tag.  Defaults to
+                      Project if not specified.
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_tagstagbindings.tags.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_tagstagbindings.tags.cnrm.cloud.google.com.yaml
@@ -83,8 +83,8 @@ spec:
                       where {{value}} is the `number` field of a `Project` resource.'
                     type: string
                   kind:
-                    default: Project
-                    description: Kind of the referent.
+                    description: Kind to which we are binding the tag.  Defaults to
+                      Project if not specified.
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_final_object.diff
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_final_object.diff
@@ -1,4 +1,4 @@
 6d5
 <     cnrm.cloud.google.com/state-into-spec: absent
-28a28
+29a29
 >   externalRef: tagBindings/%2F%2Fstorage.googleapis.com%2Fprojects%2F_%2Fbuckets%2Fstoragebucket-${uniqueId}/tagValues/${tagValueID}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_final_object_old_controller.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_final_object_old_controller.golden.yaml
@@ -16,6 +16,7 @@ spec:
   location: us-east4
   parentRef:
     external: //storage.googleapis.com/projects/_/buckets/storagebucket-${uniqueId}
+    kind: StorageBucket
   resourceID: tagBindings/%2F%2Fstorage.googleapis.com%2Fprojects%2F_%2Fbuckets%2Fstoragebucket-${uniqueId}/tagValues/${tagValueID}
   tagValueRef:
     name: tagstagvalue-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_generated_object_tagslocationtagbinding_bucket.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1alpha1/tagslocationtagbinding/tagslocationtagbinding_bucket/_generated_object_tagslocationtagbinding_bucket.golden.yaml
@@ -15,6 +15,7 @@ spec:
   location: us-east4
   parentRef:
     external: //storage.googleapis.com/projects/_/buckets/storagebucket-${uniqueId}
+    kind: StorageBucket
   resourceID: tagBindings/%2F%2Fstorage.googleapis.com%2Fprojects%2F_%2Fbuckets%2Fstoragebucket-${uniqueId}/tagValues/${tagValueID}
   tagValueRef:
     name: tagstagvalue-${uniqueId}


### PR DESCRIPTION
Setting the default means that we actually populate the value as Project,
but I think we want to keep it unset, because Kind can be optional
if External is specified.