### PR TITLE
feat: Support SharedSettings in ComputeFutureReservation

### DIFF
--- a/apis/refs/v1beta1/projectref.go
+++ b/apis/refs/v1beta1/projectref.go
@@ -98,6 +98,14 @@ type ExtendedProjectRef struct {
 	External string `json:"external,omitempty"`
 }
 
+func (r *ExtendedProjectRef) GetGVK() schema.GroupVersionKind {
+	// If Kind is not specified, default to "Project"
+	if r.Kind == "" {
+		return ProjectGVK
+	}
+	return schema.FromAPIVersionAndKind(r.APIVersion, r.Kind)
+}
+
 func (r *ExtendedProjectRef) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{
 		Name:      r.Name,
@@ -106,11 +114,48 @@ func (r *ExtendedProjectRef) GetNamespacedName() types.NamespacedName {
 }
 
 func (r *ExtendedProjectRef) GroupVersionKind() schema.GroupVersionKind {
-	return schema.FromAPIVersionAndKind(r.APIVersion, r.Kind)
+	return r.GetGVK()
 }
 
 func (r *ExtendedProjectRef) SetGroupVersionKind(gvk schema.GroupVersionKind) {
 	r.APIVersion, r.Kind = gvk.ToAPIVersionAndKind()
+}
+
+func (r *ExtendedProjectRef) GetExternal() string {
+	return r.External
+}
+
+func (r *ExtendedProjectRef) SetExternal(ref string) {
+	r.External = ref
+}
+
+func (r *ExtendedProjectRef) ValidateExternal(ref string) error {
+	// If Kind is not specified, default to "Project"
+	if r.Kind == "" || r.Kind == "Project" {
+		id := &ProjectIdentity{}
+		if err := id.FromExternal(ref); err != nil {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func (r *ExtendedProjectRef) Normalize(ctx context.Context, reader client.Reader, defaultNamespace string) error {
+	// If Kind is not specified, default to "Project"
+	if r.Kind == "" || r.Kind == "Project" {
+		projectRef := &ProjectRef{
+			External:  r.External,
+			Name:      r.Name,
+			Namespace: r.Namespace,
+		}
+		if err := projectRef.Normalize(ctx, reader, defaultNamespace); err != nil {
+			return err
+		}
+		r.External = projectRef.External
+		return nil
+	}
+	return Normalize(ctx, reader, r, defaultNamespace)
 }
 
 type ProjectIdentity struct {

--- a/apis/refs/v1beta1/projectref.go
+++ b/apis/refs/v1beta1/projectref.go
@@ -89,7 +89,6 @@ func AsProjectRef(in *deprecatedrefs.ResourceRef) *ProjectRef {
 // The resource reference that defaults to Project if Kind is not specified.
 type ExtendedProjectRef struct {
 	// Kind of the referenced resource
-	// +kubebuilder:default=Project
 	Kind      string `json:"kind,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name,omitempty"`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefuturereservations.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computefuturereservations.compute.cnrm.cloud.google.com.yaml
@@ -248,15 +248,12 @@ spec:
                               - external
                             required:
                             - name
-                            - kind
                           - not:
                               anyOf:
                               - required:
                                 - name
                               - required:
                                 - namespace
-                              - required:
-                                - kind
                             required:
                             - external
                           properties:
@@ -267,7 +264,6 @@ spec:
                               description: The external name of the referenced resource
                               type: string
                             kind:
-                              default: Project
                               description: Kind of the referenced resource
                               type: string
                             name:

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -504,43 +504,47 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 		testgcp.RecaptchaEnterpriseTestProject.Set("kcc-recaptcha-enterprise")
 		testgcp.TestKCCAlloyDBProject.Set("mock-project")
 		testgcp.TestKCCAlloyDBProjectNumber.Set("518915279")
-		testgcp.TestSharedReservationsProject.Set("mock-project")
-
-		crm := h.getCloudResourceManagerClient(kccConfig.HTTPClient)
-		req := &cloudresourcemanagerv1.Project{
-			ProjectId: "mock-project",
-		}
-		op, err := crm.Projects.Create(req).Context(ctx).Do()
-		if err != nil {
-			t.Fatalf("error creating project: %v", err)
-		}
-
-		// Wait for the project to be created, up to 10 seconds.
-		for i := 0; i < 100; i++ {
-			if op.Done {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-			latest, err := crm.Operations.Get(op.Name).Context(ctx).Do()
-			if err != nil {
-				t.Fatalf("error getting operation %q: %v", op.Name, err)
-			}
-			op = latest
-		}
-		if !op.Done {
-			t.Fatalf("FAIL: expected mock create project operation to be done (timed out after 5 seconds); operation state was %+v", op)
-		}
-		found, err := crm.Projects.Get(req.ProjectId).Context(ctx).Do()
-		if err != nil {
-			t.Fatalf("FAIL: error reading created project: %v", err)
-		}
-		project := testgcp.GCPProject{
-			ProjectID:     found.ProjectId,
-			ProjectNumber: found.ProjectNumber,
-		}
 		testgcp.TestKCCAttachedClusterProject.Set("mock-project")
 		testgcp.TestKCCAttachedClusterPlatformVersion.Set("1.30.0-gke.1")
-		h.Project = project
+		testgcp.TestSharedReservationsProject.Set("shared-reservations-project")
+
+		crm := h.getCloudResourceManagerClient(kccConfig.HTTPClient)
+		createProject := func(projectID string) *cloudresourcemanagerv1.Project {
+			req := &cloudresourcemanagerv1.Project{
+				ProjectId: projectID,
+			}
+			op, err := crm.Projects.Create(req).Context(ctx).Do()
+			if err != nil {
+				t.Fatalf("error creating project %q: %v", projectID, err)
+			}
+
+			// Wait for the project to be created, up to 10 seconds.
+			for i := 0; i < 100; i++ {
+				if op.Done {
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+				latest, err := crm.Operations.Get(op.Name).Context(ctx).Do()
+				if err != nil {
+					t.Fatalf("error getting operation %q: %v", op.Name, err)
+				}
+				op = latest
+			}
+			if !op.Done {
+				t.Fatalf("FAIL: expected mock create project operation %q to be done (timed out after 10 seconds); operation state was %+v", projectID, op)
+			}
+			found, err := crm.Projects.Get(projectID).Context(ctx).Do()
+			if err != nil {
+				t.Fatalf("FAIL: error reading created project %q: %v", projectID, err)
+			}
+			return found
+		}
+		createProject("shared-reservations-project")
+		mockProject := createProject("mock-project")
+		h.Project = testgcp.GCPProject{
+			ProjectID:     mockProject.ProjectId,
+			ProjectNumber: mockProject.ProjectNumber,
+		}
 	} else if h.GCPTarget == GCPTargetModeVCR && os.Getenv("VCR_MODE") == "replay" {
 		h.gcpAccessToken = "dummytoken"
 		kccConfig.GCPAccessToken = h.gcpAccessToken

--- a/mockgcp/common/fields/updatemask.go
+++ b/mockgcp/common/fields/updatemask.go
@@ -97,6 +97,11 @@ func replace(original, update protoreflect.Message, fieldName string) error {
 	originalFd := findField(original, fieldName)
 	originalVal := original.Get(originalFd)
 	updateFd := findField(update, fieldName)
+	if !update.Has(updateFd) {
+		// If the field is in the mask but not in the update message, it should be cleared (AIP-134).
+		original.Clear(originalFd)
+		return nil
+	}
 	updateVal := update.Get(updateFd)
 
 	// Update Map

--- a/mockgcp/mockcompute/futurereservationsv1.go
+++ b/mockgcp/mockcompute/futurereservationsv1.go
@@ -17,6 +17,7 @@ package mockcompute
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -119,6 +120,16 @@ func (s *FutureReservationsV1) Insert(ctx context.Context, req *pb.InsertFutureR
 		if obj.ShareSettings != nil && obj.ShareSettings.GetShareType() == "LOCAL" {
 			obj.ShareSettings = nil
 		}
+		if obj.ShareSettings != nil && obj.ShareSettings.GetShareType() == "SPECIFIC_PROJECTS" {
+			if obj.GetShareSettings().GetProjectMap() == nil {
+				return nil, status.Error(codes.InvalidArgument, "Invalid value for field 'resource.shareSettings.projects': ''. Shared future reservation must be shared with at least one project.")
+			}
+			newMap, err := s.convertProjectMap(ctx, obj.GetShareSettings().GetProjectMap())
+			if err != nil {
+				return nil, err
+			}
+			obj.ShareSettings.ProjectMap = newMap
+		}
 		if obj.GetSchedulingType() == "FLEXIBLE" {
 			obj.SchedulingType = nil
 		}
@@ -219,6 +230,16 @@ func (s *FutureReservationsV1) Update(ctx context.Context, req *pb.UpdateFutureR
 		// Simulate realGCP
 		if obj.Description == nil {
 			obj.Description = direct.PtrTo("")
+		}
+		if obj.ShareSettings != nil && obj.ShareSettings.GetShareType() == "LOCAL" {
+			obj.ShareSettings = nil
+		}
+		if obj.ShareSettings != nil && obj.ShareSettings.GetShareType() == "SPECIFIC_PROJECTS" {
+			newMap, err := s.convertProjectMap(ctx, obj.GetShareSettings().GetProjectMap())
+			if err != nil {
+				return nil, err
+			}
+			obj.ShareSettings.ProjectMap = newMap
 		}
 
 		if err := s.storage.Update(ctx, fqn, obj); err != nil {
@@ -354,6 +375,24 @@ func (s *MockService) parseFutureReservationName(name string) (*futureReservatio
 	} else {
 		return nil, status.Errorf(codes.InvalidArgument, "name %q is not valid", name)
 	}
+}
+
+func (s *MockService) convertProjectMap(ctx context.Context, projectMap map[string]*pb.ShareSettingsProjectConfig) (map[string]*pb.ShareSettingsProjectConfig, error) {
+	if projectMap == nil {
+		return nil, nil
+	}
+	newMap := make(map[string]*pb.ShareSettingsProjectConfig)
+	for idOrNumber, config := range projectMap {
+		project, err := s.Projects.GetProjectByIDOrNumber(idOrNumber)
+		if err != nil {
+			return nil, err
+		}
+		projectNumber := strconv.FormatInt(project.Number, 10)
+		newConfig := proto.Clone(config).(*pb.ShareSettingsProjectConfig)
+		newConfig.ProjectId = &projectNumber
+		newMap[projectNumber] = newConfig
+	}
+	return newMap, nil
 }
 
 func parseDuration(startTime *string, duration *pb.Duration) (time.Time, error) {

--- a/mockgcp/mockgcptests/harness.go
+++ b/mockgcp/mockgcptests/harness.go
@@ -178,7 +178,6 @@ func (t *Harness) Init() {
 		testgcp.TestDependentFolderProjectID.Set("example-project-02")
 		testgcp.IdentityPlatformTestProject.Set("kcc-identity-platform")
 		testgcp.RecaptchaEnterpriseTestProject.Set("kcc-recaptcha-enterprise")
-		testgcp.TestSharedReservationsProject.Set("mock-project")
 
 		crm := t.getCloudResourceManagerClient(t.HTTPClient)
 		req := &cloudresourcemanagerv1.Project{

--- a/pkg/controller/direct/common/visitfields.go
+++ b/pkg/controller/direct/common/visitfields.go
@@ -84,7 +84,7 @@ func (w *visitorWalker) visitAny(path string, v reflect.Value) {
 			w.errs = append(w.errs, fmt.Errorf("visiting slice of type %v is not supported", elemType.Kind()))
 		}
 
-	case reflect.String, reflect.Bool, reflect.Int32, reflect.Int64, reflect.Float64:
+	case reflect.String, reflect.Bool, reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint32, reflect.Uint64, reflect.Float64:
 		// "leaf", nothing to recurse into
 	default:
 		w.errs = append(w.errs, fmt.Errorf("visiting type %v is not supported", v.Kind()))

--- a/pkg/controller/direct/compute/futurereservation_controller.go
+++ b/pkg/controller/direct/compute/futurereservation_controller.go
@@ -25,6 +25,10 @@ import (
 	"sort"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
+
 	refsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -87,10 +91,11 @@ func (m *futureReservationModel) AdapterForObject(ctx context.Context, op *direc
 	}
 
 	return &FutureReservationAdapter{
-		gcpClient: futureReservationClient,
-		id:        id.(*krm.ComputeFutureReservationIdentity),
-		desired:   obj,
-		reader:    reader,
+		gcpClient:     futureReservationClient,
+		projectMapper: m.config.ProjectMapper,
+		id:            id.(*krm.ComputeFutureReservationIdentity),
+		desired:       obj,
+		reader:        reader,
 	}, nil
 }
 
@@ -100,11 +105,12 @@ func (m *futureReservationModel) AdapterForURL(ctx context.Context, url string) 
 }
 
 type FutureReservationAdapter struct {
-	gcpClient *compute.FutureReservationsClient
-	id        *v1alpha1.ComputeFutureReservationIdentity
-	desired   *krm.ComputeFutureReservation
-	actual    *computepb.FutureReservation
-	reader    client.Reader
+	gcpClient     *compute.FutureReservationsClient
+	projectMapper *projects.ProjectMapper
+	id            *v1alpha1.ComputeFutureReservationIdentity
+	desired       *krm.ComputeFutureReservation
+	actual        *computepb.FutureReservation
+	reader        client.Reader
 }
 
 var _ directbase.Adapter = &FutureReservationAdapter{}
@@ -141,6 +147,9 @@ func (a *FutureReservationAdapter) Create(ctx context.Context, createOp *directb
 	mapCtx := &direct.MapContext{}
 
 	desired := a.desired.DeepCopy()
+	if err := ResolveComputeFutureReservationRefs(ctx, a.reader, a.projectMapper, desired); err != nil {
+		return err
+	}
 	resource := ComputeFutureReservationSpec_v1alpha1_ToProto(mapCtx, &desired.Spec)
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
@@ -185,6 +194,9 @@ func (a *FutureReservationAdapter) Update(ctx context.Context, updateOp *directb
 	mapCtx := &direct.MapContext{}
 
 	desired := a.desired.DeepCopy()
+	if err := ResolveComputeFutureReservationRefs(ctx, a.reader, a.projectMapper, desired); err != nil {
+		return err
+	}
 	resource := ComputeFutureReservationSpec_v1alpha1_ToProto(mapCtx, &desired.Spec)
 	if mapCtx.Err() != nil {
 		return mapCtx.Err()
@@ -296,6 +308,16 @@ func (a *FutureReservationAdapter) Update(ctx context.Context, updateOp *directb
 				updateMask.Paths = append(updateMask.Paths, "specific_sku_properties.instance_properties.min_cpu_platform")
 			}
 		}
+	}
+
+	desiredShareSettings := resource.GetShareSettings()
+	if desiredShareSettings != nil && desiredShareSettings.GetShareType() == "LOCAL" {
+		desiredShareSettings = nil
+	}
+
+	if !proto.Equal(desiredShareSettings, a.actual.GetShareSettings()) {
+		report.AddField("share_settings", a.actual.GetShareSettings(), resource.GetShareSettings())
+		updateMask.Paths = append(updateMask.Paths, "share_settings")
 	}
 
 	if len(updateMask.Paths) == 0 {

--- a/pkg/controller/direct/compute/futurereservation_resolverefs.go
+++ b/pkg/controller/direct/compute/futurereservation_resolverefs.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/apis/common/projects"
+
+	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/compute/v1alpha1"
+	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResolveComputeFutureReservationRefs(ctx context.Context, reader client.Reader, projectMapper *projects.ProjectMapper, obj *krm.ComputeFutureReservation) error {
+	if obj.Spec.ShareSettings == nil {
+		return nil
+	}
+	for i := range obj.Spec.ShareSettings.ProjectMap {
+		entry := &obj.Spec.ShareSettings.ProjectMap[i]
+		if entry.KeyRef != nil {
+			kind := entry.KeyRef.Kind
+			switch kind {
+			// If Kind is not specified, default to "Project"
+			case "Project", "":
+				projectRef := &refs.ProjectRef{
+					External:  entry.KeyRef.External,
+					Name:      entry.KeyRef.Name,
+					Namespace: entry.KeyRef.Namespace,
+				}
+				project, err := refs.ResolveProject(ctx, reader, obj.Namespace, projectRef)
+				if err != nil {
+					return err
+				}
+				projectID := project.ProjectID
+				projectNumber, err := projectMapper.LookupProjectNumber(ctx, projectID)
+				if err != nil {
+					return err
+				}
+				entry.KeyRef.External = fmt.Sprintf("%d", projectNumber)
+
+			default:
+				return fmt.Errorf("unsupported kind %q for ExtendedProjectRef", kind)
+			}
+		}
+		if entry.Value != nil && entry.Value.ProjectIDRef != nil {
+			project, err := refs.ResolveProject(ctx, reader, obj.Namespace, entry.Value.ProjectIDRef)
+			if err != nil {
+				return err
+			}
+			projectID := project.ProjectID
+			projectNumber, err := projectMapper.LookupProjectNumber(ctx, projectID)
+			if err != nil {
+				return err
+			}
+			entry.Value.ProjectIDRef.External = fmt.Sprintf("%d", projectNumber)
+		}
+	}
+
+	// Sort by KeyRef.External to ensure stability in the fixtures test log
+	sort.Slice(obj.Spec.ShareSettings.ProjectMap, func(i, j int) bool {
+		iKeyRef := obj.Spec.ShareSettings.ProjectMap[i].KeyRef
+		jKeyRef := obj.Spec.ShareSettings.ProjectMap[j].KeyRef
+
+		if iKeyRef == nil && jKeyRef == nil {
+			return false
+		}
+		if iKeyRef == nil {
+			return true
+		}
+		if jKeyRef == nil {
+			return false
+		}
+		return iKeyRef.External < jKeyRef.External
+	})
+
+	return nil
+}

--- a/pkg/controller/direct/compute/futurereservation_resolverefs.go
+++ b/pkg/controller/direct/compute/futurereservation_resolverefs.go
@@ -23,6 +23,7 @@ import (
 
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/compute/v1alpha1"
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,44 +31,22 @@ func ResolveComputeFutureReservationRefs(ctx context.Context, reader client.Read
 	if obj.Spec.ShareSettings == nil {
 		return nil
 	}
+
+	if err := common.NormalizeReferences(ctx, reader, obj, nil); err != nil {
+		return err
+	}
+
 	for i := range obj.Spec.ShareSettings.ProjectMap {
 		entry := &obj.Spec.ShareSettings.ProjectMap[i]
-		if entry.KeyRef != nil {
-			kind := entry.KeyRef.Kind
-			switch kind {
-			// If Kind is not specified, default to "Project"
-			case "Project", "":
-				projectRef := &refs.ProjectRef{
-					External:  entry.KeyRef.External,
-					Name:      entry.KeyRef.Name,
-					Namespace: entry.KeyRef.Namespace,
-				}
-				project, err := refs.ResolveProject(ctx, reader, obj.Namespace, projectRef)
-				if err != nil {
-					return err
-				}
-				projectID := project.ProjectID
-				projectNumber, err := projectMapper.LookupProjectNumber(ctx, projectID)
-				if err != nil {
-					return err
-				}
-				entry.KeyRef.External = fmt.Sprintf("%d", projectNumber)
-
-			default:
-				return fmt.Errorf("unsupported kind %q for ExtendedProjectRef", kind)
+		if entry.KeyRef != nil && (entry.KeyRef.Kind == "" || entry.KeyRef.Kind == "Project") {
+			if err := convertToProjectNumber(ctx, projectMapper, &entry.KeyRef.External); err != nil {
+				return err
 			}
 		}
 		if entry.Value != nil && entry.Value.ProjectIDRef != nil {
-			project, err := refs.ResolveProject(ctx, reader, obj.Namespace, entry.Value.ProjectIDRef)
-			if err != nil {
+			if err := convertToProjectNumber(ctx, projectMapper, &entry.Value.ProjectIDRef.External); err != nil {
 				return err
 			}
-			projectID := project.ProjectID
-			projectNumber, err := projectMapper.LookupProjectNumber(ctx, projectID)
-			if err != nil {
-				return err
-			}
-			entry.Value.ProjectIDRef.External = fmt.Sprintf("%d", projectNumber)
 		}
 	}
 
@@ -88,5 +67,18 @@ func ResolveComputeFutureReservationRefs(ctx context.Context, reader client.Read
 		return iKeyRef.External < jKeyRef.External
 	})
 
+	return nil
+}
+
+func convertToProjectNumber(ctx context.Context, projectMapper *projects.ProjectMapper, external *string) error {
+	id := &refs.ProjectIdentity{}
+	if err := id.FromExternal(*external); err != nil {
+		return err
+	}
+	projectNumber, err := projectMapper.LookupProjectNumber(ctx, id.ProjectID)
+	if err != nil {
+		return err
+	}
+	*external = fmt.Sprintf("%d", projectNumber)
 	return nil
 }

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_generated_object_sharereservation-add-project.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_generated_object_sharereservation-add-project.golden.yaml
@@ -1,0 +1,57 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  shareSettings:
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}
+    - keyRef:
+        name: project-${uniqueId}
+      value:
+        projectIDRef:
+          name: project-${uniqueId}
+    shareType: SPECIFIC_PROJECTS
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_http.log
@@ -1,0 +1,731 @@
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+403 Forbidden
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The caller does not have permission",
+        "reason": "forbidden"
+      }
+    ],
+    "message": "The caller does not have permission",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.ProjectCreationStatus",
+    "gettable": true,
+    "ready": true
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.Project",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "labels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "lifecycleState": "ACTIVE",
+    "name": "project-${uniqueId}",
+    "parent": {
+      "id": "${organizationID}",
+      "type": "organization"
+    },
+    "projectId": "project-${uniqueId}",
+    "projectNumber": "${projectNumber}"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/project-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2Fproject-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "project-${uniqueId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "organizations/${organizationID}",
+  "projectId": "project-${uniqueId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      },
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      },
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/_http.log
@@ -14,13 +14,6 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The caller does not have permission",
-        "reason": "forbidden"
-      }
-    ],
     "message": "The caller does not have permission",
     "status": "PERMISSION_DENIED"
   }
@@ -257,17 +250,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -401,6 +387,10 @@ X-Xss-Protection: 0
     "totalCount": "1"
   },
   "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
     "procurementStatus": "DRAFTING"
   },
   "timeWindow": {
@@ -438,8 +428,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectNumber}",
   "parent": "organizations/${organizationID}",
   "projectId": "project-${uniqueId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/create.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/dependencies.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: project-${uniqueId}
+spec:
+  organizationRef:
+    external: ${TEST_ORG_ID}
+  name: "project-${uniqueId}"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-add-project/update.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}
+    - keyRef:
+        name: project-${uniqueId}
+      value:
+        projectIDRef:
+          name: project-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_generated_object_sharereservation-change-project.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_generated_object_sharereservation-change-project.golden.yaml
@@ -1,0 +1,52 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  shareSettings:
+    projectMap:
+    - keyRef:
+        name: project-${uniqueId}
+      value:
+        projectIDRef:
+          name: project-${uniqueId}
+    shareType: SPECIFIC_PROJECTS
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_http.log
@@ -1,0 +1,755 @@
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+429 Too Many Requests
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 429,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'cloudresourcemanager.googleapis.com' for consumer 'project_number:764086051850'.",
+        "reason": "rateLimitExceeded"
+      }
+    ],
+    "message": "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'cloudresourcemanager.googleapis.com' for consumer 'project_number:764086051850'.",
+    "status": "RESOURCE_EXHAUSTED"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+403 Forbidden
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The caller does not have permission",
+        "reason": "forbidden"
+      }
+    ],
+    "message": "The caller does not have permission",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.ProjectCreationStatus",
+    "gettable": true,
+    "ready": true
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.Project",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "labels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "lifecycleState": "ACTIVE",
+    "name": "project-${uniqueId}",
+    "parent": {
+      "id": "${organizationID}",
+      "type": "organization"
+    },
+    "projectId": "project-${uniqueId}",
+    "projectNumber": "${projectNumber}"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/project-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2Fproject-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "project-${uniqueId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "organizations/${organizationID}",
+  "projectId": "project-${uniqueId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/_http.log
@@ -1,36 +1,6 @@
 GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
-429 Too Many Requests
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 429,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'cloudresourcemanager.googleapis.com' for consumer 'project_number:764086051850'.",
-        "reason": "rateLimitExceeded"
-      }
-    ],
-    "message": "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'cloudresourcemanager.googleapis.com' for consumer 'project_number:764086051850'.",
-    "status": "RESOURCE_EXHAUSTED"
-  }
-}
-
----
-
-GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
 403 Forbidden
 Content-Type: application/json; charset=UTF-8
 Server: ESF
@@ -44,13 +14,6 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The caller does not have permission",
-        "reason": "forbidden"
-      }
-    ],
     "message": "The caller does not have permission",
     "status": "PERMISSION_DENIED"
   }
