### PR TITLE
Update generated Go client for ComputeForwardingRule

### DIFF
--- a/pkg/clients/generated/apis/compute/v1beta1/computeforwardingrule_types.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/computeforwardingrule_types.go
@@ -401,6 +401,10 @@ type ComputeForwardingRuleStatus struct {
 	/* The internal fully qualified service name for this Forwarding Rule. This field is only used for INTERNAL load balancing. */
 	// +optional
 	ServiceName *string `json:"serviceName,omitempty"`
+
+	/* The target resource to receive the matched traffic. */
+	// +optional
+	Target *string `json:"target,omitempty"`
 }
 
 // +genclient

--- a/pkg/clients/generated/apis/compute/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/compute/v1beta1/zz_generated.deepcopy.go
@@ -2882,6 +2882,11 @@ func (in *ComputeForwardingRuleStatus) DeepCopyInto(out *ComputeForwardingRuleSt
 		*out = new(string)
 		**out = **in
 	}
+	if in.Target != nil {
+		in, out := &in.Target, &out.Target
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Update the go client with `make generate-go-client` this is a follow up to PR #7371 which passed all presubmit checks but was still missing running this command