### PR TITLE
Remove 'v' prefix from version in build-images

### DIFF
--- a/dev/tasks/build-images
+++ b/dev/tasks/build-images
@@ -29,6 +29,8 @@ if [[ -z "${IMAGE_TAG:-}" ]]; then
     IMAGE_TAG="${EXACT_TAG}"
     # If there is a github/ prefix (as there is in our internal mirror), remove it
     IMAGE_TAG=${IMAGE_TAG#github/}
+    # Remove the prefixed "v" if it exists
+    IMAGE_TAG=${IMAGE_TAG#v}
   else
     IMAGE_TAG=$(git rev-parse --short=7 HEAD)
   fi


### PR DESCRIPTION
The version is in the format of 'github/v1.xx.x', and we want it to be '1.xx.x'.

TAG=agy