@@ -287,17 +250,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -431,6 +387,10 @@ X-Xss-Protection: 0
     "totalCount": "1"
   },
   "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
     "procurementStatus": "DRAFTING"
   },
   "timeWindow": {
@@ -468,8 +428,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectNumber}",
   "parent": "organizations/${organizationID}",
   "projectId": "project-${uniqueId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/create.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/dependencies.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: project-${uniqueId}
+spec:
+  organizationRef:
+    external: ${TEST_ORG_ID}
+  name: "project-${uniqueId}"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-change-project/update.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+      - keyRef:
+          name: project-${uniqueId}
+        value:
+          projectIDRef:
+            name: project-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_generated_object_sharereservation-disable.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_generated_object_sharereservation-disable.golden.yaml
@@ -1,0 +1,41 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_generated_object_sharereservation-disable.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_generated_object_sharereservation-disable.golden.yaml
@@ -37,5 +37,8 @@ status:
     selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
       procurementStatus: DRAFTING
     zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_http.log
@@ -46,17 +46,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -190,6 +183,10 @@ X-Xss-Protection: 0
     "totalCount": "1"
   },
   "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
     "procurementStatus": "DRAFTING"
   },
   "timeWindow": {
@@ -278,49 +275,6 @@ X-Xss-Protection: 0
   "targetId": "${futureReservationID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
   "user": "user@example.com",
-  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "",
-  "id": "000000000000000000000",
-  "kind": "compute#futureReservation",
-  "name": "${futureReservationID}",
-  "planningStatus": "DRAFT",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "specificReservationRequired": false,
-  "specificSkuProperties": {
-    "instanceProperties": {
-      "machineType": "n1-standard-1"
-    },
-    "totalCount": "1"
-  },
-  "status": {
-    "procurementStatus": "DRAFTING"
-  },
-  "timeWindow": {
-    "endTime": "2026-11-11T00:00:00Z",
-    "startTime": "2026-11-10T00:00:00Z"
-  },
   "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
 }
 

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/_http.log
@@ -1,0 +1,439 @@
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/create.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+      - keyRef:
+          external: ${projectId}
+        value:
+          projectIDRef:
+            external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable/update.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_generated_object_sharereservation-disable2.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_generated_object_sharereservation-disable2.golden.yaml
@@ -1,0 +1,46 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  shareSettings:
+    shareType: LOCAL
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_http.log
@@ -46,17 +46,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -146,56 +139,6 @@ X-Xss-Protection: 0
   "targetId": "${futureReservationID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
   "user": "user@example.com",
