### PR TITLE
Add structured reporting diff to ComputeNetworkAttachment

### DIFF
--- a/pkg/controller/direct/compute/networkattachment_controller.go
+++ b/pkg/controller/direct/compute/networkattachment_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 )
 
 func init() {
@@ -203,6 +204,11 @@ func (a *NetworkAttachmentAdapter) Update(ctx context.Context, updateOp *directb
 		// even though there is no update, we still want to update KRM status
 		updated = a.actual
 	} else {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
 
 		req := &computepb.PatchNetworkAttachmentRequest{
 			Project:                   a.id.Parent().ProjectID,


### PR DESCRIPTION
### BRIEF Change description

Fixes #6557

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/compute/networkattachment_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.