### PR TITLE
Re-enable ApigeeEnvironment sample test

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -412,6 +412,7 @@ func ListMatchingSamples(t *testing.T, regex *regexp.Regexp) []SampleKey {
 					return fmt.Errorf("getting relative path for sample %q: %w", sampleName, err)
 				}
 				sampleKey.TestKey = relativeDir
+				sampleKey.files = append(sampleKey.files, path)
 				// The sampleKey.APIGroup can be found from the Kind, the Kind is in the path as config/samples/resources/<KIND>,
 				// Then by iterating the files under the sourceDir, you can find the `apiGroup` value if the `kind` matches <KIND>
 				if sampleKey.APIGroup == "" {

--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -209,11 +209,6 @@ var testDisabledList = map[string]bool{
 	"basic-certificate":     true,
 	"cert-sign-certificate": true,
 	"complex-certificate":   true,
-	// TODO(b/240327420): The ApigeeEnvironment test seems to be timing out,
-	// thereby causing the samples test to fail and blocking the  release.
-	// Disable the test for now and re-enable it once the issue has been
-	// resolved.
-	"apigeeenvironment": true,
 	// This sample test is failing because of parallel deletion failure from the API.
 	// Disable the test for now while we are figuring out the long term fix with the
 	// service team (b/260214463).


### PR DESCRIPTION
This change re-enables the `ApigeeEnvironment` sample test in the integration suite. It also includes a fix for the sample loading mechanism to ensure that multiple YAML files within a sample directory are correctly identified and processed by the test runner.

---
*PR created automatically by Jules for task [14981532171820553507](https://jules.google.com/task/14981532171820553507) started by @cheftako*