### PR TITLE
Fix BigQueryDataTransferConfig resource duplication loop

### DIFF
--- a/apis/bigquerydatatransfer/v1alpha1/config_types.go
+++ b/apis/bigquerydatatransfer/v1alpha1/config_types.go
@@ -83,7 +83,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	Parent `json:",inline"`
 
-	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
+	// Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Data transfer schedule.

--- a/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
+++ b/apis/bigquerydatatransfer/v1beta1/transferconfig_types.go
@@ -122,7 +122,7 @@ type BigQueryDataTransferConfigSpec struct {
 
 	Parent `json:",inline"`
 
-	// The BigQueryDataTransferConfig name. If not given, the metadata.name will be used.
+	// Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// Data transfer schedule.

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_bigquerydatatransferconfigs.bigquerydatatransfer.cnrm.cloud.google.com.yaml
@@ -236,8 +236,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: The BigQueryDataTransferConfig name. If not given, the
-                  metadata.name will be used.
+                description: Immutable. Optional. The service-generated name of the
+                  resource. Used for acquisition only. Leave unset to create a new
+                  resource.
                 type: string
               schedule:
                 description: |-
@@ -620,8 +621,9 @@ spec:
                     type: string
                 type: object
               resourceID:
-                description: The BigQueryDataTransferConfig name. If not given, the
-                  metadata.name will be used.
+                description: Immutable. Optional. The service-generated name of the
+                  resource. Used for acquisition only. Leave unset to create a new
+                  resource.
                 type: string
               schedule:
                 description: |-

--- a/pkg/clients/generated/apis/bigquerydatatransfer/v1beta1/bigquerydatatransferconfig_types.go
+++ b/pkg/clients/generated/apis/bigquerydatatransfer/v1beta1/bigquerydatatransferconfig_types.go
@@ -154,7 +154,7 @@ type BigQueryDataTransferConfigSpec struct {
 	// +optional
 	PubSubTopicRef *v1alpha1.ResourceRef `json:"pubSubTopicRef,omitempty"`
 
-	/* The BigQueryDataTransferConfig name. If not given, the metadata.name will be used. */
+	/* Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource. */
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 

--- a/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransferconfig_controller.go
+++ b/pkg/controller/direct/bigquerydatatransfer/bigquerydatatransferconfig_controller.go
@@ -227,8 +227,6 @@ func (a *Adapter) Find(ctx context.Context) (bool, error) {
 }
 
 func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperation) error {
-	u := createOp.GetUnstructured()
-
 	log := klog.FromContext(ctx)
 	log.V(2).Info("creating BigQueryDataTransferConfig", "name", a.id.FullyQualifiedName())
 	mapCtx := &direct.MapContext{}
@@ -270,7 +268,7 @@ func (a *Adapter) Create(ctx context.Context, createOp *directbase.CreateOperati
 	a.id.transferConfigID = serviceGeneratedID
 	status.ExternalRef = a.id.AsExternalRef()
 
-	return setStatus(u, status)
+	return createOp.UpdateStatus(ctx, status, nil)
 }
 
 func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperation) error {
@@ -372,7 +370,7 @@ func (a *Adapter) Update(ctx context.Context, updateOp *directbase.UpdateOperati
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
 	}
-	return setStatus(u, status)
+	return updateOp.UpdateStatus(ctx, status, nil)
 }
 
 func (a *Adapter) Export(ctx context.Context) (*unstructured.Unstructured, error) {
@@ -414,22 +412,4 @@ func (a *Adapter) Delete(ctx context.Context, deleteOp *directbase.DeleteOperati
 	log.V(2).Info("successfully deleted BigQueryDataTransferConfig", "name", a.id.FullyQualifiedName())
 
 	return true, nil
-}
-
-func setStatus(u *unstructured.Unstructured, typedStatus any) error {
-	status, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedStatus)
-	if err != nil {
-		return fmt.Errorf("error converting status to unstructured: %w", err)
-	}
-
-	old, _, _ := unstructured.NestedMap(u.Object, "status")
-	if old != nil {
-		status["conditions"] = old["conditions"]
-		status["observedGeneration"] = old["observedGeneration"]
-		status["externalRef"] = old["externalRef"]
-	}
-
-	u.Object["status"] = status
-
-	return nil
 }

--- a/scripts/generate-google3-docs/resource-lists/generated/_resources-with-service-generated-resource-id.html
+++ b/scripts/generate-google3-docs/resource-lists/generated/_resources-with-service-generated-resource-id.html
@@ -3,6 +3,7 @@
 <ul>
 <li><code>AccessContextManagerAccessPolicy</code></li>
 <li><code>ApigeeOrganization</code></li>
+<li><code>BigQueryDataTransferConfig</code></li>
 <li><code>BillingBudgetsBudget</code></li>
 <li><code>CloudIdentityGroup</code></li>
 <li><code>CloudIdentityMembership</code></li>

--- a/scripts/generate-google3-docs/resource-lists/main.go
+++ b/scripts/generate-google3-docs/resource-lists/main.go
@@ -109,6 +109,7 @@ func resourcesWithServerGeneratedResourceID(smLoader *servicemappingloader.Servi
 	// todo: temporarily list current direct resources with generated ID until we can generate them by code
 	// This is needed otherwise "make resource-docs" will revert the resource-lists
 	directResources := []schema.GroupVersionKind{
+		{Group: "bigquerydatatransfer.cnrm.cloud.google.com", Version: "v1beta1", Kind: "BigQueryDataTransferConfig"},
 		{Group: "datacatalog.cnrm.cloud.google.com", Version: "v1beta1", Kind: "DataCatalogPolicyTag"},
 		{Group: "datacatalog.cnrm.cloud.google.com", Version: "v1beta1", Kind: "DataCatalogTaxonomy"},
 		{Group: "essentialcontacts.cnrm.cloud.google.com", Version: "v1beta1", Kind: "EssentialContactsContact"},

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_http01.log
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_http01.log
@@ -1,0 +1,85 @@
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/dependency-sa@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Unknown service account",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Unknown service account",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "accountId": "dependency-sa",
+  "serviceAccount": {
+    "displayName": "Dependency SA"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "Dependency SA",
+  "email": "dependency-sa@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/dependency-sa@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}
+
+---
+
+GET https://iam.googleapis.com/v1/projects/${projectId}/serviceAccounts/dependency-sa@${projectId}.iam.gserviceaccount.com?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "displayName": "Dependency SA",
+  "email": "dependency-sa@${projectId}.iam.gserviceaccount.com",
+  "etag": "abcdef0123A=",
+  "name": "projects/${projectId}/serviceAccounts/dependency-sa@${projectId}.iam.gserviceaccount.com",
+  "oauth2ClientId": "888888888888888888888",
+  "projectId": "${projectId}",
+  "uniqueId": "111111111111111111111"
+}

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_http02.log
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_http02.log
@@ -1,0 +1,50 @@
+POST https://bigquerydatatransfer.googleapis.com/v1/projects/${projectId}/locations/us/transferConfigs?%24alt=json%3Benum-encoding%3Dint&serviceAccountName=dependency-sa%40${projectId}.iam.gserviceaccount.com
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus
+
+{
+  "dataSourceId": "scheduled_query",
+  "displayName": "duplication test",
+  "params": {
+    "destination_table_name_template": "my_table",
+    "query": "SELECT 1",
+    "write_disposition": "WRITE_APPEND"
+  },
+  "schedule": "every day 05:00"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "dataSourceId": "scheduled_query",
+  "datasetRegion": "us",
+  "displayName": "duplication test",
+  "encryptionConfiguration": {},
+  "name": "projects/${projectNumber}/locations/us/transferConfigs/${transferConfigID}",
+  "nextRunTime": "2024-04-01T12:34:56.123456Z",
+  "ownerInfo": {
+    "email": "user@google.com"
+  },
+  "params": {
+    "destination_table_name_template": "my_table",
+    "query": "SELECT 1",
+    "write_disposition": "WRITE_APPEND"
+  },
+  "schedule": "every day 05:00",
+  "scheduleOptionsV2": {
+    "timeBasedSchedule": {
+      "schedule": "every day 05:00"
+    }
+  },
+  "updateTime": "2024-04-01T12:34:56.123456Z",
+  "userId": "123"
+}

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object00.yaml
@@ -1,0 +1,30 @@
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+  generation: 1
+  name: bqdt-duplication-test
+  namespace: ${projectId}
+spec:
+  dataSourceID: scheduled_query
+  displayName: duplication test
+  location: us
+  params:
+    destination_table_name_template: my_table
+    query: SELECT 1
+    write_disposition: WRITE_APPEND
+  projectRef:
+    external: ${projectId}
+  schedule: every day 05:00
+  serviceAccountRef:
+    name: dependency-sa
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: 'Update call failed: referenced IAMServiceAccount ${projectId}/dependency-sa
+      not found'
+    reason: UpdateFailed
+    status: "False"
+    type: Ready
+  observedGeneration: 1

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object01.yaml
@@ -1,0 +1,28 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: dependency-sa
+  namespace: ${projectId}
+spec:
+  displayName: Dependency SA
+  resourceID: dependency-sa
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  email: dependency-sa@${projectId}.iam.gserviceaccount.com
+  member: serviceAccount:dependency-sa@${projectId}.iam.gserviceaccount.com
+  name: projects/${projectId}/serviceAccounts/dependency-sa@${projectId}.iam.gserviceaccount.com
+  observedGeneration: 2
+  uniqueId: "12345678"

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object02.yaml
@@ -1,0 +1,42 @@
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    test.cnrm.cloud.google.com/reconcile-cookie: (removed)
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 1
+  name: bqdt-duplication-test
+  namespace: ${projectId}
+spec:
+  dataSourceID: scheduled_query
+  displayName: duplication test
+  location: us
+  params:
+    destination_table_name_template: my_table
+    query: SELECT 1
+    write_disposition: WRITE_APPEND
+  projectRef:
+    external: ${projectId}
+  schedule: every day 05:00
+  serviceAccountRef:
+    name: dependency-sa
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: //bigquerydatatransfer.googleapis.com/projects/${projectId}/locations/us/transferConfigs/${transferConfigID}
+  observedGeneration: 1
+  observedState:
+    datasetRegion: us
+    name: projects/${projectNumber}/locations/us/transferConfigs/${transferConfigID}
+    nextRunTime: "1970-01-01T00:00:00Z"
+    ownerInfo:
+      email: user@google.com
+    updateTime: "1970-01-01T00:00:00Z"
+    userID: "0000000000000000000"

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object03.yaml
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/_object03.yaml
@@ -1,0 +1,42 @@
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${projectId}
+    test.cnrm.cloud.google.com/reconcile-cookie: (removed)
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 1
+  name: bqdt-duplication-test
+  namespace: ${projectId}
+spec:
+  dataSourceID: scheduled_query
+  displayName: duplication test
+  location: us
+  params:
+    destination_table_name_template: my_table
+    query: SELECT 1
+    write_disposition: WRITE_APPEND
+  projectRef:
+    external: ${projectId}
+  schedule: every day 05:00
+  serviceAccountRef:
+    name: dependency-sa
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: //bigquerydatatransfer.googleapis.com/projects/${projectId}/locations/us/transferConfigs/${transferConfigID}
+  observedGeneration: 1
+  observedState:
+    datasetRegion: us
+    name: projects/${projectNumber}/locations/us/transferConfigs/${transferConfigID}
+    nextRunTime: "1970-01-01T00:00:00Z"
+    ownerInfo:
+      email: user@google.com
+    updateTime: "1970-01-01T00:00:00Z"
+    userID: "0000000000000000000"

--- a/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/script.yaml
+++ b/tests/e2e/testdata/scenarios/bigquerydatatransferconfig_duplication/script.yaml
@@ -1,0 +1,56 @@
+# Step 0: Create BQDT with missing dependency
+# Use APPLY-10-SEC to record the expected failure and missing externalRef
+# without waiting for the full 20-minute timeout.
+TEST: APPLY-10-SEC
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  name: bqdt-duplication-test
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us
+  displayName: "duplication test"
+  dataSourceID: "scheduled_query"
+  params:
+    destination_table_name_template: "my_table"
+    write_disposition: "WRITE_APPEND"
+    query:  "SELECT 1"
+  schedule: "every day 05:00"
+  serviceAccountRef:
+    name: dependency-sa
+---
+# Step 1: Create the dependency
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: dependency-sa
+spec:
+  displayName: "Dependency SA"
+---
+# Step 2: Touch BQDT to trigger reconciliation
+TEST: TOUCH
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  name: bqdt-duplication-test
+---
+# Step 3: Ensure BQDT is Ready before cleanup to avoid long deletion timeouts
+# Default APPLY will wait for BQDT to be Ready
+apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataTransferConfig
+metadata:
+  name: bqdt-duplication-test
+spec:
+  projectRef:
+    external: ${projectId}
+  location: us
+  displayName: "duplication test"
+  dataSourceID: "scheduled_query"
+  params:
+    destination_table_name_template: "my_table"
+    write_disposition: "WRITE_APPEND"
+    query:  "SELECT 1"
+  schedule: "every day 05:00"
+  serviceAccountRef:
+    name: dependency-sa


### PR DESCRIPTION
Ensures `externalRef` is preserved in `BigQueryDataTransferConfig` status updates, preventing a "permanent amnesia" loop that leads to multiple duplicate scheduled queries in GCP.

### BRIEF Change description

This PR fixes a bug where `BigQueryDataTransferConfig` reconciliation fails to persist the link to the underlying GCP resource, leading to the creation of multiple duplicate scheduled queries.

The issue occurs because the `setStatus` helper function unconditionally overwrites the newly generated `externalRef` (from a successful `Create` call) with the potentially empty `externalRef` from the old Kubernetes object status. Since `BigQueryDataTransferConfig` uses service-generated IDs, the loss of this reference causes KCC to lose track of the resource, leading it to create a new instance on every subsequent reconciliation loop.

Fixes # (Internal Bug b/493812753)

#### WHY do we need this change?

1. **Identity Loss:** `BigQueryDataTransferConfig` relies entirely on `status.externalRef` to identify the existing resource in GCP. If this field is lost, KCC's `Find()` method returns `false`, and the controller concludes the resource does not exist.
2. **Duplication Loop:** When a resource is successfully created but the `externalRef` is immediately wiped from the status, KCC enters a state of "permanent amnesia." On the next sync (which is triggered immediately by the status update), KCC calls `Create()` again, resulting in an infinite loop of duplicate resources in GCP.
3. **Dependency Sensitivity:** This behavior is particularly triggered when dependencies (like Service Accounts or Datasets) are temporarily unhealthy, as the error-reporting path for those failures initializes an empty status that then "infects" the successful creation path via unconditional inheritance.
4. **Orphaned objects:** On the parent CR deletion, the corresponding GCP objects won't be deleted due to the lost link between the CR and the GCP resource.

#### Special notes for your reviewer:

The fix is surgical and targeted at the `setStatus` function in the `BigQueryDataTransferConfig` direct reconciler.

#### Does this PR add something which needs to be 'release noted'?

```release-note
Fixed a bug in BigQueryDataTransferConfig where the link to the GCP resource (externalRef) could be lost during status updates, causing KCC to create multiple duplicate scheduled queries in GCP.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
NONE
```

#### Intended Milestone

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [x] Verified the fix in a live cluster using custom container images (with the fix).
- [x] Confirmed that `externalRef` is correctly persisted and duplication stops after the first successful reconciliation.
- [x] Verified that unhealthy dependency states (missing SA/Dataset) no longer trigger a duplication loop once the dependencies become healthy.