### PR TITLE
Add structured reporting diff to KMSKeyHandle

### DIFF
--- a/pkg/controller/direct/kms/keyhandle/keyhandle_controller.go
+++ b/pkg/controller/direct/kms/keyhandle/keyhandle_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/kms/apiv1"
 
@@ -202,6 +203,12 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 		status.ExternalRef = &externalRef
 		return updateOp.UpdateStatus(ctx, status, nil)
 	} else {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
+
 		return fmt.Errorf("update operation not supported for resource %v %v, field(s) changed: %v",
 			a.desired.GroupVersionKind(), k8s.GetNamespacedName(a.desired), paths)
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6590

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/kms/keyhandle/keyhandle_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.