### PR TITLE
Add structured reporting diff to ColabRuntimeTemplate

### DIFF
--- a/pkg/controller/direct/colab/runtimetemplate_controller.go
+++ b/pkg/controller/direct/colab/runtimetemplate_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 )
 
 func init() {
@@ -269,7 +270,14 @@ func (a *runtimeTemplateAdapter) Update(ctx context.Context, updateOp *directbas
 
 			return updateOp.UpdateStatus(ctx, a.desired.Status, nil)
 		}
+	} else {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
 	}
+
 	updateMask := &fieldmaskpb.FieldMask{
 		Paths: sets.List(paths),
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6554

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/colab/runtimetemplate_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.