### PR TITLE
Add CRUD testdata for MemorystoreInstanceBackup mocks

### DIFF
--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/memorystore/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocks"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
 type instanceServer struct {
@@ -330,6 +331,140 @@ func (r *instanceServer) DeleteInstance(ctx context.Context, req *pb.DeleteInsta
 	})
 }
 
+func (r *instanceServer) GetBackup(ctx context.Context, req *pb.GetBackupRequest) (*pb.Backup, error) {
+	name, err := r.parseBackupName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+
+	obj := &pb.Backup{}
+	if err := r.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%s' was not found", fqn)
+		}
+		return nil, err
+	}
+
+	retObj := proto.Clone(obj).(*pb.Backup)
+	return retObj, nil
+}
+
+func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInstanceRequest) (*longrunning.Operation, error) {
+	instanceName, err := r.parseInstanceName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceFqn := instanceName.String()
+	instanceObj := &pb.Instance{}
+	if err := r.storage.Get(ctx, instanceFqn, instanceObj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%s' was not found", instanceFqn)
+		}
+		return nil, err
+	}
+
+	backupCollectionName := ""
+	if instanceObj.BackupCollection != nil {
+		backupCollectionName = *instanceObj.BackupCollection
+	} else {
+		backupCollectionName = fmt.Sprintf("projects/%s/locations/%s/backupCollections/backupCollection-%s", instanceName.Project.ID, instanceName.Location, instanceName.Name)
+		instanceObj.BackupCollection = direct.LazyPtr(backupCollectionName)
+		if err := r.storage.Update(ctx, instanceFqn, instanceObj); err != nil {
+			return nil, err
+		}
+	}
+
+	reqName := fmt.Sprintf("%s/backups/%s", backupCollectionName, req.GetBackupId())
+	name, err := r.parseBackupName(reqName)
+	if err != nil {
+		return nil, err
+	}
+
+	fqn := name.String()
+	now := time.Now()
+
+	obj := &pb.Backup{
+		BackupType: pb.Backup_ON_DEMAND,
+		BackupFiles: []*pb.BackupFile{
+			&pb.BackupFile{
+				FileName:   fmt.Sprintf("file-%s.rdb", req.GetBackupId()),
+				SizeBytes:  141,
+				CreateTime: timestamppb.New(now),
+			},
+		},
+		CreateTime:     timestamppb.New(now),
+		ExpireTime:     timestamppb.New(now),
+		EngineVersion:  instanceObj.EngineVersion,
+		Instance:       instanceName.String(),
+		InstanceUid:    instanceObj.Uid,
+		Name:           fqn,
+		NodeType:       instanceObj.NodeType,
+		ShardCount:     instanceObj.ShardCount,
+		State:          pb.Backup_ACTIVE,
+		TotalSizeBytes: 141,
+		Uid:            fmt.Sprintf("backup-%s", req.GetBackupId()),
+	}
+	if req.GetTtl() != nil {
+		ttl := now.Add(req.GetTtl().AsDuration())
+		obj.ExpireTime = timestamppb.New(ttl)
+	}
+	if err := r.storage.Create(ctx, fqn, obj); err != nil {
+		return nil, err
+	}
+
+	prefix := name.OperationPrefix()
+	metadata := &pb.OperationMetadata{
+		ApiVersion: "v1",
+		CreateTime: timestamppb.New(now),
+		Target:     instanceName.String(),
+		Verb:       "backup",
+	}
+
+	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return proto.Clone(instanceObj).(*pb.Instance), nil
+	})
+}
+
+func (r *instanceServer) DeleteBackup(ctx context.Context, req *pb.DeleteBackupRequest) (*longrunning.Operation, error) {
+	name, err := r.parseBackupName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	fqn := name.String()
+
+	now := time.Now()
+
+	obj := &pb.Backup{}
+
+	if err := r.storage.Get(ctx, fqn, obj); err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, status.Errorf(codes.NotFound, "Resource '%s' was not found", fqn)
+		}
+		return nil, err
+	}
+
+	deletedObj := &pb.Backup{}
+	if err := r.storage.Delete(ctx, fqn, deletedObj); err != nil {
+		return nil, err
+	}
+
+	metadata := &pb.OperationMetadata{
+		ApiVersion: "v1",
+		CreateTime: timestamppb.New(now),
+		Target:     fqn,
+		Verb:       "delete",
+	}
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
+	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
+		metadata.EndTime = timestamppb.Now()
+		return &emptypb.Empty{}, nil
+	})
+}
+
 type instanceName struct {
 	Project  *projects.ProjectData
 	Location string
@@ -388,5 +523,48 @@ func (s *instanceServer) parseNetworkName(name string) (*networkName, error) {
 			Name:    tokens[4],
 		}, nil
 	}
+	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
+}
+
+type backupName struct {
+	Project          *projects.ProjectData
+	Location         string
+	BackupCollection string
+	Name             string
+}
+
+func (n *backupName) String() string {
+	return fmt.Sprintf("%s/backups/%s", n.Parent(), n.Name)
+}
+
+func (n *backupName) Parent() string {
+	return fmt.Sprintf("%s/backupCollections/%s", n.OperationPrefix(), n.BackupCollection)
+}
+
+func (n *backupName) OperationPrefix() string {
+	return fmt.Sprintf("projects/%s/locations/%s", n.Project.ID, n.Location)
+}
+
+// parseBackupName parses a string into a backup name.
+// The expected form is `projects/*/locations/*/backupCollections/*/backups/*`.
+func (r *instanceServer) parseBackupName(name string) (*backupName, error) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 8 && tokens[0] == "projects" && tokens[2] == "locations" && tokens[4] == "backupCollections" && tokens[6] == "backups" {
+		project, err := r.Projects.GetProjectByID(tokens[1])
+		if err != nil {
+			return nil, err
+		}
+
+		name := &backupName{
+			Project:          project,
+			Location:         tokens[3],
+			BackupCollection: tokens[5],
+			Name:             tokens[7],
+		}
+
+		return name, nil
+	}
+
 	return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
 }

--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -17,7 +17,6 @@ package mockmemorystore
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -73,8 +72,8 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 	obj := proto.Clone(req.GetInstance()).(*pb.Instance)
 	obj.Name = fqn
 	obj.CreateTime = timestamppb.New(now)
