### PR TITLE
Add crd filtering for preview recorder

### DIFF
--- a/pkg/cli/preview/recorder.go
+++ b/pkg/cli/preview/recorder.go
@@ -369,7 +369,7 @@ func (r *Recorder) PreloadGKNN(ctx context.Context, config *rest.Config, namespa
 		return fmt.Errorf("failed to get preferred resources: %w", err)
 	}
 	for _, apiResourceList := range apiResourceLists {
-		if !strings.Contains(apiResourceList.GroupVersion, ".cnrm.cloud.google.com/") {
+		if !strings.Contains(apiResourceList.GroupVersion, "."+constants.CNRMDomain+"/") {
 			continue
 		}
 
@@ -452,12 +452,12 @@ func toTrackedGVR(apiResource metav1.APIResource, apiResourceListGroupVersion sc
 		gvr.Version = apiResourceListGroupVersion.Version
 	}
 	// Not tracking CC and CCC objects.
-	if strings.HasSuffix(gvr.Group, "core.cnrm.cloud.google.com") {
+	if strings.HasSuffix(gvr.Group, constants.CoreCNRMGroup) {
 		return gvr, false
 	}
 
 	// Not tracking non-CNRM objects.
-	if !strings.Contains(gvr.Group, "cnrm.cloud.google.com") {
+	if !(strings.HasSuffix(gvr.Group, "."+constants.CNRMDomain) || gvr.Group == constants.CNRMDomain) {
 		return gvr, false
 	}
 

--- a/pkg/cli/preview/recorder_test.go
+++ b/pkg/cli/preview/recorder_test.go
@@ -118,6 +118,24 @@ func TestToTrackedGVR(t *testing.T) {
 			},
 			wantOk: false,
 		},
+		{
+			name: "Fake CNRM group (ignored)",
+			apiResource: metav1.APIResource{
+				Name:    "storagebuckets",
+				Group:   "fake-cnrm.cloud.google.com",
+				Version: "v1beta1",
+			},
+			apiResourceListGroupVersion: schema.GroupVersion{
+				Group:   "fake-cnrm.cloud.google.com",
+				Version: "v1beta1",
+			},
+			wantGVR: schema.GroupVersionResource{
+				Group:    "fake-cnrm.cloud.google.com",
+				Version:  "v1beta1",
+				Resource: "storagebuckets",
+			},
+			wantOk: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### BRIEF Change description
Added CRD filtering for the preview recorder in pkg/cli/preview/recorder.go to skip non-CNRM objects and resources listed in IgnoredCRDList.

  Fixes #


#### WHY do we need this change?
The preview recorder currently attempts to preload all resources available in the discovery client. This includes non-CNRM objects and CRDs that should be ignored, which can lead to performance overhead or potential errors when attempting to list resources that KCC is not intended to manage.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
