### PR TITLE
Add structured reporting diff to CertificateManagerDNSAuthorization

### DIFF
--- a/pkg/controller/direct/certificatemanager/dnsauthorization_controller.go
+++ b/pkg/controller/direct/certificatemanager/dnsauthorization_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/label"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	certificatemanagerpb "cloud.google.com/go/certificatemanager/apiv1/certificatemanagerpb"
 	"google.golang.org/api/option"
@@ -215,19 +216,25 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	log := klog.FromContext(ctx)
 	log.V(2).Info("updating DnsAuthorization", "name", a.id.FullyQualifiedName())
 	mapCtx := &direct.MapContext{}
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+
 	updateMask := &fieldmaskpb.FieldMask{}
 
 	if !reflect.DeepEqual(a.desired.Description, a.actual.Description) {
+		report.AddField("description", a.actual.Description, a.desired.Description)
 		updateMask.Paths = append(updateMask.Paths, "description")
 	}
 
 	if !reflect.DeepEqual(a.desired.Labels, a.actual.Labels) {
+		report.AddField("labels", a.actual.Labels, a.desired.Labels)
 		updateMask.Paths = append(updateMask.Paths, "labels")
 	}
 
 	if len(updateMask.Paths) == 0 {
 		return nil
 	}
+	structuredreporting.ReportDiff(ctx, report)
 
 	req := &certificatemanagerpb.UpdateDnsAuthorizationRequest{
 		UpdateMask:       updateMask,


### PR DESCRIPTION
### BRIEF Change description

Fixes #6549

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/certificatemanager/dnsauthorization_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.