-
-	obj.State = pb.Instance_CREATING
+	obj.UpdateTime = timestamppb.New(now)
+	obj.State = pb.Instance_ACTIVE
 
 	if err := r.populateDefaultsForInstance(name, obj); err != nil {
 		return nil, err
@@ -86,7 +85,7 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 
 	updatedObj := proto.Clone(obj).(*pb.Instance)
 	updatedObj.CreateTime = nil
-	prefix := fmt.Sprintf("projects/%d/locations/%s", name.Project.Number, name.Location)
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
 
 	metadata := &pb.OperationMetadata{
 		ApiVersion: "v1",
@@ -119,21 +118,68 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 		obj.NodeType = pb.Instance_HIGHMEM_MEDIUM
 	}
 
-	if obj.Endpoints == nil {
-		pscConnectionID := time.Now().UnixNano()
-
+	if obj.Mode == pb.Instance_MODE_UNSPECIFIED {
+		obj.Mode = pb.Instance_CLUSTER
+	}
+	if obj.PscAttachmentDetails == nil {
+		var types []pb.ConnectionType
+		switch obj.GetMode() {
+		case pb.Instance_CLUSTER:
+			types = append(types, pb.ConnectionType_CONNECTION_TYPE_DISCOVERY)
+			types = append(types, pb.ConnectionType_CONNECTION_TYPE_UNSPECIFIED)
+		default:
+			types = append(types, pb.ConnectionType_CONNECTION_TYPE_PRIMARY)
+			types = append(types, pb.ConnectionType_CONNECTION_TYPE_READER)
+		}
+		obj.PscAttachmentDetails = []*pb.PscAttachmentDetail{
+			{
+				ServiceAttachment: fmt.Sprintf("projects/tp-%s/regions/%s/serviceAttachments/sa-%s", name.Name, name.Location, name.Name),
+				ConnectionType:    types[0],
+			},
+			{
+				ServiceAttachment: fmt.Sprintf("projects/tp-%s/regions/%s/serviceAttachments/sa-%s-2", name.Name, name.Location, name.Name),
+				ConnectionType:    types[1],
+			},
+		}
+	}
+	if len(obj.Endpoints) > 0 {
+		if len(obj.Endpoints[0].Connections) > 0 {
+			connections := obj.Endpoints[0].Connections
+			if len(connections) == 1 {
+				autoConnection := connections[0].GetPscAutoConnection()
+				if autoConnection != nil {
+					obj.Endpoints[0].Connections = append(obj.Endpoints[0].Connections, &pb.Instance_ConnectionDetail{
+						Connection: &pb.Instance_ConnectionDetail_PscAutoConnection{
+							PscAutoConnection: &pb.PscAutoConnection{
+								Ports:     autoConnection.Ports,
+								Network:   autoConnection.Network,
+								ProjectId: autoConnection.ProjectId,
+							},
+						},
+					})
+				}
+			}
+		}
+		pscConnectionID := int64(1234567890123456789)
 		for _, endpoint := range obj.Endpoints {
-			for _, connections := range endpoint.Connections {
+			for i, connections := range endpoint.Connections {
+				attachmentDetails := obj.PscAttachmentDetails[i%2]
 				if connections.GetPscAutoConnection() != nil {
 					autoConnection := connections.GetPscAutoConnection()
 					network, err := s.parseNetworkName(autoConnection.GetNetwork())
 					if err != nil {
 						return status.Errorf(codes.InvalidArgument, "unexpected format for network %q", autoConnection.Network)
 					}
-					forwardingRuleID := fmt.Sprintf("ssc-auto-fr-%x", pscConnectionID)
-					autoConnection.IpAddress = fmt.Sprintf("10.128.0.%d", rand.IntN(100))
-					autoConnection.ForwardingRule = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/forwardingRules/%s", network.Project.ID, name.Location, forwardingRuleID)
+					autoConnection.IpAddress = fmt.Sprintf("10.128.0.%d", pscConnectionID%256)
+					autoConnection.ForwardingRule = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/forwardingRules/sca-auto-fr-%x", network.Project.ID, name.Location, pscConnectionID)
 					autoConnection.PscConnectionId = fmt.Sprintf("%d", pscConnectionID)
+					autoConnection.ConnectionType = attachmentDetails.ConnectionType
+					autoConnection.ServiceAttachment = attachmentDetails.ServiceAttachment
+					if autoConnection.Ports == nil {
+						autoConnection.Ports = &pb.PscAutoConnection_Port{
+							Port: 6379,
+						}
+					}
 					pscConnectionID++
 				}
 				if connections.GetPscConnection() != nil {
@@ -142,11 +188,9 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 					if err != nil {
 						return status.Errorf(codes.InvalidArgument, "unexpected format for network %q", userConnection.Network)
 					}
-					forwardingRuleID := fmt.Sprintf("ssc-auto-fr-%x", pscConnectionID)
-					userConnection.IpAddress = fmt.Sprintf("10.128.0.%d", rand.IntN(100))
-					userConnection.ForwardingRule = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/forwardingRules/%s", network.Project.ID, name.Location, forwardingRuleID)
-					userConnection.PscConnectionId = fmt.Sprintf("%d", pscConnectionID)
-					pscConnectionID++
+					userConnection.ProjectId = network.Project.ID
+					userConnection.PscConnectionStatus = pb.PscConnectionStatus_ACTIVE
+					userConnection.ConnectionType = attachmentDetails.ConnectionType
 				}
 			}
 		}
@@ -162,8 +206,8 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 	if obj.ReplicaCount == nil {
 		obj.ReplicaCount = mocks.PtrTo[int32](0)
 	}
-	if obj.Mode == pb.Instance_MODE_UNSPECIFIED {
-		obj.Mode = pb.Instance_CLUSTER
+	if obj.NodeConfig == nil {
+		obj.NodeConfig = &pb.NodeConfig{}
 	}
 	nodeCapacity := float64(1)
 	switch obj.GetNodeType() {
@@ -178,18 +222,13 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 	default:
 		return fmt.Errorf("unknown node type %v", obj.GetNodeType())
 	}
-
-	if obj.NodeConfig == nil {
-		obj.NodeConfig = &pb.NodeConfig{
-			SizeGb: *mocks.PtrTo(float64(nodeCapacity)),
-		}
-	}
+	obj.NodeConfig.SizeGb = *mocks.PtrTo(float64(nodeCapacity))
 
 	if obj.TransitEncryptionMode == pb.Instance_TRANSIT_ENCRYPTION_MODE_UNSPECIFIED {
 		obj.TransitEncryptionMode = pb.Instance_TRANSIT_ENCRYPTION_DISABLED
 	}
 	if obj.Uid == "" {
-		obj.Uid = fmt.Sprintf("%x", time.Now().UnixNano())
+		obj.Uid = fmt.Sprintf("instance-%s", name.Name)
 	}
 	if obj.ZoneDistributionConfig == nil {
 		obj.ZoneDistributionConfig = &pb.ZoneDistributionConfig{}
@@ -199,6 +238,59 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 	}
 	if obj.EngineVersion == "" {
 		obj.EngineVersion = "VALKEY_7_2"
+	}
+	if obj.AutomatedBackupConfig == nil {
+		obj.AutomatedBackupConfig = &pb.AutomatedBackupConfig{}
+	}
+	if obj.AutomatedBackupConfig.AutomatedBackupMode == pb.AutomatedBackupConfig_AUTOMATED_BACKUP_MODE_UNSPECIFIED {
+		obj.AutomatedBackupConfig.AutomatedBackupMode = pb.AutomatedBackupConfig_DISABLED
+	}
+	if crr := obj.CrossInstanceReplicationConfig; crr != nil {
+		crr.UpdateTime = timestamppb.New(time.Now())
+		switch crr.InstanceRole {
+		case pb.CrossInstanceReplicationConfig_PRIMARY:
+			crr.PrimaryInstance = nil
+			crr.Membership = &pb.CrossInstanceReplicationConfig_Membership{
+				PrimaryInstance: &pb.CrossInstanceReplicationConfig_RemoteInstance{
+					Instance: name.String(),
+					Uid:      obj.Uid,
+				},
+				SecondaryInstances: []*pb.CrossInstanceReplicationConfig_RemoteInstance{},
+			}
+			for _, secondaryInstance := range crr.SecondaryInstances {
+				secondaryName, err := s.parseInstanceName(secondaryInstance.Instance)
+				if err != nil {
+					return err
+				}
+				secondaryInstance.Uid = fmt.Sprintf("instance-%s", secondaryName.Name)
+				crr.Membership.SecondaryInstances = append(crr.Membership.SecondaryInstances, &pb.CrossInstanceReplicationConfig_RemoteInstance{
+					Instance: secondaryInstance.Instance,
+					Uid:      secondaryInstance.Uid,
+				})
+			}
+		case pb.CrossInstanceReplicationConfig_SECONDARY:
+			primaryName, err := s.parseInstanceName(crr.PrimaryInstance.Instance)
+			if err != nil {
+				return err
+			}
+			crr.PrimaryInstance.Uid = fmt.Sprintf("instance-%s", primaryName.Name)
+			crr.Membership = &pb.CrossInstanceReplicationConfig_Membership{
+				PrimaryInstance: &pb.CrossInstanceReplicationConfig_RemoteInstance{
+					Instance: crr.PrimaryInstance.Instance,
+					Uid:      crr.PrimaryInstance.Uid,
+				},
+				SecondaryInstances: []*pb.CrossInstanceReplicationConfig_RemoteInstance{
+					&pb.CrossInstanceReplicationConfig_RemoteInstance{
+						Instance: name.String(),
+						Uid:      obj.Uid,
+					},
+				},
+			}
+		case pb.CrossInstanceReplicationConfig_NONE, pb.CrossInstanceReplicationConfig_INSTANCE_ROLE_UNSPECIFIED:
+			obj.CrossInstanceReplicationConfig = nil
+		default:
+			return fmt.Errorf("unknown instance role %v", crr.InstanceRole)
+		}
 	}
 	return nil
 }
@@ -242,22 +334,34 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 
 	for _, path := range paths {
 		switch path {
+		case "labels":
+			obj.Labels = req.Instance.Labels
 		case "replicaCount":
 			obj.ReplicaCount = req.Instance.ReplicaCount
 		case "shardCount":
 			obj.ShardCount = req.Instance.ShardCount
-		case "deletionProtectionEnabled":
-			obj.DeletionProtectionEnabled = req.Instance.DeletionProtectionEnabled
-		case "persistenceConfig":
-			obj.PersistenceConfig = req.Instance.PersistenceConfig
-		case "engineConfigs":
-			obj.EngineConfigs = req.Instance.EngineConfigs
-		case "endpoints":
-			obj.Endpoints = req.Instance.Endpoints
-		case "labels":
-			obj.Labels = req.Instance.Labels
 		case "nodeType":
 			obj.NodeType = req.Instance.NodeType
+		case "persistenceConfig":
+			obj.PersistenceConfig = req.Instance.PersistenceConfig
+		case "engineVersion":
+			obj.EngineVersion = req.Instance.EngineVersion
+		case "engineConfigs":
+			obj.EngineConfigs = req.Instance.EngineConfigs
+		case "deletionProtectionEnabled":
+			obj.DeletionProtectionEnabled = req.Instance.DeletionProtectionEnabled
+		case "endpoints":
+			obj.Endpoints = req.Instance.Endpoints
+		case "maintenancePolicy":
+			obj.MaintenancePolicy = req.Instance.MaintenancePolicy
+		case "automatedBackupConfig":
+			obj.AutomatedBackupConfig = req.Instance.AutomatedBackupConfig
+		case "crossInstanceReplicationConfig":
+			obj.CrossInstanceReplicationConfig = req.Instance.CrossInstanceReplicationConfig
+		case "gcsBucket":
+			obj.ImportSources = &pb.Instance_GcsSource{GcsSource: req.Instance.GetGcsSource()}
+		case "managedBackupSource":
+			obj.ImportSources = &pb.Instance_ManagedBackupSource_{ManagedBackupSource: req.Instance.GetManagedBackupSource()}
 
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not supported by mockgcp", path)
@@ -268,6 +372,8 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		return nil, err
 	}
 
+	obj.State = pb.Instance_ACTIVE
+	obj.UpdateTime = timestamppb.New(time.Now())
 	if err := r.storage.Update(ctx, fqn, obj); err != nil {
 		return nil, err
 	}

--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -24,13 +24,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/common/projects"
 	pb "github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/generated/mockgcp/cloud/memorystore/v1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mocks"
-	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
 type instanceServer struct {
@@ -55,6 +55,7 @@ func (r *instanceServer) GetInstance(ctx context.Context, req *pb.GetInstanceReq
 	}
 
 	retObj := proto.Clone(obj).(*pb.Instance)
+	retObj.State = pb.Instance_ACTIVE
 	return retObj, nil
 }
 
@@ -73,7 +74,7 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 	obj.Name = fqn
 	obj.CreateTime = timestamppb.New(now)
 	obj.UpdateTime = timestamppb.New(now)
-	obj.State = pb.Instance_ACTIVE
+	obj.State = pb.Instance_CREATING
 
 	if err := r.populateDefaultsForInstance(name, obj); err != nil {
 		return nil, err
@@ -83,17 +84,13 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 		return nil, err
 	}
 
-	updatedObj := proto.Clone(obj).(*pb.Instance)
-	updatedObj.CreateTime = nil
-	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
-
 	metadata := &pb.OperationMetadata{
 		ApiVersion: "v1",
 		CreateTime: timestamppb.New(now),
 		Target:     fqn,
 		Verb:       "create",
 	}
-
+	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
 	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
 		metadata.EndTime = timestamppb.Now()
 
@@ -249,6 +246,9 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 		crr.UpdateTime = timestamppb.New(time.Now())
 		switch crr.InstanceRole {
 		case pb.CrossInstanceReplicationConfig_PRIMARY:
+			if len(crr.SecondaryInstances) == 0 {
+				return status.Errorf(codes.InvalidArgument, "no secondary instances specified")
+			}
 			crr.PrimaryInstance = nil
 			crr.Membership = &pb.CrossInstanceReplicationConfig_Membership{
 				PrimaryInstance: &pb.CrossInstanceReplicationConfig_RemoteInstance{
@@ -269,6 +269,9 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 				})
 			}
 		case pb.CrossInstanceReplicationConfig_SECONDARY:
+			if crr.PrimaryInstance == nil {
+				return status.Errorf(codes.InvalidArgument, "no primary instance specified")
+			}
 			primaryName, err := s.parseInstanceName(crr.PrimaryInstance.Instance)
 			if err != nil {
 				return err
@@ -310,7 +313,6 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 	if err := r.storage.Get(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
-	obj.State = pb.Instance_UPDATING
 
 	// Required. Mask of fields to update. At least one path must be supplied in
 	// this field. The elements of the repeated paths field may only include these
@@ -358,7 +360,7 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 			obj.AutomatedBackupConfig = req.Instance.AutomatedBackupConfig
 		case "crossInstanceReplicationConfig":
 			obj.CrossInstanceReplicationConfig = req.Instance.CrossInstanceReplicationConfig
-		case "gcsBucket":
+		case "gcsSource":
 			obj.ImportSources = &pb.Instance_GcsSource{GcsSource: req.Instance.GetGcsSource()}
 		case "managedBackupSource":
 			obj.ImportSources = &pb.Instance_ManagedBackupSource_{ManagedBackupSource: req.Instance.GetManagedBackupSource()}
@@ -372,7 +374,7 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		return nil, err
 	}
 
-	obj.State = pb.Instance_ACTIVE
+	obj.State = pb.Instance_UPDATING
 	obj.UpdateTime = timestamppb.New(time.Now())
 	if err := r.storage.Update(ctx, fqn, obj); err != nil {
 		return nil, err
@@ -477,13 +479,18 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 		backupCollectionName = *instanceObj.BackupCollection
 	} else {
 		backupCollectionName = fmt.Sprintf("projects/%s/locations/%s/backupCollections/backupCollection-%s", instanceName.Project.ID, instanceName.Location, instanceName.Name)
-		instanceObj.BackupCollection = direct.LazyPtr(backupCollectionName)
+		instanceObj.BackupCollection = mocks.PtrTo(backupCollectionName)
 		if err := r.storage.Update(ctx, instanceFqn, instanceObj); err != nil {
 			return nil, err
 		}
 	}
 
-	reqName := fmt.Sprintf("%s/backups/%s", backupCollectionName, req.GetBackupId())
+	backupID := req.GetBackupId()
+	if backupID == "" {
+		backupID = fmt.Sprintf("%s-backup", instanceName.Name)
+	}
+
+	reqName := fmt.Sprintf("%s/backups/%s", backupCollectionName, backupID)
 	name, err := r.parseBackupName(reqName)
 	if err != nil {
 		return nil, err
@@ -492,17 +499,23 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 	fqn := name.String()
 	now := time.Now()
 
+	// Default TTL is 100 years
+	ttl := durationpb.New(100 * 365 * 24 * time.Hour)
+	if req.GetTtl() != nil {
+		ttl = req.GetTtl()
+	}
+
 	obj := &pb.Backup{
 		BackupType: pb.Backup_ON_DEMAND,
 		BackupFiles: []*pb.BackupFile{
 			&pb.BackupFile{
-				FileName:   fmt.Sprintf("file-%s.rdb", req.GetBackupId()),
+				FileName:   fmt.Sprintf("file-%s.rdb", backupID),
 				SizeBytes:  141,
 				CreateTime: timestamppb.New(now),
 			},
 		},
 		CreateTime:     timestamppb.New(now),
-		ExpireTime:     timestamppb.New(now),
+		ExpireTime:     timestamppb.New(now.Add(ttl.AsDuration())),
 		EngineVersion:  instanceObj.EngineVersion,
 		Instance:       instanceName.String(),
 		InstanceUid:    instanceObj.Uid,
@@ -511,11 +524,7 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 		ShardCount:     instanceObj.ShardCount,
 		State:          pb.Backup_ACTIVE,
 		TotalSizeBytes: 141,
-		Uid:            fmt.Sprintf("backup-%s", req.GetBackupId()),
-	}
-	if req.GetTtl() != nil {
-		ttl := now.Add(req.GetTtl().AsDuration())
-		obj.ExpireTime = timestamppb.New(ttl)
+		Uid:            fmt.Sprintf("backup-%s", backupID),
 	}
 	if err := r.storage.Create(ctx, fqn, obj); err != nil {
 		return nil, err

--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -145,11 +145,7 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 				if autoConnection != nil {
 					obj.Endpoints[0].Connections = append(obj.Endpoints[0].Connections, &pb.Instance_ConnectionDetail{
 						Connection: &pb.Instance_ConnectionDetail_PscAutoConnection{
-							PscAutoConnection: &pb.PscAutoConnection{
-								Ports:     autoConnection.Ports,
-								Network:   autoConnection.Network,
-								ProjectId: autoConnection.ProjectId,
-							},
+							PscAutoConnection: proto.Clone(autoConnection).(*pb.PscAutoConnection),
 						},
 					})
 				}
@@ -244,6 +240,10 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 	}
 	if obj.AutomatedBackupConfig.AutomatedBackupMode == pb.AutomatedBackupConfig_AUTOMATED_BACKUP_MODE_UNSPECIFIED {
 		obj.AutomatedBackupConfig.AutomatedBackupMode = pb.AutomatedBackupConfig_DISABLED
+	}
+	if obj.MaintenancePolicy != nil && obj.MaintenancePolicy.CreateTime == nil {
+		obj.MaintenancePolicy.CreateTime = timestamppb.New(time.Now())
+		obj.MaintenancePolicy.UpdateTime = obj.MaintenancePolicy.CreateTime
 	}
 	if crr := obj.CrossInstanceReplicationConfig; crr != nil {
 		switch crr.InstanceRole {
@@ -359,11 +359,17 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		case "endpoints":
 			obj.Endpoints = req.Instance.Endpoints
 		case "maintenancePolicy":
-			obj.MaintenancePolicy = req.Instance.MaintenancePolicy
+			if req.Instance.MaintenancePolicy != nil {
+				obj.MaintenancePolicy = req.Instance.MaintenancePolicy
+				obj.MaintenancePolicy.UpdateTime = timestamppb.New(now)
+			}
 		case "automatedBackupConfig":
 			obj.AutomatedBackupConfig = req.Instance.AutomatedBackupConfig
 		case "crossInstanceReplicationConfig":
-			obj.CrossInstanceReplicationConfig = req.Instance.CrossInstanceReplicationConfig
+			if req.Instance.CrossInstanceReplicationConfig != nil {
+				obj.CrossInstanceReplicationConfig = req.Instance.CrossInstanceReplicationConfig
+				obj.CrossInstanceReplicationConfig.UpdateTime = timestamppb.New(now)
+			}
 		case "gcsSource":
 			if gcsSource := req.Instance.GetGcsSource(); gcsSource != nil {
 				obj.ImportSources = &pb.Instance_GcsSource{GcsSource: gcsSource}

--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -55,7 +55,6 @@ func (r *instanceServer) GetInstance(ctx context.Context, req *pb.GetInstanceReq
 	}
 
 	retObj := proto.Clone(obj).(*pb.Instance)
-	retObj.State = pb.Instance_ACTIVE
 	return retObj, nil
 }
 
@@ -98,6 +97,7 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 		// pscConfigs is not included in the response
 		retObj.PscAutoConnections = nil
 		retObj.State = pb.Instance_ACTIVE
+		r.storage.Update(ctx, fqn, retObj)
 		return retObj, nil
 	})
 }
@@ -172,7 +172,7 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 					autoConnection.PscConnectionId = fmt.Sprintf("%d", pscConnectionID)
 					autoConnection.ConnectionType = attachmentDetails.ConnectionType
 					autoConnection.ServiceAttachment = attachmentDetails.ServiceAttachment
-					if autoConnection.Ports == nil {
+					if autoConnection.Ports == nil && autoConnection.ConnectionType != pb.ConnectionType_CONNECTION_TYPE_UNSPECIFIED {
 						autoConnection.Ports = &pb.PscAutoConnection_Port{
 							Port: 6379,
 						}
@@ -188,6 +188,11 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 					userConnection.ProjectId = network.Project.ID
 					userConnection.PscConnectionStatus = pb.PscConnectionStatus_ACTIVE
 					userConnection.ConnectionType = attachmentDetails.ConnectionType
+					if userConnection.Ports == nil && userConnection.ConnectionType != pb.ConnectionType_CONNECTION_TYPE_UNSPECIFIED {
+						userConnection.Ports = &pb.PscConnection_Port{
+							Port: 6379,
+						}
+					}
 				}
 			}
 		}
@@ -395,6 +400,7 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		retObj.PscAutoConnections = nil
 		retObj.State = pb.Instance_ACTIVE
 		retObj.UpdateTime = timestamppb.New(time.Now())
+		r.storage.Update(ctx, fqn, retObj)
 		return retObj, nil
 	})
 }

--- a/mockgcp/mockmemorystore/instance.go
+++ b/mockgcp/mockmemorystore/instance.go
@@ -94,8 +94,6 @@ func (r *instanceServer) CreateInstance(ctx context.Context, req *pb.CreateInsta
 		metadata.EndTime = timestamppb.Now()
 
 		retObj := proto.Clone(obj).(*pb.Instance)
-		// pscConfigs is not included in the response
-		retObj.PscAutoConnections = nil
 		retObj.State = pb.Instance_ACTIVE
 		r.storage.Update(ctx, fqn, retObj)
 		return retObj, nil
@@ -118,7 +116,7 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 	if obj.Mode == pb.Instance_MODE_UNSPECIFIED {
 		obj.Mode = pb.Instance_CLUSTER
 	}
-	if obj.PscAttachmentDetails == nil {
+	if len(obj.PscAttachmentDetails) == 0 {
 		var types []pb.ConnectionType
 		switch obj.GetMode() {
 		case pb.Instance_CLUSTER:
@@ -140,7 +138,7 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 		}
 	}
 	if len(obj.Endpoints) > 0 {
-		if len(obj.Endpoints[0].Connections) > 0 {
+		if obj.Endpoints[0] != nil && len(obj.Endpoints[0].Connections) > 0 {
 			connections := obj.Endpoints[0].Connections
 			if len(connections) == 1 {
 				autoConnection := connections[0].GetPscAutoConnection()
@@ -248,7 +246,6 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 		obj.AutomatedBackupConfig.AutomatedBackupMode = pb.AutomatedBackupConfig_DISABLED
 	}
 	if crr := obj.CrossInstanceReplicationConfig; crr != nil {
-		crr.UpdateTime = timestamppb.New(time.Now())
 		switch crr.InstanceRole {
 		case pb.CrossInstanceReplicationConfig_PRIMARY:
 			if len(crr.SecondaryInstances) == 0 {
@@ -288,7 +285,7 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 					Uid:      crr.PrimaryInstance.Uid,
 				},
 				SecondaryInstances: []*pb.CrossInstanceReplicationConfig_RemoteInstance{
-					&pb.CrossInstanceReplicationConfig_RemoteInstance{
+					{
 						Instance: name.String(),
 						Uid:      obj.Uid,
 					},
@@ -300,6 +297,8 @@ func (s *instanceServer) populateDefaultsForInstance(name *instanceName, obj *pb
 			return fmt.Errorf("unknown instance role %v", crr.InstanceRole)
 		}
 	}
+	// PscAutoConnections is not included in the response
+	obj.PscAutoConnections = nil
 	return nil
 }
 
@@ -366,10 +365,13 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		case "crossInstanceReplicationConfig":
 			obj.CrossInstanceReplicationConfig = req.Instance.CrossInstanceReplicationConfig
 		case "gcsSource":
-			obj.ImportSources = &pb.Instance_GcsSource{GcsSource: req.Instance.GetGcsSource()}
+			if gcsSource := req.Instance.GetGcsSource(); gcsSource != nil {
+				obj.ImportSources = &pb.Instance_GcsSource{GcsSource: gcsSource}
+			}
 		case "managedBackupSource":
-			obj.ImportSources = &pb.Instance_ManagedBackupSource_{ManagedBackupSource: req.Instance.GetManagedBackupSource()}
-
+			if managedBackupSource := req.Instance.GetManagedBackupSource(); managedBackupSource != nil {
+				obj.ImportSources = &pb.Instance_ManagedBackupSource_{ManagedBackupSource: managedBackupSource}
+			}
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "update_mask path %q not supported by mockgcp", path)
 		}
@@ -396,8 +398,6 @@ func (r *instanceServer) UpdateInstance(ctx context.Context, req *pb.UpdateInsta
 		metadata.EndTime = timestamppb.Now()
 
 		retObj := proto.Clone(obj).(*pb.Instance)
-		// pscConfigs is not included in the response
-		retObj.PscAutoConnections = nil
 		retObj.State = pb.Instance_ACTIVE
 		retObj.UpdateTime = timestamppb.New(time.Now())
 		r.storage.Update(ctx, fqn, retObj)
@@ -427,8 +427,8 @@ func (r *instanceServer) DeleteInstance(ctx context.Context, req *pb.DeleteInsta
 		return nil, status.Errorf(codes.FailedPrecondition, "The instance is deletion protected. Please disable deletion protection to delete the instance. To disable, update DeleteProtectionEnabled to false via the Update API")
 	}
 
-	deletedObj := &pb.Instance{}
-	if err := r.storage.Delete(ctx, fqn, deletedObj); err != nil {
+	obj.State = pb.Instance_DELETING
+	if err := r.storage.Update(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
 
@@ -441,6 +441,8 @@ func (r *instanceServer) DeleteInstance(ctx context.Context, req *pb.DeleteInsta
 	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
 	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
 		metadata.EndTime = timestamppb.Now()
+		deletedObj := &pb.Instance{}
+		r.storage.Delete(ctx, fqn, deletedObj)
 		return &emptypb.Empty{}, nil
 	})
 }
@@ -493,7 +495,7 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 
 	backupID := req.GetBackupId()
 	if backupID == "" {
-		backupID = fmt.Sprintf("%s-backup", instanceName.Name)
+		backupID = time.Now().Format("20060102150405")
 	}
 
 	reqName := fmt.Sprintf("%s/backups/%s", backupCollectionName, backupID)
@@ -514,7 +516,7 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 	obj := &pb.Backup{
 		BackupType: pb.Backup_ON_DEMAND,
 		BackupFiles: []*pb.BackupFile{
-			&pb.BackupFile{
+			{
 				FileName:   fmt.Sprintf("file-%s.rdb", backupID),
 				SizeBytes:  141,
 				CreateTime: timestamppb.New(now),
@@ -528,7 +530,7 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 		Name:           fqn,
 		NodeType:       instanceObj.NodeType,
 		ShardCount:     instanceObj.ShardCount,
-		State:          pb.Backup_ACTIVE,
+		State:          pb.Backup_CREATING,
 		TotalSizeBytes: 141,
 		Uid:            fmt.Sprintf("backup-%s", backupID),
 	}
@@ -546,6 +548,8 @@ func (r *instanceServer) BackupInstance(ctx context.Context, req *pb.BackupInsta
 
 	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
 		metadata.EndTime = timestamppb.Now()
+		obj.State = pb.Backup_ACTIVE
+		r.storage.Update(ctx, fqn, obj)
 		return proto.Clone(instanceObj).(*pb.Instance), nil
 	})
 }
@@ -568,8 +572,8 @@ func (r *instanceServer) DeleteBackup(ctx context.Context, req *pb.DeleteBackupR
 		return nil, err
 	}
 
-	deletedObj := &pb.Backup{}
-	if err := r.storage.Delete(ctx, fqn, deletedObj); err != nil {
+	obj.State = pb.Backup_DELETING
+	if err := r.storage.Update(ctx, fqn, obj); err != nil {
 		return nil, err
 	}
 
@@ -582,6 +586,8 @@ func (r *instanceServer) DeleteBackup(ctx context.Context, req *pb.DeleteBackupR
 	prefix := fmt.Sprintf("projects/%s/locations/%s", name.Project.ID, name.Location)
 	return r.operations.StartLRO(ctx, prefix, metadata, func() (proto.Message, error) {
 		metadata.EndTime = timestamppb.Now()
+		deletedObj := &pb.Backup{}
+		r.storage.Delete(ctx, fqn, deletedObj)
 		return &emptypb.Empty{}, nil
 	})
 }

--- a/mockgcp/mockmemorystore/normalize.go
+++ b/mockgcp/mockmemorystore/normalize.go
@@ -21,8 +21,12 @@ import (
 var _ mockgcpregistry.SupportsNormalization = &MockService{}
 
 func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.NormalizingVisitor) {
-	replacements.ReplacePath(".pscAttachmentDetails[].serviceAttachment", "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment")
-	replacements.ReplacePath(".response.pscAttachmentDetails[].serviceAttachment", "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment")
+	replacements.ReplacePath(".backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".response.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".response.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".status.observedState.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".status.observedState.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
 }
 
 func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {

--- a/mockgcp/mockmemorystore/normalize.go
+++ b/mockgcp/mockmemorystore/normalize.go
@@ -29,9 +29,13 @@ func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.
 	replacements.ReplacePath(".backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".expireTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".maintenancePolicy.createTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".maintenancePolicy.updateTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.expireTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".response.maintenancePolicy.createTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".response.maintenancePolicy.updateTime", "2024-04-01T12:34:56.123456Z")
 }
 
 func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {

--- a/mockgcp/mockmemorystore/normalize.go
+++ b/mockgcp/mockmemorystore/normalize.go
@@ -15,16 +15,23 @@
 package mockmemorystore
 
 import (
+	"strings"
+
 	"github.com/GoogleCloudPlatform/k8s-config-connector/mockgcp/mockgcpregistry"
 )
 
 var _ mockgcpregistry.SupportsNormalization = &MockService{}
 
 func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.NormalizingVisitor) {
+	if !strings.HasPrefix(url, "https://memorystore.googleapis.com") {
+		return
+	}
 	replacements.ReplacePath(".backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".expireTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
+	replacements.ReplacePath(".response.expireTime", "2024-04-01T12:34:56.123456Z")
 }
 
 func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {

--- a/mockgcp/mockmemorystore/normalize.go
+++ b/mockgcp/mockmemorystore/normalize.go
@@ -25,8 +25,6 @@ func (s *MockService) ConfigureVisitor(url string, replacements mockgcpregistry.
 	replacements.ReplacePath(".crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
 	replacements.ReplacePath(".response.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
-	replacements.ReplacePath(".status.observedState.backupFiles[].createTime", "2024-04-01T12:34:56.123456Z")
-	replacements.ReplacePath(".status.observedState.crossInstanceReplicationConfig.updateTime", "2024-04-01T12:34:56.123456Z")
 }
 
 func (s *MockService) Previsit(event mockgcpregistry.Event, replacements mockgcpregistry.NormalizingVisitor) {

--- a/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
@@ -1,0 +1,278 @@
+POST https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}:backup?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+Content-Type: application/json
+
+{
+  "backupId": "test-backup-${uniqueId}",
+  "ttl": "86400s"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
+    "verb": "backup"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
+    "verb": "backup"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
+    "authorizationMode": "AUTH_DISABLED",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
+    "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260217_02_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
+    "engineVersion": "VALKEY_7_2",
+    "mode": "CLUSTER_DISABLED",
+    "name": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
+    "nodeConfig": {
+      "sizeGb": 13
+    },
+    "nodeType": "HIGHMEM_MEDIUM",
+    "persistenceConfig": {
+      "mode": "DISABLED"
+    },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_PRIMARY",
+        "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+      },
+      {
+        "connectionType": "CONNECTION_TYPE_READER",
+        "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+      }
+    ],
+    "replicaCount": 0,
+    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
+    "shardCount": 1,
+    "state": "ACTIVE",
+    "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
+    "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
+    "zoneDistributionConfig": {
+      "mode": "SINGLE_ZONE",
+      "zone": "us-central1-a"
+    }
+  }
+}
+
+---
+
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "authorizationMode": "AUTH_DISABLED",
+  "automatedBackupConfig": {
+    "automatedBackupMode": "DISABLED"
+  },
+  "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "deletionProtectionEnabled": false,
+  "effectiveMaintenanceVersion": "MEMORYSTORE_20260217_02_00",
+  "encryptionInfo": {
+    "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+  },
+  "engineVersion": "VALKEY_7_2",
+  "mode": "CLUSTER_DISABLED",
+  "name": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
+  "nodeConfig": {
+    "sizeGb": 13
+  },
+  "nodeType": "HIGHMEM_MEDIUM",
+  "persistenceConfig": {
+    "mode": "DISABLED"
+  },
+  "pscAttachmentDetails": [
+    {
+      "connectionType": "CONNECTION_TYPE_PRIMARY",
+      "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+    },
+    {
+      "connectionType": "CONNECTION_TYPE_READER",
+      "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+    }
+  ],
+  "replicaCount": 0,
+  "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
+  "shardCount": 1,
+  "state": "ACTIVE",
+  "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
+  "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "zoneDistributionConfig": {
+    "mode": "SINGLE_ZONE",
+    "zone": "us-central1-a"
+  }
+}
+
+---
+
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "backupFiles": [
+    {
+      "createTime": "2026-03-18T18:17:22.249Z",
+      "fileName": "422194abb71048816e6ac32e9513b3ec311e9634.rdb",
+      "sizeBytes": "141"
+    }
+  ],
+  "backupType": "ON_DEMAND",
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "encryptionInfo": {
+    "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION",
+    "lastUpdateTime": "2026-03-18T18:17:22.249Z"
+  },
+  "engineVersion": "VALKEY_7_2",
+  "expireTime": "2024-04-01T12:34:56.123456Z",
+  "instance": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
+  "instanceUid": "c8ea3fab-2172-4a2b-8c0f-664b4b11177f",
+  "name": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
+  "nodeType": "HIGHMEM_MEDIUM",
+  "shardCount": 1,
+  "state": "ACTIVE",
+  "totalSizeBytes": "141",
+  "uid": "111111111111111111111"
+}
+
+---
+
+DELETE https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": false,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
+}
+
+---
+
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
+    "target": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}

--- a/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
@@ -89,7 +89,7 @@ X-Xss-Protection: 0
     ],
     "replicaCount": 0,
     "shardCount": 1,
-    "state": "CREATING",
+    "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z",

--- a/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
@@ -223,3 +223,36 @@ X-Xss-Protection: 0
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
 }
+
+---
+
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}?alt=json
+Accept: application/json
+Authorization: (removed)
+Connection: keep-alive
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
+    "apiVersion": "v1",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "endTime": "2024-04-01T12:34:56.123456Z",
+    "target": "projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}/backups/test-backup-${uniqueId}",
+    "verb": "delete"
+  },
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.protobuf.Empty"
+  }
+}

--- a/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
@@ -89,7 +89,7 @@ X-Xss-Protection: 0
     ],
     "replicaCount": 0,
     "shardCount": 1,
-    "state": "ACTIVE",
+    "state": "CREATING",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
     "uid": "111111111111111111111",
     "updateTime": "2024-04-01T12:34:56.123456Z",

--- a/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/_http.log
@@ -20,12 +20,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
     "verb": "backup"
   },
@@ -56,7 +54,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
     "verb": "backup"
   },
@@ -67,13 +64,9 @@ X-Xss-Protection: 0
     "automatedBackupConfig": {
       "automatedBackupMode": "DISABLED"
     },
-    "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f",
+    "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260217_02_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "engineVersion": "VALKEY_7_2",
     "mode": "CLUSTER_DISABLED",
     "name": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
@@ -87,15 +80,14 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_PRIMARY",
-        "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+        "serviceAttachment": "projects/tp-test-instance-${uniqueId}/regions/us-central1/serviceAttachments/sa-test-instance-${uniqueId}"
       },
       {
         "connectionType": "CONNECTION_TYPE_READER",
-        "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+        "serviceAttachment": "projects/tp-test-instance-${uniqueId}/regions/us-central1/serviceAttachments/sa-test-instance-${uniqueId}-2"
       }
     ],
     "replicaCount": 0,
-    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 1,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -130,13 +122,9 @@ X-Xss-Protection: 0
   "automatedBackupConfig": {
     "automatedBackupMode": "DISABLED"
   },
-  "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f",
+  "backupCollection": "projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}",
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
-  "effectiveMaintenanceVersion": "MEMORYSTORE_20260217_02_00",
-  "encryptionInfo": {
-    "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-  },
   "engineVersion": "VALKEY_7_2",
   "mode": "CLUSTER_DISABLED",
   "name": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
@@ -150,15 +138,14 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": "CONNECTION_TYPE_PRIMARY",
-      "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+      "serviceAttachment": "projects/tp-test-instance-${uniqueId}/regions/us-central1/serviceAttachments/sa-test-instance-${uniqueId}"
     },
     {
       "connectionType": "CONNECTION_TYPE_READER",
-      "serviceAttachment": "projects/1234567890/regions/us-central1/serviceAttachments/sampleServiceAttachment"
+      "serviceAttachment": "projects/tp-test-instance-${uniqueId}/regions/us-central1/serviceAttachments/sa-test-instance-${uniqueId}-2"
     }
   ],
   "replicaCount": 0,
-  "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
   "shardCount": 1,
   "state": "ACTIVE",
   "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -172,7 +159,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}?alt=json
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}/backups/test-backup-${uniqueId}?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
@@ -190,22 +177,18 @@ X-Xss-Protection: 0
 {
   "backupFiles": [
     {
-      "createTime": "2026-03-18T18:17:22.249Z",
-      "fileName": "422194abb71048816e6ac32e9513b3ec311e9634.rdb",
+      "createTime": "2024-04-01T12:34:56.123456Z",
+      "fileName": "file-test-backup-${uniqueId}.rdb",
       "sizeBytes": "141"
     }
   ],
   "backupType": "ON_DEMAND",
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "encryptionInfo": {
-    "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION",
-    "lastUpdateTime": "2026-03-18T18:17:22.249Z"
-  },
   "engineVersion": "VALKEY_7_2",
   "expireTime": "2024-04-01T12:34:56.123456Z",
   "instance": "projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId}",
-  "instanceUid": "c8ea3fab-2172-4a2b-8c0f-664b4b11177f",
-  "name": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
+  "instanceUid": "instance-test-instance-${uniqueId}",
+  "name": "projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}/backups/test-backup-${uniqueId}",
   "nodeType": "HIGHMEM_MEDIUM",
   "shardCount": 1,
   "state": "ACTIVE",
@@ -215,7 +198,7 @@ X-Xss-Protection: 0
 
 ---
 
-DELETE https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}?alt=json
+DELETE https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}/backups/test-backup-${uniqueId}?alt=json
 Accept: application/json
 Authorization: (removed)
 Connection: keep-alive
