### PR TITLE
Trigger presubmits with a trivial change

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Common controller dependencies.
+// Trivial change to trigger presubmits.
 type Deps struct {
 	TFProvider        *tfschema.Provider
 	TFLoader          *servicemappingloader.ServiceMappingLoader


### PR DESCRIPTION
Add a trivial comment to pkg/controller/config.go to trigger CI presubmits.

This PR was generated by Overseer (powered by the gemini-3-flash-preview model).