### PR TITLE
feat: add CloudBuildWorkerPool identity and reference types

### DIFF
--- a/apis/cloudbuild/v1beta1/workerpool_identity.go
+++ b/apis/cloudbuild/v1beta1/workerpool_identity.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/identity"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/gcpurls"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	_ identity.IdentityV2 = &CloudBuildWorkerPoolIdentity{}
+	_ identity.Resource   = &CloudBuildWorkerPool{}
+)
+
+var CloudBuildWorkerPoolIdentityFormat = gcpurls.Template[CloudBuildWorkerPoolIdentity]("cloudbuild.googleapis.com", "projects/{project}/locations/{location}/workerPools/{resourceID}")
+
+// +k8s:deepcopy-gen=false
+type CloudBuildWorkerPoolIdentity struct {
+	Project    string
+	Location   string
+	ResourceID string
+}
+
+func (i *CloudBuildWorkerPoolIdentity) String() string {
+	return CloudBuildWorkerPoolIdentityFormat.ToString(*i)
+}
+
+func (i *CloudBuildWorkerPoolIdentity) FromExternal(ref string) error {
+	parsed, match, err := CloudBuildWorkerPoolIdentityFormat.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("format of CloudBuildWorkerPool external=%q was not known (use %s): %w", ref, CloudBuildWorkerPoolIdentityFormat.CanonicalForm(), err)
+	}
+	if !match {
+		return fmt.Errorf("format of CloudBuildWorkerPool external=%q was not known (use %s)", ref, CloudBuildWorkerPoolIdentityFormat.CanonicalForm())
+	}
+
+	*i = *parsed
+	return nil
+}
+
+func (i *CloudBuildWorkerPoolIdentity) Host() string {
+	return CloudBuildWorkerPoolIdentityFormat.Host()
+}
+
+func (obj *CloudBuildWorkerPool) GetIdentity(ctx context.Context, reader client.Reader) (identity.Identity, error) {
+	// Get desired ID
+	resourceID := common.ValueOf(obj.Spec.ResourceID)
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
+	if resourceID == "" {
+		return nil, fmt.Errorf("cannot resolve resource ID")
+	}
+
+	// Get Location
+	location := obj.Spec.Location
+	if location == "" {
+		return nil, fmt.Errorf("cannot resolve location")
+	}
+
+	// Get Project
+	projectID := obj.GetAnnotations()["cnrm.cloud.google.com/project-id"]
+	if projectID == "" {
+		projectID = obj.GetNamespace()
+	}
+	if projectID == "" {
+		return nil, fmt.Errorf("cannot resolve project")
+	}
+
+	// Use approved External
+	// Status.Name matches the google.devtools.cloudbuild.v1.WorkerPool.name field, which is the full resource name.
+	externalRef := common.ValueOf(obj.Status.ExternalRef)
+	if externalRef != "" {
+		// Validate desired with actual
+		actualIdentity := &CloudBuildWorkerPoolIdentity{}
+		if err := actualIdentity.FromExternal(externalRef); err != nil {
+			return nil, err
+		}
+		if actualIdentity.Project != projectID {
+			return nil, fmt.Errorf("project changed, expect %s, got %s", actualIdentity.Project, projectID)
+		}
+		if actualIdentity.Location != location {
+			return nil, fmt.Errorf("location changed, expect %s, got %s", actualIdentity.Location, location)
+		}
+		if actualIdentity.ResourceID != resourceID {
+			return nil, fmt.Errorf("cannot reset `metadata.name` or `spec.resourceID` to %s, since it has already assigned to %s",
+				resourceID, actualIdentity.ResourceID)
+		}
+	}
+
+	return &CloudBuildWorkerPoolIdentity{
+		Project:    projectID,
+		Location:   location,
+		ResourceID: resourceID,
+	}, nil
+}

--- a/apis/cloudbuild/v1beta1/workerpool_reference.go
+++ b/apis/cloudbuild/v1beta1/workerpool_reference.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/identity"
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var CloudBuildWorkerPoolGVK = schema.GroupVersionKind{
+	Group:   "cloudbuild.cnrm.cloud.google.com",
+	Version: "v1beta1",
+	Kind:    "CloudBuildWorkerPool",
+}
+
+var _ refs.Ref = &CloudBuildWorkerPoolRef{}
+
+// CloudBuildWorkerPoolRef defines the resource reference to CloudBuildWorkerPool, which "External" field
+// holds the GCP identifier for the KRM object.
+type CloudBuildWorkerPoolRef struct {
+	// A reference to an externally managed CloudBuildWorkerPool resource.
+	// Should be in the format "projects/{{projectID}}/locations/{{location}}/workerPools/{{workerPoolID}}".
+	External string `json:"external,omitempty"`
+
+	// The name of a CloudBuildWorkerPool resource.
+	Name string `json:"name,omitempty"`
+
+	// The namespace of a CloudBuildWorkerPool resource.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+func init() {
+	refs.Register(&CloudBuildWorkerPoolRef{})
+}
+
+func (r *CloudBuildWorkerPoolRef) GetGVK() schema.GroupVersionKind {
+	return CloudBuildWorkerPoolGVK
+}
+
+func (r *CloudBuildWorkerPoolRef) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      r.Name,
+		Namespace: r.Namespace,
+	}
+}
+
+func (r *CloudBuildWorkerPoolRef) GetExternal() string {
+	return r.External
+}
+
+func (r *CloudBuildWorkerPoolRef) SetExternal(ref string) {
+	r.External = ref
+}
+
+func (r *CloudBuildWorkerPoolRef) ValidateExternal(ref string) error {
+	id := &CloudBuildWorkerPoolIdentity{}
+	if err := id.FromExternal(ref); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CloudBuildWorkerPoolRef) ParseExternalToIdentity() (identity.Identity, error) {
+	id := &CloudBuildWorkerPoolIdentity{}
+	if err := id.FromExternal(r.External); err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+func (r *CloudBuildWorkerPoolRef) Normalize(ctx context.Context, reader client.Reader, defaultNamespace string) error {
+	fallback := func(u *unstructured.Unstructured) string {
+		resourceID, err := refs.GetResourceID(u)
+		if err != nil {
+			return ""
+		}
+
+		location, err := refs.GetLocation(u)
+		if err != nil {
+			return ""
+		}
+
+		projectID, err := refs.ResolveProjectID(ctx, reader, u)
+		if err != nil {
+			return ""
+		}
+
+		return fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", projectID, location, resourceID)
+	}
+	return refs.NormalizeWithFallback(ctx, reader, r, defaultNamespace, fallback)
+}


### PR DESCRIPTION
### BRIEF Change description
add CloudBuildWorkerPool identity and reference types

Part of the work required for #6318

#### WHY do we need this change?
Unblocks the proper on boarding of CloudDeployTarget

