### PR TITLE
iam: report structured diff for IAMAuditConfig creation

### DIFF
--- a/pkg/controller/iam/iamclient/tfiamclient.go
+++ b/pkg/controller/iam/iamclient/tfiamclient.go
@@ -284,6 +284,29 @@ func (t *TFIAMClient) SetAuditConfig(ctx context.Context, auditConfig *v1beta1.I
 		logger.Info("underlying resource is already up to date", "resource", k8s.GetNamespacedName(auditConfig))
 		return auditConfig, nil
 	}
+
+	// Report diff to structured-reporting subsystem
+	{
+		report := &structuredreporting.Diff{}
+		u, err := resource.MarshalAsUnstructured()
+		if err != nil {
+			log := log.FromContext(ctx)
+			log.Error(err, "error reporting diff")
+		}
+		report.Object = u
+		if diff != nil {
+			for k, attr := range diff.Attributes {
+				report.Fields = append(report.Fields, structuredreporting.DiffField{
+					ID:  k,
+					Old: attr.Old,
+					New: attr.New,
+				})
+			}
+		}
+		report.IsNewObject = liveState.Empty()
+		structuredreporting.ReportDiff(ctx, report)
+	}
+
 	newState, diagnostics := resource.TFResource.Apply(ctx, liveState, diff, t.provider.Meta())
 	if err := krmtotf.NewErrorFromDiagnostics(diagnostics); err != nil {
 		return nil, fmt.Errorf("error applying changes: %w", err)


### PR DESCRIPTION
This adds structured diff reporting for IAMAuditConfig resources when they are created, improving observability.