### PR TITLE
Add structured reporting diff to BatchJob

### DIFF
--- a/pkg/controller/direct/batch/job_controller.go
+++ b/pkg/controller/direct/batch/job_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/label"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -184,6 +185,12 @@ func (a *jobAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOper
 		return err
 	}
 	if len(paths) != 0 {
+		report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+		for path := range paths {
+			report.AddField(path, nil, nil)
+		}
+		structuredreporting.ReportDiff(ctx, report)
+
 		log.V(2).Info("This resource does not support update", "name", a.id.String())
 		return nil
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #6539

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/batch/job_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.