### PR TITLE
Add structured reporting diff to DocumentAIProcessor

### DIFF
--- a/pkg/controller/direct/documentai/processor_controller.go
+++ b/pkg/controller/direct/documentai/processor_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/documentai/apiv1"
 	pb "cloud.google.com/go/documentai/apiv1/documentaipb"
@@ -186,6 +187,10 @@ func (a *ProcessorAdapter) Update(ctx context.Context, updateOp *directbase.Upda
 		}
 		return updateOp.UpdateStatus(ctx, status, nil)
 	}
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	report.AddField("default_processor_version", a.actual.DefaultProcessorVersion, desiredPb.DefaultProcessorVersion)
+	structuredreporting.ReportDiff(ctx, report)
 
 	req := &pb.SetDefaultProcessorVersionRequest{
 		Processor:               a.id.String(),


### PR DESCRIPTION
### BRIEF Change description

Fixes #6576

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/documentai/processor_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.