@@ -231,48 +214,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
-    "target": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
+    "target": "projects/${projectId}/locations/us-central1/backupCollections/backupCollection-test-instance-${uniqueId}/backups/test-backup-${uniqueId}",
     "verb": "delete"
   },
   "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
-}
-
----
-
-GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}?alt=json
-Accept: application/json
-Authorization: (removed)
-Connection: keep-alive
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "done": true,
-  "metadata": {
-    "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
-    "apiVersion": "v1",
-    "createTime": "2024-04-01T12:34:56.123456Z",
-    "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
-    "target": "projects/${projectId}/locations/us-central1/backupCollections/ee37999e-2b25-44b8-a151-b994a309b58f/backups/test-backup-${uniqueId}",
-    "verb": "delete"
-  },
-  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
-  "response": {
-    "@type": "type.googleapis.com/google.protobuf.Empty"
-  }
 }

--- a/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
@@ -1,6 +1,8 @@
+- pre: mkdir -p /tmp/tmp.${uniqueId}
 - pre: gcloud memorystore instances create test-instance-${uniqueId} --location=us-central1 --project=${projectId} --mode=cluster-disabled --zone-distribution-config-mode=single-zone --zone-distribution-config=us-central1-a --shard-count=1 --replica-count=0
 - exec: gcloud memorystore instances backup projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --backup-id=test-backup-${uniqueId} --ttl=1d
