### PR TITLE
Add structured reporting diff to NetworkConnectivityInternalRange

### DIFF
--- a/pkg/controller/direct/networkconnectivity/internalrange_controller.go
+++ b/pkg/controller/direct/networkconnectivity/internalrange_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 )
 
 func init() {
@@ -188,30 +189,40 @@ func (a *internalRangeAdapter) Update(ctx context.Context, updateOp *directbase.
 		return mapCtx.Err()
 	}
 
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+
 	paths := []string{}
 	if desired.Spec.Description != nil && !reflect.DeepEqual(resource.Description, a.actual.Description) {
+		report.AddField("description", a.actual.Description, resource.Description)
 		paths = append(paths, "description")
 	}
 	if desired.Spec.IPCIDRRange != nil && !reflect.DeepEqual(resource.IpCidrRange, a.actual.IpCidrRange) {
+		report.AddField("ip_cidr_range", a.actual.IpCidrRange, resource.IpCidrRange)
 		paths = append(paths, "ipCidrRange")
 	}
 	if desired.Spec.Labels != nil && !reflect.DeepEqual(resource.Labels, a.actual.Labels) {
+		report.AddField("labels", a.actual.Labels, resource.Labels)
 		paths = append(paths, "labels")
 	}
 	if desired.Spec.Peering != nil && !reflect.DeepEqual(resource.Peering, a.actual.Peering) {
+		report.AddField("peering", a.actual.Peering, resource.Peering)
 		paths = append(paths, "peering")
 	}
 	if desired.Spec.PrefixLength != nil && !reflect.DeepEqual(resource.PrefixLength, a.actual.PrefixLength) {
+		report.AddField("prefix_length", a.actual.PrefixLength, resource.PrefixLength)
 		paths = append(paths, "prefixLength")
 	}
 	if desired.Spec.TargetCIDRRange != nil && !reflect.DeepEqual(resource.TargetCidrRange, a.actual.TargetCidrRange) {
+		report.AddField("target_cidr_range", a.actual.TargetCidrRange, resource.TargetCidrRange)
 		paths = append(paths, "targetCidrRange")
 	}
 	if desired.Spec.Usage != nil && !reflect.DeepEqual(resource.Usage, a.actual.Usage) {
+		report.AddField("usage", a.actual.Usage, resource.Usage)
 		paths = append(paths, "usage")
 	}
 
 	if len(paths) > 0 {
+		structuredreporting.ReportDiff(ctx, report)
 		resource.Name = a.id.String() // we need to set the name so that GCP API can identify the resource
 		req := &api.InternalRange{}
 		if err := convertProtoToAPI(resource, req); err != nil {


### PR DESCRIPTION
### BRIEF Change description

Fixes #6598

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/networkconnectivity/internalrange_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.