### PR TITLE
Add structured reporting diff to ComputeFirewallPolicyRule

### DIFF
--- a/pkg/controller/direct/compute/firewallpolicyrule_controller.go
+++ b/pkg/controller/direct/compute/firewallpolicyrule_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -212,6 +213,12 @@ func (a *firewallPolicyRuleAdapter) Update(ctx context.Context, updateOp *direct
 		// even though there is no update, we still want to update KRM status
 		updated = a.actual
 	} else {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
+
 		tokens := strings.Split(a.id.String(), "/")
 		priority, err := strconv.ParseInt(tokens[5], 10, 32)
 		// Should not hit this error because we have verified priority in parseComputeFirewallPolicyRuleExternal`


### PR DESCRIPTION
### BRIEF Change description

Fixes #6555

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/compute/firewallpolicyrule_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.