### PR TITLE
Add structured reporting diff to StorageAnywhereCache

### DIFF
--- a/pkg/controller/direct/storage/control/anywherecache_client_interface.go
+++ b/pkg/controller/direct/storage/control/anywherecache_client_interface.go
@@ -21,6 +21,7 @@ import (
 	controlpb "cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	"github.com/googleapis/gax-go/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type AnywhereCacheAPI interface {
@@ -36,4 +37,5 @@ type AnywhereCacheAPI interface {
 type DirectBaseUpdateOperation interface {
 	UpdateStatus(ctx context.Context, typedStatus any, readyCondition *v1alpha1.Condition) error
 	RequestRequeue()
+	GetUnstructured() *unstructured.Unstructured
 }

--- a/pkg/controller/direct/storage/control/anywherecache_controller.go
+++ b/pkg/controller/direct/storage/control/anywherecache_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	v1 "k8s.io/api/core/v1"
@@ -327,6 +328,12 @@ func (a *AnywhereCacheAdapter) UpdateCache(ctx context.Context, updateOp DirectB
 
 	// At this point, cache is in "running" state, with no previous updates pending, and metadata changes are required.
 	log.Info(fmt.Sprintf("Metadata fields needing update: %v", sets.List(paths)))
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	for _, path := range sets.List(paths) {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
 	updateMask := &fieldmaskpb.FieldMask{
 		Paths: sets.List(paths),
 	}

--- a/pkg/controller/direct/storage/control/anywherecache_controller_test.go
+++ b/pkg/controller/direct/storage/control/anywherecache_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type ProtoMatcher struct {
@@ -215,6 +216,7 @@ func TestAnywhereCacheAdapter_Update(t *testing.T) {
 		}
 		mockClient.EXPECT().UpdateAnywhereCache(ctx, ProtoEq(expectedUpdateReq), gomock.Any()).Return(nil, nil).Times(1)
 		mockClient.EXPECT().GetAnywhereCache(ctx, ProtoEq(&pb.GetAnywhereCacheRequest{Name: anywhereCacheName}), gomock.Any()).Return(getActualPB(mapCtx, anywhereCacheStateRunning, "admit-on-first-miss", "86400s", true), nil).Times(1)
+		mockUpdateOp.EXPECT().GetUnstructured().Return(&unstructured.Unstructured{}).Times(1)
 		mockUpdateOp.EXPECT().UpdateStatus(ctx, gomock.Any(), getReadyCondition(v1.ConditionFalse, k8s.Updating, k8s.UpdatingMessage)).Return(nil).Times(1)
 		if mapCtx.Err() != nil {
 			t.Fatalf("unexpected error setting mocks: %v", mapCtx.Err())

--- a/pkg/controller/direct/storage/control/mock_anywherecache.go
+++ b/pkg/controller/direct/storage/control/mock_anywherecache.go
@@ -18,6 +18,7 @@ import (
 	v1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/apis/k8s/v1alpha1"
 	gax "github.com/googleapis/gax-go/v2"
 	gomock "go.uber.org/mock/gomock"
+	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // MockAnywhereCacheAPI is a mock of AnywhereCacheAPI interface.
@@ -231,4 +232,18 @@ func (m *MockDirectBaseUpdateOperation) UpdateStatus(ctx context.Context, typedS
 func (mr *MockDirectBaseUpdateOperationMockRecorder) UpdateStatus(ctx, typedStatus, readyCondition any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockDirectBaseUpdateOperation)(nil).UpdateStatus), ctx, typedStatus, readyCondition)
+}
+
+// GetUnstructured mocks base method.
+func (m *MockDirectBaseUpdateOperation) GetUnstructured() *unstructured.Unstructured {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnstructured")
+	ret0, _ := ret[0].(*unstructured.Unstructured)
+	return ret0
+}
+
+// GetUnstructured indicates an expected call of GetUnstructured.
+func (mr *MockDirectBaseUpdateOperationMockRecorder) GetUnstructured() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnstructured", reflect.TypeOf((*MockDirectBaseUpdateOperation)(nil).GetUnstructured))
 }


### PR DESCRIPTION
### BRIEF Change description

Fixes #6618

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/storage/control/anywherecache_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.