-- pre: gcloud memorystore instances describe projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --format="value(backupCollection)" | sed 's|.*/backupCollections/||' > /tmp/backup_collection_id-${uniqueId}
-- exec: gcloud memorystore backup-collections backups describe projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id-${uniqueId})/backups/test-backup-${uniqueId}
-- exec: gcloud memorystore backup-collections backups delete projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id-${uniqueId})/backups/test-backup-${uniqueId} --quiet
+- pre: gcloud memorystore instances describe projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --format="value(backupCollection)" | sed 's|.*/backupCollections/||' > /tmp/tmp.${uniqueId}/backup_collection_id
+- exec: gcloud memorystore backup-collections backups describe projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/tmp.${uniqueId}/backup_collection_id)/backups/test-backup-${uniqueId}
+- exec: gcloud memorystore backup-collections backups delete projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/tmp.${uniqueId}/backup_collection_id)/backups/test-backup-${uniqueId} --quiet
 - post: gcloud memorystore instances delete projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --quiet --async
+- post: rm -rf /tmp/tmp.${uniqueId}

--- a/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
@@ -1,0 +1,8 @@
+- pre: gcloud memorystore instances create test-instance-${uniqueId} --location=us-central1 --project=${projectId} --mode=cluster-disabled --zone-distribution-config-mode=single-zone --zone-distribution-config=us-central1-a --shard-count=1 --replica-count=0
+- exec: gcloud memorystore instances backup projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --backup-id=test-backup-${uniqueId} --ttl=1d
+- pre: |
+    rm -f /tmp/backup_collection_id
+    gcloud memorystore instances describe projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --format="value(backupCollection)" | sed 's|.*/backupCollections/||' > /tmp/backup_collection_id
+- exec: gcloud memorystore backup-collections backups describe projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id)/backups/test-backup-${uniqueId}
+- exec: gcloud memorystore backup-collections backups delete projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id)/backups/test-backup-${uniqueId} --quiet --async
+- post: gcloud memorystore instances delete projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --quiet --async

