### PR TITLE
Revert "chore: exclude .agents, .gemini and hack folders from CI triggers"

### DIFF
--- a/.github/workflows/ci-presubmit.yaml
+++ b/.github/workflows/ci-presubmit.yaml
@@ -22,26 +22,17 @@ on:
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   push:
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   merge_group:
     types: [checks_requested]
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
 
 
 jobs:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -24,26 +24,17 @@ on:
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   push:
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   merge_group:
     types: [checks_requested]
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
 
 
 jobs:

--- a/dev/tasks/generate-github-actions
+++ b/dev/tasks/generate-github-actions
@@ -48,26 +48,17 @@ on:
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   push:
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
   merge_group:
     types: [checks_requested]
     branches: ["master", "release-*"]
     paths:
       - '**'
       - '!experiments/**'
-      - '!.agents/**'
-      - '!.gemini/**'
-      - '!hack/tools/greenfield/**'
 
 
 jobs:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/k8s-config-connector#8550

See: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8550#issuecomment-4523443346