### PR TITLE
cherry-pick: release-1.134: Updating the prometheus-to-sd image being used.

### DIFF
--- a/hack/update-images.sh
+++ b/hack/update-images.sh
@@ -13,14 +13,26 @@
 # limitations under the License.
 
 #/bin/bash
-#export PROM_2_SD_VERSION="$(gcrane ls gke.gcr.io/prometheus-to-sd | egrep "prometheus-to-sd:v" | sort -r --version-sort | head -1)"
 export PROM_2_SD_VERSION="$(gcrane ls gcr.io/gke-release/prometheus-to-sd | egrep "prometheus-to-sd:v" | sort -r --version-sort | head -1)"
 echo "Switching to use the $PROM_2_SD_VERSION image"
-for file in `find . -name '*.yaml'`
-do 
+files=`find . -name '*.yaml' | egrep -v "operator/channels/packages/configconnector"`
+for file in ${files}
+do
 	#if grep -q "gke.gcr.io/prometheus-to-sd" $file 
 	if grep -q "gcr.io/gke-release/prometheus-to-sd" $file 
 	then
 		sed -i -E "s|gcr.io/gke-release/prometheus-to-sd:.*|$PROM_2_SD_VERSION|g" $file
+	fi
+done
+export PROM_2_SD_VERSION="$(gcrane ls gke.gcr.io/prometheus-to-sd | egrep "prometheus-to-sd:v" | sort -r --version-sort | head -1)"
+echo "Switching to use the $PROM_2_SD_VERSION image"
+files=`find . -name 'manifest.go'`
+files+=" "`find . -name 'customization.go'`
+for file in ${files}
+do
+	#if grep -q "gcr.io/gke-release/prometheus-to-sd" $file 
+	if grep -q "gke.gcr.io/prometheus-to-sd" $file 
+	then
+		sed -i -E "s|gke.gcr.io/prometheus-to-sd:.*|$PROM_2_SD_VERSION|g" $file
 	fi
 done

--- a/operator/config/channels/cluster-workload-identity/manager_sidecar_patch.yaml
+++ b/operator/config/channels/cluster-workload-identity/manager_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/config/channels/cluster-workload-identity/recorder_sidecar_patch.yaml
+++ b/operator/config/channels/cluster-workload-identity/recorder_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:48797?whitelisted=applied_resources_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/config/channels/namespaced-main/recorder_sidecar_patch.yaml
+++ b/operator/config/channels/namespaced-main/recorder_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:48797?whitelisted=applied_resources_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/config/channels/namespaced-per-namespace-components/manager_sidecar_patch.yaml
+++ b/operator/config/channels/namespaced-per-namespace-components/manager_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/pkg/test/controller/customization.go
+++ b/operator/pkg/test/controller/customization.go
@@ -389,7 +389,7 @@ spec:
           requests:
             memory: 256Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `, `
 apiVersion: apps/v1
@@ -528,7 +528,7 @@ spec:
           requests:
             memory: 512Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `, `
 apiVersion: apps/v1
@@ -667,7 +667,7 @@ spec:
           requests:
             memory: 256Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `, `
 apiVersion: apps/v1
@@ -808,7 +808,7 @@ spec:
           requests:
             memory: 256Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `, `
 apiVersion: apps/v1
@@ -937,7 +937,7 @@ spec:
         image: gcr.io/gke-release/cnrm/controller:4af93f1
         name: manager
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `}
 
@@ -999,7 +999,7 @@ spec:
           requests:
             memory: 512Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `}
 
@@ -1056,7 +1056,7 @@ spec:
         image: gcr.io/gke-release/cnrm/controller:4af93f1
         name: manager
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `}
 
@@ -1118,7 +1118,7 @@ spec:
           requests:
             memory: 256Mi
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `, `
 apiVersion: apps/v1

--- a/operator/pkg/test/controller/manifest.go
+++ b/operator/pkg/test/controller/manifest.go
@@ -107,7 +107,7 @@ spec:
         image: gcr.io/gke-release/cnrm/controller:4af93f1
         name: manager
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `}
 
@@ -201,7 +201,7 @@ spec:
         image: gcr.io/gke-release/cnrm/controller:4af93f1
         name: manager
       - command: ["/monitor", "--source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]&customLabels[pod_name]", "--stackdriver-prefix=kubernetes.io/internal/addons"]
-        image: gke.gcr.io/prometheus-to-sd:v0.11.12-gke.11
+        image: gke.gcr.io/prometheus-to-sd:v0.12.7-gke.0
         name: prom-to-sd
 `}
 

--- a/operator/scripts/update-kcc-manifest/manager_sidecar_patch.yaml
+++ b/operator/scripts/update-kcc-manifest/manager_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:8888?whitelisted=reconcile_requests_total,reconcile_request_duration_seconds,reconcile_workers_total,reconcile_occupied_workers_total,internal_errors_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME

--- a/operator/scripts/update-kcc-manifest/recorder_sidecar_patch.yaml
+++ b/operator/scripts/update-kcc-manifest/recorder_sidecar_patch.yaml
@@ -19,7 +19,7 @@
     - /monitor
     - --source=configconnector:http://localhost:48797?whitelisted=applied_resources_total&customResourceType=k8s_container&customLabels[container_name]&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)
     - --stackdriver-prefix=kubernetes.io/internal/addons
-    image: gcr.io/gke-release/prometheus-to-sd:v0.12.1-gke.17
+    image: gcr.io/gke-release/prometheus-to-sd:v0.12.7-gke.0
     name: prom-to-sd
     env:
     - name: POD_NAME


### PR DESCRIPTION
Cherry picking PR #6665

### BRIEF Change description

Switched to the latest prometheus-to-sd image.
Fixed the script to correctly work with the test go files. Fixed the script to ignore the legacy release channels.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
