### PR TITLE
Fix case sensitivity in SQLInstance availabilityType

### DIFF
--- a/pkg/controller/direct/sql/sqlinstance_equality.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
 	api "google.golang.org/api/sqladmin/v1beta4"
@@ -119,7 +120,7 @@ func DiffSettings(desired *api.Settings, actual *api.Settings) *structuredreport
 	if !slicesMatch(desired.AuthorizedGaeApplications, actual.AuthorizedGaeApplications) {
 		diff.AddField(".settings.authorizedGaeApplications", actual.AuthorizedGaeApplications, desired.AuthorizedGaeApplications)
 	}
-	if desired.AvailabilityType != actual.AvailabilityType {
+	if !strings.EqualFold(desired.AvailabilityType, actual.AvailabilityType) {
 		diff.AddField(".settings.availabilityType", actual.AvailabilityType, desired.AvailabilityType)
 	}
 	diff.AddDiff(DiffBackupConfiguration(desired.BackupConfiguration, actual.BackupConfiguration))

--- a/pkg/controller/direct/sql/sqlinstance_equality_test.go
+++ b/pkg/controller/direct/sql/sqlinstance_equality_test.go
@@ -213,3 +213,23 @@ func TestDiffInstances_UserLabelsDiff(t *testing.T) {
 		}
 	}
 }
+
+func TestDiffInstances_AvailabilityTypeCasing(t *testing.T) {
+	desired := &api.DatabaseInstance{
+		Settings: &api.Settings{
+			AvailabilityType: "Zonal",
+		},
+	}
+
+	actual := &api.DatabaseInstance{
+		Settings: &api.Settings{
+			AvailabilityType: "ZONAL",
+		},
+	}
+
+	diff := DiffInstances(desired, actual)
+
+	if diff.HasDiff() {
+		t.Errorf("DiffInstances() expected no diffs, but got: %v", diff.Fields)
+	}
+}


### PR DESCRIPTION
This PR fixes a regression in SQLInstance where case sensitivity in .settings.availabilityType caused spurious drift and restarts. It uses strings.EqualFold for comparison and adds a unit test.

Internal bug ID: b/510919254