### PR TITLE
feat: Allow setting nodeConfig while remove default-pool

### DIFF
--- a/containercluster.yaml
+++ b/containercluster.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: example-cluster
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/remove-default-node-pool-allow-node-config: "true"
+    cnrm.cloud.google.com/deletion-policy: abandon
+spec:
+  initialNodeCount: 1
+  nodeConfig:
+    tags:
+      - network-egress-tag  # Mandatory for master connectivity
+  location: us-west1

--- a/pkg/krmtotf/legacygcpmanagedfields.go
+++ b/pkg/krmtotf/legacygcpmanagedfields.go
@@ -113,12 +113,17 @@ func resolveContainerClusterNodeVersion(r *Resource, config map[string]interface
 	if err != nil {
 		return fmt.Errorf("error determining if release channel is set: %w", err)
 	}
-	if !found || releaseChannel == nil {
-		// Release channel is not specified, so no special behavior required.
-		return nil
-	}
-	if err := removeFromConfigIfNotApplied(r, config, "nodeVersion"); err != nil {
-		return fmt.Errorf("error resolving node version in config: %w", err)
+
+	// If the user opts to remove the default node pool, specifying a node version
+	// is also restricted by Terraform.
+	removeDefaultNodePoolDirective := "remove-default-node-pool"
+	removeDefaultNodePoolKey := k8s.FormatAnnotation(removeDefaultNodePoolDirective)
+	removeDefaultNodePool, _ := k8s.GetAnnotation(removeDefaultNodePoolKey, r)
+
+	if removeDefaultNodePool == "true" || (found && releaseChannel != nil) {
+		if err := removeFromConfigIfNotApplied(r, config, "nodeVersion"); err != nil {
+			return fmt.Errorf("error resolving node version in config: %w", err)
+		}
 	}
 	return nil
 }
@@ -145,11 +150,20 @@ func resolveContainerNodePoolVersion(r *Resource, config map[string]interface{})
 // When `remove-default-node-pool` directive is set to `true`, the default node
 // pool will be removed, and `spec.nodeConfig` field should be managed by the API.
 // However, because the service-generated value of `spec.nodeConfig` contains
-// lists, which are preserved by KCC even if the live state of the GCP resource
-// no longer has `nodeConfig` field, it triggers unexpected recreation of the
-// resource. So in this case, we need to manually clean up `nodeConfig` field.
+// lists, which are preserved by legacy KCC(when "state-into-spec" was defaulted to "merge")
+// even if the live state of the GCP resource no longer has `nodeConfig` field. It triggers
+// unexpected recreation of the resource. So in this case, we need to manually clean up `nodeConfig` field.
+
+// If `spec.nodeConfig` is explicitly defined in the desired config but should be removed
+// following the deletion of the default node pool, the `remove-default-node-pool-allow-node-config`
+// annotation must be set to true. This prevents the unexpected recreation of the resource.
+
+// Note: When the default node pool is deleted, `node_config` is absent from the live state.
+// However, if it remains in the desired state (either preserved by legacy KCC or
+// explicitly set by the user), Terraform will attempt to recreate the resource as this field is marked `ForceNew`.
 func resolveContainerClusterNodeConfig(r *Resource, liveState *terraform.InstanceState, config map[string]interface{}) error {
 	removeDefaultNodePoolDirective := "remove-default-node-pool"
+	allowNodeConfigOverrideDirective := "remove-default-node-pool-allow-node-config"
 	nodeConfigFieldInTFState := "node_config"
 	nodeConfigFieldInKRMConfig := text.SnakeCaseToLowerCamelCase(nodeConfigFieldInTFState)
 
@@ -165,6 +179,22 @@ func resolveContainerClusterNodeConfig(r *Resource, liveState *terraform.Instanc
 		return fmt.Errorf("error resolving field '%v' in 'ContainerCluster': %w", nodeConfigFieldInKRMConfig, err)
 	}
 	if exists {
+		return nil
+	}
+
+	// If the resource is being created, we MUST NOT strip node_config, because the user may have specified
+	// important settings like network tags that are required for the temporary default pool to connect
+	// to the master during provisioning.
+	if liveState.ID == "" {
+		return nil
+	}
+
+	// Opt-in logic to allow specifying nodeConfig for the temporary default pool
+	// (unblocking OrgPolicies/custom requirements) without causing a permanent
+	// reconciliation loop once GKE deletes the pool.
+	allowNodeConfigOverrideKey := k8s.FormatAnnotation(allowNodeConfigOverrideDirective)
+	if override, ok := k8s.GetAnnotation(allowNodeConfigOverrideKey, r); ok && override == "true" {
+		unstructured.RemoveNestedField(config, nodeConfigFieldInKRMConfig)
 		return nil
 	}
 

--- a/pkg/krmtotf/legacygcpmanagedfields_test.go
+++ b/pkg/krmtotf/legacygcpmanagedfields_test.go
@@ -32,11 +32,55 @@ func TestResolveGCPManagedFields(t *testing.T) {
 	tests := []struct {
 		name              string
 		kind              string
+		annotations       map[string]string
 		lastAppliedConfig map[string]interface{}
 		resourceExists    bool
+		liveStateAttr     map[string]string
 		inputConfig       map[string]interface{}
 		expectedConfig    map[string]interface{}
 	}{
+		{
+			name: "ContainerCluster removes node version when remove-default-node-pool set",
+			kind: "ContainerCluster",
+			annotations: map[string]string{
+				"cnrm.cloud.google.com/remove-default-node-pool": "true",
+			},
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"location": "us-central1-a",
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"location":    "us-central1-a",
+				"nodeVersion": "1.27",
+			},
+			expectedConfig: map[string]interface{}{
+				"location": "us-central1-a",
+			},
+		},
+		{
+			name: "ContainerCluster respects node version when explicitly applied even if remove-default-node-pool set",
+			kind: "ContainerCluster",
+			annotations: map[string]string{
+				"cnrm.cloud.google.com/remove-default-node-pool": "true",
+			},
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"location":    "us-central1-a",
+					"nodeVersion": "1.27",
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"location":    "us-central1-a",
+				"nodeVersion": "1.27",
+			},
+			expectedConfig: map[string]interface{}{
+				"location":    "us-central1-a",
+				"nodeVersion": "1.27",
+			},
+		},
 		{
 			name: "ContainerCluster treats node version as GCP-managed when release channel set",
 			kind: "ContainerCluster",
@@ -496,7 +540,7 @@ func TestResolveGCPManagedFields(t *testing.T) {
 			},
 		},
 		{
-			name: "BigtableInstance removes an existing numNodes, if the value is removed",
+			name: "ContainerCluster removes an existing numNodes, if the value is removed",
 			kind: "BigtableInstance",
 			lastAppliedConfig: map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -530,6 +574,76 @@ func TestResolveGCPManagedFields(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ContainerCluster removes nodeConfig when remove-default-node-pool set and node_config not in live state",
+			kind: "ContainerCluster",
+			annotations: map[string]string{
+				"cnrm.cloud.google.com/remove-default-node-pool": "true",
+			},
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"location": "us-central1-a",
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"location": "us-central1-a",
+				"nodeConfig": []map[string]interface{}{
+					{"machineType": "n1-standard-1"},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"location": "us-central1-a",
+			},
+		},
+		{
+			name: "ContainerCluster keeps nodeConfig when remove-default-node-pool set and node_config not in live state but it is a new creation",
+			kind: "ContainerCluster",
+			annotations: map[string]string{
+				"cnrm.cloud.google.com/remove-default-node-pool": "true",
+			},
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"location": "us-central1-a",
+				},
+			},
+			resourceExists: false,
+			inputConfig: map[string]interface{}{
+				"location": "us-central1-a",
+				"nodeConfig": []map[string]interface{}{
+					{"machineType": "n1-standard-1"},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"location": "us-central1-a",
+				"nodeConfig": []map[string]interface{}{
+					{"machineType": "n1-standard-1"},
+				},
+			},
+		},
+		{
+			name: "ContainerCluster removes nodeConfig when remove-default-node-pool-allow-node-config is true even if node_config not in live state",
+			kind: "ContainerCluster",
+			annotations: map[string]string{
+				"cnrm.cloud.google.com/remove-default-node-pool":                   "true",
+				"cnrm.cloud.google.com/remove-default-node-pool-allow-node-config": "true",
+			},
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"location": "us-central1-a",
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"location": "us-central1-a",
+				"nodeConfig": []map[string]interface{}{
+					{"machineType": "n1-standard-1"},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"location": "us-central1-a",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -539,17 +653,25 @@ func TestResolveGCPManagedFields(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error marshaling last applied config: %v", err)
 			}
-			r.SetAnnotations(map[string]string{
-				k8s.LastAppliedConfigurationAnnotation: string(lastAppliedConfigJSON),
-			})
+			annotations := make(map[string]string)
+			for k, v := range tc.annotations {
+				annotations[k] = v
+			}
+			annotations[k8s.LastAppliedConfigurationAnnotation] = string(lastAppliedConfigJSON)
+			r.SetAnnotations(annotations)
 			var liveState *terraform.InstanceState
 			if tc.resourceExists {
 				// The content of the instance state does not matter here,
 				// as the diff function later handles the merge. We just
 				// need to supply *something* to mark this resource
 				// as already existing.
+				attr := tc.liveStateAttr
+				if attr == nil {
+					attr = make(map[string]string)
+				}
 				liveState = &terraform.InstanceState{
-					ID: "foo",
+					ID:         "foo",
+					Attributes: attr,
 				}
 			}
 			config := tc.inputConfig

--- a/tests/e2e/script_test.go
+++ b/tests/e2e/script_test.go
@@ -207,6 +207,47 @@ func TestE2EScript(t *testing.T) {
 						applyObject(h, obj)
 						time.Sleep(10 * time.Second)
 
+					case "APPLY-MOCK-RECREATION-ERROR":
+						applyObject(h, obj)
+
+						// Mock logic for simulated-tf-remove-default-node-pool
+						if obj.GroupVersionKind().Kind == "ContainerCluster" {
+							_, nodeConfigFound, _ := unstructured.NestedMap(obj.Object, "spec", "nodeConfig")
+							var removeDefaultNodePool string
+							var allowNodeConfig string
+							if annotations := obj.GetAnnotations(); annotations != nil {
+								removeDefaultNodePool = annotations["cnrm.cloud.google.com/remove-default-node-pool"]
+								allowNodeConfig = annotations["cnrm.cloud.google.com/remove-default-node-pool-allow-node-config"]
+							}
+
+							if nodeConfigFound && removeDefaultNodePool == "true" && allowNodeConfig != "true" {
+								// For this specific test case, we want to simulate the TF error
+								// which is otherwise hard to trigger in mockgcp.
+								// We manually patch the status to include the error.
+								u := &unstructured.Unstructured{}
+								u.SetGroupVersionKind(obj.GroupVersionKind())
+								u.SetName(obj.GetName())
+								u.SetNamespace(obj.GetNamespace())
+
+								if err := h.GetClient().Get(ctx, client.ObjectKeyFromObject(u), u); err == nil {
+									conditions := []interface{}{
+										map[string]interface{}{
+											"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+											"message":            "Update failed: node_version can only be specified if remove_default_node_pool is not true",
+											"reason":             "UpdateFailed",
+											"status":             "False",
+											"type":               "Ready",
+										},
+									}
+									unstructured.SetNestedSlice(u.Object, conditions, "status", "conditions")
+									if err := h.GetClient().Status().Update(ctx, u); err != nil {
+										t.Logf("failed to update status for mock: %v", err)
+									}
+								}
+							}
+						}
+						time.Sleep(10 * time.Second)
+
 					case "READ-OBJECT":
 						appliedObjects = append(appliedObjects, obj)
 

--- a/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_http01.log
+++ b/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_http01.log
@@ -1,0 +1,430 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}.",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "cluster": {
+    "autopilot": {
+      "enabled": false
+    },
+    "autoscaling": {
+      "enableNodeAutoprovisioning": false
+    },
+    "binaryAuthorization": {
+      "enabled": false
+    },
+    "controlPlaneEndpointsConfig": {
+      "dnsEndpointConfig": {
+        "allowExternalTraffic": false,
+        "enableK8sTokensViaDns": false
+      },
+      "ipEndpointsConfig": {
+        "authorizedNetworksConfig": {},
+        "enablePublicEndpoint": true,
+        "enabled": true,
+        "globalAccess": false,
+        "privateEndpointSubnetwork": ""
+      }
+    },
+    "initialNodeCount": 1,
+    "ipAllocationPolicy": {
+      "stackType": "IPV4",
+      "useIpAliases": false
+    },
+    "legacyAbac": {
+      "enabled": false
+    },
+    "maintenancePolicy": {
+      "window": {}
+    },
+    "name": "cluster-${uniqueId}",
+    "network": "projects/${projectId}/global/networks/default",
+    "networkConfig": {},
+    "networkPolicy": {},
+    "nodeConfig": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "machineType": "n1-standard-1"
+    },
+    "notificationConfig": {
+      "pubsub": {}
+    },
+    "resourceLabels": {
+      "managed-by-cnrm": "true"
+    },
+    "shieldedNodes": {
+      "enabled": true
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "progress": {
+    "metrics": [
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING"
+      },
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING_TOTAL"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING_TOTAL"
+      },
+      {
+        "intValue": "1",
+        "name": "CLUSTER_HEALTHCHECKING"
+      },
+      {
+        "intValue": "2",
+        "name": "CLUSTER_HEALTHCHECKING_TOTAL"
+      }
+    ]
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+DELETE https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}/nodePools/default-pool?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "DELETE_NODE_POOL",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "DELETE_NODE_POOL",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.27.3-gke.100",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "cluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}

--- a/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_object00.yaml
@@ -1,0 +1,23 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+  generation: 1
+  name: cluster-${uniqueId}
+  namespace: ${projectId}
+spec:
+  initialNodeCount: 1
+  location: us-central1-a
+  nodeConfig:
+    machineType: n1-standard-1
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: 'Update failed: node_version can only be specified if remove_default_node_pool
+      is not true'
+    reason: UpdateFailed
+    status: "False"
+    type: Ready

--- a/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/_object01.yaml
@@ -1,0 +1,44 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/remove-default-node-pool-allow-node-config: "true"
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: cluster-${uniqueId}
+  namespace: ${projectId}
+spec:
+  initialNodeCount: 1
+  location: us-central1-a
+  nodeConfig:
+    machineType: n1-standard-1
+  resourceID: cluster-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  endpoint: 1.23.456.78
+  labelFingerprint: abcdef0123A=
+  masterVersion: 1.30.5-gke.1014001
+  observedGeneration: 2
+  observedState:
+    controlPlaneEndpointsConfig:
+      dnsEndpointConfig:
+        endpoint: gke-12345trewq-${projectNumber}.us-central1-a.gke.goog
+    masterAuth:
+      clusterCaCertificate: 1234567890abcdefghijklmn
+    privateClusterConfig:
+      privateEndpoint: 10.128.0.2
+      publicEndpoint: 8.8.8.8
+  selfLink: https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}
+  servicesIpv4Cidr: 34.118.224.0/20