--- a/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
+++ b/mockgcp/mockmemorystore/testdata/backup/crud/script.yaml
@@ -1,8 +1,6 @@
 - pre: gcloud memorystore instances create test-instance-${uniqueId} --location=us-central1 --project=${projectId} --mode=cluster-disabled --zone-distribution-config-mode=single-zone --zone-distribution-config=us-central1-a --shard-count=1 --replica-count=0
 - exec: gcloud memorystore instances backup projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --backup-id=test-backup-${uniqueId} --ttl=1d
-- pre: |
-    rm -f /tmp/backup_collection_id
-    gcloud memorystore instances describe projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --format="value(backupCollection)" | sed 's|.*/backupCollections/||' > /tmp/backup_collection_id
-- exec: gcloud memorystore backup-collections backups describe projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id)/backups/test-backup-${uniqueId}
-- exec: gcloud memorystore backup-collections backups delete projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id)/backups/test-backup-${uniqueId} --quiet --async
+- pre: gcloud memorystore instances describe projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --format="value(backupCollection)" | sed 's|.*/backupCollections/||' > /tmp/backup_collection_id-${uniqueId}
+- exec: gcloud memorystore backup-collections backups describe projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id-${uniqueId})/backups/test-backup-${uniqueId}
+- exec: gcloud memorystore backup-collections backups delete projects/${projectId}/locations/us-central1/backupCollections/$(cat /tmp/backup_collection_id-${uniqueId})/backups/test-backup-${uniqueId} --quiet
 - post: gcloud memorystore instances delete projects/${projectId}/locations/us-central1/instances/test-instance-${uniqueId} --quiet --async

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
@@ -43,12 +43,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
@@ -79,7 +77,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
@@ -92,10 +89,6 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "engineVersion": "VALKEY_7_2",
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -109,15 +102,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
       }
     ],
     "replicaCount": 0,
