### PR TITLE
preview: early exit when no resources found to reconcile

### DIFF
--- a/pkg/cli/cmd/preview/execute.go
+++ b/pkg/cli/cmd/preview/execute.go
@@ -58,6 +58,11 @@ func Execute(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("error preloading the list of resources to reconcile: %w", err)
 	}
 
+	if recorder.RemainResourcesCount == 0 {
+		klog.V(0).Info("No resources found to reconcile")
+		return nil
+	}
+
 	authorization, err := getGCPAuthorization(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("error building GCP authorization: %w", err)


### PR DESCRIPTION
### BRIEF Change description

Added an early exit in the `preview` command's execution flow when no resources are found to reconcile.

Fixes #

#### WHY do we need this change?

When running the `preview` command in a namespace or cluster with no Config Connector resources, the command would previously continue to attempt GCP authorization and set up the manager, even though there was no work to perform. By checking `recorder.RemainResourcesCount` immediately after preloading the resources, we can provide a clear message to the user and exit early, avoiding unnecessary API calls and potential errors related to missing credentials in environments where no managed resources exist.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
