### PR TITLE
Introduce skip-name-validation flag and consolidate tests

### DIFF
--- a/cmd/deletiondefender/main.go
+++ b/cmd/deletiondefender/main.go
@@ -49,11 +49,13 @@ func main() {
 
 	var enablePprof bool
 	var pprofPort int
+	var skipNameValidation bool
 
 	profiler.AddFlag(flag.CommandLine)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.BoolVar(&enablePprof, "enable-pprof", false, "Enable the pprof server.")
 	flag.IntVar(&pprofPort, "pprof-port", 6060, "The port that the pprof server binds to if enabled.")
+	flag.BoolVar(&skipNameValidation, "skip-name-validation", false, "option to bypass the duplicate controller name check during registration; false by default")
 	flag.Parse()
 
 	// this enables packages using the kubernetes controller-runtime logging package to log
@@ -99,7 +101,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create controllers for
 	// all our resources.
-	if err := registration.AddDeletionDefender(mgr, &controller.Deps{}); err != nil {
+	if err := registration.AddDeletionDefender(mgr, &controller.Deps{SkipNameValidation: skipNameValidation}); err != nil {
 		log.Fatal(err, "error adding registration controller")
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,6 +61,7 @@ func main() {
 		rateLimitQps             float32
 		rateLimitBurst           int
 		leaderElectionMode       string
+		skipNameValidation       bool
 	)
 	flag.StringVar(&prometheusScrapeEndpoint, "prometheus-scrape-endpoint", ":8888", "configure the Prometheus scrape endpoint; :8888 as default")
 	flag.BoolVar(&controllermetrics.ResourceNameLabel, "resource-name-label", false, "option to enable the resource name label on some Prometheus metrics; false by default")
@@ -72,6 +73,7 @@ func main() {
 	flag.Float32Var(&rateLimitQps, "qps", 20.0, "The client-side token bucket rate limit qps.")
 	flag.IntVar(&rateLimitBurst, "burst", 30, "The client-side token bucket rate limit burst.")
 	flag.StringVar(&leaderElectionMode, "leader-election-type", "disabled", "Leader election mode. One of: default, multicluster.")
+	flag.BoolVar(&skipNameValidation, "skip-name-validation", false, "option to bypass the duplicate controller name check during registration; false by default")
 	profiler.AddFlag(flag.CommandLine)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
@@ -116,7 +118,7 @@ func main() {
 	// Set client site rate limiter to optimize the configconnector re-reconciliation performance.
 	ratelimiter.SetMasterRateLimiter(restCfg, rateLimitQps, rateLimitBurst)
 	logger.Info("Creating the manager")
-	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection)
+	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection, skipNameValidation)
 	if err != nil {
 		logging.Fatal(err, "error creating the manager")
 	}
@@ -172,7 +174,7 @@ func main() {
 	logging.ExitInfo("main.go finished execution; exiting ...")
 }
 
-func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool) (manager.Manager, error) {
+func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool, skipNameValidation bool) (manager.Manager, error) {
 	krmtotf.SetUserAgentForTerraformProvider()
 	controllersCfg := kccmanager.Config{
 		ManagerOptions: manager.Options{
@@ -182,7 +184,8 @@ func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace strin
 				},
 			},
 		},
-		MultiClusterLease: multiclusterlease,
+		MultiClusterLease:  multiclusterlease,
+		SkipNameValidation: skipNameValidation,
 	}
 
 	controllersCfg.UserProjectOverride = userProjectOverride

--- a/cmd/unmanageddetector/main.go
+++ b/cmd/unmanageddetector/main.go
@@ -50,12 +50,14 @@ func main() {
 	var enablePprof bool
 	var pprofPort int
 	var managerNamespaceIsolation string
+	var skipNameValidation bool
 
 	profiler.AddFlag(flag.CommandLine)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.BoolVar(&enablePprof, "enable-pprof", false, "Enable the pprof server.")
 	flag.IntVar(&pprofPort, "pprof-port", 6060, "The port that the pprof server binds to if enabled.")
 	flag.StringVar(&managerNamespaceIsolation, k8s.ManagerNamespaceIsolationFlag, k8s.ManagerNamespaceIsolationShared, fmt.Sprintf("'%s' if all controller managers run in shared 'cnrm-system' namespace, '%s' if controller managers run in dedicated namespace. Default is '%s'", k8s.ManagerNamespaceIsolationShared, k8s.ManagerNamespaceIsolationDedicated, k8s.ManagerNamespaceIsolationShared))
+	flag.BoolVar(&skipNameValidation, "skip-name-validation", false, "option to bypass the duplicate controller name check during registration; false by default")
 	flag.Parse()
 
 	switch managerNamespaceIsolation {
@@ -113,7 +115,7 @@ func main() {
 
 	// Register the registration controller, which will dynamically create
 	// controllers for all our resources.
-	if err := registration.AddUnmanagedDetector(mgr, &controller.Deps{}); err != nil {
+	if err := registration.AddUnmanagedDetector(mgr, &controller.Deps{SkipNameValidation: skipNameValidation}); err != nil {
 		logging.Fatal(err, "error adding registration controller")
 	}
 

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -731,6 +731,7 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 	})
 	kccConfig.ManagerOptions.Logger = filterLogs(log)
 	kccConfig.ManagerOptions.Controller.SkipNameValidation = ptr.To(true)
+	kccConfig.SkipNameValidation = true
 
 	krmtotf.SetUserAgentForTerraformProvider()
 
@@ -747,7 +748,7 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 	}
 
 	// Register the deletion defender controller.
-	if err := registration.AddDeletionDefender(mgr, &controller.Deps{}); err != nil {
+	if err := registration.AddDeletionDefender(mgr, &controller.Deps{SkipNameValidation: kccConfig.SkipNameValidation}); err != nil {
 		t.Fatalf("error adding registration controller for deletion defender controllers: %v", err)
 	}
 	// Start the manager, Start(...) is a blocking operation so it needs to be done asynchronously.

--- a/pkg/config/controllerconfig.go
+++ b/pkg/config/controllerconfig.go
@@ -58,6 +58,9 @@ type ControllerConfig struct {
 
 	// ProjectMapper maps between project ids and numbers
 	ProjectMapper *projects.ProjectMapper
+
+	// SkipNameValidation bypasses the duplicate controller name check during registration
+	SkipNameValidation bool
 }
 
 func (c *ControllerConfig) Init(ctx context.Context) error {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -33,4 +33,7 @@ type Deps struct {
 	Defaulters        []k8s.Defaulter
 	JitterGen         jitter.Generator
 	DependencyTracker *gcpwatch.DependencyTracker
+	// SkipNameValidation maps to the SkipNameValidation field in controller-runtime's controller.Options.
+	// It avoids a controller-runtime bug when running multiple managers in the same process (even if not running them concurrently).
+	SkipNameValidation bool
 }

--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -102,6 +101,7 @@ func NewReconciler(mgr manager.Manager, immediateReconcileRequests chan event.Ge
 		jitterGenerator: deps.JitterGenerator,
 		defaulters:      deps.Defaulters,
 		iamDeps:         deps.IAMAdapterDeps,
+		SkipNameValidation: deps.SkipNameValidation,
 	}
 	return &r, nil
 }
@@ -116,7 +116,7 @@ func add(mgr manager.Manager, r *DirectReconciler) error {
 	controllerBuilder := builder.
 		ControllerManagedBy(mgr).
 		Named(r.controllerName).
-		WithOptions(crcontroller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, SkipNameValidation: ptr.To(true), RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(crcontroller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, SkipNameValidation: &r.SkipNameValidation, RateLimiter: ratelimiter.NewRateLimiter()}).
 		WatchesRawSource(
 			source.TypedChannel(r.immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicateList...))
@@ -161,6 +161,8 @@ type Deps struct {
 
 	// There are Dependencies for Adapters in particular (not the reconcilers)
 	IAMAdapterDeps *IAMAdapterDeps
+
+	SkipNameValidation bool
 }
 
 // TODO(kcc-team): we want to remove these in the future
@@ -193,6 +195,8 @@ type DirectReconciler struct {
 
 	// reconcilePredicate is the predicate which determines if we should be reconciling this object
 	reconcilePredicate predicate.Predicate
+
+	SkipNameValidation bool
 }
 
 type reconcileContext struct {

--- a/pkg/controller/gsakeysecretgenerator/gsakey_secret_generator.go
+++ b/pkg/controller/gsakeysecretgenerator/gsakey_secret_generator.go
@@ -66,7 +66,7 @@ func Add(mgr manager.Manager, crd *apiextensions.CustomResourceDefinition, deps 
 	_, err := builder.
 		ControllerManagedBy(mgr).
 		Named(controllerName).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter(), SkipNameValidation: &deps.SkipNameValidation}).
 		For(obj, builder.OnlyMetadata).
 		Build(r)
 	if err != nil {

--- a/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
+++ b/pkg/controller/iam/auditconfig/iamauditconfig_controller.go
@@ -79,7 +79,10 @@ func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 	if err != nil {
 		return err
 	}
-	return add(mgr, reconciler)
+	opt := controller.Options{
+		SkipNameValidation: &deps.SkipNameValidation,
+	}
+	return add(mgr, reconciler, opt)
 }
 
 func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *servicemappingloader.ServiceMappingLoader, converter *conversion.Converter, dclConfig *mmdcl.Config, immediateReconcileRequests chan event.GenericEvent, resourceWatcherRoutines *semaphore.Weighted, defaulters []k8s.Defaulter, jg jitter.Generator) (*Reconciler, error) {
@@ -101,12 +104,19 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler.
-func add(mgr manager.Manager, r *Reconciler) error {
+func add(mgr manager.Manager, r *Reconciler, opt controller.Options) error {
+	if opt.MaxConcurrentReconciles == 0 {
+		opt.MaxConcurrentReconciles = k8s.ControllerMaxConcurrentReconciles
+	}
+	if opt.RateLimiter == nil {
+		opt.RateLimiter = ratelimiter.NewRateLimiter()
+	}
+
 	obj := &iamv1beta1.IAMAuditConfig{}
 	_, err := builder.
 		ControllerManagedBy(mgr).
 		Named(controllerName).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(opt).
 		WatchesRawSource(source.TypedChannel(r.immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)

--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -82,7 +82,10 @@ func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 	if err != nil {
 		return err
 	}
-	return add(mgr, reconciler)
+	opt := controller.Options{
+		SkipNameValidation: &deps.SkipNameValidation,
+	}
+	return add(mgr, reconciler, opt)
 }
 
 // NewReconciler returns a new reconcile.Reconciler.
@@ -108,12 +111,19 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler.
-func add(mgr manager.Manager, r *ReconcileIAMPolicy) error {
+func add(mgr manager.Manager, r *ReconcileIAMPolicy, opt controller.Options) error {
+	if opt.MaxConcurrentReconciles == 0 {
+		opt.MaxConcurrentReconciles = k8s.ControllerMaxConcurrentReconciles
+	}
+	if opt.RateLimiter == nil {
+		opt.RateLimiter = ratelimiter.NewRateLimiter()
+	}
+
 	obj := &iamv1beta1.IAMPolicy{}
 	_, err := builder.
 		ControllerManagedBy(mgr).
 		Named(controllerName).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(opt).
 		WatchesRawSource(source.TypedChannel(r.immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)

--- a/pkg/controller/iam/policymember/iampolicymember_controller.go
+++ b/pkg/controller/iam/policymember/iampolicymember_controller.go
@@ -83,7 +83,10 @@ func Add(mgr manager.Manager, deps *kontroller.Deps) error {
 	if err != nil {
 		return err
 	}
-	return add(mgr, reconciler)
+	opt := controller.Options{
+		SkipNameValidation: &deps.SkipNameValidation,
+	}
+	return add(mgr, reconciler, opt)
 }
 
 // NewReconciler returns a new reconcile.Reconciler.
@@ -108,12 +111,19 @@ func NewReconciler(mgr manager.Manager, provider *tfschema.Provider, smLoader *s
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler.
-func add(mgr manager.Manager, r *Reconciler) error {
+func add(mgr manager.Manager, r *Reconciler, opt controller.Options) error {
+	if opt.MaxConcurrentReconciles == 0 {
+		opt.MaxConcurrentReconciles = k8s.ControllerMaxConcurrentReconciles
+	}
+	if opt.RateLimiter == nil {
+		opt.RateLimiter = kccratelimiter.NewRateLimiter()
+	}
+
 	obj := &iamv1beta1.IAMPolicyMember{}
 	_, err := builder.
 		ControllerManagedBy(mgr).
 		Named(controllerName).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: kccratelimiter.NewRateLimiter()}).
+		WithOptions(opt).
 		WatchesRawSource(source.TypedChannel(r.immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicate.UnderlyingResourceOutOfSyncPredicate{})).
 		Build(r)

--- a/pkg/controller/kccmanager/kccmanager.go
+++ b/pkg/controller/kccmanager/kccmanager.go
@@ -101,6 +101,9 @@ type Config struct {
 	// Configure manager to participate in leader election if MultiClusterLease is enabled.
 	MultiClusterLease bool
 
+	// SkipNameValidation bypasses the duplicate controller name check during registration
+	SkipNameValidation bool
+
 	// used for smoke testing only; options not meant to be used in production.
 	testConfig
 }
@@ -286,6 +289,7 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 		GRPCUnaryClientInterceptor: cfg.GRPCUnaryClientInterceptor,
 		UserAgent:                  gcp.KCCUserAgent(),
 		EnableMetricsTransport:     cfg.EnableMetricsTransport,
+		SkipNameValidation:         cfg.SkipNameValidation,
 	}
 	if !cfg.skipControllerRegistration {
 		// Bootstrap the Google Terraform provider
@@ -346,6 +350,7 @@ func New(ctx context.Context, restConfig *rest.Config, cfg Config) (manager.Mana
 			Defaulters: []k8s.Defaulter{
 				stateIntoSpecDefaulter,
 			},
+			SkipNameValidation: cfg.SkipNameValidation,
 		}
 
 		fetcher, err := gcpwatch.NewIAMFetcher(ctx, controllerConfig)

--- a/pkg/controller/kccmanager/kccmanager_test.go
+++ b/pkg/controller/kccmanager/kccmanager_test.go
@@ -63,6 +63,7 @@ func TestSchemeIsUniqueAcrossManagers(t *testing.T) {
 				BindAddress: "0",
 			},
 		},
+		SkipNameValidation: true,
 	}
 	schemePtrMap := make(map[*runtime.Scheme]string)
 	schemePtrMap[clusterModeManager.GetScheme()] = "clusterModeMgr"
@@ -79,9 +80,41 @@ func TestSchemeIsUniqueAcrossManagers(t *testing.T) {
 	}
 }
 
+func TestSkipNameValidation(t *testing.T) {
+	ctx := context.TODO()
+
+	controllersCfg := kccmanager.Config{
+		ManagerOptions: manager.Options{
+			// disable prometheus metrics as by default, the metrics server binds to the same port in all instances
+			Metrics: server.Options{
+				BindAddress: "0",
+			},
+		},
+		SkipNameValidation: false,
+	}
+
+	_, err := kccmanager.New(ctx, clusterModeManager.GetConfig(), controllersCfg)
+	if err != nil {
+		t.Fatalf("error creating manager 1: %v", err)
+	}
+
+	// This should fail because it tries to register controllers with same names.
+	// controller-runtime (at least in some versions) has a global registry of controller names.
+	_, err = kccmanager.New(ctx, clusterModeManager.GetConfig(), controllersCfg)
+	if err == nil {
+		t.Fatalf("expected error creating manager 2 without SkipNameValidation, but got nil")
+	}
+
+	controllersCfg.SkipNameValidation = true
+	_, err = kccmanager.New(ctx, clusterModeManager.GetConfig(), controllersCfg)
+	if err != nil {
+		t.Fatalf("error creating manager 3 with SkipNameValidation: %v", err)
+	}
+}
+
 func TestClusterModeManager(t *testing.T) {
 	ctx := context.TODO()
-	mgr, err := kccmanager.New(ctx, clusterModeManager.GetConfig(), kccmanager.Config{StateIntoSpecDefaultValue: stateintospec.StateIntoSpecDefaultValueV1Beta1})
+	mgr, err := kccmanager.New(ctx, clusterModeManager.GetConfig(), kccmanager.Config{StateIntoSpecDefaultValue: stateintospec.StateIntoSpecDefaultValueV1Beta1, SkipNameValidation: true})
 	if err != nil {
 		t.Fatalf("error creating manager: %v", err)
 	}
@@ -120,6 +153,7 @@ func TestNamespacedModeManager(t *testing.T) {
 				},
 			},
 		},
+		SkipNameValidation: true,
 	}
 	mgr1, err := kccmanager.New(ctx, namespacedModeManager.GetConfig(), controllersCfg1)
 	if err != nil {
@@ -163,6 +197,7 @@ func TestNamespacedModeManager(t *testing.T) {
 				},
 			},
 		},
+		SkipNameValidation: true,
 	}
 	// start controllers for the second namespace and verify that the second resource does reconcile
 	mgr2, err := kccmanager.New(ctx, namespacedModeManager.GetConfig(), controllersCfg2)

--- a/pkg/controller/parent/controller.go
+++ b/pkg/controller/parent/controller.go
@@ -73,7 +73,14 @@ type ParentReconciler struct {
 	reconcilers Reconcilers
 }
 
-func Add(mgr manager.Manager, gvk schema.GroupVersionKind, reconcilers *Reconcilers) error {
+func Add(mgr manager.Manager, gvk schema.GroupVersionKind, reconcilers *Reconcilers, opt controller.Options) error {
+	if opt.MaxConcurrentReconciles == 0 {
+		opt.MaxConcurrentReconciles = k8s.ControllerMaxConcurrentReconciles
+	}
+	if opt.RateLimiter == nil {
+		opt.RateLimiter = ratelimiter.NewRateLimiter()
+	}
+
 	controllerName := fmt.Sprintf("%v-parent-controller", strings.ToLower(gvk.Kind))
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
@@ -97,7 +104,7 @@ func Add(mgr manager.Manager, gvk schema.GroupVersionKind, reconcilers *Reconcil
 		Named(controllerName).
 		For(obj, builder.OnlyMetadata, builder.WithPredicates(predicates...)).
 		WatchesRawSource(source.TypedChannel(immediateReconcileRequests, &handler.EnqueueRequestForObject{})).
-		WithOptions(controller.Options{MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles, RateLimiter: ratelimiter.NewRateLimiter()}).
+		WithOptions(opt).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("error creating new parent controller: %w", err)

--- a/pkg/controller/registration/registration_controller.go
+++ b/pkg/controller/registration/registration_controller.go
@@ -86,7 +86,7 @@ func AddDeletionDefender(mgr manager.Manager, rd *controller.Deps) error {
 		ControllerName: "deletion-defender-registration-controller",
 	}
 
-	if err := add(mgr, &controller.Deps{}, registerDeletionDefenderController, opt); err != nil {
+	if err := add(mgr, rd, registerDeletionDefenderController, opt); err != nil {
 		return fmt.Errorf("error adding deletion-defender registration controller: %w", err)
 	}
 	return nil
@@ -105,13 +105,16 @@ func AddUnmanagedDetector(mgr manager.Manager, rd *controller.Deps) error {
 		if _, ok := k8s.IgnoredKindList[gvk.Kind]; ok {
 			return nil, nil
 		}
-		if err := unmanageddetector.Add(ctx, r.mgr, gvk); err != nil {
+		opt := crcontroller.Options{
+			SkipNameValidation: &r.SkipNameValidation,
+		}
+		if err := unmanageddetector.Add(ctx, r.mgr, gvk, opt); err != nil {
 			return nil, fmt.Errorf("error registering unmanaged detector controller for '%v': %w", gvk.Kind, err)
 		}
 		return nil, nil
 	}
 
-	if err := add(mgr, &controller.Deps{}, registerUnmanagedDetectorController, opt); err != nil {
+	if err := add(mgr, rd, registerUnmanagedDetectorController, opt); err != nil {
 		return fmt.Errorf("error adding unmanaged-detector registration controller: %w", err)
 	}
 	return nil
@@ -143,11 +146,13 @@ func add(mgr manager.Manager, rd *controller.Deps, regFunc registrationFunc, opt
 		reconcilers:                make(map[schema.GroupVersionKind]*parent.Reconcilers),
 		immediateReconcileRequests: make(chan event.GenericEvent, k8s.ImmediateReconcileRequestsBufferSize),
 		resourceWatcherRoutines:    semaphore.NewWeighted(k8s.MaxNumResourceWatcherRoutines),
+		SkipNameValidation:         rd.SkipNameValidation,
 	}
 	c, err := crcontroller.New(opts.ControllerName, mgr,
 		crcontroller.Options{
 			Reconciler:              r,
 			MaxConcurrentReconciles: k8s.ControllerMaxConcurrentReconciles,
+			SkipNameValidation:      &r.SkipNameValidation,
 		})
 	if err != nil {
 		return err
@@ -179,6 +184,8 @@ type ReconcileRegistration struct {
 	resourceWatcherRoutines    *semaphore.Weighted // Used to cap number of goroutines watching unready dependencies
 
 	mu sync.Mutex
+
+	SkipNameValidation bool
 }
 
 type controllerContext struct {
@@ -265,6 +272,7 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 		JitterGen:    r.jitterGenerator,
 		Defaulters:   r.defaulters,
 		//DependencyTracker: r.dependencyTracker,
+		SkipNameValidation: r.SkipNameValidation,
 	}
 
 	// todo acpana house in KCC mgr flag
@@ -294,7 +302,7 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 		// register the controller to automatically create secrets for GSA keys
 		if isServiceAccountKeyCRD(crd) {
 			logger.Info("registering the GSA-Key-to-Secret generation controller")
-			if err := gsakeysecretgenerator.Add(r.mgr, crd, &controller.Deps{JitterGen: r.jitterGenerator}); err != nil {
+			if err := gsakeysecretgenerator.Add(r.mgr, crd, &controller.Deps{JitterGen: r.jitterGenerator, SkipNameValidation: r.SkipNameValidation}); err != nil {
 				return nil, fmt.Errorf("error adding the gsa-to-secret generator for %v to a manager: %w", crd.Spec.Names.Kind, err)
 			}
 		}
@@ -338,12 +346,14 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 						IAMAdapterDeps: &directbase.IAMAdapterDeps{
 							KubeClient: r.Client,
 							ControllerDeps: &controller.Deps{
-								TFProvider:   r.provider,
-								TFLoader:     r.smLoader,
-								DCLConfig:    r.dclConfig,
-								DCLConverter: r.dclConverter,
+								TFProvider:         r.provider,
+								TFLoader:           r.smLoader,
+								DCLConfig:          r.dclConfig,
+								DCLConverter:       r.dclConverter,
+								SkipNameValidation: r.SkipNameValidation,
 							},
 						},
+						SkipNameValidation: r.SkipNameValidation,
 					}
 					reconcilers.Direct, err = directbase.NewReconciler(r.mgr, nil, nil, gvk, model, deps)
 					if err != nil {
@@ -352,7 +362,10 @@ func registerDefaultController(ctx context.Context, r *ReconcileRegistration, co
 				}
 			}
 			r.reconcilers[gvk] = reconcilers
-			if err := parent.Add(r.mgr, gvk, reconcilers); err != nil {
+			opt := crcontroller.Options{
+				SkipNameValidation: &r.SkipNameValidation,
+			}
+			if err := parent.Add(r.mgr, gvk, reconcilers, opt); err != nil {
 				return nil, fmt.Errorf("error adding parent controller for %v to a manager: %w", crd.Spec.Names.Kind, err)
 			}
 		}
@@ -364,7 +377,10 @@ func registerDeletionDefenderController(r *ReconcileRegistration, crd *apiextens
 	if _, ok := k8s.IgnoredKindList[crd.Spec.Names.Kind]; ok {
 		return nil, nil
 	}
-	if err := deletiondefender.Add(r.mgr, crd); err != nil {
+	opt := crcontroller.Options{
+		SkipNameValidation: &r.SkipNameValidation,
+	}
+	if err := deletiondefender.Add(r.mgr, crd, opt); err != nil {
 		return nil, fmt.Errorf("error registering deletion defender controller for '%v': %w", crd.GetName(), err)
 	}
 	return nil, nil


### PR DESCRIPTION
### BRIEF Change description

Introduce `skip-name-validation` flag to bypass duplicate controller name checks during registration and consolidate related tests.

#### WHY do we need this change?

In integration tests and certain multi-manager scenarios, creating multiple managers in the same process can lead to conflicts in `controller-runtime`'s global controller name registry. This flag allows for opting out of that check when such conflicts are expected or managed.

#### Special notes for your reviewer:

Merged `pkg/controller/kccmanager/kccmanager_skipnamevalidation_test.go` into `pkg/controller/kccmanager/kccmanager_test.go` to maintain a cleaner package structure.

#### Does this PR add something which needs to be 'release noted'?
```release-note
Added a `--skip-name-validation` flag to Config Connector controllers to bypass duplicate controller name checks during registration.
```

- [x] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:
```docs
NONE
```

#### Intended Milestone
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

Ran all tests in `pkg/controller/kccmanager` package:
`go test -v ./pkg/controller/kccmanager -tags=integration`

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
