### PR TITLE
Add structured reporting diff to BigLakeTable

### DIFF
--- a/pkg/controller/direct/bigquerybiglake/table_controller.go
+++ b/pkg/controller/direct/bigquerybiglake/table_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	gcp "cloud.google.com/go/bigquery/biglake/apiv1"
 	bigquerybiglakepb "cloud.google.com/go/bigquery/biglake/apiv1/biglakepb"
@@ -175,6 +176,13 @@ func (a *TableAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOp
 		log.V(2).Info("no field needs update", "name", a.id)
 		return nil
 	}
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	for path := range paths {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
+
 	updateMask := &fieldmaskpb.FieldMask{
 		Paths: sets.List(paths),
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6542

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/bigquerybiglake/table_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.