### PR TITLE
Add structured reporting diff to BigQueryReservationAssignment

### DIFF
--- a/pkg/controller/direct/bigqueryreservation/assignment_controller.go
+++ b/pkg/controller/direct/bigqueryreservation/assignment_controller.go
@@ -197,10 +197,6 @@ func (a *AssignmentAdapter) moveAssignment(ctx context.Context, updateOp *direct
 	log := klog.FromContext(ctx)
 	log.V(2).Info("moving assignment to another reservation", "name", a.id.String())
 
-	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
-	report.AddField("reservationRef", currentReservation, a.destinationId)
-	structuredreporting.ReportDiff(ctx, report)
-
 	req := &pb.MoveAssignmentRequest{
 		Name:          a.actual.GetName(),
 		DestinationId: a.destinationId,
@@ -295,6 +291,9 @@ func (a *AssignmentAdapter) Update(ctx context.Context, updateOp *directbase.Upd
 
 	// Case1: Move the assignment to another reservation
 	if currentReservation.String() != a.destinationId {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		report.AddField("reservation_id", currentReservation, a.destinationId)
+		structuredreporting.ReportDiff(ctx, report)
 		return a.moveAssignment(ctx, updateOp, desiredSpec, currentReservation.String())
 	}
 


### PR DESCRIPTION
### BRIEF Change description

Fixes #6546

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/bigqueryreservation/assignment_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.