### PR TITLE
refactor: ci: fast make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,12 @@ GOLANGCI_LINT_VERSION := v2.7.1
 # multi-stage builds (https://github.com/moby/moby/issues/38132)
 DOCKER_BUILD := DOCKER_BUILDKIT=1 docker build
 
-KUSTOMIZE=go run sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
+KUSTOMIZE=bin/kustomize
+ADDLICENSE=bin/addlicense
+
+.PHONY: build-tools
+build-tools:
+	dev/tasks/build-tools
 
 GKE_DISTROLESS_IMG := gcr.io/gke-release/gke-distroless/static:gke_distroless_20260207.00_p0
 
@@ -75,11 +80,11 @@ generate-crds:
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
-manifests: generate
-	make -C operator manifests
+manifests: build-tools generate
+	$(MAKE) -C operator manifests
 	rm -rf config/crds/resources
 	rm -rf config/crds/tmp_resources
-	go build -o bin/generate-crds ./scripts/generate-crds && ./bin/generate-crds -output-dir=config/crds/tmp_resources
+	bin/generate-crds -output-dir=config/crds/tmp_resources
 	# add kustomize patches on all CRDs
 	mkdir config/crds/resources
 	cp config/crds/kustomization.yaml kustomization.yaml
@@ -106,7 +111,7 @@ fmt:
 	make -C operator fmt
 	dev/tasks/fix-gofmt
 	# 04bfe4ee9ca5764577b029acc6a1957fd1997153 includes fix to not log "Skipped" for each skipped file
-	GOFLAGS= go run github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153 -c "Google LLC" -l apache \
+	GOFLAGS= $(ADDLICENSE) -c "Google LLC" -l apache \
 	-ignore ".build/**" -ignore "vendor/**" -ignore "third_party/**" \
 	-ignore "config/crds/**" -ignore "config/cloudcodesnippets/**" \
 	-ignore "**/*.html" -ignore "config/installbundle/components/clusterroles/cnrm_admin.yaml" \

--- a/apis/accesscontextmanager/v1beta1/generate.sh
+++ b/apis/accesscontextmanager/v1beta1/generate.sh
@@ -23,10 +23,10 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --config ${REPO_ROOT}/apis/accesscontextmanager/v1beta1/generatetypes.yaml
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.identity.accesscontextmanager.v1 \
     --api-version accesscontextmanager.cnrm.cloud.google.com/v1beta1
 
@@ -34,4 +34,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/accesscontextmanager/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/accesscontextmanager/

--- a/apis/alloydb/v1beta1/generate.sh
+++ b/apis/alloydb/v1beta1/generate.sh
@@ -23,16 +23,16 @@ REPO_ROOT="${SCRIPT_DIR}/../../.."
 
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.alloydb.v1beta \
   --api-version alloydb.cnrm.cloud.google.com/v1beta1 \
   --resource AlloyDBCluster:Cluster \
   --resource AlloyDBInstance:Instance \
   --resource AlloyDBBackup:Backup
 
-go run . generate-mapper --service google.cloud.alloydb.v1beta --api-version alloydb.cnrm.cloud.google.com/v1beta1
+${CONTROLLERBUILDER:-go run .} generate-mapper --service google.cloud.alloydb.v1beta --api-version alloydb.cnrm.cloud.google.com/v1beta1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/alloydb/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/alloydb/

--- a/apis/analytics/v1alpha1/generate.sh
+++ b/apis/analytics/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.analytics.admin.v1beta \
     --api-version "analytics.cnrm.cloud.google.com/v1alpha1" \
     --resource AnalyticsAccount:Account
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.analytics.admin.v1beta \
     --api-version "analytics.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/analytics/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/analytics/

--- a/apis/artifactregistry/v1beta1/generate.sh
+++ b/apis/artifactregistry/v1beta1/generate.sh
@@ -22,11 +22,11 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.devtools.artifactregistry.v1 \
   --api-version artifactregistry.cnrm.cloud.google.com/v1beta1  \
   --resource ArtifactRegistryRepository:Repository
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.devtools.artifactregistry.v1 \
   --api-version artifactregistry.cnrm.cloud.google.com/v1beta1

--- a/apis/asset/v1beta1/generate.sh
+++ b/apis/asset/v1beta1/generate.sh
@@ -22,12 +22,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.asset.v1 \
     --api-version asset.cnrm.cloud.google.com/v1beta1 \
     --resource AssetFeed:Feed \
     --resource AssetSavedQuery:SavedQuery
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.asset.v1 \
     --api-version asset.cnrm.cloud.google.com/v1beta1 \

--- a/apis/assuredworkloads/v1alpha1/generate.sh
+++ b/apis/assuredworkloads/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.assuredworkloads.v1 \
     --api-version "assuredworkloads.cnrm.cloud.google.com/v1alpha1" \
     --resource AssuredWorkloadsWorkload:Workload
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.assuredworkloads.v1 \
     --api-version "assuredworkloads.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/assuredworkloads/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/assuredworkloads/

--- a/apis/backupdr/v1alpha1/generate.sh
+++ b/apis/backupdr/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1alpha1 \
     --resource BackupDRManagementServer:ManagementServer
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1alpha1
@@ -37,4 +37,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/backupdr/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/backupdr/

--- a/apis/backupdr/v1beta1/generate.sh
+++ b/apis/backupdr/v1beta1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1beta1 \
     --resource BackupDRBackupPlanAssociation:BackupPlanAssociation \
@@ -31,7 +31,7 @@ go run . generate-types \
     --resource BackupDRBackupVault:BackupVault \
 
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.backupdr.v1 \
     --api-version backupdr.cnrm.cloud.google.com/v1beta1
@@ -40,4 +40,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/backupdr/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/backupdr/

--- a/apis/batch/v1alpha1/generate.sh
+++ b/apis/batch/v1alpha1/generate.sh
@@ -23,18 +23,18 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.batch.v1 \
     --api-version "batch.cnrm.cloud.google.com/v1alpha1" \
     --resource BatchJob:Job \
     --resource BatchTask:Task
 
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.batch.v1 \
     --api-version "batch.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/batch/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/batch/

