### PR TITLE
Add documentation for config-connector CLI and preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ controllers, CRDs, install bundles, and sample resource configurations.
 
 See https://cloud.google.com/config-connector/docs/overview.
 
+See [Config Connector CLI](./docs/cli/README.md) for documentation on the `config-connector` command-line tool.
+
 See
 [Choosing an installation type](https://cloud.google.com/config-connector/docs/concepts/installation-types)
 to decide how you want to install Config Connector.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,34 @@
+# Config Connector CLI (config-connector)
+
+The `config-connector` CLI provides tools for managing Config Connector resources, such as exporting, previewing, and bulk-exporting resource definitions.
+
+## Installation
+
+The CLI can be installed as a component of the Google Cloud SDK (gcloud).
+
+### Prerequisites
+
+- [Google Cloud SDK (gcloud)](https://cloud.google.com/sdk/docs/install) installed and configured.
+
+### Install via gcloud component
+
+Run the following command to install the `config-connector` component:
+
+```bash
+gcloud components install config-connector
+```
+
+Once installed, the `config-connector` command should be available in your PATH.
+
+## Commands
+
+- [preview](../../pkg/cli/cmd/preview/README.md): Preview reconciliation behavior and validate migrations.
+- **export**: Export existing GCP resources into Config Connector YAML.
+- **bulk-export**: Export all GCP resources in a project, folder, or organization.
+- **print-resources**: Print the list of resources supported by Config Connector.
+- **version**: Print the version of the CLI.
+- **licenses**: Print licenses for third-party dependencies.
+
+## Usage
+
+See the documentation for each command for specific usage details. For example, for the `preview` command, see [Previewing Reconciliation](../../pkg/cli/cmd/preview/README.md).

--- a/pkg/cli/cmd/preview/README.md
+++ b/pkg/cli/cmd/preview/README.md
@@ -1,0 +1,90 @@
+# Config Connector Preview Command
+
+The `config-connector preview` command allows you to preview the reconciliation behavior of Config Connector resources. It is particularly useful for validating how resources will behave when migrated from one controller type to another (e.g., from Terraform-based controllers to the "direct" approach).
+
+## Overview
+
+The `preview` command performs two separate reconciliation runs:
+
+1.  **Default Run (Baseline):** Reconciles resources using their default configured controllers. This establishes a baseline of the current "healthy" state of your resources.
+2.  **Alternative Run:** Reconciles the same resources but forces them to use an alternative controller type (if supported for that resource kind). This is typically used to test the "direct" controller implementation for resources currently managed by Terraform or DCL.
+
+After both runs complete, the tool generates a summary report comparing the results, highlighting any differences in resource state (diffs) or reconciliation health.
+
+## Requirements
+
+-   The `config-connector` CLI must be installed. See the [installation guide](../../../../docs/cli/README.md) for details on installing via `gcloud`.
+-   The tool requires credentials to access the Kubernetes cluster (via `kubeconfig`).
+-   The tool requires GCP credentials (ADC) to perform read-only checks against GCP resources to verify state.
+
+## How it Works
+
+1.  **Resource Discovery:** The tool connects to your Kubernetes cluster and lists all Config Connector resources (either in a specific namespace or across all namespaces).
+2.  **In-Memory Reconciliation:** It uses an internal manager that mimics the standard Config Connector controller but captures all interactions (Kube API calls, GCP API calls, and object diffs) without actually applying changes to the cluster or GCP (it uses interceptors).
+3.  **Analysis:** It tracks whether resources reached a "Healthy" state (successfully reconciled without unexpected GCP side effects) or an "Unhealthy" state.
+4.  **Reporting:** It outputs a summary report and detailed logs of any discrepancies found during the alternative run.
+
+## Usage
+
+### Basic Usage
+
+Preview all resources in the current context:
+
+```bash
+config-connector preview
+```
+
+Preview resources in a specific namespace:
+
+```bash
+config-connector preview --namespace my-namespace
+```
+
+### Advanced Usage
+
+Enable full reports with detailed object events:
+
+```bash
+config-connector preview --full-report
+```
+
+Adjust GCP API rate limiting:
+
+```bash
+config-connector preview --gcp-qps 10 --gcp-burst 10
+```
+
+## Flags
+
+| Flag | Description | Default |
+| :--- | :--- | :--- |
+| `--kubeconfig` | Path to the kubeconfig file. | Uses default rules |
+| `--namespace`, `-n` | Namespace to preview. If not specified, all namespaces are previewed. | All namespaces |
+| `--timeout` | Timeout for each reconciliation run in minutes. | 15 |
+| `--report-prefix` | Prefix for the generated report files. A timestamp is appended. | `preview-report` |
+| `--full-report`, `-f` | Write a full report with all captured objects and events. | `false` |
+| `--gcp-qps`, `-q` | Maximum QPS for GCP API requests per service. Set to 0 to disable. | 5.0 |
+| `--gcp-burst`, `-b` | Maximum burst for GCP API requests per service. | 5 |
+| `--in-cluster` | Run the tool within a GKE cluster (uses in-cluster config). | `false` |
+| `--verbose`, `-v` | Log verbosity level (klog). | 0 |
+
+## Reports
+
+The tool generates several files:
+
+-   `preview-report-<timestamp>`: A summary table showing the Group, Kind, Name, and the reconciliation status/diffs for both the default and alternative runs.
+-   `preview-report-<timestamp>-detail`: (Generated if errors occur) A JSON file containing detailed information about "Unhealthy" resources.
+-   `preview-report-<timestamp>-full-default`: (Generated if `--full-report` is set) Detailed event log for the default run.
+-   `preview-report-<timestamp>-full-alternative`: (Generated if `--full-report` is set) Detailed event log for the alternative run.
+
+### Understanding the Summary Report
+
+The summary report contains the following columns:
+
+-   **GROUP/KIND/NAME**: Identifies the resource.
+-   **DEFAULT-CONTROLLER**: The controller used in the baseline run (e.g., `Terraform`, `Direct`).
+-   **DEFAULT-RESULT**: `HEALTHY` or `UNHEALTHY`.
+-   **DEFAULT-DIFFS**: Fields that had diffs during reconciliation.
+-   **ALTERNATIVE-CONTROLLER**: The alternative controller being tested.
+-   **ALTERNATIVE-RESULT**: `HEALTHY`, `UNHEALTHY`, or `Missing` (if the alternative controller failed to pick up the resource).
+-   **ALTERNATIVE-DIFFS**: Fields that had diffs during the alternative run.


### PR DESCRIPTION
### BRIEF Change description

This pull request adds comprehensive documentation for the `config-connector` CLI and specifically for the `preview` command.

Key additions:
- **`docs/cli/README.md`**: Installation guide via `gcloud component` and overview of CLI commands.
- **`pkg/cli/cmd/preview/README.md`**: Detailed documentation for the `preview` command, including its two-run reconciliation logic (baseline vs. alternative), usage examples, flags, and report explanations.
- Updated the root **`README.md`** to link to the new CLI documentation.

Fixes #

#### WHY do we need this change?
To help users understand how to install and use the `config-connector` CLI, especially the `preview` tool for validating resource migrations between different controller types.

#### Special notes for your reviewer:
The `preview` command is currently marked as `Hidden: true` in the CLI, but we are providing documentation to facilitate testing and future rollout.

#### Does this PR add something which needs to be 'release noted'?
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:
```docs
- [CLI Installation]: https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/935d79b96db83490594fad2816f780fe84d20091/docs/cli/README.md
- [Preview Command Guide]: https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/935d79b96db83490594fad2816f780fe84d20091/pkg/cli/cmd/preview/README.md
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

Verified the links and the rendered markdown.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
