### PR TITLE
test(preview): run preview package unit tests in a separate presubmit job

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -3487,6 +3487,27 @@ jobs:
           path: /tmp/artifacts/
 
 
+  tests-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: 'go.mod'
+      - name: "Run dev/ci/presubmits/tests-preview"
+        run: |
+          ./dev/ci/presubmits/tests-preview
+        env:
+          ARTIFACTS: /tmp/artifacts
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: artifacts-tests-preview
+          path: /tmp/artifacts/
+
+
   tests-scenarios-acquisition:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/dev/ci/presubmits/tests-preview
+++ b/dev/ci/presubmits/tests-preview
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function on_error() {
+  echo "<hint_for_agent>Run 'dev/ci/presubmits/tests-preview' to fix.</hint_for_agent>"
+}
+trap on_error ERR
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+. ${REPO_ROOT}/dev/tasks/install-gcloud
+. ${REPO_ROOT}/dev/tasks/setup-envtest
+
+echo "Running preview CLI tests..."
+# A dummy default project id is required for a few unit test cases
+gcloud config set project foobar --quiet
+
+go test -test.count=1 -v ./pkg/cli/preview/...

--- a/pkg/cli/preview/result_test.go
+++ b/pkg/cli/preview/result_test.go
@@ -111,6 +111,11 @@ func TestCombinedSummaryReport(t *testing.T) {
 				ControllerType:  k8s.ReconcilerType("tf"),
 				ReconcileStatus: ReconcileStatusHealthy,
 			},
+			{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"}: {
+				GKNN:            GKNN{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"},
+				ControllerType:  k8s.ReconcilerType("tf"),
+				ReconcileStatus: ReconcileStatusUnhealthy,
+			},
 		},
 	}
 	alt := &RecorderReconciledResults{
@@ -125,6 +130,11 @@ func TestCombinedSummaryReport(t *testing.T) {
 				ControllerType:  k8s.ReconcilerType("direct"),
 				ReconcileStatus: ReconcileStatusHealthy,
 			},
+			{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"}: {
+				GKNN:            GKNN{Group: "g3", Kind: "K3", Namespace: "n3", Name: "name3"},
+				ControllerType:  k8s.ReconcilerType("direct"),
+				ReconcileStatus: ReconcileStatusUnhealthy,
+			},
 		},
 	}
 
@@ -133,11 +143,13 @@ func TestCombinedSummaryReport(t *testing.T) {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 	defer os.Remove(tmpFile.Name())
+	defer os.Remove(tmpFile.Name() + "-detail")
 	tmpFile.Close()
 
 	altExpectedMap := map[schema.GroupKind]k8s.ReconcilerType{
 		{Group: "g1", Kind: "K1"}: k8s.ReconcilerType("direct"),
 		{Group: "g2", Kind: "K2"}: k8s.ReconcilerType("direct"),
+		{Group: "g3", Kind: "K3"}: k8s.ReconcilerType("direct"),
 	}
 
 	if err := r.CombinedSummaryReport(tmpFile.Name(), alt, altExpectedMap); err != nil {
@@ -154,6 +166,7 @@ func TestCombinedSummaryReport(t *testing.T) {
 		"GROUP   KIND   NAME    DEFAULT-CONTROLLER   DEFAULT-RESULT   DEFAULT-DIFFS   ALTERNATIVE-CONTROLLER   ALTERNATIVE-RESULT   ALTERNATIVE-DIFFS",
 		"g1      K1     name1   tf                   HEALTHY          N/A             direct                   UNHEALTHY            N/A",
 		"g2      K2     name2   N/A                  N/A              N/A             direct                   HEALTHY              N/A",
+		"g3      K3     name3   tf                   UNHEALTHY        N/A             direct                   UNHEALTHY            N/A",
 	}
 
 	for _, row := range expectedRows {
@@ -171,5 +184,17 @@ func TestCombinedSummaryReport(t *testing.T) {
 				t.Errorf("expected row %q not found in content:\n%s", row, string(content))
 			}
 		}
+	}
+
+	// Verify the detail report contains the expected bad results and is deduplicated/sorted correctly
+	detailContent, err := os.ReadFile(tmpFile.Name() + "-detail")
+	if err != nil {
+		t.Fatalf("failed to read detail file: %v", err)
+	}
+	if !strings.Contains(string(detailContent), "name1") {
+		t.Errorf("expected detail report to contain name1")
+	}
+	if !strings.Contains(string(detailContent), "name3") {
+		t.Errorf("expected detail report to contain name3")
 	}
 }

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -20,7 +20,7 @@ cd "${REPO_ROOT}"
 make -C operator test
 # Env var VALIDATE_URLS needs to be unset to avoid calling URLs in TestReferenceDocConsistency under scripts/generate-google3-docs/.
 unset VALIDATE_URLS
-UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/...  ./scripts/resource-autogen/... ./scripts/generate-google3-docs/... ./tests/... | grep -v tests/e2e)
+UNIT_TEST_PACKAGES=$(go list ./pkg/... ./cmd/... ./config/tests/...  ./scripts/resource-autogen/... ./scripts/generate-google3-docs/... ./tests/... | grep -v tests/e2e | grep -v pkg/cli/preview)
 if [ -z ${GITHUB_ACTION+x} ]; then
     go run gotest.tools/gotestsum@latest --format testname -- ${UNIT_TEST_PACKAGES} -coverprofile cover.out -count=1
 else


### PR DESCRIPTION
Fixes #8379
Partially addresses #8116

### Description

Currently, the preview CLI package unit tests (`pkg/cli/preview/...`) are run as part of the general `unit-tests` job since they are under the `pkg/...` directory hierarchy.
However, preview tests start a local `envtest` API server and mock GCP client, which are slow and can make the standard `unit-tests` suite take longer or fail due to timeouts or flakiness.

### Proposed Solution

- Exclude the `pkg/cli/preview` package from the default `scripts/unit-test.sh` package list.
- Create a dedicated presubmit script `dev/ci/presubmits/tests-preview`.
- Update the generated GitHub Actions workflows by running `generate-github-actions` to declare the `tests-preview` job as a separate workflow task.