### PR TITLE
nit: Add final status for make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ lint:
 	docker run --rm -v $(shell pwd):/app \
 		-v ${GOLANGCI_LINT_CACHE}:/root/.cache/golangci-lint \
 		-w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine \
-		golangci-lint run -v --timeout=10m
+		golangci-lint run -v --timeout=10m && echo "✅ Linting passed successfully!" || (echo "❌ Linting failed! Please fix the errors above."; exit 1)
 
 .PHONY: lint-custom
 lint-custom:


### PR DESCRIPTION
## Description
This PR updates the `make lint` command to output clear, human-friendly success or failure messages.
- Displays `✅ Linting passed successfully!` if `golangci-lint` succeeds.
- Displays `❌ Linting failed! Please fix the errors above.` and exits with code `1` if it fails, ensuring the build step correctly registers the failure.