### PR TITLE
Add detailed diffs for UserLabels in SQLInstance

### DIFF
--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -173,9 +174,7 @@ func DiffSettings(desired *api.Settings, actual *api.Settings) *structuredreport
 	if desired.TimeZone != actual.TimeZone {
 		diff.AddField(".settings.timeZone", actual.TimeZone, desired.TimeZone)
 	}
-	if !mapsMatch(desired.UserLabels, actual.UserLabels) {
-		diff.AddField(".settings.userLabels", actual.UserLabels, desired.UserLabels)
-	}
+	mapsMatch(diff, ".settings.userLabels", desired.UserLabels, actual.UserLabels)
 	// Ignore ForceSendFields. Assume it is set correctly in desired.
 	// Ignore NullFields. Assume it is set correctly in desired.
 	return diff
@@ -195,14 +194,25 @@ func slicesMatch[T any](desired []T, actual []T) bool {
 
 // mapsMatch checks if two maps are equal, matching with reflect.DeepEqual.
 // As a special-case, the empty map is treated the same as the nil map
-func mapsMatch[K comparable, V any](desired map[K]V, actual map[K]V) bool {
-	if len(desired) != len(actual) {
-		return false
+func mapsMatch[K comparable, V comparable](diff *structuredreporting.Diff, path string, desired map[K]V, actual map[K]V) bool {
+	matches := true
+	for k, vDesired := range desired {
+		vActual, ok := actual[k]
+		if !ok {
+			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", nil, vDesired)
+			matches = false
+		} else if vDesired != vActual {
+			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", vActual, vDesired)
+			matches = false
+		}
 	}
-	if len(desired) == 0 && len(actual) == 0 {
-		return true
+	for k, vActual := range actual {
+		if _, ok := desired[k]; !ok {
+			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", vActual, nil)
+			matches = false
+		}
 	}
-	return reflect.DeepEqual(desired, actual)
+	return matches
 }
 
 func DiffMysqlReplicaConfiguration(desired *api.MySqlReplicaConfiguration, actual *api.MySqlReplicaConfiguration) *structuredreporting.Diff {

--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -192,8 +192,8 @@ func slicesMatch[T any](desired []T, actual []T) bool {
 	return reflect.DeepEqual(desired, actual)
 }
 
-// mapsMatch checks if two maps are equal, matching with reflect.DeepEqual.
-// As a special-case, the empty map is treated the same as the nil map
+// mapsMatch checks if two maps are equal, reporting differences to the provided Diff object.
+// It returns true if the maps match.
 func mapsMatch[K comparable, V comparable](diff *structuredreporting.Diff, path string, desired map[K]V, actual map[K]V) bool {
 	matches := true
 	for k, vDesired := range desired {
@@ -201,7 +201,7 @@ func mapsMatch[K comparable, V comparable](diff *structuredreporting.Diff, path 
 		if !ok {
 			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", nil, vDesired)
 			matches = false
-		} else if vDesired != vActual {
+		} else if !reflect.DeepEqual(vDesired, vActual) {
 			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", vActual, vDesired)
 			matches = false
 		}

--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -193,26 +193,21 @@ func slicesMatch[T any](desired []T, actual []T) bool {
 }
 
 // mapsMatch checks if two maps are equal, reporting differences to the provided Diff object.
-// It returns true if the maps match.
-func mapsMatch[K comparable, V comparable](diff *structuredreporting.Diff, path string, desired map[K]V, actual map[K]V) bool {
-	matches := true
+func mapsMatch[K comparable, V any](diff *structuredreporting.Diff, path string, desired map[K]V, actual map[K]V) {
 	for k, vDesired := range desired {
 		vActual, ok := actual[k]
+		kStr := fmt.Sprint(k)
 		if !ok {
-			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", nil, vDesired)
-			matches = false
+			diff.AddField(path+"[+\""+kStr+"\"]", nil, vDesired)
 		} else if !reflect.DeepEqual(vDesired, vActual) {
-			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", vActual, vDesired)
-			matches = false
+			diff.AddField(path+"[*\""+kStr+"\"]", vActual, vDesired)
 		}
 	}
 	for k, vActual := range actual {
 		if _, ok := desired[k]; !ok {
-			diff.AddField(path+"[\""+fmt.Sprint(k)+"\"]", vActual, nil)
-			matches = false
+			diff.AddField(path+"[-\""+fmt.Sprint(k)+"\"]", vActual, nil)
 		}
 	}
-	return matches
 }
 
 func DiffMysqlReplicaConfiguration(desired *api.MySqlReplicaConfiguration, actual *api.MySqlReplicaConfiguration) *structuredreporting.Diff {

--- a/pkg/controller/direct/sql/sqlinstance_equality_test.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality_test.go
@@ -190,9 +190,9 @@ func TestDiffInstances_UserLabelsDiff(t *testing.T) {
 		Old any
 		New any
 	}{
-		".settings.userLabels[\"key2\"]": {Old: "val2", New: "val2-changed"},
-		".settings.userLabels[\"key3\"]": {Old: nil, New: "val3-new"},
-		".settings.userLabels[\"key4\"]": {Old: "val4-removed", New: nil},
+		".settings.userLabels[*\"key2\"]": {Old: "val2", New: "val2-changed"},
+		".settings.userLabels[+\"key3\"]": {Old: nil, New: "val3-new"},
+		".settings.userLabels[-\"key4\"]": {Old: "val4-removed", New: nil},
 	}
 
 	if len(diff.Fields) != len(expectedDiffs) {

--- a/pkg/controller/direct/sql/sqlinstance_equality_test.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality_test.go
@@ -158,3 +158,58 @@ func TestDiffInstances_DatabaseFlagsSorting(t *testing.T) {
 		t.Errorf("DiffInstances() identified unexpected diffs due to DatabaseFlags sorting: %v", diff.Fields)
 	}
 }
+
+func TestDiffInstances_UserLabelsDiff(t *testing.T) {
+	desired := &api.DatabaseInstance{
+		Settings: &api.Settings{
+			UserLabels: map[string]string{
+				"key1": "val1",
+				"key2": "val2-changed",
+				"key3": "val3-new",
+			},
+		},
+	}
+
+	actual := &api.DatabaseInstance{
+		Settings: &api.Settings{
+			UserLabels: map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+				"key4": "val4-removed",
+			},
+		},
+	}
+
+	diff := DiffInstances(desired, actual)
+
+	if !diff.HasDiff() {
+		t.Errorf("DiffInstances() expected diffs, but got none")
+	}
+
+	expectedDiffs := map[string]struct {
+		Old any
+		New any
+	}{
+		".settings.userLabels[\"key2\"]": {Old: "val2", New: "val2-changed"},
+		".settings.userLabels[\"key3\"]": {Old: nil, New: "val3-new"},
+		".settings.userLabels[\"key4\"]": {Old: "val4-removed", New: nil},
+	}
+
+	if len(diff.Fields) != len(expectedDiffs) {
+		t.Fatalf("DiffInstances() expected %d diffs, got %d. Fields: %v", len(expectedDiffs), len(diff.Fields), diff.Fields)
+	}
+
+	for _, field := range diff.Fields {
+		expected, ok := expectedDiffs[field.ID]
+		if !ok {
+			t.Errorf("Unexpected diff field ID %q", field.ID)
+			continue
+		}
+		if field.Old != expected.Old {
+			t.Errorf("For field %q, expected Old=%v, got %v", field.ID, expected.Old, field.Old)
+		}
+		if field.New != expected.New {
+			t.Errorf("For field %q, expected New=%v, got %v", field.ID, expected.New, field.New)
+		}
+	}
+}


### PR DESCRIPTION
This PR improves the structured diff reporting for maps in SQLInstance by providing detailed, key-level differences.

  The mapsMatch utility in sqlinstance_equality.go now reports changes using the following indicators:
   - [*"key"]: Value changed for an existing key.
   - [+"key"]: Key added to the map.
   - [-"key"]: Key removed from the map.

  Example diff output:
   - .settings.userLabels[*"env"]: prod -> staging
   - .settings.userLabels[+"new-label"]: nil -> val
   - .settings.userLabels[-"old-label"]: val -> nil