--- a/apis/bigquerybiglake/v1alpha1/generate.sh
+++ b/apis/bigquerybiglake/v1alpha1/generate.sh
@@ -23,17 +23,17 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1alpha1" \
     --resource BigLakeCatalog:Catalog \
     --resource BigLakeDatabase:Database
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigquerybiglake/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigquerybiglake/

--- a/apis/bigquerybiglake/v1beta1/generate.sh
+++ b/apis/bigquerybiglake/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1beta1" \
     --resource BigLakeTable:Table
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.bigquery.biglake.v1 \
     --api-version "bigquerybiglake.cnrm.cloud.google.com/v1beta1"
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigquerybiglake/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigquerybiglake/

--- a/apis/bigquerydatatransfer/v1beta1/generate.sh
+++ b/apis/bigquerydatatransfer/v1beta1/generate.sh
@@ -22,10 +22,10 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types --config ${REPO_ROOT}/apis/bigquerydatatransfer/v1beta1/generatetypes.yaml
-# go run . generate-mapper --config ${REPO_ROOT}/apis/bigquerydatatransfer/v1beta1/generatetypes.yaml
+${CONTROLLERBUILDER:-go run .} generate-types --config ${REPO_ROOT}/apis/bigquerydatatransfer/v1beta1/generatetypes.yaml
+# ${CONTROLLERBUILDER:-go run .} generate-mapper --config ${REPO_ROOT}/apis/bigquerydatatransfer/v1beta1/generatetypes.yaml
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigquerydatatransfer/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigquerydatatransfer/

--- a/apis/bigqueryreservation/v1beta1/generate.sh
+++ b/apis/bigqueryreservation/v1beta1/generate.sh
@@ -23,17 +23,17 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.bigquery.reservation.v1 \
     --api-version "bigqueryreservation.cnrm.cloud.google.com/v1beta1" \
     --resource BigQueryReservationReservation:Reservation \
     --resource BigQueryReservationAssignment:Assignment
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.bigquery.reservation.v1 \
     --api-version "bigqueryreservation.cnrm.cloud.google.com/v1beta1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigqueryreservation/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigqueryreservation/

--- a/apis/bigtable/v1alpha1/generate.sh
+++ b/apis/bigtable/v1alpha1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1alpha1  \
   --resource BigtableAuthorizedView:AuthorizedView \
@@ -32,7 +32,7 @@ go run . generate-types \
   --resource BigtableLogicalView:LogicalView \
   --resource BigtableMaterializedView:MaterializedView
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1alpha1
 
@@ -40,4 +40,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigtable/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigtable/

--- a/apis/bigtable/v1beta1/generate.sh
+++ b/apis/bigtable/v1beta1/generate.sh
@@ -23,13 +23,13 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
   --resource BigtableAppProfile:AppProfile \
   --resource BigtableTable:Table
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --multiversion \
   --service google.bigtable.admin.v2 \
   --api-version bigtable.cnrm.cloud.google.com/v1beta1
@@ -37,4 +37,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/bigtable/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/bigtable/

--- a/apis/billing/v1alpha1/generate.sh
+++ b/apis/billing/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.billing.v1 \
   --api-version billing.cnrm.cloud.google.com/v1alpha1  \
   --resource BillingAccount:BillingAccount
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.billing.v1 \
   --api-version billing.cnrm.cloud.google.com/v1alpha1
 
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/billing/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/billing/

--- a/apis/certificatemanager/v1alpha1/generate.sh
+++ b/apis/certificatemanager/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1" \
     --resource CertificateManagerCertificateIssuanceConfig:CertificateIssuanceConfig
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/certificatemanager/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/certificatemanager/

--- a/apis/certificatemanager/v1beta1/generate.sh
+++ b/apis/certificatemanager/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1" \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.certificatemanager.v1 \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/certificatemanager/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/certificatemanager/

--- a/apis/cloudbuild/v1beta1/generate.sh
+++ b/apis/cloudbuild/v1beta1/generate.sh
@@ -22,13 +22,13 @@ REPO_ROOT="${SCRIPT_DIR}/../../.."
 
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.devtools.cloudbuild.v1 \
   --api-version cloudbuild.cnrm.cloud.google.com/v1beta1 \
   --resource CloudBuildTrigger:BuildTrigger \
   --include-skipped-output
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.devtools.cloudbuild.v1 \
   --api-version cloudbuild.cnrm.cloud.google.com/v1beta1 \
   --include-skipped-output

--- a/apis/clouddeploy/v1alpha1/generate.sh
+++ b/apis/clouddeploy/v1alpha1/generate.sh
@@ -23,18 +23,18 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1alpha1  \
   --resource DeployCustomTargetType:CustomTargetType \
   --resource CloudDeployDeployPolicy:DeployPolicy \
   --resource CloudDeployTarget:Target
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1alpha1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddeploy/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/clouddeploy/

--- a/apis/clouddeploy/v1beta1/generate.sh
+++ b/apis/clouddeploy/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1beta1  \
   --resource CloudDeployDeliveryPipeline:DeliveryPipeline
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.deploy.v1 \
   --api-version clouddeploy.cnrm.cloud.google.com/v1beta1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddeploy/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/clouddeploy/

--- a/apis/clouddms/v1alpha1/generate.sh
+++ b/apis/clouddms/v1alpha1/generate.sh
@@ -23,18 +23,18 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.clouddms.v1 \
     --api-version "clouddms.cnrm.cloud.google.com/v1alpha1" \
     --resource CloudDMSConversionWorkspace:ConversionWorkspace \
     --resource CloudDMSPrivateConnection:PrivateConnection \
     --resource CloudDMSMigrationJob:MigrationJob
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.clouddms.v1 \
     --api-version "clouddms.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/clouddms/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/clouddms/

--- a/apis/cloudquota/v1beta1/generate.sh
+++ b/apis/cloudquota/v1beta1/generate.sh
@@ -23,17 +23,17 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.api.cloudquotas.v1beta \
     --api-version cloudquota.cnrm.cloud.google.com/v1beta1 \
     --resource APIQuotaPreference:QuotaPreference \
     --resource APIQuotaAdjusterSettings:QuotaAdjusterSettings
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.api.cloudquotas.v1beta \
     --api-version cloudquota.cnrm.cloud.google.com/v1beta1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/cloudquota/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/cloudquota/

