### PR TITLE
refactor: chore, skills for greenfield types

### DIFF
--- a/.agents/direct-new-resource-types.md
+++ b/.agents/direct-new-resource-types.md
@@ -46,7 +46,7 @@ Your goal is to identify GCP resources that are missing from KCC but defined in 
 
 4.  **Task**: If no tracking issue exists, create a new issue for the resource types implementation.
     - **Title**: `ai:chore: Implement direct types for: <Kind>`
-    - **Labels**: `overseer`, `area/direct`, `priority/medium`, `step/gen-types`
+    - **Labels**: `overseer`, `area/direct`, `priority/medium`, `step/gen-types`, `greenfield`
     - **Body**: Use the **TYPES ISSUE BODY TEMPLATE** below. Append a link to this chore file (`.agents/direct-new-resource-types.md`) at the end of the issue body for traceability.
 
 ---
@@ -58,10 +58,17 @@ Your task is to implement the initial KRM types, CRD, and IdentityV2 for the `<K
 
 # Context: Implementation Versions
 To ensure stability and reproducibility, this task is pinned to the following repository versions:
+# TODO: Dynamically determine these SHAs during task generation (see PR #7946 feedback).
 - **Google APIs SHA**: `731d7f2ab6` (from `apis/git.versions`)
 - **KCC Base SHA**: `dc1dd45d0b`
 
 # Implementation Instructions
+
+### Phase 0: Tooling & Skill Activation
+
+1.  **Activate Skills**: This project uses specialized skills to ensure architectural consistency. Before starting, identify and activate relevant skills (e.g., `kcc-identity-reference`, `generate-sh-checker`) using the `activate_skill` tool to receive expert procedural guidance.
+2.  **Consult Knowledge Base**: Check the `.gemini/journals/` directory for any existing service-specific "tribal knowledge" that might apply to this resource.
+3.  **Record Versions**: Record the Google APIs and KCC SHAs (listed above) in your initial implementation notes to ensure a stable baseline.
 
 ### Phase 1: Types and CRDs
 
@@ -125,7 +132,7 @@ To ensure stability and reproducibility, this task is pinned to the following re
    - **Service-Specific Tribal Knowledge**: Quirks unique to this API (e.g., "<Kind> requires an extra field-mask check").
 
 2. **Route to the Correct Destination**:
-   - **Existing Skills**: If you have a breakthrough in an area covered by an existing skill (e.g. `kcc-identity-reference`), update that skill's `SKILL.md` or append to its `journal.md`.
+   - **Existing Skills**: If you have a breakthrough in an area covered by an existing skill (e.g. `kcc-identity-reference`), update that skill\'s `SKILL.md` or append to its `journal.md`.
    - **Service Journals**: For service-specific "gotchas" or unusual field mappings, create or append to `.gemini/journals/<service>.md`. Do **not** put these in a general skill folder.
    - **New Skill Discovery**: If you identified a complex, repeatable recipe that isn't yet documented, create a new skill directory in `.gemini/skills/` and use the `skill-creator` tool to initialize it.
 

--- a/.agents/direct-new-resource-types.md
+++ b/.agents/direct-new-resource-types.md
@@ -66,75 +66,27 @@ To ensure stability and reproducibility, this task is pinned to the following re
 
 ### Phase 0: Tooling & Skill Activation
 
-1.  **Activate Skills**: This project uses specialized skills to ensure architectural consistency. Before starting, identify and activate relevant skills (e.g., `kcc-identity-reference`, `generate-sh-checker`) using the `activate_skill` tool to receive expert procedural guidance.
+1.  **Activate Skills**: This project uses specialized skills to ensure architectural consistency. Before starting, identify and activate relevant skills (e.g., `kcc-direct-types-implementer`, `kcc-identity-reference`, `kcc-agentic-journaler`) using the `activate_skill` tool to receive expert procedural guidance.
 2.  **Consult Knowledge Base**: Check the `.gemini/journals/` directory for any existing service-specific "tribal knowledge" that might apply to this resource.
 3.  **Record Versions**: Record the Google APIs and KCC SHAs (listed above) in your initial implementation notes to ensure a stable baseline.
 
 ### Phase 1: Types and CRDs
+Implement the initial KRM types for `<Kind>` using the "direct" approach.
 
-1.  **Add to generate.sh**:
-    Modify `apis/<group>/v1alpha1/generate.sh` (create if missing) to include `<Kind>`.
-    Example:
-    ```bash
-    go run . generate-types \
-      --service <proto.package.name> \
-      --api-version <group>.cnrm.cloud.google.com/v1alpha1 \
-      --resource <Kind>:<ProtoMessageName>
-    ```
-
-2.  **Generate Scaffolding**:
-    Run `apis/<group>/v1alpha1/generate.sh`. This should create `apis/<group>/v1alpha1/<kind_lowercase>_types.go`.
-
-3.  **Copyright Headers**:
-    Ensure new files have the correct header: `// Copyright 2026 Google LLC`.
-
-4.  **Labels**:
-    Ensure the following annotations are present in the types file:
-    ```go
-    // +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true"
-    // +kubebuilder:metadata:labels="cnrm.cloud.google.com/system=true"
-    // +kubebuilder:metadata:labels="cnrm.cloud.google.com/stability-level=alpha"
-    ```
-
-5.  **References**:
-    Map proto fields to KCC references (e.g., `ProjectRef`, `NetworkRef`) using the standard `refs.` package and `+kcc:proto` tags.
-
-6.  **Status**:
-    Ensure `status.observedGeneration` is an `*int64`.
+**Tooling**: Activate the `kcc-direct-types-implementer` skill. Follow its guidance to ensure your `_types.go` file meets KCC's metadata and field-mapping standards.
 
 ### Phase 2: IdentityV2 and Resource References
