### PR TITLE
Add structured reporting diff to LoggingLink

### DIFF
--- a/pkg/controller/direct/logging/link_controller.go
+++ b/pkg/controller/direct/logging/link_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	//"net/http"
 
@@ -194,6 +195,12 @@ func (a *LoggingLinkAdapter) Update(ctx context.Context, updateOp *directbase.Up
 	if len(paths) == 0 {
 		log.V(2).Info("no field needs update", "name", a.id)
 	} else {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
+
 		log.V(2).Info("update operation not supported for resource", "groupVersionKind", a.desired.GroupVersionKind(), "namespacedName", k8s.GetNamespacedName(a.desired))
 	}
 	status := &krm.LoggingLinkStatus{}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6591

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/logging/link_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.