### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -34,6 +34,8 @@ on:
       - '**'
       - '!experiments/**'
 
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/crd-equivalence-check.yaml
+++ b/.github/workflows/crd-equivalence-check.yaml
@@ -29,6 +29,9 @@ on:
     paths:
       - 'config/crds/resources/**'
 
+permissions:
+  contents: read
+
 jobs:
   crd-equivalence-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/experiments-ci.yaml
+++ b/.github/workflows/experiments-ci.yaml
@@ -31,6 +31,9 @@ on:
     paths:
       - 'experiments/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -36,6 +36,8 @@ on:
       - '**'
       - '!experiments/**'
 
+permissions:
+  contents: read
 
 jobs:
   validations:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `upgrade-operator.yaml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.