### PR TITLE
iam: set IsNewObject for IAMPolicy creation diffs

### DIFF
--- a/pkg/controller/iam/policy/iampolicy_controller.go
+++ b/pkg/controller/iam/policy/iampolicy_controller.go
@@ -300,6 +300,9 @@ func (r *reconcileContext) doReconcile(policy *iamv1beta1.IAMPolicy) (requeue bo
 
 	diff := iamv1beta1.IAMPolicySpecDiffers(&oldIAMPolicy.Spec, &policy.Spec)
 	if diff.HasDiff() {
+		if policy.Status.ObservedGeneration == 0 {
+			diff.IsNewObject = true
+		}
 		structuredreporting.ReportDiff(r.Ctx, diff)
 	}
 


### PR DESCRIPTION
This updates the IAMPolicy controller to set IsNewObject to true when reporting diffs for resources with ObservedGeneration equal to 0, indicating they are newly managed by KCC.