### PR TITLE
Add service_lb_policy field to ComputeBackendService

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computebackendservices.compute.cnrm.cloud.google.com.yaml
@@ -1194,6 +1194,11 @@ spec:
                   Type of session affinity to use. The default is NONE. Session affinity is
                   not applicable if the protocol is UDP. Possible values: ["NONE", "CLIENT_IP", "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO", "GENERATED_COOKIE", "HEADER_FIELD", "HTTP_COOKIE"].
                 type: string
+              serviceLbPolicy:
+                description: |-
+                  The full or partial URL of the service lb policy that this backend service is associated with. Can only be set
+                  if load balancing scheme is EXTERNAL, EXTERNAL_MANAGED, INTERNAL_MANAGED or INTERNAL_SELF_MANAGED and the scope is global.
+                type: string
               subsetting:
                 description: Subsetting configuration for this BackendService. Currently
                   this is applicable only for Internal TCP/UDP load balancing and

--- a/pkg/clients/generated/apis/compute/v1beta1/computebackendservice_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computebackendservice_types.go
@@ -898,6 +898,11 @@ type ComputeBackendServiceSpec struct {
 	// +optional
 	SessionAffinity *string `json:"sessionAffinity,omitempty"`
 
+	/* The full or partial URL of the service lb policy that this backend service is associated with. Can only be set
+	if load balancing scheme is EXTERNAL, EXTERNAL_MANAGED, INTERNAL_MANAGED or INTERNAL_SELF_MANAGED and the scope is global. */
+	// +optional
+	ServiceLbPolicy *string `json:"serviceLbPolicy,omitempty"`
+
 	/* Subsetting configuration for this BackendService. Currently this is applicable only for Internal TCP/UDP load balancing and Internal HTTP(S) load balancing. */
 	// +optional
 	Subsetting *BackendserviceSubsetting `json:"subsetting,omitempty"`

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_backend_service.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute/resource_compute_backend_service.go
@@ -1090,6 +1090,13 @@ alt name matches one of the specified values.`,
 				Description: `Type of session affinity to use. The default is NONE. Session affinity is
 not applicable if the protocol is UDP. Possible values: ["NONE", "CLIENT_IP", "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO", "GENERATED_COOKIE", "HEADER_FIELD", "HTTP_COOKIE"]`,
 			},
+			"service_lb_policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+				Description: `The full or partial URL of the service lb policy that this backend service is associated with. Can only be set
+if load balancing scheme is EXTERNAL, EXTERNAL_MANAGED, INTERNAL_MANAGED or INTERNAL_SELF_MANAGED and the scope is global.`,
+			},
 			"timeout_sec": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -1418,6 +1425,12 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 	} else if v, ok := d.GetOkExists("session_affinity"); !tpgresource.IsEmptyValue(reflect.ValueOf(sessionAffinityProp)) && (ok || !reflect.DeepEqual(v, sessionAffinityProp)) {
 		obj["sessionAffinity"] = sessionAffinityProp
 	}
+	serviceLbPolicyProp, err := expandComputeBackendServiceServiceLbPolicy(d.Get("service_lb_policy"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("service_lb_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(serviceLbPolicyProp)) && (ok || !reflect.DeepEqual(v, serviceLbPolicyProp)) {
+		obj["serviceLbPolicy"] = serviceLbPolicyProp
+	}
 	timeoutSecProp, err := expandComputeBackendServiceTimeoutSec(d.Get("timeout_sec"), d, config)
 	if err != nil {
 		return err
@@ -1674,6 +1687,9 @@ func resourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("session_affinity", flattenComputeBackendServiceSessionAffinity(res["sessionAffinity"], d, config)); err != nil {
 		return fmt.Errorf("Error reading BackendService: %s", err)
 	}
+	if err := d.Set("service_lb_policy", flattenComputeBackendServiceServiceLbPolicy(res["serviceLbPolicy"], d, config)); err != nil {
+		return fmt.Errorf("Error reading BackendService: %s", err)
+	}
 	if err := d.Set("timeout_sec", flattenComputeBackendServiceTimeoutSec(res["timeoutSec"], d, config)); err != nil {
 		return fmt.Errorf("Error reading BackendService: %s", err)
 	}
@@ -1852,6 +1868,12 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 		return err
 	} else if v, ok := d.GetOkExists("session_affinity"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, sessionAffinityProp)) {
 		obj["sessionAffinity"] = sessionAffinityProp
+	}
+	serviceLbPolicyProp, err := expandComputeBackendServiceServiceLbPolicy(d.Get("service_lb_policy"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("service_lb_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, serviceLbPolicyProp)) {
+		obj["serviceLbPolicy"] = serviceLbPolicyProp
 	}
 	timeoutSecProp, err := expandComputeBackendServiceTimeoutSec(d.Get("timeout_sec"), d, config)
 	if err != nil {
@@ -3176,6 +3198,10 @@ func flattenComputeBackendServiceSecurityPolicy(v interface{}, d *schema.Resourc
 	return v
 }
 
+func flattenComputeBackendServiceServiceLbPolicy(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
 func flattenComputeBackendServiceEdgeSecurityPolicy(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -4271,6 +4297,10 @@ func expandComputeBackendServiceProtocol(v interface{}, d tpgresource.TerraformR
 }
 
 func expandComputeBackendServiceSecurityPolicy(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandComputeBackendServiceServiceLbPolicy(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 


### PR DESCRIPTION
### BRIEF Change description

Fixes #6975

Add `serviceLbPolicy` field to `ComputeBackendService`, closing the feature gap with the Terraform `google_compute_backend_service` provider which already supports `service_lb_policy`.

#### WHY do we need this change?

The Terraform google provider exposes `service_lb_policy` on `google_compute_backend_service`, allowing users to associate a `NetworkServices ServiceLbPolicy` resource with a backend service. KCC's `ComputeBackendService` was missing this field entirely — users who rely on KCC for infrastructure management had no way to set this attribute.

#### Special notes for your reviewer:

- The field is a plain string (full or partial URL), so `DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName` is applied, consistent with `security_policy` and `edge_security_policy`.
- Three files changed: TF provider schema (expand/flatten/schema), generated Go client types, and the CRD OpenAPI YAML.
- No new struct types needed; the field is a scalar string.

#### Does this PR add something which needs to be 'release noted'?

```release-note
Added `serviceLbPolicy` field to `ComputeBackendService` spec, enabling users to associate a NetworkServices ServiceLbPolicy resource with a backend service via KCC.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
- [Terraform provider reference]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service#service_lb_policy-1
- [GCP REST API BackendService]: https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
```

#### Intended Milestone

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.