### PR TITLE
Fix hardcoded ConfigConnectorContext name in parent controller

### DIFF
--- a/pkg/controller/parent/controller.go
+++ b/pkg/controller/parent/controller.go
@@ -140,7 +140,7 @@ func (r *ParentReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 		ccc := &corekccv1alpha1.ConfigConnectorContext{}
 		cccNamespacedName := types.NamespacedName{
 			Namespace: req.Namespace,
-			Name:      "configconnectorcontext",
+			Name:      corekccv1alpha1.ConfigConnectorContextAllowedName,
 		}
 		if err := r.Get(ctx, cccNamespacedName, ccc); err != nil {
 			if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
This PR fixes a bug in the parent controller where the `ConfigConnectorContext` resource name was hardcoded to `"configconnectorcontext"`. In namespace mode, the operator creates the resource with the full name `"configconnectorcontext.core.cnrm.cloud.google.com"`, causing the controller to fail to find it and silently ignore unsupported controller overrides.

I have updated the code to use the constant `corekccv1alpha1.ConfigConnectorContextAllowedName` which resolves to the correct full name.

**Note on Verification:**
During verification, the error message about the unsupported override might not appear in the `ConfigConnectorContext` status due to the operator immediately overwriting it back to healthy. However, I have validated that the fix works by deploying the custom image to the cluster and observing the log message `"Attempting to update CCC status with error"` in the controller pod logs when reconciliation was triggered.

```
{"severity":"info","timestamp":"2026-04-29T15:30:54.241Z","msg":"Attempting to update CCC status with error","controller":"sqlinstance-parent-controller","controllerGroup":"sql.cnrm.cloud.google.com","controllerKind":"SQLInstance","SQLInstance":{"name":"sqlinstance-optin-testing","namespace":"optin-testing"},"namespace":"optin-testing","name":"sqlinstance-optin-testing","reconcileID":"4ff47dab-7e92-4bfd-a3f4-972cae7c5cf1","msg":"controller type \"tf\" is not supported for resource \"SQLInstance.sql.cnrm.cloud.google.com\". Supported types are: [direct]. Falling back to default \"direct\"."}
```

Closes #7720