-  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "id": "000000000000000000000",
-  "kind": "compute#futureReservation",
-  "name": "${futureReservationID}",
-  "planningStatus": "DRAFT",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "shareSettings": {
-    "projectMap": {
-      "${projectNumber}": {
-        "projectId": "${projectNumber}"
-      }
-    },
-    "shareType": "SPECIFIC_PROJECTS"
-  },
-  "specificReservationRequired": false,
-  "specificSkuProperties": {
-    "instanceProperties": {
-      "machineType": "n1-standard-1"
-    },
-    "totalCount": "1"
-  },
-  "status": {
-    "procurementStatus": "DRAFTING"
-  },
-  "timeWindow": {
-    "endTime": "2026-11-11T00:00:00Z",
-    "startTime": "2026-11-10T00:00:00Z"
-  },
   "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
 }
 

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/_http.log
@@ -1,0 +1,453 @@
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "shareType": "LOCAL"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/create.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+      - keyRef:
+          external: ${projectId}
+        value:
+          projectIDRef:
+            external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-disable2/update.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: LOCAL

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_generated_object_sharereservation-enable.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_generated_object_sharereservation-enable.golden.yaml
@@ -45,5 +45,8 @@ status:
     selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
       procurementStatus: DRAFTING
     zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_generated_object_sharereservation-enable.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_generated_object_sharereservation-enable.golden.yaml
