### PR TITLE
Add structured reporting diff to ReCAPTCHAEnterpriseFirewallPolicy

### DIFF
--- a/pkg/controller/direct/recaptchaenterprise/firewallpolicy_controller.go
+++ b/pkg/controller/direct/recaptchaenterprise/firewallpolicy_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/recaptchaenterprise/v2/apiv1"
 	pb "cloud.google.com/go/recaptchaenterprise/v2/apiv1/recaptchaenterprisepb"
@@ -186,6 +187,12 @@ func (a *FirewallPolicyAdapter) Update(ctx context.Context, updateOp *directbase
 		log.V(2).Info("no field needs update", "name", a.id)
 		return nil
 	}
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	for path := range paths {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
 
 	req := &pb.UpdateFirewallPolicyRequest{
 		FirewallPolicy: desiredPb,


### PR DESCRIPTION
### BRIEF Change description

Fixes #6608

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/recaptchaenterprise/firewallpolicy_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.