--- a/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/script.yaml
+++ b/tests/e2e/testdata/scenarios/container/tf-remove-default-node-pool/script.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Step 1: Create ContainerCluster with remove-default-node-pool: "true"
+# We expect a mock error since nodeConfig is present.
+TEST: APPLY-MOCK-RECREATION-ERROR
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+  name: cluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  nodeConfig:
+    machineType: n1-standard-1
+
+---
+
+# Step 2: Add the fix annotation.
+# This should strip nodeConfig and allow the resource to become Ready.
+TEST: APPLY
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/remove-default-node-pool-allow-node-config: "true"
+  name: cluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  nodeConfig:
+    machineType: n1-standard-1


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
When the `cnrm.cloud.google.com/remove-default-node-pool: "true"` directive is used, as KCC's automated "GCP-unmanaged fields" logic overlays the nodeVersion (fetched from GCP) onto the desired state, triggering a validation conflict in the underlying Terraform provider. The validation should only happen during new creation([code](https://github.com/gemmahou/terraform-provider-google-beta/blob/main/google-beta/services/container/resource_container_cluster.go#L8321-L8322)).

Setting `nodeConfig` caused Terraform to interpret the reconciliation as a resource recreation. This **likely** occurs because `node_config` is marked as `ForceNew` in the TF schema. Once the default pool is deleted, `node_config` is absent from the live state; the resulting diff between the desired state (containing `node_config`) and the live state (missing it) triggers a replacement rather than an update, leading to the above error.

#### WHY do we need this change?
To avoid unintended re-creation in Terraform, we should ensure `nodeConfig` is removed from the desired state after the initial cluster provisioning. We eliminate the drift that causes the `ForceNew` logic to trigger.

This change is necessary because customers may require `nodeConfig` on the default node pool to satisfy system requirements during the initial cluster creation process. They also need to remove the default node pool later and manage their own nodes using the `ContainerNodePool` resource.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce "cnrm.cloud.google.com/remove-default-node-pool-allow-node-config" annotation to unblock cluster creation and reconciliation with restricted security policies that requires "nodeConfig".
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
