### PR TITLE
Updating gcp-setup.sh to use `gpg` instead of `apt-key` as the latter…

### DIFF
--- a/scripts/environment-setup/gcp-setup.sh
+++ b/scripts/environment-setup/gcp-setup.sh
@@ -48,8 +48,8 @@ fi
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key \
-    --keyring /usr/share/keyrings/cloud.google.gpg add -
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o \
+    /usr/share/keyrings/cloud.google.gpg
 
 sudo apt-get update && sudo apt-get install google-cloud-cli
 


### PR DESCRIPTION
Updating gcp-setup.sh to use `gpg` instead of `apt-key` as the latter has been deprecated
