### PR TITLE
Add structured reporting diff to APIKeysKey

### DIFF
--- a/pkg/controller/direct/apikeys/apikeyskey_controller.go
+++ b/pkg/controller/direct/apikeys/apikeyskey_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 
 	. "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/mappings" //nolint:revive
 )
@@ -255,6 +256,12 @@ func (a *adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 		klog.Warningf("unexpected empty update mask, desired: %v, actual: %v", a.desired, a.actual)
 		return nil
 	}
+
+	report := &structuredreporting.Diff{Object: updateOp.GetUnstructured()}
+	for _, path := range updateMask.Paths {
+		report.AddField(path, nil, nil)
+	}
+	structuredreporting.ReportDiff(ctx, report)
 
 	key := &pb.Key{}
 	if err := keyMapping.Map(a.desired, key); err != nil {


### PR DESCRIPTION
### BRIEF Change description

Fixes #6534

#### WHY do we need this change?

Add structured reporting diff to the controller in `pkg/controller/direct/apikeys/apikeyskey_controller.go`.
The `structuredreporting.ReportDiff` should be used in the `Update` method of the adapter to report which fields are being updated.
This helps in debugging reconciliation loops and provides better visibility into what changed.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.