### PR TITLE
Add structured reporting diff to DataprocJob

### DIFF
--- a/pkg/controller/direct/dataproc/job_controller.go
+++ b/pkg/controller/direct/dataproc/job_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 )
 
 const (
@@ -340,6 +341,10 @@ func (a *dataprocJobAdapter) Update(ctx context.Context, updateOp *directbase.Up
 
 	// If only labels changed, proceed with label update
 	if !MapsEqual(a.desired.Labels, a.actual.Labels) {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		report.AddField("labels", a.actual.Labels, a.desired.Labels)
+		structuredreporting.ReportDiff(ctx, report)
+
 		klog.V(2).Infof("updating labels for dataproc job %q", a.id)
 		req := &pb.UpdateJobRequest{
 			ProjectId: a.id.Parent().ProjectID,


### PR DESCRIPTION
### BRIEF Change description

Fixes #6571

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/dataproc/job_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.