### PR TITLE
feature: enable debug structured-diff reporting Listener

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,6 +61,7 @@ func main() {
 		rateLimitQps             float32
 		rateLimitBurst           int
 		leaderElectionMode       string
+		debugStructuredDiff      bool
 	)
 	flag.StringVar(&prometheusScrapeEndpoint, "prometheus-scrape-endpoint", ":8888", "configure the Prometheus scrape endpoint; :8888 as default")
 	flag.BoolVar(&controllermetrics.ResourceNameLabel, "resource-name-label", false, "option to enable the resource name label on some Prometheus metrics; false by default")
@@ -72,6 +73,8 @@ func main() {
 	flag.Float32Var(&rateLimitQps, "qps", 20.0, "The client-side token bucket rate limit qps.")
 	flag.IntVar(&rateLimitBurst, "burst", 30, "The client-side token bucket rate limit burst.")
 	flag.StringVar(&leaderElectionMode, "leader-election-type", "disabled", "Leader election mode. One of: default, multicluster.")
+	flag.BoolVar(&debugStructuredDiff, "debug-structured-diff", false, "Enable verbose structured diffs.")
+
 	profiler.AddFlag(flag.CommandLine)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
@@ -116,7 +119,7 @@ func main() {
 	// Set client site rate limiter to optimize the configconnector re-reconciliation performance.
 	ratelimiter.SetMasterRateLimiter(restCfg, rateLimitQps, rateLimitBurst)
 	logger.Info("Creating the manager")
-	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection)
+	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection, debugStructuredDiff)
 	if err != nil {
 		logging.Fatal(err, "error creating the manager")
 	}
@@ -172,7 +175,7 @@ func main() {
 	logging.ExitInfo("main.go finished execution; exiting ...")
 }
 
-func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool) (manager.Manager, error) {
+func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool, debugStructuredDiff bool) (manager.Manager, error) {
 	krmtotf.SetUserAgentForTerraformProvider()
 	controllersCfg := kccmanager.Config{
 		ManagerOptions: manager.Options{
@@ -182,7 +185,8 @@ func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace strin
 				},
 			},
 		},
-		MultiClusterLease: multiclusterlease,
+		MultiClusterLease:            multiclusterlease,
+		DebugStructuredDiffReporting: debugStructuredDiff,
 	}
 
 	controllersCfg.UserProjectOverride = userProjectOverride

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -101,6 +101,9 @@ type Config struct {
 	// Configure manager to participate in leader election if MultiClusterLease is enabled.
 	MultiClusterLease bool
 
+	// DebugStructuredDiffReporting enables enhanced structured diff reporting.
+	DebugStructuredDiffReporting bool
+
 	// used for smoke testing only; options not meant to be used in production.
 	testConfig
 }
@@ -240,7 +243,11 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 	opts.BaseContext = func() context.Context {
 		// If listener already exists, do not add another
 		if _, exists := structuredreporting.GetListenerFromContext(ctx); !exists {
-			return structuredreporting.ContextWithListener(ctx, &structuredreporting.LogFieldUpdates{})
+			if cfg.DebugStructuredDiffReporting {
+				return structuredreporting.ContextWithListener(ctx, &structuredreporting.DebugLogListener{})
+			} else {
+				return structuredreporting.ContextWithListener(ctx, &structuredreporting.LogFieldUpdates{})
+			}
 		}
 
 		return ctx


### PR DESCRIPTION
Provide the ability to enable a debug Listener object. This will enable enhanced log events from  `pkg/structuredreporting` (OnDiff) when change found within ReportDiff.

new controller manager flag = `debug-structured-diff`

### BRIEF Change description

Fixes #6225 , #6193 

The kccmanager creates and inserts a Listener to the context that does not provide detailed diff reporting (`structuredreporting.LogFieldUpdates{}`). This change allows the user to create the context with the `structuredreporting.DebugLogListener{}` 

#### WHY do we need this change?

We can now see detailed diffs on KCC reconcilation.

```sh
go run cmd/manager/main.go --debug-structured-diff |grep -i structuredreporting

...
{"severity":"info","timestamp":"2026-01-22T20:27:50.681Z","msg":"structuredreporting OnReconcileStart","controller":"sqlinstance-parent-controller","controllerGroup":"sql.cnrm.cloud.google.com","controllerKind":"SQLInstance","SQLInstance":{"name":"jesseward-psql-test","namespace":"kcc-test"},"namespace":"kcc-test","name":"jesseward-psql-test","reconcileID":"7f0a4ff3-862a-4034-9a1c-70cdc51f182b","object.kind":"SQLInstance","object.name":"jesseward-psql-test"}
{"severity":"info","timestamp":"2026-01-22T20:27:51.137Z","msg":"structuredreporting OnDiff","controller":"sqlinstance-parent-controller","controllerGroup":"sql.cnrm.cloud.google.com","controllerKind":"SQLInstance","SQLInstance":{"name":"jesseward-psql-test","namespace":"kcc-test"},"namespace":"kcc-test","name":"jesseward-psql-test","reconcileID":"7f0a4ff3-862a-4034-9a1c-70cdc51f182b","diff.fields":[{"ID":".settings.insightsConfig","Old":{"queryInsightsEnabled":true,"queryPlansPerMinute":5,"queryStringLength":4500},"New":{"queryInsightsEnabled":true,"queryStringLength":4500}}],"diff.isNewObject":false}
...
```

#### Special notes for your reviewer:

Alternatively the context Listener object could be created inside of `cmd/manager.main.go` instead of passing the flag around.

Let me know if this should change.

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds manager CLI flag to allow detailed diff reporting. To enable, launch the controller with `--debug-structured-diff`
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

* b/469693633

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
