### PR TITLE
Unskip TestPreview in unit tests

### DIFF
--- a/pkg/cli/preview/preview_test.go
+++ b/pkg/cli/preview/preview_test.go
@@ -34,8 +34,6 @@ import (
 
 // TestPreview creates an object using KCC, and then runs the preview command to look for additional changes
 func TestPreview(t *testing.T) {
-	// TODO(anhdle-sso): Fix the flake test
-	t.Skip("Skipping flaky test")
 	log.SetLogger(klogr.New())
 
 	if os.Getenv("KUBEBUILDER_ASSETS") == "" {


### PR DESCRIPTION
### Description
This PR unskips `TestPreview` in `pkg/cli/preview/preview_test.go`.

### Key Changes
- Removed `t.Skip("Skipping flaky test")` from `TestPreview`.

### Dependencies
This PR depends on #7592 to fix the connection error in the preview tool.
