### PR TITLE
directbase: report structured diff on resource creation

### DIFF
--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -429,6 +429,11 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 
 	if !existsAlready {
 		createOp := NewCreateOperation(r.Reconciler.LifecycleHandler, r.Reconciler.Client, u)
+		diff := structuredreporting.Diff{
+			Object:      u,
+			IsNewObject: true,
+		}
+		structuredreporting.ReportDiff(ctx, &diff)
 		if err := adapter.Create(ctx, createOp); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))


### PR DESCRIPTION
This PR adds structured diff reporting for direct controllers during resource creation.
### Changes
- In `pkg/controller/direct/directbase/directbase_controller.go`, added structured diff reporting just before calling `adapter.Create`.
- It creates a `structuredreporting.Diff` with `IsNewObject: true` and the unstructured object `u`, and reports it using `structuredreporting.ReportDiff`.
### Rationale
This improves observability by ensuring that creation events are also logged with structured diffs in direct controllers, aligning with similar patterns in TF and DCL controllers.