### PR TITLE
Add structured reporting diff to OrgPolicyPolicy

### DIFF
--- a/pkg/controller/direct/orgpolicy/policy_controller.go
+++ b/pkg/controller/direct/orgpolicy/policy_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/orgpolicy/apiv2"
 
@@ -190,6 +191,11 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 	req.UpdateMask = &fieldmaskpb.FieldMask{
 		Paths: []string{"policy.spec", "policy.dry_run_spec"},
 	}
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	for _, path := range req.UpdateMask.Paths {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
 
 	updated, err := a.gcpClient.UpdatePolicy(ctx, req)
 	if err != nil {

--- a/pkg/controller/direct/orgpolicy/policy_controller.go
+++ b/pkg/controller/direct/orgpolicy/policy_controller.go
@@ -170,17 +170,19 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 		return mapCtx.Err()
 	}
 
-	if proto.Equal(a.actual.GetSpec(), desiredPb.GetSpec()) && proto.Equal(a.actual.GetDryRunSpec(), desiredPb.GetDryRunSpec()) {
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	if !proto.Equal(a.actual.GetSpec(), desiredPb.GetSpec()) {
+		report.AddField("policy.spec", a.actual.GetSpec(), desiredPb.GetSpec())
+	}
+
+	if !proto.Equal(a.actual.GetDryRunSpec(), desiredPb.GetDryRunSpec()) {
+		report.AddField("policy.dry_run_spec", a.actual.GetDryRunSpec(), desiredPb.GetDryRunSpec())
+	}
+
+	if !report.HasDiff() {
 		log.V(2).Info("Policy is already up to date", "name", a.id)
 		// The resource is already up to date, but we still need to update the status
-		// to reflect the actual state from the backend.
-		status := &krm.OrgPolicyPolicyStatus{}
-		status.ObservedState = OrgPolicyPolicyObservedState_FromProto(mapCtx, a.actual)
-		if mapCtx.Err() != nil {
-			return mapCtx.Err()
-		}
-		status.ExternalRef = direct.LazyPtr(a.id.String())
-		return updateOp.UpdateStatus(ctx, status, nil)
+		return updateStatus(ctx, updateOp, a)
 	}
 
 	req := &orgpolicypb.UpdatePolicyRequest{
@@ -191,10 +193,6 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 	req.UpdateMask = &fieldmaskpb.FieldMask{
 		Paths: []string{"policy.spec", "policy.dry_run_spec"},
 	}
-	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
-	for _, path := range req.UpdateMask.Paths {
-		report.AddField(path, nil, nil)
-	}
 	structuredreporting.ReportDiff(ctx, report)
 
 	updated, err := a.gcpClient.UpdatePolicy(ctx, req)
@@ -202,9 +200,14 @@ func (a *PolicyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateO
 		return fmt.Errorf("updating Policy %s: %w", a.id, err)
 	}
 	log.V(2).Info("successfully updated Policy", "name", a.id)
+	a.actual = updated
+	return updateStatus(ctx, updateOp, a)
+}
 
+func updateStatus(ctx context.Context, updateOp *directbase.UpdateOperation, a *PolicyAdapter) error {
+	mapCtx := &direct.MapContext{}
 	status := &krm.OrgPolicyPolicyStatus{}
-	status.ObservedState = OrgPolicyPolicyObservedState_FromProto(mapCtx, updated)
+	status.ObservedState = OrgPolicyPolicyObservedState_FromProto(mapCtx, a.actual)
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6604

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/orgpolicy/policy_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.