### PR TITLE
sql: fix DataCacheConfig diff when enabled=false

### DIFF
--- a/mockgcp/mocksql/sqlinstance.go
+++ b/mockgcp/mocksql/sqlinstance.go
@@ -799,6 +799,10 @@ func populateDefaults(obj *pb.DatabaseInstance) {
 		}
 	}
 
+	if settings.DataCacheConfig != nil && !settings.DataCacheConfig.DataCacheEnabled {
+		settings.DataCacheConfig = nil
+	}
+
 	if backupConfiguration.PointInTimeRecoveryEnabled != nil && isMysql(obj) {
 		backupConfiguration.PointInTimeRecoveryEnabled = nil
 	}

--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -352,18 +352,17 @@ func BackupRetentionSettingsMatch(desired *api.BackupRetentionSettings, actual *
 }
 
 func DataCacheConfigsMatch(desired *api.DataCacheConfig, actual *api.DataCacheConfig) bool {
-	if desired == nil && actual == nil {
-		return true
+	// GCP omits DataCacheConfig when DataCacheEnabled is false.
+	// Treat nil and false as equivalent.
+	desiredEnabled := false
+	if desired != nil {
+		desiredEnabled = desired.DataCacheEnabled
 	}
-	if !PointersMatch(desired, actual) {
-		return false
+	actualEnabled := false
+	if actual != nil {
+		actualEnabled = actual.DataCacheEnabled
 	}
-	if desired.DataCacheEnabled != actual.DataCacheEnabled {
-		return false
-	}
-	// Ignore ForceSendFields. Assume it is set correctly in desired.
-	// Ignore NullFields. Assume it is set correctly in desired.
-	return true
+	return desiredEnabled == actualEnabled
 }
 
 func DatabaseFlagListsMatch(desired []*api.DatabaseFlags, actual []*api.DatabaseFlags) bool {

--- a/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct/_http.log
@@ -194,7 +194,6 @@ X-Xss-Protection: 0
       "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
-    "dataCacheConfig": {},
     "dataDiskSizeGb": "10",
     "dataDiskType": "PD_SSD",
     "deletionProtectionEnabled": false,
@@ -340,7 +339,6 @@ X-Xss-Protection: 0
       "transactionalLogStorageState": "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"
     },
     "connectorEnforcement": "NOT_REQUIRED",
-    "dataCacheConfig": {},
     "dataDiskSizeGb": "10",
     "dataDiskType": "PD_SSD",
     "deletionProtectionEnabled": false,


### PR DESCRIPTION
### BRIEF Change description

This PR fixes a diff in `SQLInstance` where `.settings.dataCacheConfig` is incorrectly detected as different when `dataCacheEnabled` is `false`, because GCP omits the field in its response.

Fixes #7144

#### WHY do we need this change?

When `dataCacheEnabled` is set to `false`, GCP returns a `nil` object for `dataCacheConfig`. The previous equality logic used `PointersMatch`, which failed when comparing a non-nil `desired` object (with `dataCacheEnabled: false`) against a `nil` `actual` object.

#### Special notes for your reviewer:

None.

#### Does this PR add something which needs to be 'release noted'?
NONE

#### Additional documentation e.g., references, usage docs, etc.:
NONE

#### Intended Milestone
NONE

### Tests you have done
- Verified using `hack/compare-mock pkg/test/resourcefixture/testdata/basic/sql/v1beta1/sqlinstance/sqlinstance-datacacheconfig-direct` that the resource becomes `Ready`.
