### PR TITLE
Fix typo 'bar]' to 'bar' in RunService samples and test fixtures

### DIFF
--- a/config/samples/resources/computeregionnetworkendpointgroup/cloud-run-region-network-endpoint-group/run_v1beta1_runservice.yaml
+++ b/config/samples/resources/computeregionnetworkendpointgroup/cloud-run-region-network-endpoint-group/run_v1beta1_runservice.yaml
@@ -27,7 +27,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/config/samples/resources/runservice/run-service-basic/run_v1beta1_runservice.yaml
+++ b/config/samples/resources/runservice/run-service-basic/run_v1beta1_runservice.yaml
@@ -27,7 +27,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudruncomputeregionnetworkendpointgroup/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudruncomputeregionnetworkendpointgroup/_http.log
@@ -39,7 +39,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
         "env": [
           {
             "name": "FOO",
-            "value": "bar]"
+            "value": "bar"
           }
         ],
         "image": "gcr.io/cloudrun/hello"
@@ -88,7 +88,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -162,7 +162,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -216,7 +216,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -287,7 +287,7 @@ X-Xss-Protection: 0
         "env": [
           {
             "name": "FOO",
-            "value": "bar]"
+            "value": "bar"
           }
         ],
         "image": "gcr.io/cloudrun/hello",
@@ -554,7 +554,7 @@ X-Xss-Protection: 0
         "env": [
           {
             "name": "FOO",
-            "value": "bar]"
+            "value": "bar"
           }
         ],
         "image": "gcr.io/cloudrun/hello",
@@ -626,7 +626,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -700,7 +700,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -754,7 +754,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudruncomputeregionnetworkendpointgroup/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computeregionnetworkendpointgroup/cloudruncomputeregionnetworkendpointgroup/dependencies.yaml
@@ -28,7 +28,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/pkg/test/resourcefixture/testdata/basic/eventarc/v1beta1/eventarctrigger/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/eventarc/v1beta1/eventarctrigger/dependencies.yaml
@@ -56,7 +56,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicebasic/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicebasic/_http.log
@@ -39,7 +39,7 @@ User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-confi
         "env": [
           {
             "name": "FOO",
-            "value": "bar]"
+            "value": "bar"
           }
         ],
         "image": "gcr.io/cloudrun/hello"
@@ -88,7 +88,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -162,7 +162,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -216,7 +216,7 @@ X-Xss-Protection: 0
           "env": [
             {
               "name": "FOO",
-              "value": "bar]"
+              "value": "bar"
             }
           ],
           "image": "gcr.io/cloudrun/hello",
@@ -287,7 +287,7 @@ X-Xss-Protection: 0
         "env": [
           {
             "name": "FOO",
-            "value": "bar]"
+            "value": "bar"
           }
         ],
         "image": "gcr.io/cloudrun/hello",

--- a/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicebasic/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/run/v1beta1/runservice/runservicebasic/create.yaml
@@ -26,7 +26,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeregionnetworkendpointgroup.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/compute/computeregionnetworkendpointgroup.md
@@ -577,7 +577,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runservice.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/run/runservice.md
@@ -2163,7 +2163,7 @@ spec:
     containers:
       - env:
           - name: "FOO"
-            value: "bar]"
+            value: "bar"
         image: "gcr.io/cloudrun/hello"
     scaling:
       maxInstanceCount: 2


### PR DESCRIPTION
### BRIEF Change description
This PR corrects a pervasive typo in `RunService` environment variable values, where `bar]` was used instead of `bar`. 

The fix updates:
- Active KCC samples in `config/samples/resources/runservice` and `config/samples/resources/computeregionnetworkendpointgroup`.
- Integration test fixtures in `pkg/test/resourcefixture/testdata/basic/`.
- Generated documentation in `scripts/generate-google3-docs/`.

#### WHY do we need this change?
To ensure documentation accuracy and clean up confusing sample values for users.

#### Special notes for your reviewer:
Golden logs (`_http.log`) were updated using `mockgcp` to reflect the change in the requested environment variable values.

#### Does this PR add something which needs to be 'release noted'?
NONE

#### Additional documentation e.g., references, usage docs, etc.:
NONE

### Tests you have done
- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
- Verified passing tests for `runservicebasic` and `cloudruncomputeregionnetworkendpointgroup` against `mockgcp`.