--- a/apis/composer/v1beta1/generate.sh
+++ b/apis/composer/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.orchestration.airflow.service.v1 \
     --api-version "composer.cnrm.cloud.google.com/v1beta1" \
     --resource ComposerEnvironment:Environment
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.orchestration.airflow.service.v1 \
     --api-version "composer.cnrm.cloud.google.com/v1beta1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/composer/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/composer/

--- a/apis/compute/v1alpha1/generate.sh
+++ b/apis/compute/v1alpha1/generate.sh
@@ -21,7 +21,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.compute.v1 \
     --api-version compute.cnrm.cloud.google.com/v1alpha1
@@ -29,4 +29,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/compute/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/compute/

--- a/apis/compute/v1beta1/generate.sh
+++ b/apis/compute/v1beta1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.compute.v1 \
   --api-version compute.cnrm.cloud.google.com/v1beta1  \
   --resource ComputeFirewallPolicyRule:FirewallPolicyRule \
@@ -32,7 +32,7 @@ go run . generate-types \
   --resource ComputeSubnetwork:Subnetwork \
   --resource ComputeTargetTcpProxy:TargetTcpProxy
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.compute.v1 \
     --api-version compute.cnrm.cloud.google.com/v1beta1
@@ -40,4 +40,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/compute/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/compute/

--- a/apis/configdelivery/v1alpha1/generate.sh
+++ b/apis/configdelivery/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.configdelivery.v1 \
     --api-version "configdelivery.cnrm.cloud.google.com/v1alpha1" \
     --resource ConfigDeliveryResourceBundle:ResourceBundle
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.configdelivery.v1 \
     --api-version "configdelivery.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/configdelivery/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/configdelivery/

--- a/apis/datacatalog/v1beta1/generate.sh
+++ b/apis/datacatalog/v1beta1/generate.sh
@@ -20,13 +20,13 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.datacatalog.v1 \
   --api-version datacatalog.cnrm.cloud.google.com/v1beta1 \
   --resource DataCatalogPolicyTag:PolicyTag \
   --include-skipped-output
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.datacatalog.v1 \
   --api-version datacatalog.cnrm.cloud.google.com/v1beta1 \
   --include-skipped-output

--- a/apis/dataflow/v1beta1/generate.sh
+++ b/apis/dataflow/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.dataflow.v1beta3 \
   --api-version dataflow.cnrm.cloud.google.com/v1beta1  \
   --resource DataflowFlexTemplateJob:FlexTemplateRuntimeEnvironment # Note: this is an unusual resource, and the mapping is not 1:1
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.dataflow.v1beta3 \
   --api-version dataflow.cnrm.cloud.google.com/v1beta1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/dataflow/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/dataflow/

--- a/apis/dataplex/v1alpha1/generate.sh
+++ b/apis/dataplex/v1alpha1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.dataplex.v1 \
     --api-version "dataplex.cnrm.cloud.google.com/v1alpha1" \
     --resource DataplexLake:Lake \
@@ -32,11 +32,11 @@ go run . generate-types \
     --resource DataplexEntryGroup:EntryGroup \
     --resource DataplexEntryType:EntryType
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.dataplex.v1 \
     --api-version "dataplex.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/dataplex/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/dataplex/

--- a/apis/datastream/v1alpha1/generate.sh
+++ b/apis/datastream/v1alpha1/generate.sh
@@ -23,14 +23,14 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.datastream.v1 \
     --api-version datastream.cnrm.cloud.google.com/v1alpha1 \
     --resource DatastreamPrivateConnection:PrivateConnection \
     --resource DatastreamConnectionProfile:ConnectionProfile \
     --resource DatastreamRoute:Route
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.datastream.v1 \
     --api-version datastream.cnrm.cloud.google.com/v1alpha1
 
@@ -38,4 +38,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/datastream/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/datastream/

--- a/apis/discoveryengine/v1alpha1/generate.sh
+++ b/apis/discoveryengine/v1alpha1/generate.sh
@@ -23,15 +23,15 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types --service google.cloud.discoveryengine.v1 --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
+${CONTROLLERBUILDER:-go run .} generate-types --service google.cloud.discoveryengine.v1 --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
   --resource DiscoveryEngineDataStore:DataStore \
   --resource DiscoveryEngineEngine:Engine \
   --resource DiscoveryEngineTargetSite:TargetSite
 
-go run . generate-mapper --service google.cloud.discoveryengine.v1 --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1
+${CONTROLLERBUILDER:-go run .} generate-mapper --service google.cloud.discoveryengine.v1 --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1
 
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/discoveryengine/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/discoveryengine/

--- a/apis/documentai/v1alpha1/generate.sh
+++ b/apis/documentai/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1alpha1 \
     --resource DocumentAIProcessor:Processor
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1alpha1
@@ -37,4 +37,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/documentai/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/documentai/

--- a/apis/documentai/v1beta1/generate.sh
+++ b/apis/documentai/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1beta1 \
     --resource DocumentAIProcessorVersion:ProcessorVersion
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --multiversion \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1beta1
@@ -37,4 +37,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/documentai/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/documentai/

--- a/apis/edgecontainer/v1alpha1/generate.sh
+++ b/apis/edgecontainer/v1alpha1/generate.sh
@@ -22,11 +22,11 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1 --resource EdgeContainerMachine:Machine
+${CONTROLLERBUILDER:-go run .} generate-types --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1 --resource EdgeContainerMachine:Machine
 
-go run . generate-mapper --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1
+${CONTROLLERBUILDER:-go run .} generate-mapper --service google.cloud.edgecontainer.v1 --api-version edgecontainer.cnrm.cloud.google.com/v1alpha1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/edgecontainer/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/edgecontainer/

--- a/apis/essentialcontacts/v1beta1/generate.sh
+++ b/apis/essentialcontacts/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.essentialcontacts.v1 \
     --api-version "essentialcontacts.cnrm.cloud.google.com/v1beta1" \
     --resource EssentialContactsContact:Contact
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.essentialcontacts.v1 \
     --api-version "essentialcontacts.cnrm.cloud.google.com/v1beta1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/essentialcontacts/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/essentialcontacts/

--- a/apis/firestore/v1alpha1/generate.sh
+++ b/apis/firestore/v1alpha1/generate.sh
@@ -22,14 +22,14 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.firestore.admin.v1 \
   --api-version firestore.cnrm.cloud.google.com/v1alpha1  \
   --resource FirestoreDocument:google.firestore.v1.Document \
   --resource FirestoreField:Field \
   --resource FirestoreBackupSchedule:BackupSchedule
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --multiversion \
   --service google.firestore.admin.v1 \
   --service google.firestore.v1 \
