### PR TITLE
Add structured reporting diff to KMSAutokeyConfig

### DIFF
--- a/pkg/controller/direct/kms/autokeyconfig/autokeyconfig_controller.go
+++ b/pkg/controller/direct/kms/autokeyconfig/autokeyconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/kms/apiv1"
 
@@ -148,7 +149,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 		return mapCtx.Err()
 	}
 
-	updated, err := a.updateAutokeyConfig(ctx, resource)
+	updated, err := a.updateAutokeyConfig(ctx, resource, updateOp)
 	if err != nil {
 		return err
 	}
@@ -163,7 +164,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	return updateOp.UpdateStatus(ctx, status, nil)
 }
 
-func (a *Adapter) updateAutokeyConfig(ctx context.Context, resource *kmspb.AutokeyConfig) (*kmspb.AutokeyConfig, error) {
+func (a *Adapter) updateAutokeyConfig(ctx context.Context, resource *kmspb.AutokeyConfig, updateOp *directbase.UpdateOperation) (*kmspb.AutokeyConfig, error) {
 	log := klog.FromContext(ctx)
 	// To populate a.actual calling a.Find()
 	isExist, err := a.Find(ctx)
@@ -173,8 +174,12 @@ func (a *Adapter) updateAutokeyConfig(ctx context.Context, resource *kmspb.Autok
 	if err != nil {
 		return nil, err
 	}
+
 	updateMask := &fieldmaskpb.FieldMask{}
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+
 	if resource.KeyProject != "" && !reflect.DeepEqual(resource.KeyProject, a.actual.KeyProject) {
+		report.AddField("key_project", a.actual.KeyProject, resource.KeyProject)
 		updateMask.Paths = append(updateMask.Paths, "key_project")
 	}
 
@@ -182,6 +187,9 @@ func (a *Adapter) updateAutokeyConfig(ctx context.Context, resource *kmspb.Autok
 		log.V(2).Info("no field needs update", "name", a.id)
 		return nil, nil
 	}
+
+	structuredreporting.ReportDiff(ctx, report)
+
 	req := &kmspb.UpdateAutokeyConfigRequest{
 		UpdateMask:    updateMask,
 		AutokeyConfig: resource,
@@ -232,7 +240,7 @@ func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperati
 	// make a copy of the a.actual i.e. from krm.AutokeyConfig to kmspb.AutokeyConfig
 	tempKrmAutokeyResource := AutokeyConfig_FromProto(mapCtx, a.actual)
 	resource := AutokeyConfig_ToProto(mapCtx, tempKrmAutokeyResource)
-	updated, err := a.updateAutokeyConfig(ctx, resource)
+	updated, err := a.updateAutokeyConfig(ctx, resource, nil)
 	if err != nil {
 		return false, fmt.Errorf("updating AutokeyConfig %s: %w", a.id, err)
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6588

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/kms/autokeyconfig/autokeyconfig_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.