### PR TITLE
Fixing TF reconcile for ContainerCluster

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_cluster.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_cluster.go
@@ -1857,14 +1857,15 @@ func ResourceContainerCluster() *schema.Resource {
 				MaxItems:    1,
 				Optional:    true,
 				Computed:    true,
-				Description: `Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key.`,
+				Description: `Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "ALL_OBJECTS_ENCRYPTION_ENABLED"; "DECRYPTED". key_name is the name of a CloudKMS key.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"state": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
-							Description:  `ENCRYPTED or DECRYPTED.`,
+							ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false),
+							Description:  `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`,
+							DiffSuppressFunc: DatabaseEncryptionSuppress,
 						},
 						"key_name": {
 							Type:        schema.TypeString,
@@ -6564,6 +6565,18 @@ func validateNodePoolAutoConfig(cluster *container.Cluster) error {
 	}
 
 	return nil
+}
+
+func DatabaseEncryptionSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The API sometimes returns ALL_OBJECTS_ENCRYPTION_ENABLED when the user sets ENCRYPTED
+	// and vice versa (depending on the cluster version and underlying resource storage).
+	if old == "ALL_OBJECTS_ENCRYPTION_ENABLED" && new == "ENCRYPTED" {
+		return true
+	}
+	if old == "ENCRYPTED" && new == "ALL_OBJECTS_ENCRYPTION_ENABLED" {
+                return true
+	}
+        return false
 }
 
 func containerClusterSurgeSettingsCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {


### PR DESCRIPTION
### BRIEF Change description

Recent GKE change causes infinite reconcile due to databaseEncryption.state Patching our MMv1 with https://github.com/GoogleCloudPlatform/magic-modules/pull/17206

PR adds a DiffSuppressFunc to the database_encryption.state field within the google_container_cluster resource.

Currently, when a user sets the database encryption state to ENCRYPTED in their Terraform configuration, the Google Cloud API returns ALL_OBJECTS_ENCRYPTION_ENABLED for newer versions of GKE clusters. This discrepancy triggers a continuous diff (permadiff), causing Terraform to attempt an update on every run. This PR suppresses the diff specifically for this scenario, allowing Terraform to recognize that the infrastructure matches the intended configuration.

Fixes hashicorp/terraform-provider-google#26882

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?

```release-note
Fixes issue with databaseEncryption.state on GKE 1.35 and newer clusters.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs
None
```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
