### PR TITLE
refactor: sanitize CertificateManager DnsAuthorization labels

### DIFF
--- a/pkg/controller/direct/certificatemanager/dnsauthorization_fuzzer.go
+++ b/pkg/controller/direct/certificatemanager/dnsauthorization_fuzzer.go
@@ -32,7 +32,7 @@ func dnsAuthorizationFuzzer() fuzztesting.KRMFuzzer {
 
 	fuzzer.UnimplementedFields.Insert(".dns_resource_record")
 	fuzzer.UnimplementedFields.Insert(".name")
-	fuzzer.UnimplementedFields.Insert(".labels")
+	fuzzer.Unimplemented_LabelsAnnotations(".labels")
 	fuzzer.UnimplementedFields.Insert(".type")
 
 	fuzzer.StatusFields.Insert(".create_time")


### PR DESCRIPTION
Sanitize Kubernetes labels to avoid 400 errors from invalid characters (e.g. '/'). Also refactor the Adapter to use the proto object for desired state.

Fixes #3457

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [X] Perform necessary E2E testing for changed resources.