-    "satisfiesPzi": false,
-    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 3,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -153,10 +144,6 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
-  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-  "encryptionInfo": {
-    "encryptionType": 1
-  },
   "engineVersion": "VALKEY_7_2",
   "mode": 2,
   "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -170,15 +157,13 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
     },
     {
-      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
     }
   ],
   "replicaCount": 0,
-  "satisfiesPzi": false,
-  "serverCaMode": 0,
   "shardCount": 3,
   "state": 2,
   "transitEncryptionMode": 1,
@@ -212,12 +197,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "update"
   },
@@ -248,7 +231,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "update"
   },
@@ -261,10 +243,6 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "engineVersion": "VALKEY_7_2",
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -278,15 +256,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
       }
     ],
     "replicaCount": 0,
-    "satisfiesPzi": false,
-    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 10,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -322,10 +298,6 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
-  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-  "encryptionInfo": {
-    "encryptionType": 1
-  },
   "engineVersion": "VALKEY_7_2",
   "mode": 2,
   "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -339,15 +311,13 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
     },
     {
-      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
     }
   ],
   "replicaCount": 0,
-  "satisfiesPzi": false,
-  "serverCaMode": 0,
   "shardCount": 10,
   "state": 2,
   "transitEncryptionMode": 1,
@@ -376,12 +346,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "delete"
   },
@@ -412,7 +380,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "delete"
   },

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
@@ -50,15 +50,15 @@ X-Xss-Protection: 0
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
-  "name": "projects/${projectNumber}/locations/us-central1/operations/${operationID}"
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
 }
 
 ---
 
-GET https://memorystore.googleapis.com/v1/projects/${projectNumber}/locations/us-central1/operations/${operationID}
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectNumber}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -80,10 +80,13 @@ X-Xss-Protection: 0
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
-  "name": "projects/${projectNumber}/locations/us-central1/operations/${operationID}",
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "AUTH_DISABLED",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "engineVersion": "VALKEY_7_2",
@@ -96,11 +99,21 @@ X-Xss-Protection: 0
     "persistenceConfig": {
       "mode": "DISABLED"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 0,
     "shardCount": 3,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
     "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
     "zoneDistributionConfig": {
       "mode": "MULTI_ZONE"
     }
@@ -126,6 +139,9 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 1,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "engineVersion": "VALKEY_7_2",
@@ -138,11 +154,21 @@ X-Xss-Protection: 0
   "persistenceConfig": {
     "mode": 1
   },
+  "pscAttachmentDetails": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+    },
+    {
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+    }
+  ],
   "replicaCount": 0,
   "shardCount": 3,
-  "state": 1,
+  "state": 2,
   "transitEncryptionMode": 1,
   "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
   "zoneDistributionConfig": {
     "mode": 1
   }
@@ -212,6 +238,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "AUTH_DISABLED",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "engineVersion": "VALKEY_7_2",
@@ -224,6 +253,15 @@ X-Xss-Protection: 0
     "persistenceConfig": {
       "mode": "DISABLED"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 0,
     "shardCount": 10,
     "state": "ACTIVE",
@@ -255,6 +293,9 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 1,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "engineVersion": "VALKEY_7_2",
@@ -267,11 +308,21 @@ X-Xss-Protection: 0
   "persistenceConfig": {
     "mode": 1
   },
+  "pscAttachmentDetails": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+    },
+    {
+      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+    }
+  ],
   "replicaCount": 0,
   "shardCount": 10,
-  "state": 3,
+  "state": 2,
   "transitEncryptionMode": 1,
   "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
   "zoneDistributionConfig": {
     "mode": 1
   }

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/basicmemorystoreinstance/_http.log
@@ -43,10 +43,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
@@ -77,6 +79,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "create"
   },
@@ -89,6 +92,10 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "engineVersion": "VALKEY_7_2",
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -102,13 +109,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
       }
     ],
     "replicaCount": 0,
+    "satisfiesPzi": false,
+    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 3,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -144,6 +153,10 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
+  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+  "encryptionInfo": {
+    "encryptionType": 1
+  },
   "engineVersion": "VALKEY_7_2",
   "mode": 2,
   "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -157,13 +170,15 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
     },
     {
-      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
     }
   ],
   "replicaCount": 0,
+  "satisfiesPzi": false,
+  "serverCaMode": 0,
   "shardCount": 3,
   "state": 2,
   "transitEncryptionMode": 1,
@@ -197,10 +212,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "update"
   },
@@ -231,6 +248,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "update"
   },
@@ -243,6 +261,10 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "engineVersion": "VALKEY_7_2",
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -256,13 +278,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+        "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
       }
     ],
     "replicaCount": 0,
+    "satisfiesPzi": false,
+    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 10,
     "state": "ACTIVE",
     "transitEncryptionMode": "TRANSIT_ENCRYPTION_DISABLED",
@@ -298,6 +322,10 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
+  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+  "encryptionInfo": {
+    "encryptionType": 1
+  },
   "engineVersion": "VALKEY_7_2",
   "mode": 2,
   "name": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
@@ -311,13 +339,15 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}"
+      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa"
     },
     {
-      "serviceAttachment": "projects/tp-memorystoreinstance-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystoreinstance-${uniqueId}-2"
+      "serviceAttachment": "projects/886208510394/regions/us-central1/serviceAttachments/gcp-memorystore-auto-g6df18e4c841b340-psc-sa-2"
     }
   ],
   "replicaCount": 0,
+  "satisfiesPzi": false,
+  "serverCaMode": 0,
   "shardCount": 10,
   "state": 2,
   "transitEncryptionMode": 1,
@@ -346,10 +376,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "delete"
   },
@@ -380,6 +412,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystoreinstance-${uniqueId}",
     "verb": "delete"
   },

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
@@ -58,7 +58,19 @@ status:
     createTime: "1970-01-01T00:00:00Z"
     endpoints:
     - connections:
-      - pscAutoConnection: {}
+      - pscAutoConnection:
+          connectionType: CONNECTION_TYPE_DISCOVERY
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115
+          ipAddress: 10.128.0.21
+          port: 6379
+          pscConnectionID: "1234567890123456789"
+          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}
+      - pscAutoConnection:
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116
+          ipAddress: 10.128.0.22
+          port: 6379
+          pscConnectionID: "1234567890123456790"
+          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2
     nodeConfig:
       sizeGB: 6.5
     state: ACTIVE

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
@@ -60,16 +60,16 @@ status:
     - connections:
       - pscAutoConnection:
           connectionType: CONNECTION_TYPE_DISCOVERY
-          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b
-          ipAddress: 10.128.0.2
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115
+          ipAddress: 10.128.0.21
           port: 6379
-          pscConnectionID: "168060640244531202"
-          serviceAttachment: projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa
+          pscConnectionID: "1234567890123456789"
+          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}
       - pscAutoConnection:
-          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b
-          ipAddress: 10.128.0.3
-          pscConnectionID: "168060640244531203"
-          serviceAttachment: projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116
+          ipAddress: 10.128.0.22
+          pscConnectionID: "1234567890123456790"
+          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2
     nodeConfig:
       sizeGB: 6.5
     state: ACTIVE

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_generated_object_fullmemorystoreinstance.golden.yaml
@@ -60,17 +60,16 @@ status:
     - connections:
       - pscAutoConnection:
           connectionType: CONNECTION_TYPE_DISCOVERY
-          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115
-          ipAddress: 10.128.0.21
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b
+          ipAddress: 10.128.0.2
           port: 6379
-          pscConnectionID: "1234567890123456789"
-          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}
+          pscConnectionID: "168060640244531202"
+          serviceAttachment: projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa
       - pscAutoConnection:
-          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116
-          ipAddress: 10.128.0.22
-          port: 6379
-          pscConnectionID: "1234567890123456790"
-          serviceAttachment: projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2
+          forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b
+          ipAddress: 10.128.0.3
+          pscConnectionID: "168060640244531203"
+          serviceAttachment: projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2
     nodeConfig:
       sizeGB: 6.5
     state: ACTIVE

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
@@ -585,15 +585,15 @@ X-Xss-Protection: 0
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
-  "name": "projects/${projectNumber}/locations/us-central1/operations/${operationID}"
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}"
 }
 
 ---
 
-GET https://memorystore.googleapis.com/v1/projects/${projectNumber}/locations/us-central1/operations/${operationID}
+GET https://memorystore.googleapis.com/v1/projects/${projectId}/locations/us-central1/operations/${operationID}
 Content-Type: application/json
 User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: name=projects%2F${projectNumber}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
+X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2Foperations%2F${operationID}
 
 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -615,10 +615,13 @@ X-Xss-Protection: 0
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
-  "name": "projects/${projectNumber}/locations/us-central1/operations/${operationID}",
+  "name": "projects/${projectId}/locations/us-central1/operations/${operationID}",
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
     "endpoints": [
@@ -626,8 +629,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -653,11 +673,21 @@ X-Xss-Protection: 0
       },
       "mode": "AOF"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 2,
     "shardCount": 6,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
     "uid": "111111111111111111111",
