### PR TITLE
feat: Add SkipControllerNameValidation flag to allow preview to run passes

### DIFF
--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -374,6 +374,9 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
 	if !cfg.skipControllerRegistration {
+		if opts.Controller.SkipNameValidation != nil {
+			registration.SkipControllerNameValidation = *opts.Controller.SkipNameValidation
+		}
 		if err := registration.AddDefaultControllers(ctx, mgr, &rd, controllerConfig); err != nil {
 			return nil, fmt.Errorf("error adding registration controller: %w", err)
 		}

--- a/pkg/controller/parent/controller.go
+++ b/pkg/controller/parent/controller.go
@@ -64,6 +64,11 @@ type CustomReconciler struct {
 	Reconciler reconcile.Reconciler
 }
 
+// SkipControllerNameValidation allows skipping the controller name validation
+// in controller-runtime. This is useful when running multiple managers in the same process
+// (e.g. in preview mode or tests) to avoid "controller name already exists" errors.
+var SkipControllerNameValidation bool
+
 // ParentReconciler is a top-level controller that decides which underlying
 // reconciler (TF, DCL, Direct) should be used for a given resource.
 type ParentReconciler struct {
@@ -97,7 +102,7 @@ func Add(mgr manager.Manager, gvk schema.GroupVersionKind, reconcilers *Reconcil
 		Named(controllerName).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicates...)).
 		WatchesRawSource(source.TypedChannel(immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter(), SkipNameValidation: &SkipControllerNameValidation}).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("error creating new parent controller: %w", err)


### PR DESCRIPTION
We want to run kcc manager multiple times for different controller type. The new flag allows us to bypass duplicated controller name metrics check

### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
