### PR TITLE
docs: add design decision for `projectRef` in direct migration

### DIFF
--- a/docs/design-decisions/project-ref-in-migrating-resources.md
+++ b/docs/design-decisions/project-ref-in-migrating-resources.md
@@ -1,0 +1,27 @@
+# Design Decision: ProjectRef in Migrating Resources
+
+## Context
+As Config Connector (KCC) migrates resources from legacy controllers (Terraform/DCL) to the "Direct" controller approach, we must maintain strict backward compatibility for `v1beta1` resources.
+
+A common pattern for **new** Direct resources is to include a `projectRef` field in the `Spec` to define the parent GCP project. However, adding this field to **existing** resources during migration presents several challenges.
+
+## Problem Statement
+Adding `spec.projectRef` to a resource currently managed by a legacy controller (while keeping the same API version) introduces the following risks:
+
+1. **Ignored Intent:** Legacy controllers (TF/DCL) are unaware of the `projectRef` field. If a user specifies it, the controller will ignore it and continue using the legacy resolution logic (namespace name or `cnrm.cloud.google.com/project-id` annotation), leading to "silent failures" where the resource is deployed to the wrong project.
+2. **Controller Divergence:** If a user forces the Direct controller (via annotation), the resource might suddenly respect `projectRef` and move to a different project. This creates inconsistent behavior between controllers for the same API version.
+3. **Schema Pollution:** Adding fields to a stable version (`v1beta1`) that only work under specific internal conditions is confusing for users and breaks the "Source of Truth" principle for the CRD schema.
+
+## Decision
+For all resources migrating from Terraform or DCL to the Direct controller within an existing API version:
+
+1. **Do Not Add ProjectRef:** The `projectRef` field MUST NOT be added to the Go types or the CRD schema for existing versions.
+2. **Use Annotation Resolution:** The Direct controller implementation MUST use `refsv1beta1.ResolveProjectFromAnnotation` to determine the parent project. This ensures parity with the legacy controllers.
+3. **Support Location/Region Fields:** While `projectRef` is avoided, `location` or `region` fields can be included if they were already part of the schema or are required for the Direct controller's identity resolution, provided they follow existing patterns.
+
+## Future Roadmap
+The `projectRef` field should only be introduced after the TF Controller is no longer supported for the resource.
+
+Once the direct controller is the sole engine for the resource, we could theoretically introduce projectRef as an optional, additive field.
+We should either use the direct controller or enhance the existing webhooks to check `projectRef first`, and fall back to the `project-id` annotation if `projectRef` isn't provided.
+However, we'd still have to support the annotation indefinitely to avoid breaking existing users.


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
This PR adds a formal design decision document clarifying our approach to the `projectRef` field when migrating existing resources from legacy controllers (Terraform/DCL) to the Direct controller.

Why this is needed:

When generating types for Direct controllers, scaffolding tools often include a `projectRef` field by default. While this is the standard pattern for brand new resources, adding it to existing resources (e.g., modifying a stable v1beta1 schema) introduces significant risks:
   1. Ignored Intent: Legacy controllers silently ignore `projectRef`, continuing to use namespace annotations. A user specifying `projectRef` will see their resource deployed to the wrong project without any error.
   2. Divergent Behavior: If a user forces the Direct controller (via annotation), the resource might suddenly respect `projectRef` and move to a different project, breaking backward compatibility.
   3. Schema Confusion: Exposing fields in the CRD that only function correctly under specific, hidden controller implementations violates the "Source of Truth" principle for Kubernetes APIs.

What this document establishes:
   * Do Not Add `projectRef`: The `projectRef` field MUST NOT be added to Go types or CRD schemas for existing API versions during migration.
   * Maintain Parity: Direct controller implementations MUST continue using `refsv1beta1.ResolveProjectFromAnnotation` to determine the parent project, ensuring identical behavior to the legacy controllers.
   * Future Roadmap: Outlines that `projectRef` should be introduced the legacy controller is no longer supported for the resource.


#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