+    "updateTime": "2024-04-01T12:34:56.123456Z",
     "zoneDistributionConfig": {
       "mode": "SINGLE_ZONE",
       "zone": "us-central1-b"
@@ -684,6 +714,9 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 2,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": true,
   "endpoints": [
@@ -691,8 +724,25 @@ X-Xss-Protection: 0
       "connections": [
         {
           "pscAutoConnection": {
+            "connectionType": 1,
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+            "ipAddress": "10.128.0.21",
             "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}"
+            "port": 6379,
+            "projectId": "${projectId}",
+            "pscConnectionId": "1234567890123456789",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+          }
+        },
+        {
+          "pscAutoConnection": {
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+            "ipAddress": "10.128.0.22",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "port": 6379,
+            "projectId": "${projectId}",
+            "pscConnectionId": "1234567890123456790",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
           }
         }
       ]
@@ -718,11 +768,21 @@ X-Xss-Protection: 0
     },
     "mode": 3
   },
+  "pscAttachmentDetails": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+    },
+    {
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+    }
+  ],
   "replicaCount": 2,
   "shardCount": 6,
-  "state": 1,
+  "state": 2,
   "transitEncryptionMode": 2,
   "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
   "zoneDistributionConfig": {
     "mode": 2,
     "zone": "us-central1-b"
@@ -832,6 +892,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
     "endpoints": [
@@ -839,8 +902,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -866,6 +946,15 @@ X-Xss-Protection: 0
       },
       "mode": "AOF"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 6,
     "state": "ACTIVE",
@@ -982,6 +1071,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
     "endpoints": [
@@ -989,8 +1081,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1016,6 +1125,15 @@ X-Xss-Protection: 0
       },
       "mode": "AOF"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1132,6 +1250,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "endpoints": [
@@ -1139,8 +1260,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1166,6 +1304,15 @@ X-Xss-Protection: 0
       },
       "mode": "AOF"
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1282,6 +1429,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "endpoints": [
@@ -1289,8 +1439,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1317,6 +1484,15 @@ X-Xss-Protection: 0
         "rdbSnapshotStartTime": "2029-10-02T15:01:23Z"
       }
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1433,6 +1609,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "endpoints": [
@@ -1440,8 +1619,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1469,6 +1665,15 @@ X-Xss-Protection: 0
         "rdbSnapshotStartTime": "2029-10-02T15:01:23Z"
       }
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1585,6 +1790,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "endpoints": [
@@ -1592,8 +1800,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1621,6 +1846,15 @@ X-Xss-Protection: 0
         "rdbSnapshotStartTime": "2029-10-02T15:01:23Z"
       }
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1737,6 +1971,9 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.Instance",
     "authorizationMode": "IAM_AUTH",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "endpoints": [
@@ -1744,8 +1981,25 @@ X-Xss-Protection: 0
         "connections": [
           {
             "pscAutoConnection": {
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}"
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "port": 6379,
+              "projectId": "${projectId}",
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1774,6 +2028,15 @@ X-Xss-Protection: 0
         "rdbSnapshotStartTime": "2029-10-02T15:01:23Z"
       }
     },
+    "pscAttachmentDetails": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      },
+      {
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      }
+    ],
     "replicaCount": 1,
     "shardCount": 12,
     "state": "ACTIVE",
@@ -1806,6 +2069,9 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 2,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "endpoints": [
@@ -1813,8 +2079,25 @@ X-Xss-Protection: 0
       "connections": [
         {
           "pscAutoConnection": {
+            "connectionType": 1,
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+            "ipAddress": "10.128.0.21",
             "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}"
+            "port": 6379,
+            "projectId": "${projectId}",
+            "pscConnectionId": "1234567890123456789",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+          }
+        },
+        {
+          "pscAutoConnection": {
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+            "ipAddress": "10.128.0.22",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "port": 6379,
+            "projectId": "${projectId}",
+            "pscConnectionId": "1234567890123456790",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
           }
         }
       ]
@@ -1843,11 +2126,21 @@ X-Xss-Protection: 0
       "rdbSnapshotStartTime": "2029-10-02T15:01:23Z"
     }
   },
+  "pscAttachmentDetails": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+    },
+    {
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+    }
+  ],
   "replicaCount": 1,
   "shardCount": 12,
-  "state": 3,
+  "state": 2,
   "transitEncryptionMode": 2,
   "uid": "111111111111111111111",
+  "updateTime": "2024-04-01T12:34:56.123456Z",
   "zoneDistributionConfig": {
     "mode": 2,
     "zone": "us-central1-b"

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
@@ -119,10 +119,6 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -248,9 +244,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -266,7 +260,8 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY"
+  "stackType": "IPV4_ONLY",
+  "state": "READY"
 }
 
 ---
@@ -320,12 +315,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -354,7 +347,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -427,12 +419,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -461,7 +451,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -589,12 +578,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
@@ -625,7 +612,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
@@ -638,33 +624,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -674,6 +656,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -689,15 +675,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 2,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 6,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -734,33 +718,29 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": true,
-  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-  "encryptionInfo": {
-    "encryptionType": 1
-  },
   "endpoints": [
     {
       "connections": [
         {
           "pscAutoConnection": {
             "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-            "ipAddress": "10.128.0.2",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+            "ipAddress": "10.128.0.21",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "168060640244531202",
-            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+            "pscConnectionId": "1234567890123456789",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
           }
         },
         {
           "pscAutoConnection": {
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-            "ipAddress": "10.128.0.3",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+            "ipAddress": "10.128.0.22",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "projectId": "${projectId}",
-            "pscConnectionId": "168060640244531203",
-            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+            "pscConnectionId": "1234567890123456790",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
           }
         }
       ]
@@ -789,15 +769,13 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
     },
     {
-      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
     }
   ],
   "replicaCount": 2,
-  "satisfiesPzi": false,
-  "serverCaMode": 1,
   "shardCount": 6,
   "state": 2,
   "transitEncryptionMode": 2,
@@ -871,12 +849,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -907,7 +883,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -920,33 +895,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -956,6 +927,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -971,15 +946,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 6,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1054,12 +1027,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1090,7 +1061,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1103,33 +1073,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1139,6 +1105,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1154,15 +1124,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1237,12 +1205,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1273,7 +1239,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1286,33 +1251,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1322,6 +1283,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1337,15 +1302,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1420,12 +1383,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1456,7 +1417,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1469,33 +1429,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1505,6 +1461,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1521,15 +1481,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1604,12 +1562,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1640,7 +1596,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1653,33 +1608,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1690,6 +1641,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1706,15 +1661,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1789,12 +1742,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1825,7 +1776,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1838,33 +1788,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -1875,6 +1821,10 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1891,15 +1841,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1974,12 +1922,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -2010,7 +1956,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -2023,33 +1968,29 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
-    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-    "encryptionInfo": {
-      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
-    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-              "ipAddress": "10.128.0.2",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+              "ipAddress": "10.128.0.21",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531202",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+              "pscConnectionId": "1234567890123456789",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-              "ipAddress": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+              "ipAddress": "10.128.0.22",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "projectId": "${projectId}",
-              "pscConnectionId": "168060640244531203",
-              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+              "pscConnectionId": "1234567890123456790",
+              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
             }
           }
         ]
@@ -2060,6 +2001,11 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
+    "labels": {
+      "key1": "val1",
+      "key2": "val2",
+      "keyx": "valx"
+    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -2076,15 +2022,13 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
       },
       {
-        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
       }
     ],
     "replicaCount": 1,
-    "satisfiesPzi": false,
-    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -2121,33 +2065,29 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
-  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
-  "encryptionInfo": {
-    "encryptionType": 1
-  },
   "endpoints": [
     {
       "connections": [
         {
           "pscAutoConnection": {
             "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
-            "ipAddress": "10.128.0.2",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
+            "ipAddress": "10.128.0.21",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "168060640244531202",
-            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+            "pscConnectionId": "1234567890123456789",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
           }
         },
         {
           "pscAutoConnection": {
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
-            "ipAddress": "10.128.0.3",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
+            "ipAddress": "10.128.0.22",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "projectId": "${projectId}",
-            "pscConnectionId": "168060640244531203",
-            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+            "pscConnectionId": "1234567890123456790",
+            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
           }
         }
       ]
@@ -2179,15 +2119,13 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
     },
     {
-      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
+      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
     }
   ],
   "replicaCount": 1,
-  "satisfiesPzi": false,
-  "serverCaMode": 1,
   "shardCount": 12,
   "state": 2,
   "transitEncryptionMode": 2,
@@ -2217,12 +2155,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "delete"
   },
@@ -2253,7 +2189,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "delete"
   },
@@ -2310,12 +2245,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -2344,7 +2277,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -2371,9 +2303,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -2389,7 +2319,8 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY"
+  "stackType": "IPV4_ONLY",
+  "state": "READY"
 }
 
 ---
@@ -2480,10 +2411,6 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -2536,16 +2463,6 @@ X-Xss-Protection: 0
 
 {
   "endTime": "2024-04-01T12:34:56.123456Z",
-  "error": {
-    "errors": [
-      {
-        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
-        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-ba5h4uquy4cktbsldj6ba2g3-v6'"
-      }
-    ]
-  },
-  "httpErrorMessage": "BAD REQUEST",
-  "httpErrorStatusCode": 400,
   "id": "000000000000000000000",
   "insertTime": "2024-04-01T12:34:56.123456Z",
   "kind": "compute#operation",
@@ -2558,430 +2475,4 @@ X-Xss-Protection: 0
   "targetId": "${networkID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "autoCreateSubnetworks": false,
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "Test network for the project",
-  "id": "000000000000000000000",
-  "kind": "compute#network",
-  "name": "${networkID}",
-  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 0,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "RUNNING",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "endTime": "2024-04-01T12:34:56.123456Z",
-  "error": {
-    "errors": [
-      {
-        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
-        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-ba5h4uquy4cktbsldj6ba2g3-v6'"
-      }
-    ]
-  },
-  "httpErrorMessage": "BAD REQUEST",
-  "httpErrorStatusCode": 400,
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 100,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "DONE",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "autoCreateSubnetworks": false,
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "Test network for the project",
-  "id": "000000000000000000000",
-  "kind": "compute#network",
-  "name": "${networkID}",
-  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 0,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "RUNNING",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "autoCreateSubnetworks": false,
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "Test network for the project",
-  "id": "000000000000000000000",
-  "kind": "compute#network",
-  "name": "${networkID}",
-  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 0,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "RUNNING",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "autoCreateSubnetworks": false,
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "Test network for the project",
-  "id": "000000000000000000000",
-  "kind": "compute#network",
-  "name": "${networkID}",
-  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 0,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "RUNNING",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "endTime": "2024-04-01T12:34:56.123456Z",
-  "error": {
-    "errors": [
-      {
-        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
-        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-odm2l5xrgkhkgaqqdwsg4qbt'"
-      }
-    ]
-  },
-  "httpErrorMessage": "BAD REQUEST",
-  "httpErrorStatusCode": 400,
-  "id": "000000000000000000000",
-  "insertTime": "2024-04-01T12:34:56.123456Z",
-  "kind": "compute#operation",
-  "name": "${operationID}",
-  "operationType": "delete",
-  "progress": 100,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
-  "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "DONE",
-  "targetId": "${networkID}",
-  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "user": "user@example.com"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "autoCreateSubnetworks": false,
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "Test network for the project",
-  "id": "000000000000000000000",
-  "kind": "compute#network",
-  "name": "${networkID}",
-  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
-}
-
----
-
-DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-400 Bad Request
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 400,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The resource 'projects/${projectId}/global/networks/${networkID}' is not ready",
-        "reason": "resourceNotReady"
-      }
-    ],
-    "message": "The resource 'projects/${projectId}/global/networks/${networkID}' is not ready"
-  }
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The resource 'projects/${projectId}/global/networks/${networkID}' was not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "The resource 'projects/${projectId}/global/networks/${networkID}' was not found"
-  }
 }

