### PR TITLE
Add structured reporting diff to SecretManagerSecret

### DIFF
--- a/pkg/controller/direct/secretmanager/secret_controller.go
+++ b/pkg/controller/direct/secretmanager/secret_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/label"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -290,6 +291,12 @@ func (a *Adapter) Update(ctx context.Context, op *directbase.UpdateOperation) er
 		log.V(2).Info("no field needs update", "name", a.id)
 		return nil
 	}
+
+	report := &structuredreporting.Diff{Object: op.GetUnstructured()}
+	for path := range paths {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
 
 	req := &secretmanagerpb.UpdateSecretRequest{
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: sets.List(paths)},


### PR DESCRIPTION
### BRIEF Change description

Fixes #6610

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/secretmanager/secret_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.