### PR TITLE
Allow read-only POST requests in preview mode

### DIFF
--- a/pkg/cli/preview/intercepting_gcp_client.go
+++ b/pkg/cli/preview/intercepting_gcp_client.go
@@ -193,21 +193,29 @@ func (c *interceptingGCPClient) RoundTrip(req *http.Request) (*http.Response, er
 	return c.blockedHTTPMethod(req)
 }
 
+// checkGCPRequestIsAllowed determines if an outgoing HTTP request to the GCP API is permitted.
+// In preview mode, we want to allow read-only operations and block any modifications.
 func (c *interceptingGCPClient) checkGCPRequestIsAllowed(req *http.Request) bool {
+	// Allow all GET requests as they are read-only.
 	if req.Method == "GET" {
 		return true
 	}
 
+	// POST requests are blocked by default, unless they are specific read-only custom methods.
 	if req.Method == "POST" {
 		allowedCustomMethods := map[string]bool{
 			"getIamPolicy": true,
 			"getOrgPolicy": true,
 		}
 
+		// Check if the URL path ends with a custom method (e.g., ":getIamPolicy").
 		if idx := strings.LastIndex(req.URL.Path, ":"); idx != -1 {
-			customMethod := req.URL.Path[idx+1:]
-			if allowedCustomMethods[customMethod] {
-				return true
+			// Ensure there is only one colon to avoid ambiguity in parsing.
+			if strings.Count(req.URL.Path, ":") == 1 {
+				customMethod := req.URL.Path[idx+1:]
+				if allowedCustomMethods[customMethod] {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/cli/preview/intercepting_gcp_client.go
+++ b/pkg/cli/preview/intercepting_gcp_client.go
@@ -161,10 +161,7 @@ func (c *interceptingGCPClient) RoundTrip(req *http.Request) (*http.Response, er
 	ctx := req.Context()
 	log := klog.FromContext(ctx)
 
-	requestIsAllowed := false
-	if req.Method == "GET" {
-		requestIsAllowed = true
-	}
+	requestIsAllowed := c.checkGCPRequestIsAllowed(req)
 	if c.qps > 0 {
 		limiter, err := c.getOrCreateRateLimiter(req.URL)
 		if err != nil {
@@ -194,6 +191,27 @@ func (c *interceptingGCPClient) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	return c.blockedHTTPMethod(req)
+}
+
+func (c *interceptingGCPClient) checkGCPRequestIsAllowed(req *http.Request) bool {
+	if req.Method == "GET" {
+		return true
+	}
+
+	if req.Method == "POST" {
+		allowedCustomMethods := map[string]bool{
+			"getIamPolicy": true,
+			"getOrgPolicy": true,
+		}
+
+		if idx := strings.LastIndex(req.URL.Path, ":"); idx != -1 {
+			customMethod := req.URL.Path[idx+1:]
+			if allowedCustomMethods[customMethod] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // GRPCUnaryClientInterceptor intercepts GCP GRPC API calls.

--- a/pkg/cli/preview/intercepting_gcp_client_test.go
+++ b/pkg/cli/preview/intercepting_gcp_client_test.go
@@ -56,9 +56,9 @@ func TestCheckGCPRequestIsAllowed(t *testing.T) {
 			allowed:  true,
 		},
 		{
-			name:    "POST testIamPermissions allowed",
+			name:    "POST getOrgPolicy allowed",
 			method:  "POST",
-			path:    "/v1/projects/foo:testIamPermissions",
+			path:    "/v1/projects/foo:getOrgPolicy",
 			allowed: true,
 		},
 		{

--- a/pkg/cli/preview/intercepting_gcp_client_test.go
+++ b/pkg/cli/preview/intercepting_gcp_client_test.go
@@ -67,6 +67,12 @@ func TestCheckGCPRequestIsAllowed(t *testing.T) {
 			path:    "/v1/projects/foo:setIamPolicy",
 			allowed: false,
 		},
+		{
+			name:    "POST with multiple colons blocked",
+			method:  "POST",
+			path:    "/v1/projects/foo:bar:getIamPolicy",
+			allowed: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/cli/preview/intercepting_gcp_client_test.go
+++ b/pkg/cli/preview/intercepting_gcp_client_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preview
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestCheckGCPRequestIsAllowed(t *testing.T) {
+	client := &interceptingGCPClient{}
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		rawQuery string
+		allowed  bool
+	}{
+		{
+			name:    "GET request allowed",
+			method:  "GET",
+			path:    "/v1/projects/foo",
+			allowed: true,
+		},
+		{
+			name:    "POST request blocked by default",
+			method:  "POST",
+			path:    "/v1/projects/foo",
+			allowed: false,
+		},
+		{
+			name:    "POST getIamPolicy allowed",
+			method:  "POST",
+			path:    "/v1/projects/project-id/serviceAccounts/user@project-id.iam.gserviceaccount.com:getIamPolicy",
+			allowed: true,
+		},
+		{
+			name:     "POST getIamPolicy with query params allowed",
+			method:   "POST",
+			path:     "/v1/projects/foo:getIamPolicy",
+			rawQuery: "alt=json&prettyPrint=false",
+			allowed:  true,
+		},
+		{
+			name:    "POST testIamPermissions allowed",
+			method:  "POST",
+			path:    "/v1/projects/foo:testIamPermissions",
+			allowed: true,
+		},
+		{
+			name:    "POST other custom method blocked",
+			method:  "POST",
+			path:    "/v1/projects/foo:setIamPolicy",
+			allowed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{
+				Method: tc.method,
+				URL: &url.URL{
+					Path:     tc.path,
+					RawQuery: tc.rawQuery,
+				},
+			}
+			got := client.checkGCPRequestIsAllowed(req)
+			if got != tc.allowed {
+				t.Errorf("checkGCPRequestIsAllowed(%s %s) = %v, want %v", tc.method, tc.path, got, tc.allowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR allows specific read-only custom methods that use POST in preview mode. Fixes #7569.