### PR TITLE
fix: Correct resources with generated id

### DIFF
--- a/apis/alloydb/v1beta1/backup_identity.go
+++ b/apis/alloydb/v1beta1/backup_identity.go
@@ -71,10 +71,9 @@ func (obj *AlloyDBBackup) GetIdentity(ctx context.Context, reader client.Reader)
 	// Get desired resource ID
 	resourceID := common.ValueOf(obj.Spec.ResourceID)
 
-	// Server-generated ID; do not fallback to name
-	// if resourceID == "" {
-	// 	resourceID = obj.GetName()
-	// }
+	if resourceID == "" {
+		resourceID = obj.GetName()
+	}
 
 	var specIdentity *BackupIdentity
 	if resourceID != "" {

--- a/apis/alloydb/v1beta1/backup_types.go
+++ b/apis/alloydb/v1beta1/backup_types.go
@@ -42,7 +42,7 @@ type AlloyDBBackupSpec struct {
 	/* The project that this resource belongs to. */
 	ProjectRef *parent.ProjectRef `json:"projectRef"`
 
-	// Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.
+	/* Immutable. Optional. The backupId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default. */
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 }

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbbackups.alloydb.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_alloydbbackups.alloydb.cnrm.cloud.google.com.yaml
@@ -139,9 +139,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. Optional. The service-generated name of the
-                  resource. Used for acquisition only. Leave unset to create a new
-                  resource.
+                description: Immutable. Optional. The backupId of the resource. Used
+                  for creation and acquisition. When unset, the value of `metadata.name`
+                  is used as the default.
                 type: string
             required:
             - clusterNameRef
@@ -352,9 +352,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: Immutable. Optional. The service-generated name of the
-                  resource. Used for acquisition only. Leave unset to create a new
-                  resource.
+                description: Immutable. Optional. The backupId of the resource. Used
+                  for creation and acquisition. When unset, the value of `metadata.name`
+                  is used as the default.
                 type: string
             required:
             - clusterNameRef

--- a/scripts/generate-google3-docs/resource-lists/generated/_resources-with-service-generated-resource-id.html
+++ b/scripts/generate-google3-docs/resource-lists/generated/_resources-with-service-generated-resource-id.html
@@ -2,7 +2,6 @@
 
 <ul>
 <li><code>AccessContextManagerAccessPolicy</code></li>
-<li><code>AlloyDBBackup</code></li>
 <li><code>ApigeeOrganization</code></li>
 <li><code>BillingBudgetsBudget</code></li>
 <li><code>CloudIdentityGroup</code></li>

--- a/scripts/generate-google3-docs/resource-lists/main.go
+++ b/scripts/generate-google3-docs/resource-lists/main.go
@@ -106,7 +106,16 @@ func resourcesWithServerGeneratedResourceID(smLoader *servicemappingloader.Servi
 	if err != nil {
 		return nil, fmt.Errorf("error getting DCL-based resources with a server-generated resource ID: %w", err)
 	}
-	return k8s.SortGVKsByKind(append(tfResources, dclResources...)), nil
+	// todo: temporarily list current direct resources with generated ID until we can generate them by code
+	// This is needed otherwise "make resource-docs" will revert the resource-lists
+	directResources := []schema.GroupVersionKind{
+		{Group: "datacatalog.cnrm.cloud.google.com", Version: "v1beta1", Kind: "DataCatalogPolicyTag"},
+		{Group: "datacatalog.cnrm.cloud.google.com", Version: "v1beta1", Kind: "DataCatalogTaxonomy"},
+		{Group: "essentialcontacts.cnrm.cloud.google.com", Version: "v1beta1", Kind: "EssentialContactsContact"},
+		{Group: "tags.cnrm.cloud.google.com", Version: "v1beta1", Kind: "TagsTagBinding"},
+		{Group: "tags.cnrm.cloud.google.com", Version: "v1beta1", Kind: "TagsTagKey"},
+		{Group: "tags.cnrm.cloud.google.com", Version: "v1beta1", Kind: "TagsTagValue"}}
+	return k8s.SortGVKsByKind(append(append(tfResources, dclResources...), directResources...)), nil
 }
 
 func tfBasedResourcesWithServerGeneratedResourceID(smLoader *servicemappingloader.ServiceMappingLoader) []schema.GroupVersionKind {

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesslevel.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesslevel.md
@@ -570,7 +570,7 @@ title: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.{% endverbatim %}</p>
+            <p>{% verbatim %}The AccessContextManagerAccessLevel name. If not given, the metadata.name will be used.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesspolicy.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/accesscontextmanager/accesscontextmanageraccesspolicy.md
@@ -111,7 +111,7 @@ title: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The AccessContextManagerAccessPolicy name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbbackup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/alloydb/alloydbbackup.md
@@ -212,7 +212,7 @@ resourceID: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.{% endverbatim %}</p>
+            <p>{% verbatim %}Immutable. Optional. The backupId of the resource. Used for creation and acquisition. When unset, the value of `metadata.name` is used as the default.{% endverbatim %}</p>
         </td>
     </tr>
 </tbody>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/apigee/apigeeorganization.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/apigee/apigeeorganization.md
@@ -289,7 +289,7 @@ runtimeType: string
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The ApigeeOrganization name. If not given, the metadata.name will be used.{% endverbatim %}</p>
+            <p>{% verbatim %}Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.{% endverbatim %}</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/secretmanager/secretmanagersecretversion.md
@@ -123,7 +123,7 @@ secretRef:
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>{% verbatim %}The SecretVersion number. If given, Config Connector acquires the resource from the Secret Manager service. If not given, Config Connector adds a new secret version to the GCP service, and you can find out the version number from `status.observedState.version`{% endverbatim %}</p>
+            <p>{% verbatim %}The service-generated SecretVersion number. If given, Config Connector acquires the resource from the Secret Manager service. If not given, Config Connector adds a new secret version to the GCP service, and you can find out the version number from `status.observedState.version`{% endverbatim %}</p>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Followup of #6226 

- AlloyDBBackup does not have generated ID. Corrected the field description and re-generated the CRD.
- Re-generated resource docs by running "make resource-docs".

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