@@ -38,4 +38,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/firestore/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/firestore/

--- a/apis/firestore/v1beta1/generate.sh
+++ b/apis/firestore/v1beta1/generate.sh
@@ -23,13 +23,13 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.firestore.admin.v1 \
   --api-version firestore.cnrm.cloud.google.com/v1beta1  \
   --resource FirestoreDatabase:Database \
   --resource FirestoreIndex:Index
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --multiversion \
   --service google.firestore.admin.v1 \
   --service google.firestore.v1 \
@@ -38,4 +38,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/firestore/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/firestore/

--- a/apis/gkebackup/v1alpha1/generate.sh
+++ b/apis/gkebackup/v1alpha1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.gkebackup.v1  \
     --api-version gkebackup.cnrm.cloud.google.com/v1alpha1 \
     --resource GKEBackupBackupPlan:BackupPlan \
@@ -31,7 +31,7 @@ go run . generate-types \
     --resource GKEBackupBackup:Backup \
     --resource GKEBackupRestore:Restore
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.gkebackup.v1 \
     --api-version gkebackup.cnrm.cloud.google.com/v1alpha1
 
@@ -39,4 +39,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/gkebackup/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/gkebackup/

--- a/apis/gkehub/v1beta1/generate.sh
+++ b/apis/gkehub/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.gkehub.v1beta --api-version gkehub.cnrm.cloud.google.com/v1beta1 \
   --resource GKEHubFeatureMembership:MembershipFeatureSpec
 
 # NOTYET - not yet using proto
-# go run . generate-mapper \
+# ${CONTROLLERBUILDER:-go run .} generate-mapper \
 #   --service google.cloud.gkehub.v1beta --api-version gkehub.cnrm.cloud.google.com/v1beta1
 
 # NOTYET - not yet following full pattern
@@ -37,4 +37,4 @@ rm ${REPO_ROOT}/apis/gkehub/v1beta1/membershipfeaturespec_types.go
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/gkehub/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/gkehub/

--- a/apis/iam/v1alpha1/generate.sh
+++ b/apis/iam/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.iam.v2 \
   --api-version iam.cnrm.cloud.google.com/v1alpha1 \
   --resource IAMDenyPolicy:Policy
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.iam.v2 \
   --api-version iam.cnrm.cloud.google.com/v1alpha1
 
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/iam/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/iam/

--- a/apis/iam/v1beta1/generate.sh
+++ b/apis/iam/v1beta1/generate.sh
@@ -21,12 +21,12 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.iam.admin.v1 \
     --api-version iam.cnrm.cloud.google.com/v1beta1 \
     --resource IAMServiceAccountKey:ServiceAccountKey
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.iam.admin.v1 \
     --api-version iam.cnrm.cloud.google.com/v1beta1
 
@@ -34,4 +34,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/iam/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/iam/

--- a/apis/logging/v1beta1/generate.sh
+++ b/apis/logging/v1beta1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.logging.v2 \
     --api-version "logging.cnrm.cloud.google.com/v1beta1" \
     --resource LoggingLink:Link
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.logging.v2 \
     --api-version "logging.cnrm.cloud.google.com/v1beta1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/logging/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/logging/

--- a/apis/managedkafka/v1beta1/generate.sh
+++ b/apis/managedkafka/v1beta1/generate.sh
@@ -22,10 +22,10 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types --config ${REPO_ROOT}/apis/managedkafka/v1beta1/generatetypes.yaml
-# go run . generate-mapper --config ${REPO_ROOT}/apis/managedkafka/v1beta1/generatetypes.yaml
+${CONTROLLERBUILDER:-go run .} generate-types --config ${REPO_ROOT}/apis/managedkafka/v1beta1/generatetypes.yaml
+# ${CONTROLLERBUILDER:-go run .} generate-mapper --config ${REPO_ROOT}/apis/managedkafka/v1beta1/generatetypes.yaml
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/managedkafka/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/managedkafka/

--- a/apis/monitoring/v1beta1/generate.sh
+++ b/apis/monitoring/v1beta1/generate.sh
@@ -22,16 +22,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.monitoring.v3 \
   --api-version monitoring.cnrm.cloud.google.com/v1beta1  \
   --resource MonitoringNotificationChannel:NotificationChannel
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.monitoring.v3 \
   --api-version monitoring.cnrm.cloud.google.com/v1beta1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/monitoring/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/monitoring/

--- a/apis/networkmanagement/v1alpha1/generate.sh
+++ b/apis/networkmanagement/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.networkmanagement.v1 \
   --api-version networkmanagement.cnrm.cloud.google.com/v1alpha1  \
   --resource NetworkManagementConnectivityTestSpec:ConnectivityTest
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.networkmanagement.v1 \
   --api-version networkmanagement.cnrm.cloud.google.com/v1alpha1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/networkmanagement/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/networkmanagement/

--- a/apis/networksecurity/v1beta1/generate.sh
+++ b/apis/networksecurity/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.networksecurity.v1beta1 \
     --api-version networksecurity.cnrm.cloud.google.com/v1beta1 \
     --resource NetworkSecurityAuthorizationPolicy:AuthorizationPolicy
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.networksecurity.v1beta1 \
     --api-version networksecurity.cnrm.cloud.google.com/v1beta1
 

--- a/apis/networkservices/v1alpha1/generate.sh
+++ b/apis/networkservices/v1alpha1/generate.sh
@@ -22,19 +22,19 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.networkservices.v1 \
     --api-version "networkservices.cnrm.cloud.google.com/v1alpha1" \
     --resource NetworkServicesServiceBinding:ServiceBinding \
     --resource NetworkServicesLBRouteExtension:LbRouteExtension
 
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.networkservices.v1 \
     --api-version "networkservices.cnrm.cloud.google.com/v1alpha1"
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/networkservices/
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w apis/networkservices/v1alpha1/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/networkservices/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w apis/networkservices/v1alpha1/