+Implement `apis/<group>/v1alpha1/<kind_lowercase>_identity.go`.
 
-1.  **Implement IdentityV2**:
-    Create `apis/<group>/v1alpha1/<kind_lowercase>_identity.go`.
-    - Use the `gcpurls.Template` pattern and the `kcc-identity-reference` skill.
-    - Ensure it implements `identity.IdentityV2` and `identity.ExternalIdentifier`.
-    - Implement `GetIdentity(ctx, reader)` on the resource struct.
-
-2.  **Identity Unit Tests**:
-    Create `apis/<group>/v1alpha1/<kind_lowercase>_identity_test.go`.
-    - Verify `FromExternal` with full GCP URLs and interface compliance.
+**Tooling**: Activate the `kcc-identity-reference` skill. It provides the canonical `gcpurls.Template` pattern and ensures interface compliance for `IdentityV2` and `ExternalIdentifier`.
 
 ### Phase 3: Final Generation and Verification
-
-1.  **Generate Mappers**:
-    Run `dev/tasks/generate-types-and-mappers`.
-2.  **Compile**:
-    Run `make all-binary` to ensure the generated code compiles. Fix any issues discovered.
+1.  **Generate Mappers**: Run `dev/tasks/generate-types-and-mappers`.
+2.  **Compile**: Run `make all-binary` to ensure the generated code compiles. Fix any issues discovered.
 
 ---
 
 ### Phase 4: Knowledge Capture & Self-Optimization
+Reflect on your implementation and record any breakthroughs or service-specific quirks.
 
-1. **Categorize Your Findings**:
-   Reflect on the implementation. Distinguish between:
-   - **General Mechanics**: Patterns applicable to *any* KCC resource (e.g., "Efficient proto-to-KRM field mapping").
-   - **Domain-Specific Best Practices**: Reusable steps for a specific implementation area (e.g., "Canonical IdentityV2 pattern").
-   - **Service-Specific Tribal Knowledge**: Quirks unique to this API (e.g., "<Kind> requires an extra field-mask check").
-
-2. **Route to the Correct Destination**:
-   - **Existing Skills**: If you have a breakthrough in an area covered by an existing skill (e.g. `kcc-identity-reference`), update that skill\'s `SKILL.md` or append to its `journal.md`.
-   - **Service Journals**: For service-specific "gotchas" or unusual field mappings, create or append to `.gemini/journals/<service>.md`. Do **not** put these in a general skill folder.
-   - **New Skill Discovery**: If you identified a complex, repeatable recipe that isn't yet documented, create a new skill directory in `.gemini/skills/` and use the `skill-creator` tool to initialize it.
-
-3. **Validation**:
-   State in your final summary exactly what new knowledge was captured and which file was modified.
+**Tooling**: Activate the `kcc-agentic-journaler` skill. Use its routing logic to ensure your learnings are stored in the correct destination (either a general skill or a service-specific journal).