--- a/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/memorystore/v1beta1/memorystoreinstance/fullmemorystoreinstance/_http.log
@@ -119,6 +119,10 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -244,7 +248,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -260,8 +266,7 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY",
-  "state": "READY"
+  "stackType": "IPV4_ONLY"
 }
 
 ---
@@ -315,10 +320,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -347,6 +354,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -419,10 +427,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -451,6 +461,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -578,10 +589,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
@@ -612,6 +625,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "create"
   },
@@ -624,30 +638,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -657,10 +674,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -676,13 +689,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 2,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 6,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -719,30 +734,33 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": true,
+  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+  "encryptionInfo": {
+    "encryptionType": 1
+  },
   "endpoints": [
     {
       "connections": [
         {
           "pscAutoConnection": {
             "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-            "ipAddress": "10.128.0.21",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+            "ipAddress": "10.128.0.2",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "1234567890123456789",
-            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            "pscConnectionId": "168060640244531202",
+            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
           }
         },
         {
           "pscAutoConnection": {
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-            "ipAddress": "10.128.0.22",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+            "ipAddress": "10.128.0.3",
             "network": "projects/${projectId}/global/networks/${networkID}",
-            "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "1234567890123456790",
-            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+            "pscConnectionId": "168060640244531203",
+            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
           }
         }
       ]
@@ -771,13 +789,15 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
     },
     {
-      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
     }
   ],
   "replicaCount": 2,
+  "satisfiesPzi": false,
+  "serverCaMode": 1,
   "shardCount": 6,
   "state": 2,
   "transitEncryptionMode": 2,
@@ -851,10 +871,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -885,6 +907,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -897,30 +920,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -930,10 +956,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -949,13 +971,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 6,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1030,10 +1054,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1064,6 +1090,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1076,30 +1103,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": true,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -1109,10 +1139,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1128,13 +1154,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1209,10 +1237,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1243,6 +1273,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1255,30 +1286,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -1288,10 +1322,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1307,13 +1337,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1388,10 +1420,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1422,6 +1456,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1434,30 +1469,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -1467,10 +1505,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1487,13 +1521,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1568,10 +1604,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1602,6 +1640,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1614,30 +1653,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -1648,10 +1690,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1668,13 +1706,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1749,10 +1789,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1783,6 +1825,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1795,30 +1838,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -1829,10 +1875,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -1849,13 +1891,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -1930,10 +1974,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1964,6 +2010,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "update"
   },
@@ -1976,30 +2023,33 @@ X-Xss-Protection: 0
     },
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
+    "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+    "encryptionInfo": {
+      "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
+    },
     "endpoints": [
       {
         "connections": [
           {
             "pscAutoConnection": {
               "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-              "ipAddress": "10.128.0.21",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+              "ipAddress": "10.128.0.2",
               "network": "projects/${projectId}/global/networks/${networkID}",
               "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456789",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+              "pscConnectionId": "168060640244531202",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
             }
           },
           {
             "pscAutoConnection": {
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-              "ipAddress": "10.128.0.22",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+              "ipAddress": "10.128.0.3",
               "network": "projects/${projectId}/global/networks/${networkID}",
-              "port": 6379,
               "projectId": "${projectId}",
-              "pscConnectionId": "1234567890123456790",
-              "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+              "pscConnectionId": "168060640244531203",
+              "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
             }
           }
         ]
@@ -2010,11 +2060,6 @@ X-Xss-Protection: 0
       "maxmemory-policy": "volatile-ttl"
     },
     "engineVersion": "VALKEY_7_2",
-    "labels": {
-      "key1": "val1",
-      "key2": "val2",
-      "keyx": "valx"
-    },
     "mode": "CLUSTER",
     "name": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "nodeConfig": {
@@ -2031,13 +2076,15 @@ X-Xss-Protection: 0
     "pscAttachmentDetails": [
       {
         "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
       },
       {
-        "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+        "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
       }
     ],
     "replicaCount": 1,
+    "satisfiesPzi": false,
+    "serverCaMode": "GOOGLE_MANAGED_PER_INSTANCE_CA",
     "shardCount": 12,
     "state": "ACTIVE",
     "transitEncryptionMode": "SERVER_AUTHENTICATION",
@@ -2074,30 +2121,33 @@ X-Xss-Protection: 0
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
+  "effectiveMaintenanceVersion": "MEMORYSTORE_20260313_01_00",
+  "encryptionInfo": {
+    "encryptionType": 1
+  },
   "endpoints": [
     {
       "connections": [
         {
           "pscAutoConnection": {
             "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98115",
-            "ipAddress": "10.128.0.21",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-91ccced1-a4b8-4ea4-a972-e9ed74272f3b",
+            "ipAddress": "10.128.0.2",
             "network": "projects/${projectId}/global/networks/${networkID}",
             "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "1234567890123456789",
-            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+            "pscConnectionId": "168060640244531202",
+            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
           }
         },
         {
           "pscAutoConnection": {
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-112210f47de98116",
-            "ipAddress": "10.128.0.22",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/sca-auto-fr-d2ee082f-a9b1-4ed8-9f7a-1e25712e4d5b",
+            "ipAddress": "10.128.0.3",
             "network": "projects/${projectId}/global/networks/${networkID}",
-            "port": 6379,
             "projectId": "${projectId}",
-            "pscConnectionId": "1234567890123456790",
-            "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+            "pscConnectionId": "168060640244531203",
+            "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
           }
         }
       ]
@@ -2129,13 +2179,15 @@ X-Xss-Protection: 0
   "pscAttachmentDetails": [
     {
       "connectionType": 1,
-      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}"
+      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa"
     },
     {
-      "serviceAttachment": "projects/tp-memorystore-${uniqueId}/regions/us-central1/serviceAttachments/sa-memorystore-${uniqueId}-2"
+      "serviceAttachment": "projects/735231710764/regions/us-central1/serviceAttachments/gcp-memorystore-auto-b560497c3c9047d6-psc-sa-2"
     }
   ],
   "replicaCount": 1,
+  "satisfiesPzi": false,
+  "serverCaMode": 1,
   "shardCount": 12,
   "state": 2,
   "transitEncryptionMode": 2,
@@ -2165,10 +2217,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.memorystore.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "delete"
   },
@@ -2199,6 +2253,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/instances/memorystore-${uniqueId}",
     "verb": "delete"
   },
@@ -2255,10 +2310,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -2287,6 +2344,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -2313,7 +2371,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -2329,8 +2389,7 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY",
-  "state": "READY"
+  "stackType": "IPV4_ONLY"
 }
 
 ---
@@ -2421,6 +2480,10 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -2473,6 +2536,16 @@ X-Xss-Protection: 0
 
 {
   "endTime": "2024-04-01T12:34:56.123456Z",
+  "error": {
+    "errors": [
+      {
+        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
+        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-ba5h4uquy4cktbsldj6ba2g3-v6'"
+      }
+    ]
+  },
+  "httpErrorMessage": "BAD REQUEST",
+  "httpErrorStatusCode": 400,
   "id": "000000000000000000000",
   "insertTime": "2024-04-01T12:34:56.123456Z",
   "kind": "compute#operation",
@@ -2485,4 +2558,430 @@ X-Xss-Protection: 0
   "targetId": "${networkID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": false,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Test network for the project",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "error": {
+    "errors": [
+      {
+        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
+        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-ba5h4uquy4cktbsldj6ba2g3-v6'"
+      }
+    ]
+  },
+  "httpErrorMessage": "BAD REQUEST",
+  "httpErrorStatusCode": 400,
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": false,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Test network for the project",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": false,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Test network for the project",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": false,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Test network for the project",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "error": {
+    "errors": [
+      {
+        "code": "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE",
+        "message": "The network resource 'projects/${projectId}/global/networks/${networkID}' is already being used by 'projects/${projectId}/global/firewalls/${networkID}-odm2l5xrgkhkgaqqdwsg4qbt'"
+      }
+    ]
+  },
+  "httpErrorMessage": "BAD REQUEST",
+  "httpErrorStatusCode": 400,
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${networkID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "user": "user@example.com"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "autoCreateSubnetworks": false,
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "Test network for the project",
+  "id": "000000000000000000000",
+  "kind": "compute#network",
+  "name": "${networkID}",
+  "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 400,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/${projectId}/global/networks/${networkID}' is not ready",
+        "reason": "resourceNotReady"
+      }
+    ],
+    "message": "The resource 'projects/${projectId}/global/networks/${networkID}' is not ready"
+  }
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/${projectId}/global/networks/${networkID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/${projectId}/global/networks/${networkID}' was not found"
+  }
 }


### PR DESCRIPTION
### BRIEF Change description

This implements the mocks related to backups for Memorystore Instances.

#### WHY do we need this change?

Needed for mocking MemorystoreInstanceBackup types.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [X] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