@@ -1,0 +1,49 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  shareSettings:
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}
+    shareType: SPECIFIC_PROJECTS
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_http.log
@@ -1,0 +1,447 @@
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/_http.log
@@ -142,6 +142,10 @@ X-Xss-Protection: 0
     "totalCount": "1"
   },
   "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
     "procurementStatus": "DRAFTING"
   },
   "timeWindow": {
@@ -170,17 +174,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -270,57 +267,6 @@ X-Xss-Protection: 0
   "targetId": "${futureReservationID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
   "user": "user@example.com",
-  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "",
-  "id": "000000000000000000000",
-  "kind": "compute#futureReservation",
-  "name": "${futureReservationID}",
-  "planningStatus": "DRAFT",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "shareSettings": {
-    "projectMap": {
-      "${projectNumber}": {
-        "projectId": "${projectNumber}"
-      }
-    },
-    "shareType": "SPECIFIC_PROJECTS"
-  },
-  "specificReservationRequired": false,
-  "specificSkuProperties": {
-    "instanceProperties": {
-      "machineType": "n1-standard-1"
-    },
-    "totalCount": "1"
-  },
-  "status": {
-    "procurementStatus": "DRAFTING"
-  },
-  "timeWindow": {
-    "endTime": "2026-11-11T00:00:00Z",
-    "startTime": "2026-11-10T00:00:00Z"
-  },
   "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
 }
 

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/create.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-enable/update.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+      - keyRef:
+          external: ${projectId}
+        value:
+          projectIDRef:
+            external: ${projectId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_generated_object_sharereservation-remove-project.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_generated_object_sharereservation-remove-project.golden.yaml
@@ -45,5 +45,8 @@ status:
     selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
     status:
+      existingMatchingUsageInfo:
+        count: 0
+        timestamp: "2024-04-01T12:34:56.123456Z"
       procurementStatus: DRAFTING
     zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_generated_object_sharereservation-remove-project.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_generated_object_sharereservation-remove-project.golden.yaml
@@ -1,0 +1,49 @@
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  labels:
+    cnrm-test: "true"
+  name: ${futureReservationID}
+  namespace: ${uniqueId}
+spec:
+  autoDeleteAutoCreatedReservations: false
+  location: us-central1-a
+  projectRef:
+    external: shared-reservations-project
+  shareSettings:
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}
+    shareType: SPECIFIC_PROJECTS
+  specificSkuProperties:
+    instanceProperties:
+      machineType: n1-standard-1
+    totalCount: 1
+  timeWindow:
+    endTime: "2026-11-11T00:00:00Z"
+    startTime: "2026-11-10T00:00:00Z"
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  externalRef: projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+  observedGeneration: 2
+  observedState:
+    creationTimestamp: "1970-01-01T00:00:00Z"
+    id: 1111111111111111
+    kind: compute#futureReservation
+    selfLink: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    selfLinkWithID: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+    status:
+      procurementStatus: DRAFTING
+    zone: https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_http.log
@@ -1,0 +1,782 @@
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+403 Forbidden
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 403,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The caller does not have permission",
+        "reason": "forbidden"
+      }
+    ],
+    "message": "The caller does not have permission",
+    "status": "PERMISSION_DENIED"
+  }
+}
+
+---
+
+POST https://cloudresourcemanager.googleapis.com/v1/projects?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}"
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "operations/${operationID}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/operations/${operationID}?alt=json
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "done": true,
+  "metadata": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.ProjectCreationStatus",
+    "gettable": true,
+    "ready": true
+  },
+  "name": "operations/${operationID}",
+  "response": {
+    "@type": "type.googleapis.com/google.cloudresourcemanager.v1.Project",
+    "createTime": "2024-04-01T12:34:56.123456Z",
+    "labels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "lifecycleState": "ACTIVE",
+    "name": "project-${uniqueId}",
+    "parent": {
+      "id": "${organizationID}",
+      "type": "organization"
+    },
+    "projectId": "project-${uniqueId}",
+    "projectNumber": "${projectNumber}"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}' was not found"
+  }
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/${projectId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2F${projectId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "${projectId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "generative-language": "enabled",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "folders/185572751725",
+  "projectId": "${projectId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v3/projects/project-${uniqueId}?%24alt=json%3Benum-encoding%3Dint
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: name=projects%2Fproject-${uniqueId}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "displayName": "project-${uniqueId}",
+  "etag": "abcdef0123A=",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "name": "projects/${projectNumber}",
+  "parent": "organizations/${organizationID}",
+  "projectId": "project-${uniqueId}",
+  "state": 1,
+  "updateTime": "2024-04-01T12:34:56.123456Z"
+}
+
+---
+
+POST https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      },
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      },
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+PATCH https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}?updateMask=share_settings
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+{
+  "autoDeleteAutoCreatedReservations": false,
+  "name": "${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "description": "",
+  "id": "000000000000000000000",
+  "kind": "compute#futureReservation",
+  "name": "${futureReservationID}",
+  "planningStatus": "DRAFT",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "shareSettings": {
+    "projectMap": {
+      "${projectNumber}": {
+        "projectId": "${projectNumber}"
+      }
+    },
+    "shareType": "SPECIFIC_PROJECTS"
+  },
+  "specificReservationRequired": false,
+  "specificSkuProperties": {
+    "instanceProperties": {
+      "machineType": "n1-standard-1"
+    },
+    "totalCount": "1"
+  },
+  "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
+    "procurementStatus": "DRAFTING"
+  },
+  "timeWindow": {
+    "endTime": "2026-11-11T00:00:00Z",
+    "startTime": "2026-11-10T00:00:00Z"
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+DELETE https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}
+Content-Type: application/json
+User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&operation=${operationID}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "id": "000000000000000000000",
+  "insertTime": "2024-04-01T12:34:56.123456Z",
+  "kind": "compute#operation",
+  "name": "${operationID}",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetId": "${futureReservationID}",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
+  "user": "user@example.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
+}
+
+---
+
+GET https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "labels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "lifecycleState": "ACTIVE",
+  "name": "project-${uniqueId}",
+  "parent": {
+    "id": "${organizationID}",
+    "type": "organization"
+  },
+  "projectId": "project-${uniqueId}",
+  "projectNumber": "${projectNumber}"
+}
+
+---
+
+GET https://cloudbilling.googleapis.com/v1/projects/project-${uniqueId}/billingInfo?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "billingAccountName": "",
+  "billingEnabled": false,
+  "name": "projects/project-${uniqueId}/billingInfo",
+  "projectId": "project-${uniqueId}"
+}
+
+---
+
+DELETE https://cloudresourcemanager.googleapis.com/v1/projects/project-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/_http.log
@@ -14,13 +14,6 @@ X-Xss-Protection: 0
 {
   "error": {
     "code": 403,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "The caller does not have permission",
-        "reason": "forbidden"
-      }
-    ],
     "message": "The caller does not have permission",
     "status": "PERMISSION_DENIED"
   }