--- a/apis/orgpolicy/v1alpha1/generate.sh
+++ b/apis/orgpolicy/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.orgpolicy.v2  \
     --api-version orgpolicy.cnrm.cloud.google.com/v1alpha1 \
     --resource OrgPolicyPolicy:Policy
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.orgpolicy.v2 \
     --api-version orgpolicy.cnrm.cloud.google.com/v1alpha1
 
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/orgpolicy/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/orgpolicy/

--- a/apis/orgpolicy/v1beta1/generate.sh
+++ b/apis/orgpolicy/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.orgpolicy.v2  \
     --api-version orgpolicy.cnrm.cloud.google.com/v1beta1 \
     --resource OrgPolicyCustomConstraint:CustomConstraint
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.orgpolicy.v2 \
     --api-version orgpolicy.cnrm.cloud.google.com/v1beta1
 
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/orgpolicy/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/orgpolicy/

--- a/apis/parametermanager/v1alpha1/generate.sh
+++ b/apis/parametermanager/v1alpha1/generate.sh
@@ -21,13 +21,13 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 # Generate the KCC type structs from the GCP proto definitions
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.parametermanager.v1 \
   --api-version parametermanager.cnrm.cloud.google.com/v1alpha1  \
   --resource ParameterManagerParameter:Parameter
 
 # Generate the mapper functions that convert between the KCC structs and the GCP proto structs
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.parametermanager.v1 \
   --api-version parametermanager.cnrm.cloud.google.com/v1alpha1
 
@@ -38,4 +38,4 @@ cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
 # Format the generated Go code
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/parametermanager/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/parametermanager/

--- a/apis/privateca/v1beta1/generate.sh
+++ b/apis/privateca/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.security.privateca.v1 \
   --api-version privateca.cnrm.cloud.google.com/v1beta1  \
   --resource PrivateCACAPool:CaPool
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.security.privateca.v1 \
   --api-version privateca.cnrm.cloud.google.com/v1beta1
 
@@ -48,5 +48,5 @@ sed -i '/ZeroMaxIssuerPathLength/d' pkg/controller/direct/privateca/mapper.gener
 dev/tasks/generate-crds
 
 # Format files
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/privateca/
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  apis/privateca/v1beta1/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/privateca/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  apis/privateca/v1beta1/

--- a/apis/pubsub/v1beta1/generate.sh
+++ b/apis/pubsub/v1beta1/generate.sh
@@ -23,11 +23,11 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.pubsub.v1 \
     --api-version pubsub.cnrm.cloud.google.com/v1beta1 \
     --resource PubSubSnapshot:Snapshot
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.pubsub.v1 \
     --api-version pubsub.cnrm.cloud.google.com/v1beta1

--- a/apis/run/v1beta1/generate.sh
+++ b/apis/run/v1beta1/generate.sh
@@ -22,12 +22,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.run.v2 \
   --api-version run.cnrm.cloud.google.com/v1beta1 \
   --resource RunJob:Job
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.run.v2 \
   --api-version run.cnrm.cloud.google.com/v1beta1
 
@@ -35,4 +35,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w pkg/controller/direct/run/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w pkg/controller/direct/run/

--- a/apis/servicenetworking/v1alpha1/generate.sh
+++ b/apis/servicenetworking/v1alpha1/generate.sh
@@ -23,16 +23,16 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service mockgcp.cloud.servicenetworking.v1 \
   --api-version servicenetworking.cnrm.cloud.google.com/v1alpha1  \
   --resource ServiceNetworkingPeeredDNSDomain:PeeredDnsDomain
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service mockgcp.cloud.servicenetworking.v1 \
   --api-version servicenetworking.cnrm.cloud.google.com/v1alpha1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/servicenetworking/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/servicenetworking/

--- a/apis/serviceusage/v1beta1/generate.sh
+++ b/apis/serviceusage/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.api.serviceusage.v1beta1 \
   --api-version serviceusage.cnrm.cloud.google.com/v1beta1  \
   --resource ServiceIdentity:ServiceIdentity
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.api.serviceusage.v1beta1 \
   --api-version serviceusage.cnrm.cloud.google.com/v1beta1
 
@@ -36,4 +36,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/serviceusage/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/serviceusage/

--- a/apis/speech/v1alpha1/generate.sh
+++ b/apis/speech/v1alpha1/generate.sh
@@ -23,14 +23,14 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.speech.v2  \
     --api-version speech.cnrm.cloud.google.com/v1alpha1 \
     --resource SpeechRecognizer:Recognizer \
     --resource SpeechCustomClass:CustomClass \
     --resource SpeechPhraseSet:PhraseSet
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.speech.v2 \
     --api-version speech.cnrm.cloud.google.com/v1alpha1
 
@@ -38,4 +38,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/speech/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/speech/

--- a/apis/speech/v1beta1/generate.sh
+++ b/apis/speech/v1beta1/generate.sh
@@ -23,14 +23,14 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.speech.v2  \
     --api-version speech.cnrm.cloud.google.com/v1beta1 \
     --resource SpeechRecognizer:Recognizer \
     --resource SpeechCustomClass:CustomClass \
     --resource SpeechPhraseSet:PhraseSet
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.speech.v2 \
     --api-version speech.cnrm.cloud.google.com/v1beta1
 
@@ -38,4 +38,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/speech/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/speech/

--- a/apis/sql/v1beta1/generate.sh
+++ b/apis/sql/v1beta1/generate.sh
@@ -23,14 +23,14 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.sql.v1beta4 \
   --api-version sql.cnrm.cloud.google.com/v1beta1  \
   --resource SQLInstance:DatabaseInstance \
   --skip-scaffold-files \
   --include-skipped-output
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
   --service google.cloud.sql.v1beta4 \
   --api-version sql.cnrm.cloud.google.com/v1beta1 \
   --include-skipped-output
@@ -38,5 +38,5 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/sql/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/sql/
 

--- a/apis/tags/v1alpha1/generate.sh
+++ b/apis/tags/v1alpha1/generate.sh
@@ -29,4 +29,4 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-# go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/tags/
+# ${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/tags/

--- a/apis/tags/v1beta1/generate.sh
+++ b/apis/tags/v1beta1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
   --service google.cloud.resourcemanager.v3 \
   --api-version tags.cnrm.cloud.google.com/v1beta1  \
   --resource TagsTagKey:TagKey \
@@ -32,9 +32,9 @@ go run . generate-types \
   --resource TagsLocationTagBinding:TagBinding \
   --include-skipped-output
 
