### PR TITLE
Add structured reporting diff to FirestoreField

### DIFF
--- a/pkg/controller/direct/firestore/firestorefield_controller.go
+++ b/pkg/controller/direct/firestore/firestorefield_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -192,6 +193,12 @@ func (a *firestoreFieldAdapter) Update(ctx context.Context, updateOp *directbase
 
 	latest := a.desired
 	if len(req.UpdateMask.Paths) != 0 {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for _, path := range req.UpdateMask.Paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
+
 		log.V(0).Info("updating FirestoreField", "name", fqn)
 
 		op, err := a.firestoreAdminClient.UpdateField(ctx, req)


### PR DESCRIPTION
### BRIEF Change description

Fixes #6581

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/firestore/firestorefield_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.