--- a/.gemini/skills/kcc-agentic-journaler/SKILL.md
+++ b/.gemini/skills/kcc-agentic-journaler/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: kcc-agentic-journaler
+description: Provides a structured logic for capturing and routing agentic learnings to prevent knowledge pollution.
+---
+
+# KCC Agentic Journaler
+
+## Overview
+As an agent, you must record "tribal knowledge" and technical breakthroughs. This skill ensures that your learnings are stored in the most contextually relevant location.
+
+## Routing Logic
+
+When you have a new learning, follow this hierarchy to choose the destination:
+
+### Tier 1: General Mechanics
+**Scenario**: You found a better way to do something that applies to *all* KCC resources (e.g., "A more efficient way to resolve Project IDs").
+**Destination**: Update the relevant Skill's `SKILL.md` file directly.
+
+### Tier 2: Domain Best Practices
+**Scenario**: You found a trick for a specific implementation area (e.g., "How to handle OneOf fields in mappers").
+**Destination**: Append to the relevant Skill's `journal.md` file (e.g., `.gemini/skills/kcc-mapper-implementer/journal.md`).
+
+### Tier 3: Service Tribal Knowledge
+**Scenario**: You found a quirk unique to a specific GCP service (e.g., "NetworkSecurity APIs require an explicit location in the body even if it is in the URL").
+**Destination**: Create or append to `.gemini/journals/<service_name>.md`. 
+
+## Journal Entry Template
+Use this format for Tier 2 and Tier 3 entries:
+
+```markdown
+### [YYYY-MM-DD] <Brief Title>
+- **Context**: <What were you implementing? Link to Kind/PR>
+- **Problem**: <What was the unexpected behavior or hurdle?>
+- **Solution**: <How did you solve it? Provide code snippets if relevant.>
+- **Impact**: <Why should the next agent care about this?>
+```
+
+## Validation
+In your final turn of the task, you MUST state which knowledge was captured and provide the file path.

--- a/.gemini/skills/kcc-direct-types-implementer/SKILL.md
+++ b/.gemini/skills/kcc-direct-types-implementer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kcc-direct-types-implementer
+description: Guides the implementation of KRM types and CRD scaffolding for new "direct" resources.
+---
+
+# KCC Direct Types Implementer
+
+## Overview
+This skill provides the mandatory standards for creating the initial KRM types (`_types.go`) and generation scripts (`generate.sh`) for a new direct resource in Config Connector.
+
+## Workflow
+
+### 1. Configure generate.sh
+Create or update `apis/<service>/v1alpha1/generate.sh`. Use a versioned proto source path to ensure stability.
+
+```bash
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}/dev/tools/controllerbuilder
+
+# Use the pinned SHA from apis/git.versions or a specific override
+PROTO_SHA="<sha>" 
+PROTO_OUT="${REPO_ROOT}/.build/googleapis-${PROTO_SHA}.pb"
+
+./generate-proto.sh ${PROTO_SHA} ${PROTO_OUT}
+
+go run . generate-types \
+    --service <proto.package> \
+    --api-version <service>.cnrm.cloud.google.com/v1alpha1 \
+    --resource <Kind>:<ProtoMessage> \
+    --proto-source-path ${PROTO_OUT}
+```
+
+### 2. Standards for <kind>_types.go
+After running the generator, verify the `_types.go` file meets these requirements:
+
+- **Copyright**: Must be `// Copyright 2026 Google LLC`.
+- **CRD Labels**: Include exactly these labels in the type definition:
+  ```go
+  // +kubebuilder:metadata:labels="cnrm.cloud.google.com/managed-by-kcc=true"
+  // +kubebuilder:metadata:labels="cnrm.cloud.google.com/system=true"
+  // +kubebuilder:metadata:labels="cnrm.cloud.google.com/stability-level=alpha"
+  ```
+- **Proto Mapping**: Ensure `+kcc:proto` tags are present on the Spec and ObservedState structs to link them to the GCP API definitions.
+- **Status Fields**: `status.observedGeneration` must be an `*int64`.
+
+### 3. Registration
+- Ensure the new Kind is registered in `apis/<service>/v1alpha1/register.go`.
+- Run `dev/tasks/generate-crds` and verify the YAML appears in `config/crds/resources/`.


### PR DESCRIPTION
Following up on https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7949 with some offline input around organizing the instructions around skills.