### PR TITLE
fix: port contention

### DIFF
--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -152,6 +152,10 @@ func WithKubeTarget(kubeTarget string) HarnessOption {
 	}
 }
 
+// envtestWebhookMutex prevents port collision races when running envtest in parallel.
+// It locks the window between envtest allocating a free port and the manager binding it.
+var envtestWebhookMutex sync.Mutex
+
 type GCPTargetMode string
 
 const (
@@ -221,12 +225,23 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 	}
 
 	var webhooks []cnrmwebhook.Config
+	var envtestLocked bool
 
 	loadCRDs := true
 	if h.KubeTarget == "" {
 		h.KubeTarget = os.Getenv("E2E_KUBE_TARGET")
 	}
 	if h.KubeTarget == "envtest" {
+		// Lock the mutex to prevent parallel tests from stealing the port envtest is about to pick
+		envtestWebhookMutex.Lock()
+		envtestLocked = true
+		defer func() {
+			// Ensure we always unlock if something panics or t.Fatalf is called early
+			if envtestLocked {
+				envtestWebhookMutex.Unlock()
+				envtestLocked = false
+			}
+		}()
 		whCfgs, err := testwebhook.GetTestCommonWebhookConfigs()
 		if err != nil {
 			h.Fatalf("error getting common wehbook configs: %v", err)
@@ -761,6 +776,13 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 		}
 		t.Logf("waiting for webhook to start (%v)", err)
 		time.Sleep(100 * time.Millisecond)
+	}
+
+	// The port is now successfully bound by the manager. We can safely release
+	// the lock so other parallel tests can provision their own environments.
+	if envtestLocked {
+		envtestWebhookMutex.Unlock()
+		envtestLocked = false
 	}
 
 	return h


### PR DESCRIPTION
I've noticed that some of our tests' webhooks block on a port that is already in use. I suspect there'a race between the time that we get a port from the OS and actually send it to envtest to be used.