### PR TITLE
Add static metadata file and viewer for tracking migration to direct

### DIFF
--- a/dev/migration-tracker/README.md
+++ b/dev/migration-tracker/README.md
@@ -1,0 +1,25 @@
+# KCC Direct Migration Tracker
+
+This folder contains a static website and metadata file for tracking the migration of KCC resources from Terraform/DCL to Direct Controllers.
+
+## Files
+
+- `data.json`: The metadata file containing all the KCC resources and their migration status, dependencies, and steps.
+- `index.html`: The static webpage to display the data.
+- `app.js` & `style.css`: The UI logic and styles.
+- `generate_data.py`: A Python script to scaffold `data.json` initially from `hack/resource-dependencies.md`.
+
+## How to View Locally
+
+You can run any simple HTTP server to serve the static files. For example, using Python 3:
+
+```bash
+cd dev/migration-tracker
+python3 -m http.server 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your web browser.
+
+## Updating Data
+
+To update the status of a migration, simply edit `data.json` and change the relevant fields. For example, changing `"state": "Not Started"` to `"state": "In Progress"` or updating `"steps"`.

--- a/dev/migration-tracker/app.js
+++ b/dev/migration-tracker/app.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let resourceData = [];
+let currentSort = { column: 'kind', direction: 'asc' };
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetchData();
+
+    document.getElementById('search').addEventListener('input', renderTable);
+    document.getElementById('filter-state').addEventListener('change', renderTable);
+
+    document.querySelectorAll('th[data-sort]').forEach(th => {
+        th.addEventListener('click', () => {
+            const column = th.getAttribute('data-sort');
+            if (currentSort.column === column) {
+                currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+            } else {
+                currentSort.column = column;
+                currentSort.direction = 'asc';
+            }
+            updateSortIcons();
+            renderTable();
+        });
+    });
+});
+
+async function fetchData() {
+    try {
+        const response = await fetch('data.json');
+        resourceData = await response.json();
+        updateStats();
+        updateSortIcons();
+        renderTable();
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        document.getElementById('table-body').innerHTML = `<tr><td colspan="9" style="text-align: center; color: red;">Error loading data.json</td></tr>`;
+    }
+}
+
+function updateStats() {
+    const total = resourceData.length;
+    const completed = resourceData.filter(r => r.state === 'Completed').length;
+    const inProgress = resourceData.filter(r => r.state === 'In Progress').length;
+
+    document.getElementById('stat-total').textContent = total;
+    document.getElementById('stat-completed').textContent = completed;
+    document.getElementById('stat-inprogress').textContent = inProgress;
+}
+
+function updateSortIcons() {
+    document.querySelectorAll('th[data-sort] .sort-icon').forEach(icon => icon.textContent = '');
+    const activeTh = document.querySelector(`th[data-sort="${currentSort.column}"] .sort-icon`);
+    if (activeTh) {
+        activeTh.textContent = currentSort.direction === 'asc' ? ' ▲' : ' ▼';
+    }
+}
+
+function renderTable() {
+    const searchVal = document.getElementById('search').value.toLowerCase();
+    const stateVal = document.getElementById('filter-state').value;
+
+    let filteredData = resourceData.filter(row => {
+        const matchesSearch = 
+            row.kind.toLowerCase().includes(searchVal) || 
+            row.group.toLowerCase().includes(searchVal) ||
+            row.dependencies.some(d => d.toLowerCase().includes(searchVal));
+        
+        const matchesState = stateVal === 'All' || row.state === stateVal;
+
+        return matchesSearch && matchesState;
+    });
+
+    filteredData.sort((a, b) => {
+        let valA = a[currentSort.column];
+        let valB = b[currentSort.column];
+
+        if (typeof valA === 'string') valA = valA.toLowerCase();
+        if (typeof valB === 'string') valB = valB.toLowerCase();
+
+        if (valA < valB) return currentSort.direction === 'asc' ? -1 : 1;
+        if (valA > valB) return currentSort.direction === 'asc' ? 1 : -1;
+        return 0;
+    });
+
+    const tbody = document.getElementById('table-body');
+    tbody.innerHTML = '';
+
+    filteredData.forEach(row => {
+        const tr = document.createElement('tr');
+
+        const stateClass = row.state.toLowerCase().replace(' ', '-');
+        
+        // Steps mapping
+        const stepsHtml = `
+            <span class="step-indicator ${row.steps['gen-types'] ? 'done' : ''}" title="Gen Types"></span>
+            <span class="step-indicator ${row.steps['identity-reference'] ? 'done' : ''}" title="Identity Reference"></span>
+            <span class="step-indicator ${row.steps['mapper-fuzzer'] ? 'done' : ''}" title="Mapper Fuzzer"></span>
+            <span class="step-indicator ${row.steps.mocks ? 'done' : ''}" title="Mocks"></span>
+            <span class="step-indicator ${row.steps.controller ? 'done' : ''}" title="Controller"></span>
+            <span class="step-indicator ${row.steps.tests ? 'done' : ''}" title="Tests"></span>
+        `;
+
+        const depsHtml = row.dependencies.map(d => `<span class="dependency-tag">${d}</span>`).join('') || '-';
+
+        tr.innerHTML = `
+            <td><strong>${row.kind}</strong></td>
+            <td>${row.group}</td>
+            <td>${row.version}</td>
+            <td>
+                <div style="font-weight: 600;">${row.defaultController}</div>
+                <div style="font-size: 11px; color: #5f6368;">Supported: ${row.supportedControllers.join(', ')}</div>
+            </td>
+            <td><span class="badge ${stateClass}">${row.state}</span></td>
+            <td>${stepsHtml}</td>
+            <td>${depsHtml}</td>
+            <td>${row.mocksLastRefreshed}</td>
+            <td style="color: #d93025; font-size: 11px;">${row.notes || ''}</td>
+        `;
+        tbody.appendChild(tr);
+    });
+}

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -1,0 +1,9312 @@
+[
+  {
+    "group": "apigateway",
+    "kind": "APIGatewayAPI",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigateway",
+    "kind": "APIGatewayAPIConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigateway",
+    "kind": "APIGatewayGateway",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apikeys",
+    "kind": "APIKeysKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudquota",
+    "kind": "APIQuotaAdjusterSettings",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudquota",
+    "kind": "APIQuotaPreference",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerAccessLevel",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerAccessLevelCondition",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerAccessPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerGCPUserAccessBinding",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerServicePerimeter",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "accesscontextmanager",
+    "kind": "AccessContextManagerServicePerimeterResource",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "alloydb",
+    "kind": "AlloyDBBackup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "alloydb",
+    "kind": "AlloyDBCluster",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "alloydb",
+    "kind": "AlloyDBInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "alloydb",
+    "kind": "AlloyDBUser",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeAddonsConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeEndpointAttachment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeEnvgroup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeEnvgroupAttachment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeEnvironment",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeInstanceAttachment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeNATAddress",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeOrganization",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apigee",
+    "kind": "ApigeeSyncAuthorization",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "appengine",
+    "kind": "AppEngineDomainMapping",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "appengine",
+    "kind": "AppEngineFirewallRule",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "appengine",
+    "kind": "AppEngineFlexibleAppVersion",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "appengine",
+    "kind": "AppEngineServiceSplitTraffic",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "appengine",
+    "kind": "AppEngineStandardAppVersion",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "apphub",
+    "kind": "AppHubApplication",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "artifactregistry",
+    "kind": "ArtifactRegistryRepository",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "asset",
+    "kind": "AssetFeed",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "asset",
+    "kind": "AssetSavedQuery",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "backupdr",
+    "kind": "BackupDRBackupPlan",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "backupdr",
+    "kind": "BackupDRBackupPlanAssociation",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "backupdr",
+    "kind": "BackupDRBackupVault",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "backupdr",
+    "kind": "BackupDRManagementServer",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "batch",
+    "kind": "BatchJob",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "beyondcorp",
+    "kind": "BeyondCorpAppConnection",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "beyondcorp",
+    "kind": "BeyondCorpAppConnector",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "beyondcorp",
+    "kind": "BeyondCorpAppGateway",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquerybiglake",
+    "kind": "BigLakeTable",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryanalyticshub",
+    "kind": "BigQueryAnalyticsHubDataExchange",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryanalyticshub",
+    "kind": "BigQueryAnalyticsHubListing",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryconnection",
+    "kind": "BigQueryConnectionConnection",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquerydatapolicy",
+    "kind": "BigQueryDataPolicyDataPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquerydatatransfer",
+    "kind": "BigQueryDataTransferConfig",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "bigquery",
+    "kind": "BigQueryDataset",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquery",
+    "kind": "BigQueryDatasetAccess",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquery",
+    "kind": "BigQueryJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryreservation",
+    "kind": "BigQueryReservationAssignment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryreservation",
+    "kind": "BigQueryReservationCapacityCommitment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigqueryreservation",
+    "kind": "BigQueryReservationReservation",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquery",
+    "kind": "BigQueryRoutine",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigquery",
+    "kind": "BigQueryTable",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableAppProfile",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableGCPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableLogicalView",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableMaterializedView",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "bigtable",
+    "kind": "BigtableTable",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "billingbudgets",
+    "kind": "BillingBudgetsBudget",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "binaryauthorization",
+    "kind": "BinaryAuthorizationAttestor",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "binaryauthorization",
+    "kind": "BinaryAuthorizationPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "certificatemanager",
+    "kind": "CertificateManagerCertificate",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "certificatemanager",
+    "kind": "CertificateManagerCertificateMap",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "certificatemanager",
+    "kind": "CertificateManagerCertificateMapEntry",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "certificatemanager",
+    "kind": "CertificateManagerDNSAuthorization",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "cloudasset",
+    "kind": "CloudAssetFolderFeed",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudasset",
+    "kind": "CloudAssetOrganizationFeed",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudasset",
+    "kind": "CloudAssetProjectFeed",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudbuild",
+    "kind": "CloudBuildTrigger",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "cloudbuild",
+    "kind": "CloudBuildWorkerPool",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "clouddeploy",
+    "kind": "CloudDeployDeliveryPipeline",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudfunctions2",
+    "kind": "CloudFunctions2Function",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudfunctions",
+    "kind": "CloudFunctionsFunction",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudids",
+    "kind": "CloudIDSEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudiot",
+    "kind": "CloudIOTDevice",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudiot",
+    "kind": "CloudIOTDeviceRegistry",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudidentity",
+    "kind": "CloudIdentityGroup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudidentity",
+    "kind": "CloudIdentityMembership",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudscheduler",
+    "kind": "CloudSchedulerJob",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "colab",
+    "kind": "ColabRuntime",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "colab",
+    "kind": "ColabRuntimeTemplate",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "composer",
+    "kind": "ComposerEnvironment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeAddress",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeAutoscaler",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeBackendBucket",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeBackendBucketSignedURLKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeBackendService",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeBackendServiceSignedURLKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeDisk",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [
+      "ComputeImage"
+    ],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeDiskResourcePolicyAttachment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [
+      "ComputeDisk"
+    ],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeExternalVPNGateway",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeFirewall",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeFirewallPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeFirewallPolicyAssociation",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeFirewallPolicyRule",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeForwardingRule",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeGlobalNetworkEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeGlobalNetworkEndpointGroup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeHTTPHealthCheck",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeHTTPSHealthCheck",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeHealthCheck",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeImage",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [
+      "ComputeDisk"
+    ],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInstanceGroup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInstanceGroupManager",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInstanceGroupNamedPort",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInstanceTemplate",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeInterconnectAttachment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeMachineImage",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeManagedSSLCertificate",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetwork",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkAttachment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkEdgeSecurityService",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkEndpointGroup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkFirewallPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkFirewallPolicyAssociation",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkFirewallPolicyRule",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkPeering",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNetworkPeeringRoutesConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNodeGroup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeNodeTemplate",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeOrganizationSecurityPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeOrganizationSecurityPolicyAssociation",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeOrganizationSecurityPolicyRule",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputePacketMirroring",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputePerInstanceConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeProjectMetadata",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRegionAutoscaler",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRegionDiskResourcePolicyAttachment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [
+      "ComputeDisk"
+    ],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRegionNetworkEndpointGroup",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRegionPerInstanceConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRegionSSLPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeReservation",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeResourcePolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRoute",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRouter",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRouterInterface",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRouterNAT",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeRouterPeer",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSSLCertificate",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSSLPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSecurityPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeServiceAttachment",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSharedVPCHostProject",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSharedVPCServiceProject",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSnapshot",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeSubnetwork",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetGRPCProxy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetHTTPProxy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetHTTPSProxy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetPool",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetSSLProxy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetTCPProxy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeTargetVPNGateway",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeURLMap",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeVPNGateway",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "compute",
+    "kind": "ComputeVPNTunnel",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "configcontroller",
+    "kind": "ConfigControllerInstance",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "containeranalysis",
+    "kind": "ContainerAnalysisNote",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "containeranalysis",
+    "kind": "ContainerAnalysisOccurrence",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "containerattached",
+    "kind": "ContainerAttachedCluster",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "container",
+    "kind": "ContainerCluster",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "container",
+    "kind": "ContainerNodePool",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dlp",
+    "kind": "DLPDeidentifyTemplate",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dlp",
+    "kind": "DLPInspectTemplate",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dlp",
+    "kind": "DLPJobTrigger",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dlp",
+    "kind": "DLPStoredInfoType",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dns",
+    "kind": "DNSManagedZone",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dns",
+    "kind": "DNSPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dns",
+    "kind": "DNSRecordSet",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dns",
+    "kind": "DNSResponsePolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dns",
+    "kind": "DNSResponsePolicyRule",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogEntry",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogEntryGroup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogPolicyTag",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogTag",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogTagTemplate",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datacatalog",
+    "kind": "DataCatalogTaxonomy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datafusion",
+    "kind": "DataFusionInstance",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataflow",
+    "kind": "DataflowFlexTemplateJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "dataflow",
+    "kind": "DataflowJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataform",
+    "kind": "DataformRepository",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "dataplex",
+    "kind": "DataplexEntryGroup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataplex",
+    "kind": "DataplexEntryType",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataplex",
+    "kind": "DataplexLake",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataplex",
+    "kind": "DataplexTask",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataplex",
+    "kind": "DataplexZone",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataproc",
+    "kind": "DataprocAutoscalingPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "dataproc",
+    "kind": "DataprocBatch",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataproc",
+    "kind": "DataprocCluster",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataproc",
+    "kind": "DataprocJob",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dataproc",
+    "kind": "DataprocWorkflowTemplate",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datastore",
+    "kind": "DatastoreIndex",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datastream",
+    "kind": "DatastreamConnectionProfile",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datastream",
+    "kind": "DatastreamPrivateConnection",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datastream",
+    "kind": "DatastreamRoute",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "datastream",
+    "kind": "DatastreamStream",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "deploymentmanager",
+    "kind": "DeploymentManagerDeployment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflow",
+    "kind": "DialogflowAgent",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXAgent",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXEntityType",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXFlow",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXIntent",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXPage",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflowcx",
+    "kind": "DialogflowCXWebhook",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflow",
+    "kind": "DialogflowEntityType",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflow",
+    "kind": "DialogflowFulfillment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "dialogflow",
+    "kind": "DialogflowIntent",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "discoveryengine",
+    "kind": "DiscoveryEngineDataStore",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "documentai",
+    "kind": "DocumentAIProcessor",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "documentai",
+    "kind": "DocumentAIProcessorDefaultVersion",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "documentai",
+    "kind": "DocumentAIProcessorVersion",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "edgecontainer",
+    "kind": "EdgeContainerCluster",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "edgecontainer",
+    "kind": "EdgeContainerNodePool",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "edgecontainer",
+    "kind": "EdgeContainerVpnConnection",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "edgenetwork",
+    "kind": "EdgeNetworkNetwork",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "edgenetwork",
+    "kind": "EdgeNetworkSubnet",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "essentialcontacts",
+    "kind": "EssentialContactsContact",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "eventarc",
+    "kind": "EventarcChannel",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "eventarc",
+    "kind": "EventarcGoogleChannelConfig",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "eventarc",
+    "kind": "EventarcTrigger",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "filestore",
+    "kind": "FilestoreBackup",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "filestore",
+    "kind": "FilestoreInstance",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "filestore",
+    "kind": "FilestoreSnapshot",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebase",
+    "kind": "FirebaseAndroidApp",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebasedatabase",
+    "kind": "FirebaseDatabaseInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebasehosting",
+    "kind": "FirebaseHostingChannel",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebasehosting",
+    "kind": "FirebaseHostingSite",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebase",
+    "kind": "FirebaseProject",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebasestorage",
+    "kind": "FirebaseStorageBucket",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firebase",
+    "kind": "FirebaseWebApp",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firestore",
+    "kind": "FirestoreDatabase",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firestore",
+    "kind": "FirestoreDocument",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firestore",
+    "kind": "FirestoreField",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "firestore",
+    "kind": "FirestoreIndex",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "resourcemanager",
+    "kind": "Folder",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkebackup",
+    "kind": "GKEBackupBackup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkebackup",
+    "kind": "GKEBackupBackupPlan",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkebackup",
+    "kind": "GKEBackupRestore",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkebackup",
+    "kind": "GKEBackupRestorePlan",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkehub",
+    "kind": "GKEHubFeature",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "gkehub",
+    "kind": "GKEHubFeatureMembership",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "gkehub",
+    "kind": "GKEHubMembership",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "healthcare",
+    "kind": "HealthcareConsentStore",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "healthcare",
+    "kind": "HealthcareDICOMStore",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "healthcare",
+    "kind": "HealthcareDataset",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "healthcare",
+    "kind": "HealthcareFHIRStore",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "healthcare",
+    "kind": "HealthcareHL7V2Store",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMAccessBoundaryPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMAuditConfig",
+    "version": "v1beta1",
+    "controllerType": "IAMAuditConfig",
+    "defaultController": "IAMAuditConfig",
+    "supportedControllers": [
+      "IAMAuditConfig"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "iam",
+    "kind": "IAMCustomRole",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMPartialPolicy",
+    "version": "v1beta1",
+    "controllerType": "IAMPartialPolicy",
+    "defaultController": "IAMPartialPolicy",
+    "supportedControllers": [
+      "Direct",
+      "IAMPartialPolicy"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "iam",
+    "kind": "IAMPolicy",
+    "version": "v1beta1",
+    "controllerType": "IAMPolicy",
+    "defaultController": "IAMPolicy",
+    "supportedControllers": [
+      "IAMPolicy"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "iam",
+    "kind": "IAMPolicyMember",
+    "version": "v1beta1",
+    "controllerType": "IAMPolicyMember",
+    "defaultController": "IAMPolicyMember",
+    "supportedControllers": [
+      "IAMPolicyMember"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "iam",
+    "kind": "IAMServiceAccount",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMServiceAccountKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMWorkforcePool",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMWorkforcePoolProvider",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMWorkloadIdentityPool",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iam",
+    "kind": "IAMWorkloadIdentityPoolProvider",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iap",
+    "kind": "IAPBrand",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iap",
+    "kind": "IAPIdentityAwareProxyClient",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "iap",
+    "kind": "IAPSettings",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformConfig",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformDefaultSupportedIDPConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformInboundSAMLConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformOAuthIDPConfig",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformProjectDefaultConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformTenant",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformTenantDefaultSupportedIDPConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformTenantInboundSAMLConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "identityplatform",
+    "kind": "IdentityPlatformTenantOAuthIDPConfig",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSAutokeyConfig",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSCryptoKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSCryptoKeyVersion",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSImportJob",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSKeyHandle",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSKeyRing",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSKeyRingImportJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "kms",
+    "kind": "KMSSecretCiphertext",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLink",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogBucket",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogExclusion",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogMetric",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogSink",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "logging",
+    "kind": "LoggingLogView",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "mlengine",
+    "kind": "MLEngineModel",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "managedkafka",
+    "kind": "ManagedKafkaCluster",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "managedkafka",
+    "kind": "ManagedKafkaTopic",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "memcache",
+    "kind": "MemcacheInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "memorystore",
+    "kind": "MemorystoreInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "metastore",
+    "kind": "MetastoreBackup",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "metastore",
+    "kind": "MetastoreFederation",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "metastore",
+    "kind": "MetastoreService",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringAlertPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringDashboard",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringGroup",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringMetricDescriptor",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringMonitoredProject",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringNotificationChannel",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringService",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringServiceLevelObjective",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "monitoring",
+    "kind": "MonitoringUptimeCheckConfig",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "netapp",
+    "kind": "NetAppBackupPolicy",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkconnectivity",
+    "kind": "NetworkConnectivityHub",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkconnectivity",
+    "kind": "NetworkConnectivityInternalRange",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkconnectivity",
+    "kind": "NetworkConnectivityServiceConnectionPolicy",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "networkconnectivity",
+    "kind": "NetworkConnectivitySpoke",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkmanagement",
+    "kind": "NetworkManagementConnectivityTest",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networksecurity",
+    "kind": "NetworkSecurityAuthorizationPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networksecurity",
+    "kind": "NetworkSecurityClientTLSPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networksecurity",
+    "kind": "NetworkSecurityServerTLSPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesEdgeCacheKeyset",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesEdgeCacheOrigin",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesEdgeCacheService",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesEndpointPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesGRPCRoute",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesGateway",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesHTTPRoute",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesMesh",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesServiceBinding",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesTCPRoute",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "networkservices",
+    "kind": "NetworkServicesTLSRoute",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "notebooks",
+    "kind": "NotebookInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "notebooks",
+    "kind": "NotebooksEnvironment",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "osconfig",
+    "kind": "OSConfigGuestPolicy",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "osconfig",
+    "kind": "OSConfigOSPolicyAssignment",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "osconfig",
+    "kind": "OSConfigPatchDeployment",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "oslogin",
+    "kind": "OSLoginSSHPublicKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "orgpolicy",
+    "kind": "OrgPolicyCustomConstraint",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "orgpolicy",
+    "kind": "OrgPolicyPolicy",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "parametermanager",
+    "kind": "ParameterManagerParameter",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "privateca",
+    "kind": "PrivateCACAPool",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL",
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "privateca",
+    "kind": "PrivateCACertificate",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "privateca",
+    "kind": "PrivateCACertificateAuthority",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "privateca",
+    "kind": "PrivateCACertificateTemplate",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "privilegedaccessmanager",
+    "kind": "PrivilegedAccessManagerEntitlement",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "resourcemanager",
+    "kind": "Project",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsublite",
+    "kind": "PubSubLiteReservation",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsublite",
+    "kind": "PubSubLiteSubscription",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsublite",
+    "kind": "PubSubLiteTopic",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsub",
+    "kind": "PubSubSchema",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsub",
+    "kind": "PubSubSnapshot",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsub",
+    "kind": "PubSubSubscription",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "pubsub",
+    "kind": "PubSubTopic",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "recaptchaenterprise",
+    "kind": "ReCAPTCHAEnterpriseFirewallPolicy",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "recaptchaenterprise",
+    "kind": "RecaptchaEnterpriseKey",
+    "version": "v1beta1",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
+    "supportedControllers": [
+      "DCL"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "redis",
+    "kind": "RedisCluster",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "redis",
+    "kind": "RedisInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "resourcemanager",
+    "kind": "ResourceManagerLien",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "resourcemanager",
+    "kind": "ResourceManagerPolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "run",
+    "kind": "RunJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "run",
+    "kind": "RunService",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "sql",
+    "kind": "SQLDatabase",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "sql",
+    "kind": "SQLInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "sql",
+    "kind": "SQLSSLCert",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "sql",
+    "kind": "SQLUser",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "secretmanager",
+    "kind": "SecretManagerSecret",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "secretmanager",
+    "kind": "SecretManagerSecretVersion",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "securesourcemanager",
+    "kind": "SecureSourceManagerInstance",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "securesourcemanager",
+    "kind": "SecureSourceManagerRepository",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "securitycenter",
+    "kind": "SecurityCenterNotificationConfig",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "securitycenter",
+    "kind": "SecurityCenterSource",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "serviceusage",
+    "kind": "Service",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "servicedirectory",
+    "kind": "ServiceDirectoryEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "servicedirectory",
+    "kind": "ServiceDirectoryNamespace",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "servicedirectory",
+    "kind": "ServiceDirectoryService",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "serviceusage",
+    "kind": "ServiceIdentity",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "servicenetworking",
+    "kind": "ServiceNetworkingConnection",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "servicenetworking",
+    "kind": "ServiceNetworkingPeeredDNSDomain",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "serviceusage",
+    "kind": "ServiceUsageConsumerQuotaOverride",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "sourcerepo",
+    "kind": "SourceRepoRepository",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "spanner",
+    "kind": "SpannerBackupSchedule",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "spanner",
+    "kind": "SpannerDatabase",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "spanner",
+    "kind": "SpannerInstance",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "spanner",
+    "kind": "SpannerInstanceConfig",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "speech",
+    "kind": "SpeechCustomClass",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "speech",
+    "kind": "SpeechPhraseSet",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "speech",
+    "kind": "SpeechRecognizer",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageAnywhereCache",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageBucket",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageBucketAccessControl",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageDefaultObjectAccessControl",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageFolder",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageHMACKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storage",
+    "kind": "StorageNotification",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storagetransfer",
+    "kind": "StorageTransferAgentPool",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "storagetransfer",
+    "kind": "StorageTransferJob",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "tpu",
+    "kind": "TPUNode",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "tags",
+    "kind": "TagsLocationTagBinding",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "tags",
+    "kind": "TagsTagBinding",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "tags",
+    "kind": "TagsTagKey",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "tags",
+    "kind": "TagsTagValue",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "cloudtasks",
+    "kind": "TasksQueue",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEngineExternalAccessRule",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEngineExternalAddress",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEngineNetwork",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEngineNetworkPeering",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEngineNetworkPolicy",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vmwareengine",
+    "kind": "VMwareEnginePrivateCloud",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vpcaccess",
+    "kind": "VPCAccessConnector",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIDataset",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIFeaturestore",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIFeaturestoreEntityType",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIFeaturestoreEntityTypeFeature",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIIndex",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIIndexEndpoint",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAIMetadataStore",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "vertexai",
+    "kind": "VertexAITensorboard",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Terraform"
+    ],
+    "dependencies": [],
+    "state": "Not Started",
+    "steps": {
+      "gen-types": false,
+      "identity-reference": false,
+      "mapper-fuzzer": false,
+      "mocks": false,
+      "controller": false,
+      "tests": false
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "workflowexecutions",
+    "kind": "WorkflowsExecution",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": false,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "Missing _reference.go"
+  },
+  {
+    "group": "workflows",
+    "kind": "WorkflowsWorkflow",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "workstations",
+    "kind": "Workstation",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "workstations",
+    "kind": "WorkstationCluster",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  },
+  {
+    "group": "workstations",
+    "kind": "WorkstationConfig",
+    "version": "v1beta1",
+    "controllerType": "Direct",
+    "defaultController": "Direct",
+    "supportedControllers": [
+      "Direct"
+    ],
+    "dependencies": [],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": ""
+  }
+]

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+
+def parse_data(md_file_path, config_file_path):
+    resources = {}
+    
+    # Parse static_config.go first to establish the base list
+    with open(config_file_path, 'r') as f:
+        config_lines = f.readlines()
+        
+    for line in config_lines:
+        line = line.strip()
+        # Look for lines like: {Group: "...", Kind: "..."}: {DefaultController: ..., SupportedControllers: ...}
+        if not line.startswith('{Group: '):
+            continue
+            
+        group_match = re.search(r'Group:\s*"([^"]+)"', line)
+        kind_match = re.search(r'Kind:\s*"([^"]+)"', line)
+        default_ctrl_match = re.search(r'DefaultController:\s*k8s\.ReconcilerType([A-Za-z]+)', line)
+        supported_ctrls_match = re.search(r'SupportedControllers:\s*\[\]k8s\.ReconcilerType\{(.*?)\}', line)
+        
+        if group_match and kind_match:
+            group_full = group_match.group(1)
+            # extract the prefix (e.g., 'accesscontextmanager' from 'accesscontextmanager.cnrm.cloud.google.com')
+            group = group_full.split('.')[0]
+            kind = kind_match.group(1)
+            
+            resources[kind] = create_default_resource(kind, group)
+            
+            if default_ctrl_match:
+                # E.g. ReconcilerTypeTerraform -> Terraform
+                resources[kind]['defaultController'] = default_ctrl_match.group(1)
+                # Override the old controllerType field for UI backwards compatibility if needed, 
+                # or just use defaultController
+                resources[kind]['controllerType'] = default_ctrl_match.group(1)
+                
+            if supported_ctrls_match:
+                ctrls_raw = supported_ctrls_match.group(1)
+                # find all occurrences of k8s.ReconcilerTypeXXX
+                supported = re.findall(r'k8s\.ReconcilerType([A-Za-z]+)', ctrls_raw)
+                resources[kind]['supportedControllers'] = supported
+                if 'Direct' in supported:
+                    resources[kind]['state'] = 'Completed'
+                    resources[kind]['steps'] = {
+                        "gen-types": True,
+                        "identity-reference": True,
+                        "mapper-fuzzer": True,
+                        "mocks": True,
+                        "controller": True,
+                        "tests": True
+                    }
+
+    # Now parse MD file to enrich dependencies and notes
+    with open(md_file_path, 'r') as f:
+        md_lines = f.readlines()
+        
+    for line in md_lines:
+        line = line.strip()
+        if not line.startswith('- '):
+            continue
+            
+        if ' depends on: ' in line:
+            parts = line[2:].split(' depends on: ')
+            kind = parts[0].strip()
+            dep = parts[1].strip()
+            
+            # Only add if it exists in static_config.go
+            if kind in resources:
+                if dep not in resources[kind]['dependencies']:
+                    resources[kind]['dependencies'].append(dep)
+        else:
+            kind_raw = line[2:]
+            kind = kind_raw.split('(')[0].strip()
+            
+            # Only enrich if it exists in static_config.go
+            if kind in resources:
+                if 'missing _reference.go only' in line:
+                    resources[kind]['notes'] = 'Missing _reference.go'
+                    resources[kind]['steps']['identity-reference'] = False
+
+    return list(resources.values())
+
+def create_default_resource(kind, group="unknown"):
+    return {
+        "group": group,
+        "kind": kind,
+        "version": "v1beta1",
+        "controllerType": "Unknown",
+        "defaultController": "Unknown",
+        "supportedControllers": [],
+        "dependencies": [],
+        "state": "Not Started",
+        "steps": {
+            "gen-types": False,
+            "identity-reference": False,
+            "mapper-fuzzer": False,
+            "mocks": False,
+            "controller": False,
+            "tests": False
+        },
+        "mocksLastRefreshed": "Never",
+        "notes": ""
+    }
+
+if __name__ == "__main__":
+    data = parse_data('../../hack/resource-dependencies.md', '../../pkg/controller/resourceconfig/static_config.go')
+    data = sorted(data, key=lambda x: x['kind'])
+    with open('data.json', 'w') as f:
+        json.dump(data, f, indent=2)
+    print(f"Generated data.json with {len(data)} resources.")

--- a/dev/migration-tracker/index.html
+++ b/dev/migration-tracker/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KCC Migration Tracker</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="header-content">
+            <h1>KCC Direct Migration Tracker</h1>
+            <p>Tracking the migration of KCC resources from Terraform/DCL to Direct Controllers.</p>
+        </div>
+        <div class="stats">
+            <div class="stat-card">
+                <h3>Total Resources</h3>
+                <p id="stat-total">-</p>
+            </div>
+            <div class="stat-card">
+                <h3>Completed</h3>
+                <p id="stat-completed">-</p>
+            </div>
+            <div class="stat-card">
+                <h3>In Progress</h3>
+                <p id="stat-inprogress">-</p>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <div class="controls">
+            <input type="text" id="search" placeholder="Search by Kind, Group, or Dependency..." />
+            <select id="filter-state">
+                <option value="All">All States</option>
+                <option value="Not Started">Not Started</option>
+                <option value="In Progress">In Progress</option>
+                <option value="PR Sent">PR Sent</option>
+                <option value="Completed">Completed</option>
+            </select>
+        </div>
+
+        <div class="table-container">
+            <table id="migration-table">
+                <thead>
+                    <tr>
+                        <th data-sort="kind">Kind <span class="sort-icon"></span></th>
+                        <th data-sort="group">Group <span class="sort-icon"></span></th>
+                        <th data-sort="version">Version <span class="sort-icon"></span></th>
+                        <th data-sort="controllerType">Controller <span class="sort-icon"></span></th>
+                        <th data-sort="state">State <span class="sort-icon"></span></th>
+                        <th>Migration Steps</th>
+                        <th>Dependencies</th>
+                        <th data-sort="mocksLastRefreshed">Mocks Refreshed <span class="sort-icon"></span></th>
+                        <th>Notes</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <!-- Rows will be injected here by JS -->
+                </tbody>
+            </table>
+        </div>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/dev/migration-tracker/style.css
+++ b/dev/migration-tracker/style.css
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:root {
+    --bg-color: #f8f9fa;
+    --card-bg: #ffffff;
+    --text-main: #202124;
+    --text-muted: #5f6368;
+    --border-color: #dadce0;
+    --primary-color: #1a73e8;
+    --state-not-started: #f1f3f4;
+    --state-in-progress: #e8f0fe;
+    --state-pr-sent: #fef7e0;
+    --state-completed: #e6f4ea;
+    
+    --text-not-started: #5f6368;
+    --text-in-progress: #1967d2;
+    --text-pr-sent: #b06000;
+    --text-completed: #137333;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-main);
+    line-height: 1.5;
+    padding: 24px;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
+header h1 {
+    font-size: 24px;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+header p {
+    color: var(--text-muted);
+}
+
+.stats {
+    display: flex;
+    gap: 16px;
+}
+
+.stat-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 16px 24px;
+    min-width: 120px;
+    text-align: center;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.stat-card h3 {
+    font-size: 12px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+}
+
+.stat-card p {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.controls {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+input[type="text"], select {
+    padding: 10px 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+input[type="text"] {
+    flex: 1;
+    max-width: 400px;
+}
+
+input[type="text"]:focus, select:focus {
+    border-color: var(--primary-color);
+}
+
+.table-container {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow-x: auto;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+    white-space: nowrap;
+}
+
+thead th {
+    background-color: var(--bg-color);
+    border-bottom: 2px solid var(--border-color);
+    padding: 12px 16px;
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+}
+
+thead th:hover {
+    background-color: #eef0f2;
+}
+
+tbody td {
+    border-bottom: 1px solid var(--border-color);
+    padding: 12px 16px;
+    font-size: 13px;
+}
+
+tbody tr:last-child td {
+    border-bottom: none;
+}
+
+tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+.badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.badge.not-started { background: var(--state-not-started); color: var(--text-not-started); }
+.badge.in-progress { background: var(--state-in-progress); color: var(--text-in-progress); }
+.badge.pr-sent { background: var(--state-pr-sent); color: var(--text-pr-sent); }
+.badge.completed { background: var(--state-completed); color: var(--text-completed); }
+
+.step-indicator {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-right: 4px;
+    background-color: var(--border-color);
+    position: relative;
+    cursor: help;
+}
+
+.step-indicator.done {
+    background-color: var(--state-completed);
+    border: 1px solid var(--text-completed);
+}
+
+.step-indicator:hover::after {
+    content: attr(title);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    white-space: nowrap;
+    z-index: 10;
+    margin-bottom: 4px;
+}
+
+.dependency-tag {
+    display: inline-block;
+    background: #f1f3f4;
+    border: 1px solid #dadce0;
+    color: #3c4043;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    margin: 2px;
+}


### PR DESCRIPTION
### BRIEF Change description

A static page to track migration.
Will be used by overseer and updated by overseer as it makes progress.