-go run . generate-mapper --service google.cloud.resourcemanager.v3 --api-version tags.cnrm.cloud.google.com/v1beta1 --include-skipped-output
+${CONTROLLERBUILDER:-go run .} generate-mapper --service google.cloud.resourcemanager.v3 --api-version tags.cnrm.cloud.google.com/v1beta1 --include-skipped-output
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/tags/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/tags/

--- a/apis/tpu/v1alpha1/generate.sh
+++ b/apis/tpu/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1     --resource TPUVirtualMachine:Node
+${CONTROLLERBUILDER:-go run .} generate-types     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1     --resource TPUVirtualMachine:Node
 
-go run . generate-mapper     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1
+${CONTROLLERBUILDER:-go run .} generate-mapper     --service google.cloud.tpu.v2     --api-version tpu.cnrm.cloud.google.com/v1alpha1
 
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/tpu/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/tpu/

--- a/apis/vertexai/v1alpha1/generate.sh
+++ b/apis/vertexai/v1alpha1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1     --resource VertexAIFeaturestore:Featurestore
+${CONTROLLERBUILDER:-go run .} generate-types     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1     --resource VertexAIFeaturestore:Featurestore
 
-go run . generate-mapper     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1
+${CONTROLLERBUILDER:-go run .} generate-mapper     --service google.cloud.aiplatform.v1beta1     --api-version vertexai.cnrm.cloud.google.com/v1alpha1
 
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/vertexai/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/vertexai/

--- a/apis/vmwareengine/v1alpha1/generate.sh
+++ b/apis/vmwareengine/v1alpha1/generate.sh
@@ -23,7 +23,7 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1alpha1  \
     --resource VMwareEngineNetwork:VmwareEngineNetwork \
@@ -32,11 +32,11 @@ go run . generate-types \
     --resource VMwareEngineExternalAccessRule:ExternalAccessRule \
     --resource VMwareEnginePrivateCloud:PrivateCloud \
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1alpha1
 
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/vmwareengine/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/vmwareengine/

--- a/apis/vmwareengine/v1beta1/generate.sh
+++ b/apis/vmwareengine/v1beta1/generate.sh
@@ -23,12 +23,12 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 ./generate-proto.sh
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1beta1  \
     --resource VMwareEngineExternalAddress:ExternalAddress
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.vmwareengine.v1 \
     --api-version vmwareengine.cnrm.cloud.google.com/v1beta1 \
     --multiversion
@@ -37,4 +37,4 @@ go run . generate-mapper \
 cd ${REPO_ROOT}
 dev/tasks/generate-crds
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w  pkg/controller/direct/vmwareengine/
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/vmwareengine/

--- a/dev/tasks/build-tools
+++ b/dev/tasks/build-tools
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+mkdir -p bin
+
+echo "Building controllerbuilder..."
+go build -o bin/controllerbuilder ./dev/tools/controllerbuilder
+
+echo "Building controller-gen..."
+GOBIN=${REPO_ROOT}/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
+
+echo "Building kustomize..."
+GOBIN=${REPO_ROOT}/bin go install sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
+
+echo "Building addlicense..."
+GOBIN=${REPO_ROOT}/bin go install github.com/google/addlicense@04bfe4ee9ca5764577b029acc6a1957fd1997153
+
+echo "Building goimports..."
+GOBIN=${REPO_ROOT}/bin go install golang.org/x/tools/cmd/goimports@latest
+
+echo "Building generate-crds..."
+go build -o bin/generate-crds ./scripts/generate-crds

