### PR TITLE
fix: handle ALREADY_EXISTS in TagKey and TagValue controllers

### DIFF
--- a/mockgcp/mockresourcemanager/tagkeys.go
+++ b/mockgcp/mockresourcemanager/tagkeys.go
@@ -141,6 +141,19 @@ func (s *TagKeys) CreateTagKey(ctx context.Context, req *pb.CreateTagKeyRequest)
 		return nil, fmt.Errorf("ValidateOnly not yet implemented")
 	}
 
+	// Check for duplicate shortName under the same parent (real GCP enforces this).
+	normalizedParent := req.GetTagKey().GetParent()
+	tagKeyKind := (&pb.TagKey{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, tagKeyKind, storage.ListOptions{}, func(obj proto.Message) error {
+		existing := obj.(*pb.TagKey)
+		if existing.GetParent() == normalizedParent && existing.GetShortName() == req.GetTagKey().GetShortName() {
+			return status.Errorf(codes.AlreadyExists, "A TagKey with short name '%s' already exists under parent '%s'", req.GetTagKey().GetShortName(), normalizedParent)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
 	name := &tagKeyName{
 		ID: time.Now().UnixNano(),
 	}

--- a/mockgcp/mockresourcemanager/tagvalues.go
+++ b/mockgcp/mockresourcemanager/tagvalues.go
@@ -84,6 +84,27 @@ func (s *TagValues) GetNamespacedTagValue(ctx context.Context, req *pb.GetNamesp
 	return tagValues[0], nil
 }
 
+func (s *TagValues) ListTagValues(ctx context.Context, req *pb.ListTagValuesRequest) (*pb.ListTagValuesResponse, error) {
+	parentFQN := req.GetParent()
+
+	var tagValues []*pb.TagValue
+
+	tagValueKind := (&pb.TagValue{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, tagValueKind, storage.ListOptions{}, func(obj proto.Message) error {
+		tagValue := obj.(*pb.TagValue)
+		if tagValue.GetParent() == parentFQN {
+			tagValues = append(tagValues, tagValue)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &pb.ListTagValuesResponse{
+		TagValues: tagValues,
+	}, nil
+}
+
 func (s *TagValues) CreateTagValue(ctx context.Context, req *pb.CreateTagValueRequest) (*longrunningpb.Operation, error) {
 	parentName, err := s.parseTagKeyName(req.GetTagValue().GetParent())
 	if err != nil {
@@ -122,6 +143,19 @@ func (s *TagValues) CreateTagValue(ctx context.Context, req *pb.CreateTagValueRe
 
 	if req.ValidateOnly {
 		return nil, fmt.Errorf("ValidateOnly not yet implemented")
+	}
+
+	// Check for duplicate shortName under the same parent TagKey (real GCP enforces this).
+	parentFQN := parentTagKey.GetName()
+	tagValueKind := (&pb.TagValue{}).ProtoReflect().Descriptor()
+	if err := s.storage.List(ctx, tagValueKind, storage.ListOptions{}, func(obj proto.Message) error {
+		existing := obj.(*pb.TagValue)
+		if existing.GetParent() == parentFQN && existing.GetShortName() == req.GetTagValue().GetShortName() {
+			return status.Errorf(codes.AlreadyExists, "A TagValue with short name '%s' already exists under parent '%s'", req.GetTagValue().GetShortName(), parentFQN)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	name := &tagValueName{

--- a/pkg/controller/direct/maputils.go
+++ b/pkg/controller/direct/maputils.go
@@ -287,6 +287,17 @@ func IsBadRequest(err error) bool {
 	return HasHTTPCode(err, 400)
 }
 
+// IsAlreadyExists returns true if the given error is an HTTP 409 or gRPC AlreadyExists.
+func IsAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	apiError := &apierror.APIError{}
+	return errors.As(err, &apiError) && apiError.HTTPCode() == 409 ||
+		grpcStatus.Code(err) == grpcCode.AlreadyExists
+}
+
 // HasHTTPCode returns true if the given error is an HTTP response with the given code.
 func HasHTTPCode(err error, code int) bool {
 

--- a/pkg/controller/direct/maputils_test.go
+++ b/pkg/controller/direct/maputils_test.go
@@ -15,8 +15,12 @@
 package direct
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/googleapis/gax-go/v2/apierror"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -41,5 +45,66 @@ func TestStringDuration_ToProto(t *testing.T) {
 	}
 	if mapctx.Err() != nil {
 		t.Fatalf("google.protobuf.Duration -> String error: %s", mapctx.Err())
+	}
+}
+
+func TestIsAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+		{
+			name: "gRPC AlreadyExists",
+			err:  status.Error(codes.AlreadyExists, "resource already exists"),
+			want: true,
+		},
+		{
+			name: "gRPC NotFound",
+			err:  status.Error(codes.NotFound, "not found"),
+			want: false,
+		},
+		{
+			name: "gRPC AlreadyExists wrapped with apierror",
+			err: func() error {
+				grpcErr := status.Error(codes.AlreadyExists, "resource already exists")
+				apiErr, _ := apierror.ParseError(grpcErr, true)
+				return apiErr
+			}(),
+			want: true,
+		},
+		{
+			name: "gRPC NotFound wrapped with apierror",
+			err: func() error {
+				grpcErr := status.Error(codes.NotFound, "not found")
+				apiErr, _ := apierror.ParseError(grpcErr, true)
+				return apiErr
+			}(),
+			want: false,
+		},
+		{
+			name: "wrapped gRPC AlreadyExists",
+			err:  fmt.Errorf("creating resource: %w", status.Error(codes.AlreadyExists, "already exists")),
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsAlreadyExists(tc.err)
+			if got != tc.want {
+				t.Errorf("IsAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/controller/direct/tags/tagkey_controller.go
+++ b/pkg/controller/direct/tags/tagkey_controller.go
@@ -16,6 +16,7 @@ package tags
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
+	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -178,23 +180,71 @@ func (a *TagsTagKeyAdapter) Create(ctx context.Context, createOp *directbase.Cre
 
 	op, err := a.tagKeysClient.CreateTagKey(ctx, req)
 	if err != nil {
+		if direct.IsAlreadyExists(err) {
+			log.V(0).Info("TagsTagKey already exists, attempting to acquire", "parent", a.desired.GetParent(), "shortName", a.desired.GetShortName())
+			return a.acquireExistingTagKey(ctx, createOp)
+		}
 		return fmt.Errorf("creating TagsTagKey: %w", err)
 	}
 
 	created, err := op.Wait(ctx)
 	if err != nil {
+		if direct.IsAlreadyExists(err) {
+			log.V(0).Info("TagsTagKey already exists, attempting to acquire", "parent", a.desired.GetParent(), "shortName", a.desired.GetShortName())
+			return a.acquireExistingTagKey(ctx, createOp)
+		}
 		return fmt.Errorf("waiting for creation of TagsTagKey: %w", err)
 	}
 	log.V(0).Info("created TagsTagKey", "name", created.GetName())
 
-	// For compatibility, we set spec.resourceID after creation because this is a server-generated-id resource that we are migrating from terraform/DCL.
-	// More info in docs/ai/server-generated-id.md
-	resourceID := strings.TrimPrefix(created.GetName(), "tagKeys/")
+	return a.setResourceIDAndStatus(ctx, createOp, created)
+}
+
+// acquireExistingTagKey looks up an existing TagKey by parent and shortName after an ALREADY_EXISTS error,
+// then sets the resourceID and status to adopt the resource.
+func (a *TagsTagKeyAdapter) acquireExistingTagKey(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+
+	existing, err := a.findTagKeyByShortName(ctx)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("TagsTagKey with shortName %q not found under %q despite ALREADY_EXISTS error", a.desired.GetShortName(), a.desired.GetParent())
+	}
+	log.V(0).Info("acquired existing TagsTagKey", "name", existing.GetName())
+
+	return a.setResourceIDAndStatus(ctx, createOp, existing)
+}
+
+// setResourceIDAndStatus sets spec.resourceID and updates status from the given TagKey.
+// For compatibility, we set spec.resourceID after creation because this is a server-generated-id resource that we are migrating from terraform/DCL.
+// More info in docs/ai/server-generated-id.md
+func (a *TagsTagKeyAdapter) setResourceIDAndStatus(ctx context.Context, createOp *directbase.CreateOperation, tagKey *pb.TagKey) error {
+	resourceID := strings.TrimPrefix(tagKey.GetName(), "tagKeys/")
 	if err := createOp.SetSpecResourceID(ctx, resourceID); err != nil {
 		return err
 	}
+	return a.updateStatus(ctx, createOp, tagKey)
+}
 
-	return a.updateStatus(ctx, createOp, created)
+// findTagKeyByShortName lists TagKeys under the parent and returns the one matching the desired shortName.
+func (a *TagsTagKeyAdapter) findTagKeyByShortName(ctx context.Context) (*pb.TagKey, error) {
+	listReq := &pb.ListTagKeysRequest{Parent: a.desired.GetParent()}
+	it := a.tagKeysClient.ListTagKeys(ctx, listReq)
+	for {
+		tagKey, err := it.Next()
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			return nil, fmt.Errorf("listing TagsTagKeys under %q: %w", a.desired.GetParent(), err)
+		}
+		if tagKey.GetShortName() == a.desired.GetShortName() {
+			return tagKey, nil
+		}
+	}
+	return nil, nil
 }
 
 func (a *TagsTagKeyAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {

--- a/pkg/controller/direct/tags/tagvalue_controller.go
+++ b/pkg/controller/direct/tags/tagvalue_controller.go
@@ -16,6 +16,7 @@ package tags
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/directbase"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/registry"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
+	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -159,23 +161,71 @@ func (a *TagsTagValueAdapter) Create(ctx context.Context, createOp *directbase.C
 
 	op, err := a.tagValuesClient.CreateTagValue(ctx, req)
 	if err != nil {
+		if direct.IsAlreadyExists(err) {
+			log.V(0).Info("TagsTagValue already exists, attempting to acquire", "parent", a.desired.GetParent(), "shortName", a.desired.GetShortName())
+			return a.acquireExistingTagValue(ctx, createOp)
+		}
 		return fmt.Errorf("creating TagsTagValue: %w", err)
 	}
 
 	created, err := op.Wait(ctx)
 	if err != nil {
+		if direct.IsAlreadyExists(err) {
+			log.V(0).Info("TagsTagValue already exists, attempting to acquire", "parent", a.desired.GetParent(), "shortName", a.desired.GetShortName())
+			return a.acquireExistingTagValue(ctx, createOp)
+		}
 		return fmt.Errorf("waiting for creation of TagsTagValue: %w", err)
 	}
 	log.V(0).Info("created TagsTagValue", "name", created.GetName())
 
-	// For compatibility, we set spec.resourceID after creation because this is a server-generated-id resource that we are migrating from terraform/DCL.
-	// More info in docs/ai/server-generated-id.md
-	resourceID := strings.TrimPrefix(created.GetName(), "tagValues/")
+	return a.setResourceIDAndStatus(ctx, createOp, created)
+}
+
+// acquireExistingTagValue looks up an existing TagValue by parent and shortName after an ALREADY_EXISTS error,
+// then sets the resourceID and status to adopt the resource.
+func (a *TagsTagValueAdapter) acquireExistingTagValue(ctx context.Context, createOp *directbase.CreateOperation) error {
+	log := klog.FromContext(ctx)
+
+	existing, err := a.findTagValueByShortName(ctx)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("TagsTagValue with shortName %q not found under %q despite ALREADY_EXISTS error", a.desired.GetShortName(), a.desired.GetParent())
+	}
+	log.V(0).Info("acquired existing TagsTagValue", "name", existing.GetName())
+
+	return a.setResourceIDAndStatus(ctx, createOp, existing)
+}
+
+// setResourceIDAndStatus sets spec.resourceID and updates status from the given TagValue.
+// For compatibility, we set spec.resourceID after creation because this is a server-generated-id resource that we are migrating from terraform/DCL.
+// More info in docs/ai/server-generated-id.md
+func (a *TagsTagValueAdapter) setResourceIDAndStatus(ctx context.Context, createOp *directbase.CreateOperation, tagValue *pb.TagValue) error {
+	resourceID := strings.TrimPrefix(tagValue.GetName(), "tagValues/")
 	if err := createOp.SetSpecResourceID(ctx, resourceID); err != nil {
 		return err
 	}
+	return a.updateStatus(ctx, createOp, tagValue)
+}
 
-	return a.updateStatus(ctx, createOp, created)
+// findTagValueByShortName lists TagValues under the parent TagKey and returns the one matching the desired shortName.
+func (a *TagsTagValueAdapter) findTagValueByShortName(ctx context.Context) (*pb.TagValue, error) {
+	listReq := &pb.ListTagValuesRequest{Parent: a.desired.GetParent()}
+	it := a.tagValuesClient.ListTagValues(ctx, listReq)
+	for {
+		tagValue, err := it.Next()
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			return nil, fmt.Errorf("listing TagsTagValues under %q: %w", a.desired.GetParent(), err)
+		}
+		if tagValue.GetShortName() == a.desired.GetShortName() {
+			return tagValue, nil
+		}
+	}
+	return nil, nil
 }
 
 func (a *TagsTagValueAdapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyacquire/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyacquire/create.yaml
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This TagsTagKey has the same parent + shortName as the dependency.
+# The GCP API will return ALREADY_EXISTS, and the controller should
+# acquire the existing resource instead of failing.
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagKey
+metadata:
+  name: tagstagkey-${uniqueId}
+spec:
+  description: Pre-existing tag key.
+  parent: projects/${projectId}
+  shortName: keyname${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyacquire/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagkey/tagkeyacquire/dependencies.yaml
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This TagsTagKey is created first as a dependency.
+# The primary resource (create.yaml) uses the same parent + shortName,
+# which triggers an ALREADY_EXISTS error and tests the acquire path.
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagKey
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: tagstagkey-dep-${uniqueId}
+spec:
+  description: Pre-existing tag key.
+  parent: projects/${projectId}
+  shortName: keyname${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueacquire/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueacquire/create.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This TagsTagValue has the same parent + shortName as the dependency.
+# The GCP API will return ALREADY_EXISTS, and the controller should
+# acquire the existing resource instead of failing.
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagValue
+metadata:
+  name: tagstagvalue-${uniqueId}
+spec:
+  description: For valuename resources.
+  parentRef:
+    name: tagstagkey-${uniqueId}
+  shortName: valuename${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueacquire/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/tags/v1beta1/tagstagvalue/tagvalueacquire/dependencies.yaml
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagKey
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: tagstagkey-${uniqueId}
+spec:
+  description: For keyname resources.
+  parent: projects/${projectId}
+  shortName: keyname${uniqueId}
+---
+# This TagsTagValue is created first as a dependency.
+# The primary resource (create.yaml) uses the same parent + shortName,
+# which triggers an ALREADY_EXISTS error and tests the acquire path.
+apiVersion: tags.cnrm.cloud.google.com/v1beta1
+kind: TagsTagValue
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: tagstagvalue-dep-${uniqueId}
+spec:
+  description: For valuename resources.
+  parentRef:
+    name: tagstagkey-${uniqueId}
+  shortName: valuename${uniqueId}


### PR DESCRIPTION
### fix: handle ALREADY_EXISTS in TagKey and TagValue controllers

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes #

#### WHY do we need this change?

When running KCC across multiple clusters that manage the same GCP project, creating a `TagsTagKey` or `TagsTagValue` from a second cluster fails with `ALREADY_EXISTS` because the resource was already created by the first cluster. The controllers currently propagate this error instead of acquiring the existing resource.

This is a common scenario in multi-cluster setups where shared GCP-global resources (tag keys and values are unique per parent project/org) are declared in each cluster's configuration. Cluster 1 succeeds, but clusters 2-N fail permanently with:
```
Error waiting to create TagKey: Error waiting for Creating TagKey:
Error code 6, message: generic::ALREADY_EXISTS: A TagKey with short name 'X'
already exists under parent 'projects/Y'
```

The only workaround today is to look up the server-generated numeric `resourceID` from GCP and set it in `spec.resourceID` across all clusters, which is operationally painful and not easily automatable (not with KCC at least).

#### Special notes for your reviewer:

- The `IsAlreadyExists` helper in `maputils.go` checks both HTTP 409 and gRPC `AlreadyExists` (code 6) since the tag controllers use REST clients but the error could surface from either transport.
- ALREADY_EXISTS is checked on both `CreateTagKey()`/`CreateTagValue()` and `op.Wait()`.
- The list-and-filter-by-shortName approach in `findTagKeyByShortName`/`findTagValueByShortName` follows the same pattern as `TagsTagBindingAdapter.Find()` in `tagbinding_controller.go`.

##### Alternatives considered

1. **Add `tagValueNamespacedName` to the TagBinding spec** — The GCP API supports referencing tag values by human-readable namespaced name (`{parentId}/{keyShortName}/{valueShortName}`) via `tagValues.getNamespaced`, which would let users skip creating TagKey/TagValue in secondary clusters entirely. However, this adds a new API surface field to the CRD, has no precedent in KCC (no resource currently accepts a GCP namespaced name as spec input), and the mapper already marks `TagValueNamespacedName` as intentionally `MISSING`. This seems it would require a broader design discussion.

2. **Handle ALREADY_EXISTS in Create() and acquire the existing resource** (this PR) — When `CreateTagKey` or `CreateTagValue` returns `ALREADY_EXISTS`, catch the error, list existing resources under the parent, find the one matching the desired `shortName`, and adopt it by setting `spec.resourceID` and updating status. This follows the same pattern already used by the AssetFeed controller (`pkg/controller/direct/asset/feed_controller.go`).

We chose approach 2 because it follows an established pattern in the codebase, requires no CRD/API changes, and fixes the problem for all multi-cluster users transparently.

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TagsTagKey and TagsTagValue controllers now gracefully handle ALREADY_EXISTS errors by acquiring the existing GCP resource instead of failing. This fixes multi-cluster setups where multiple KCC instances manage the same tag resources.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [AssetFeed ALREADY_EXISTS precedent]: https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/v1.145.0/pkg/controller/direct/asset/feed_controller.go#L194
- [GCP Tags API - getNamespaced]: https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing#tag-keys
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
