### PR TITLE
dcl: report structured diff on resource creation

### DIFF
--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -361,6 +361,17 @@ func (r *Reconciler) sync(ctx context.Context, resource *dcl.Resource) (requeue 
 		return false, err
 	}
 	lifecycleParams := append(LifecycleParams, stateHintApplyOption)
+	if liveLite == nil {
+		u, err := resource.MarshalAsUnstructured()
+		if err != nil {
+			return false, fmt.Errorf("error marshaling resource as unstructured: %w", err)
+		}
+		diff := structuredreporting.Diff{
+			Object:      u,
+			IsNewObject: true,
+		}
+		structuredreporting.ReportDiff(ctx, &diff)
+	}
 	newState, err := dclunstruct.Apply(ctx, dclConfig, dclResource, lifecycleParams...)
 	if err != nil {
 		r.logger.Error(err, "error applying desired state", "resource", resource.GetNamespacedName())

--- a/pkg/controller/dcl/controller.go
+++ b/pkg/controller/dcl/controller.go
@@ -361,16 +361,21 @@ func (r *Reconciler) sync(ctx context.Context, resource *dcl.Resource) (requeue 
 		return false, err
 	}
 	lifecycleParams := append(LifecycleParams, stateHintApplyOption)
+	// If liveLite is nil, the resource does not exist in GCP yet, so this is a creation.
+	// Report a structured diff for the new object.
 	if liveLite == nil {
 		u, err := resource.MarshalAsUnstructured()
+		// Log error instead of failing reconciliation if marshaling fails,
+		// as diff reporting is for observability and shouldn't block execution.
 		if err != nil {
-			return false, fmt.Errorf("error marshaling resource as unstructured: %w", err)
+			r.logger.Error(err, "error marshaling resource as unstructured for diff reporting")
+		} else {
+			diff := structuredreporting.Diff{
+				Object:      u,
+				IsNewObject: true,
+			}
+			structuredreporting.ReportDiff(ctx, &diff)
 		}
-		diff := structuredreporting.Diff{
-			Object:      u,
-			IsNewObject: true,
-		}
-		structuredreporting.ReportDiff(ctx, &diff)
 	}
 	newState, err := dclunstruct.Apply(ctx, dclConfig, dclResource, lifecycleParams...)
 	if err != nil {


### PR DESCRIPTION
This PR adds structured diff reporting for DCL resources during creation.
### Changes
- In `pkg/controller/dcl/controller.go`, added a check for `liveLite == nil` just before calling `dclunstruct.Apply`.
- If `liveLite` is nil (indicating the resource does not exist in GCP), it marshals the resource as unstructured and reports it as a new object diff using `structuredreporting.ReportDiff`.
### Rationale
This improves observability by ensuring that creation events are also logged with structured diffs, consistent with recent changes in direct controllers.