--- a/dev/tasks/fix-gofmt
+++ b/dev/tasks/fix-gofmt
@@ -20,4 +20,6 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w apis pkg cmd scripts tests config/tests
+DIRS="apis pkg cmd scripts tests config/tests"
+echo "Running goimports on ${DIRS} in parallel..."
+echo ${DIRS} | xargs -n 1 -P $(nproc) ${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w

--- a/dev/tasks/generate-crds
+++ b/dev/tasks/generate-crds
@@ -27,7 +27,7 @@ fi
 
 # Run controller-gen to generate CRDs (including deepcopy)
 cd ${REPO_ROOT}/apis
-go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 \
+${CONTROLLER_GEN:-go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5} \
   object:headerFile=${REPO_ROOT}/hack/boilerplate.go.txt \
   crd:crdVersions=v1,allowDangerousTypes=true,ignoreUnexportedFields=true \
   output:crd:artifacts:config=config/crd/ \
@@ -91,4 +91,4 @@ go run ./scripts/generate-gvks/main.go -output-dir=pkg/gvks/supportedgvks
 go run ./scripts/generate-cnrm-cluster-roles/main.go
 
 # controller-gen sometimes leaves empty imports in the api files.
-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest -w apis
+${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w apis

--- a/dev/tasks/generate-types-and-mappers
+++ b/dev/tasks/generate-types-and-mappers
@@ -20,6 +20,12 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
+dev/tasks/build-tools
+export CONTROLLERBUILDER=${REPO_ROOT}/bin/controllerbuilder
+export CONTROLLER_GEN=${REPO_ROOT}/bin/controller-gen
+export KUSTOMIZE=${REPO_ROOT}/bin/kustomize
+export GOIMPORTS=${REPO_ROOT}/bin/goimports
+
 pushd dev/tools/controllerbuilder
 ./generate-proto.sh
 popd
@@ -27,7 +33,12 @@ popd
 # For efficiency, we generate CRDs only once at the end
 export SKIP_GENERATE_CRDS=1
 
-for f in $(find apis -name "generate.sh" | sort); do
+# Find all generate.sh scripts
+ALL_SCRIPTS=$(find apis -name "generate.sh" | sort)
+
+# Filter out scripts that are not up to date
+SCRIPTS_TO_RUN=""
+for f in ${ALL_SCRIPTS}; do
     # Skip some generate.sh scripts that are not up to date
     # TODO: Fix these!
 

--- a/dev/tasks/run-generate-script.sh
+++ b/dev/tasks/run-generate-script.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-# Copyright 2025 Google LLC
-#
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,15 +17,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd ${REPO_ROOT}/dev/tools/controllerbuilder
-
-./generate-proto.sh
-
-${CONTROLLERBUILDER:-go run .} generate-types --config ${REPO_ROOT}/apis/managedkafka/v1alpha1/generatetypes.yaml
-# ${CONTROLLERBUILDER:-go run .} generate-mapper --config ${REPO_ROOT}/apis/managedkafka/v1alpha1/generatetypes.yaml
-
-cd ${REPO_ROOT}
-dev/tasks/generate-crds
-
-${GOIMPORTS:-go run -mod=readonly golang.org/x/tools/cmd/goimports@latest} -w  pkg/controller/direct/managedkafka/
+script=$1
+echo "running ${script}"
+./${script}

--- a/dev/tools/controllerbuilder/generate-proto.sh
+++ b/dev/tools/controllerbuilder/generate-proto.sh
@@ -32,6 +32,24 @@ GOOGLEAPI_VERSION=${1:-$DEFAULT_GOOGLE_API_VERSION}
 # Take output path as parameter, default to .build/googleapis.pb
 OUTPUT_PATH=${2:-"${REPO_ROOT}/.build/googleapis.pb"}
 
+if [ "${GOOGLEAPI_VERSION}" == "HEAD" ]; then
+    echo "Fetching latest googleapis for HEAD version"
+    # Get latest version from https://github.com/googleapis/googleapis.git
+    GOOGLEAPI_VERSION=$(git ls-remote https://github.com/googleapis/googleapis.git refs/heads/master | awk '{print $1}')
+fi
+
+VERSIONED_OUTPUT_PATH="${OUTPUT_PATH%.pb}-${GOOGLEAPI_VERSION}.pb"
+
+if [ -f "${VERSIONED_OUTPUT_PATH}" ]; then
+    echo "Using cached googleapis pb file at ${VERSIONED_OUTPUT_PATH}"
+    # Only copy if different to avoid race conditions in parallel execution
+    if [ ! -f "${OUTPUT_PATH}" ] || ! cmp -s "${VERSIONED_OUTPUT_PATH}" "${OUTPUT_PATH}"; then
+        # Atomic copy
+        cp "${VERSIONED_OUTPUT_PATH}" "${OUTPUT_PATH}.tmp"
+        mv "${OUTPUT_PATH}.tmp" "${OUTPUT_PATH}"
+    fi
+    exit 0
+fi
 
 THIRD_PARTY=${REPO_ROOT}/.build/third_party
 mkdir -p ${THIRD_PARTY}/
@@ -40,14 +58,6 @@ cd ${THIRD_PARTY}
 if [ ! -d "googleapis" ]; then
     git clone https://github.com/googleapis/googleapis.git
 fi
-
-if [ "${GOOGLEAPI_VERSION}" == "HEAD" ]; then
-    echo "Fetching latest googleapis for HEAD version"
-    # Get latest version from https://github.com/googleapis/googleapis.git
-    GOOGLEAPI_VERSION=$(git ls-remote https://github.com/googleapis/googleapis.git refs/heads/master | awk '{print $1}')
-fi
-
-VERSIONED_OUTPUT_PATH="${OUTPUT_PATH%.pb}-${GOOGLEAPI_VERSION}.pb"
 
 cd googleapis
 
@@ -73,13 +83,6 @@ else
       echo "apt install..."
       sudo apt install -y protobuf-compiler
     fi
-fi
-
-
-if [ -f "${VERSIONED_OUTPUT_PATH}" ]; then
-    echo "Using cached googleapis pb file at ${VERSIONED_OUTPUT_PATH}"
-    cp "${VERSIONED_OUTPUT_PATH}" "${OUTPUT_PATH}"
-    exit 0
 fi
 
 protoc --include_imports --include_source_info \

--- a/dev/tools/controllerbuilder/generate.sh
+++ b/dev/tools/controllerbuilder/generate.sh
@@ -25,230 +25,230 @@ cd ${REPO_ROOT}/dev/tools/controllerbuilder
 
 
 # DiscoveryEngine
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.discoveryengine.v1 \
     --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1 \
     --resource DiscoveryEngineDataStore:DataStore \
     --resource DiscoveryEngineDataStoreTargetSite:TargetSite \
     --resource DiscoveryEngineEngine:Engine
 
-# go run . prompt --src-dir ~/kcc/k8s-config-connector --proto-dir ~/kcc/k8s-config-connector/.build/third_party/googleapis/ <<EOF
+# ${CONTROLLERBUILDER:-go run .} prompt --src-dir ~/kcc/k8s-config-connector --proto-dir ~/kcc/k8s-config-connector/.build/third_party/googleapis/ <<EOF
 # // +kcc:proto=google.cloud.discoveryengine.v1.Engine
 # EOF
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.discoveryengine.v1 \
     --api-version discoveryengine.cnrm.cloud.google.com/v1alpha1
 
 # DataFlow
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.dataflow.v1beta3 \
     --api-version dataflow.cnrm.cloud.google.com/v1beta1 \
     --resource DataflowFlexTemplateJob:FlexTemplateRuntimeEnvironment
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.dataflow.v1beta3 \
     --api-version dataflow.cnrm.cloud.google.com/v1alpha1
 
 # SecureSourceManagerInstance
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1 \
     --resource SecureSourceManagerInstance:Instance
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.securesourcemanager.v1 \
     --api-version securesourcemanager.cnrm.cloud.google.com/v1alpha1
 
 # RedisCluster
-go run . generate-types  \
+${CONTROLLERBUILDER:-go run .} generate-types  \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1alpha1 \
     --resource RedisCluster:Cluster
 
-go run . generate-types  \
+${CONTROLLERBUILDER:-go run .} generate-types  \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1beta1  \
     --resource RedisCluster:Cluster
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.redis.cluster.v1 \
     --api-version redis.cnrm.cloud.google.com/v1beta1
 
 # Bigtable
 
-go run . generate-types  \
+${CONTROLLERBUILDER:-go run .} generate-types  \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1  \
     --resource BigtableInstance:Instance
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.bigtable.admin.v2 \
     --api-version bigtable.cnrm.cloud.google.com/v1beta1
 
 # NetworkConnectivity
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1 \
     --resource NetworkConnectivityServiceConnectionPolicy:ServiceConnectionPolicy
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service mockgcp.cloud.networkconnectivity.v1 \
     --api-version networkconnectivity.cnrm.cloud.google.com/v1alpha1
 
 # BigQueryDataset
-go run . generate-types  \
+${CONTROLLERBUILDER:-go run .} generate-types  \
     --service google.cloud.bigquery.v2 \
     --api-version bigquery.cnrm.cloud.google.com/v1beta1  \
     --resource BigQueryDataset:Dataset
 
-# go run . generate-mapper \
+# ${CONTROLLERBUILDER:-go run .} generate-mapper \
 #     --service google.cloud.bigquery.v2 \
 #     --api-version bigquery.cnrm.cloud.google.com/v1beta1
 
 # BigQueryDataTransferConfig
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.bigquery.datatransfer.v1 \
     --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1beta1 \
     --resource BigQueryDataTransferConfig:TransferConfig \
     --skip-scaffold-files # skipping because the files were generated using a previous pattern, making them incompatible with the new scaffolding approach.
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.bigquery.datatransfer.v1 \
     --api-version bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
 
 # Firestore
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.firestore.admin.v1 \
     --api-version firestore.cnrm.cloud.google.com/v1beta1 \
     --resource FirestoreDatabase:Database
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.firestore.admin.v1 \
     --api-version firestore.cnrm.cloud.google.com/v1beta1
 
 # Certificate Manager DNSAuthorization
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.certificatemanager.v1  \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1beta1"
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.certificatemanager.v1  \
     --resource CertificateManagerDNSAuthorization:DnsAuthorization \
     --api-version "certificatemanager.cnrm.cloud.google.com/v1alpha1"
 
 # Workstations
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
     --resource WorkstationCluster:WorkstationCluster
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
     --resource WorkstationConfig:WorkstationConfig
 
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1 \
     --resource Workstation:Workstation
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.workstations.v1 \
     --api-version workstations.cnrm.cloud.google.com/v1beta1
 
 # SecretManager
-go run main.go generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
      --service google.cloud.secretmanager.v1 \
      --resource SecretManagerSecret:Secret \
      --api-version "secretmanager.cnrm.cloud.google.com/v1beta1"
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
    --service google.cloud.secretmanager.v1 \
    --api-version "secretmanager.cnrm.cloud.google.com/v1beta1"
 
 # Spanner
-go run main.go generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.spanner.admin.instance.v1 \
     --resource SpannerInstance:Instance \
     --api-version "spanner.cnrm.cloud.google.com/v1beta1"
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
    --service google.spanner.admin.instance.v1  \
    --api-version "spanner.cnrm.cloud.google.com/v1beta1"
 
 # IAPSettings
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.iap.v1 \
     --api-version iap.cnrm.cloud.google.com/v1beta1 \
     --resource IAPSettings:IapSettings
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.iap.v1 \
     --api-version iap.cnrm.cloud.google.com/v1beta1
 
 # ManagedKafka
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.managedkafka.v1 \
     --api-version managedkafka.cnrm.cloud.google.com/v1alpha1 \
     --resource ManagedKafkaCluster:Cluster \
     --resource ManagedKafkaTopic:Topic
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.managedkafka.v1 \
     --api-version managedkafka.cnrm.cloud.google.com/v1alpha1
 
 # PrivilegedAccessManager
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.privilegedaccessmanager.v1 \
     --api-version privilegedaccessmanager.cnrm.cloud.google.com/v1beta1
 
 # Apigee
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service mockgcp.cloud.apigee.v1 \
     --api-version apigee.cnrm.cloud.google.com/v1alpha1 \
     --resource ApigeeInstance:GoogleCloudApigeeV1Instance
 
 # CloudIdentity
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
      --service google.apps.cloudidentity.v1beta1 \
      --resource CloudIdentityGroup:Group \
      --resource CloudIdentityMembership:Membership \
      --api-version "cloudidentity.cnrm.cloud.google.com/v1beta1"
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
      --service google.apps.cloudidentity.v1beta1 \
      --api-version cloudidentity.cnrm.cloud.google.com/v1beta1
 
 # Workflow : Workflow
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
      --service google.cloud.workflows.v1 \
      --resource WorkflowsWorkflow:Workflow \
      --api-version "workflows.cnrm.cloud.google.com/v1alpha1"
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
      --service google.cloud.workflows.v1 \
      --api-version workflows.cnrm.cloud.google.com/v1alpha1
 
 # DocumentAI
-go run . generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1alpha1 \
     --resource DocumentAIProcessor:Processor
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
     --service google.cloud.documentai.v1 \
     --api-version documentai.cnrm.cloud.google.com/v1alpha1
 
 # AlloyDB
-go run main.go generate-types \
+${CONTROLLERBUILDER:-go run .} generate-types \
      --service google.cloud.alloydb.v1beta \
      --api-version alloydb.cnrm.cloud.google.com/v1beta1 \
      --resource AlloyDBCluster:Cluster \
      --resource AlloyDBInstance:Instance
 
-go run . generate-mapper \
+${CONTROLLERBUILDER:-go run .} generate-mapper \
    --service google.cloud.alloydb.v1beta  \
    --api-version alloydb.cnrm.cloud.google.com/v1alpha1
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -18,7 +18,8 @@ SHORT_SHA := $(shell git rev-parse --short=7 HEAD)
 OPERATOR_IMG ?= gcr.io/${PROJECT_ID}/cnrm/operator:${SHORT_SHA}
 GKE_DISTROLESS_IMG ?= gcr.io/gke-release/gke-distroless/static:gke_distroless_20260207.00_p0
 
-KUSTOMIZE=go run sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
+KUSTOMIZE=../bin/kustomize
+CONTROLLER_GEN=../bin/controller-gen
 
 # enable multi-versions feature for CRDs
 CRD_OPTIONS ?= "crd"
@@ -46,7 +47,7 @@ manager: generate fmt vet
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests:
-	go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 $(CRD_OPTIONS) paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
 	go run scripts/generate-image-configmap/main.go
 
 # Run go fmt against code
@@ -62,7 +63,7 @@ vet:
 # Generate code
 .PHONY: generate
 generate:
-	go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 object paths="./..."
+	$(CONTROLLER_GEN) object paths="./..."
 
 # Install CRDs into a cluster
 .PHONY: install


### PR DESCRIPTION
Gemini-ed a "pre-built" approach to the tools needed for `make manifests` to go from ~5m to ~3m! 