@@ -257,17 +250,10 @@ X-Xss-Protection: 0
 
 {
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "displayName": "${projectId}",
   "etag": "abcdef0123A=",
-  "labels": {
-    "generative-language": "enabled",
-    "managed-by-cnrm": "true"
-  },
   "name": "projects/${projectNumber}",
-  "parent": "folders/185572751725",
   "projectId": "${projectId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -298,8 +284,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectNumber}",
   "parent": "organizations/${organizationID}",
   "projectId": "project-${uniqueId}",
-  "state": 1,
-  "updateTime": "2024-04-01T12:34:56.123456Z"
+  "state": 1
 }
 
 ---
@@ -439,6 +424,10 @@ X-Xss-Protection: 0
     "totalCount": "1"
   },
   "status": {
+    "existingMatchingUsageInfo": {
+      "count": "0",
+      "timestamp": "2024-04-01T12:34:56.123456Z"
+    },
     "procurementStatus": "DRAFTING"
   },
   "timeWindow": {
@@ -535,57 +524,6 @@ X-Xss-Protection: 0
   "targetId": "${futureReservationID}",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
   "user": "user@example.com",
-  "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}
-Content-Type: application/json
-User-Agent: kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-X-Goog-Request-Params: project=shared-reservations-project&zone=us-central1-a&future_reservation=${futureReservationID}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "description": "",
-  "id": "000000000000000000000",
-  "kind": "compute#futureReservation",
-  "name": "${futureReservationID}",
-  "planningStatus": "DRAFT",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a/futureReservations/${futureReservationID}",
-  "shareSettings": {
-    "projectMap": {
-      "${projectNumber}": {
-        "projectId": "${projectNumber}"
-      }
-    },
-    "shareType": "SPECIFIC_PROJECTS"
-  },
-  "specificReservationRequired": false,
-  "specificSkuProperties": {
-    "instanceProperties": {
-      "machineType": "n1-standard-1"
-    },
-    "totalCount": "1"
-  },
-  "status": {
-    "procurementStatus": "DRAFTING"
-  },
-  "timeWindow": {
-    "endTime": "2026-11-11T00:00:00Z",
-    "startTime": "2026-11-10T00:00:00Z"
-  },
   "zone": "https://www.googleapis.com/compute/v1/projects/shared-reservations-project/zones/us-central1-a"
 }
 

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/create.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}
+    - keyRef:
+        name: project-${uniqueId}
+      value:
+        projectIDRef:
+          name: project-${uniqueId}

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/dependencies.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/dependencies.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  annotations:
+    cnrm.cloud.google.com/reconcile-interval-in-seconds: "0"
+  name: project-${uniqueId}
+spec:
+  organizationRef:
+    external: ${TEST_ORG_ID}
+  name: "project-${uniqueId}"

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1alpha1/computefuturereservation/sharereservation-remove-project/update.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+kind: ComputeFutureReservation
+metadata:
+  name: sharereservation-${uniqueId}
+spec:
+  projectRef:
+    external: ${TEST_SHARED_RESERVATIONS_PROJECT}
+  location: us-central1-a
+  # Required field
+  autoDeleteAutoCreatedReservations: false
+  specificSkuProperties:
+    totalCount: 1
+    instanceProperties:
+      machineType: n1-standard-1
+  timeWindow:
+    # Future reservation must specify a future start time.
+    startTime: 2026-11-10T00:00:00Z
+    # Future reservation end time must be at least 24 hours later than start time.
+    # One of duration or endTime must be set.
+    endTime: 2026-11-11T00:00:00Z
+  shareSettings:
+    shareType: SPECIFIC_PROJECTS
+    projectMap:
+    - keyRef:
+        external: ${projectId}
+      value:
+        projectIDRef:
+          external: ${projectId}

