### PR TITLE
enhance: Optimize build image

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -33,13 +33,13 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # Build the binaries from source. Note: the "-s -w" flags strip the tables
 # needed for debuggers, but not the line numbers for panics
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o deletiondefender github.com/GoogleCloudPlatform/k8s-config-connector/cmd/deletiondefender
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o webhook github.com/GoogleCloudPlatform/k8s-config-connector/cmd/webhook
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o recorder github.com/GoogleCloudPlatform/k8s-config-connector/cmd/recorder
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o unmanageddetector github.com/GoogleCloudPlatform/k8s-config-connector/cmd/unmanageddetector
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o manager github.com/GoogleCloudPlatform/k8s-config-connector/cmd/manager
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o config-connector github.com/GoogleCloudPlatform/k8s-config-connector/cmd/config-connector
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o deletiondefender github.com/GoogleCloudPlatform/k8s-config-connector/cmd/deletiondefender && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o webhook github.com/GoogleCloudPlatform/k8s-config-connector/cmd/webhook && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o recorder github.com/GoogleCloudPlatform/k8s-config-connector/cmd/recorder && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o unmanageddetector github.com/GoogleCloudPlatform/k8s-config-connector/cmd/unmanageddetector && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o manager github.com/GoogleCloudPlatform/k8s-config-connector/cmd/manager && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o config-connector github.com/GoogleCloudPlatform/k8s-config-connector/cmd/config-connector
 
-RUN go mod vendor -o temp-vendor # So we can load license files
-RUN go run scripts/generate-third-party-licenses/main.go
-RUN rm -rf temp-vendor
+RUN go mod vendor -o temp-vendor && \
+    go run scripts/generate-third-party-licenses/main.go && \
+    rm -rf temp-vendor

--- a/dev/tasks/free-disk-space-on-github-actions-runner
+++ b/dev/tasks/free-disk-space-on-github-actions-runner
@@ -21,6 +21,8 @@ df -h /
 
 sudo rm -rf /opt/hostedtoolcache/*  # remove pre-installed tool versions
 sudo rm -rf /usr/share/dotnet
+sudo rm -rf /usr/local/lib/android # remove Android SDK
+sudo rm -rf /usr/share/swift       # remove Swift
 sudo docker system prune -af || true
 
 echo "After cleanup:"


### PR DESCRIPTION
### BRIEF Change description
  This PR optimizes the builder Dockerfile and enhances the disk space cleanup script to resolve No space left on device errors encountered during the build-images job in GitHub Actions.


  Key changes:
   - Dockerfile Optimization: Combined multiple RUN commands in build/builder/Dockerfile to reduce image layers and ensure temporary files (like temp-vendor) are deleted in the same layer they are created.
   - Enhanced Cleanup: Updated dev/tasks/free-disk-space-on-github-actions-runner to remove additional large, unused directories (Android SDK and Swift) from the GitHub Actions runner, reclaiming approximately 10GB+ of
     additional space.

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes # (Identified in run 21957188646 (https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/21957188646))

#### WHY do we need this change?
 The build-images job builds multiple large Docker images. Recent increases in project size or runner environment changes caused the default 73GB disk to fill up, leading to System.IO.IOException: No space left on device
  failures.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
