### PR TITLE
Increase E2E mock GCP test timeout from 3 to 5 minutes

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -73,9 +73,9 @@ func TestAllInSeries(t *testing.T) {
 
 	subtestTimeout := time.Hour
 	if targetGCP := os.Getenv("E2E_GCP_TARGET"); targetGCP == "mock" {
-		// We allow a total of 3 minutes: 2 for the test itself (for deep object chains with retries),
-		// and 1 minute to shutdown envtest / allow kube-apiserver requests to time-out.
-		subtestTimeout = 3 * time.Minute
+		// We allow a total of 5 minutes: 3 for the test itself (for deep object chains with retries),
+		// and 2 minutes to shutdown envtest / allow kube-apiserver requests to time-out.
+		subtestTimeout = 5 * time.Minute
 	}
 
 	t.Run("samples", func(t *testing.T) {


### PR DESCRIPTION
## Problem
Complex BigQuery fixtures are timing out after 3 minutes during E2E tests on mock GCP.

## Failing Tests
- `TestAllInSeries/fixtures/bigquerytable-full`
- `TestAllInSeries/fixtures/bigquerytable-full-direct`
- `TestAllInSeries/fixtures/bigquerytable-labels-direct`

## Root Cause
BigQuery fixtures with multiple dependencies take ~28 seconds each to:
1. Create dependent resources (6-8 KMS keys, datasets, IAM policies)
2. Update resources
3. Delete resources with deletion defender finalization

The 3-minute timeout is insufficient for these complex fixtures.

## Solution
Increase mock GCP E2E test timeout from 3 minutes to 5 minutes in `tests/e2e/unified_test.go`

## Changes
- `3 * time.Minute` → `5 * time.Minute`

## Related
Related to PR #7323 (BigQueryTable direct controller report all diffs)