--- a/scripts/add-validation-to-crds/parse-crds.go
+++ b/scripts/add-validation-to-crds/parse-crds.go
@@ -316,6 +316,9 @@ oneOf:
 			// hack for IAMPolicy.spec.resourceRef for backwards compat
 			if fieldPath == ".spec.resourceRef" {
 				ruleYAML = resourceRefRuleWithOnlyKind
+				// hack for Compute spec.shareSettings.projectMap[].keyRef, support multi-kind reference and default kind is "Project"
+			} else if strings.HasSuffix(fieldPath, ".projectMap[].keyRef") {
+				ruleYAML = refRuleWithOptionalKind
 			} else {
 				ruleYAML = refRuleWithKind
 			}

--- a/tests/apichecks/testdata/exceptions/alpha-missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/alpha-missingfields.txt
@@ -761,8 +761,6 @@
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.deploymentType" is not set in unstructured objects
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.reservationMode" is not set in unstructured objects
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.reservationName" is not set in unstructured objects
-[missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.shareSettings.projectMap[].keyRef" is not set; neither 'external' nor 'name' are set
-[missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.shareSettings.projectMap[].value.projectIDRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.specificSkuProperties.instanceProperties.guestAccelerators[].acceleratorCount" is not set in unstructured objects
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.specificSkuProperties.instanceProperties.guestAccelerators[].acceleratorType" is not set in unstructured objects
 [missing_field] crd=computefuturereservations.compute.cnrm.cloud.google.com version=v1alpha1: field ".spec.specificSkuProperties.instanceProperties.locationHint" is not set in unstructured objects


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Addresses https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/6828, support ShareSettings in ComputeFutureReservation

#### WHY do we need this change?


#### Special notes for your reviewer:
In the GCP API, the ShareSettings.ProjectMap field can be specified as a projectID or projectNumber during creation or update, but the API only returns the projectNumber when the resource is fetched. KCC needs to convert a projectID to a projectNumber prior to comparison by reading the resource from GCP.

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support SharedSettings in ComputeFutureReservation
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
