### PR TITLE
feat: Allow setting nodeConfig with "remove-default-node-pool" annotation in ContainerCluster

### DIFF
--- a/mockgcp/mockcontainer/cluster.go
+++ b/mockgcp/mockcontainer/cluster.go
@@ -120,7 +120,7 @@ func (s *ClusterManagerV1) CreateCluster(ctx context.Context, req *pb.CreateClus
 
 	obj.ServicesIpv4Cidr = "34.118.224.0/20"
 
-	if err := s.populateClusterDefaults(name.Project, obj); err != nil {
+	if err := s.populateClusterDefaults(name.Project, obj, true); err != nil {
 		return nil, err
 	}
 
@@ -362,7 +362,8 @@ func (s *ClusterManagerV1) UpdateCluster(ctx context.Context, req *pb.UpdateClus
 		return nil, status.Errorf(codes.InvalidArgument, "update was not fully implemented ClusterUpdate=%v", prototext.Format(update))
 	}
 
-	if err := s.populateClusterDefaults(name.Project, obj); err != nil {
+	if err := s.populateClusterDefaults(name.Project, obj, false); err != nil {
+
 		return nil, err
 	}
 
@@ -473,12 +474,27 @@ func (s *ClusterManagerV1) DeleteCluster(ctx context.Context, req *pb.DeleteClus
 	})
 }
 
-func (s *ClusterManagerV1) populateClusterDefaults(project *projects.ProjectData, obj *pb.Cluster) error {
-	if obj.NodeConfig == nil {
-		obj.NodeConfig = &pb.NodeConfig{}
+func (s *ClusterManagerV1) populateClusterDefaults(project *projects.ProjectData, obj *pb.Cluster, isCreate bool) error {
+	hasDefaultPool := false
+	for _, np := range obj.NodePools {
+		if np.Name == "default-pool" {
+			hasDefaultPool = true
+			break
+		}
 	}
-	if err := s.populateNodeConfig(obj.NodeConfig); err != nil {
-		return err
+	if isCreate && len(obj.NodePools) == 0 {
+		hasDefaultPool = true
+	}
+
+	if hasDefaultPool {
+		if obj.NodeConfig == nil {
+			obj.NodeConfig = &pb.NodeConfig{}
+		}
+		if err := s.populateNodeConfig(obj.NodeConfig); err != nil {
+			return err
+		}
+	} else {
+		obj.NodeConfig = nil
 	}
 
 	// Populate new fields based on deprecated fields

--- a/mockgcp/mockcontainer/nodepool.go
+++ b/mockgcp/mockcontainer/nodepool.go
@@ -403,10 +403,35 @@ func (s *ClusterManagerV1) DeleteNodePool(ctx context.Context, req *pb.DeleteNod
 		return nil, err
 	}
 
+	clusterName := name.ClusterName()
+	clusterFqn := clusterName.String()
+	cluster := &pb.Cluster{}
+	if err := s.storage.Get(ctx, clusterFqn, cluster); err != nil {
+		return nil, err
+	}
+
 	fqn := name.String()
 
 	oldObj := &pb.NodePool{}
 	if err := s.storage.Delete(ctx, fqn, oldObj); err != nil {
+		return nil, err
+	}
+
+	// Update the cluster's NodePools list after deletion
+	var newNodePools []*pb.NodePool
+	for _, np := range cluster.NodePools {
+		if np.Name != name.NodePool {
+			newNodePools = append(newNodePools, np)
+		}
+	}
+	cluster.NodePools = newNodePools
+
+	// To match realGCP, if the default node pool is deleted, remove NodeConfig on the cluster.
+	if name.NodePool == "default-pool" {
+		cluster.NodeConfig = nil
+	}
+
+	if err := s.storage.Update(ctx, clusterFqn, cluster); err != nil {
 		return nil, err
 	}
 

--- a/pkg/krmtotf/krmtotf.go
+++ b/pkg/krmtotf/krmtotf.go
@@ -56,12 +56,10 @@ func KRMResourceToTFResourceConfig(r *Resource, c client.Client, smLoader *servi
 //   - defaultLabels: if set, these labels will be added to tfConfig.
 func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader,
 	liveState *terraform.InstanceState, jsonSchema *apiextensions.JSONSchemaProps, mustResolveSensitiveFields bool) (tfConfig *terraform.ResourceConfig, secretVersions map[string]string, err error) {
-	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull start for %v, generation %v, jsonSchema is nil: %v\n", r.GetName(), r.GetGeneration(), jsonSchema == nil)
 	config := deepcopy.MapStringInterface(r.Spec)
 	if config == nil {
 		config = make(map[string]interface{})
 	}
-	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull jsonSchema is nil: %v\n", jsonSchema == nil)
 	if jsonSchema != nil {
 		if err := ResolveLegacyGCPManagedFields(r, liveState, config); err != nil {
 			return nil, nil, fmt.Errorf("error resolving legacy GCP-managed fields: %w", err)
@@ -173,10 +171,8 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 	state := InstanceStateToMap(r.TFResource, liveState)
 	config, err = withResourceCustomResolvers(config, state, r.Kind, r.TFResource)
 	if err != nil {
-		fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull custom resolver error: %v\n", err)
 		return nil, nil, fmt.Errorf("error running resource custom resolver: %w", err)
 	}
-	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull success for %v, generation %v\n", r.GetName(), r.GetGeneration())
 	return MapToResourceConfig(r.TFResource, config), secretVersions, nil
 }
 

--- a/pkg/krmtotf/krmtotf.go
+++ b/pkg/krmtotf/krmtotf.go
@@ -56,10 +56,12 @@ func KRMResourceToTFResourceConfig(r *Resource, c client.Client, smLoader *servi
 //   - defaultLabels: if set, these labels will be added to tfConfig.
 func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *servicemappingloader.ServiceMappingLoader,
 	liveState *terraform.InstanceState, jsonSchema *apiextensions.JSONSchemaProps, mustResolveSensitiveFields bool) (tfConfig *terraform.ResourceConfig, secretVersions map[string]string, err error) {
+	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull start for %v, generation %v, jsonSchema is nil: %v\n", r.GetName(), r.GetGeneration(), jsonSchema == nil)
 	config := deepcopy.MapStringInterface(r.Spec)
 	if config == nil {
 		config = make(map[string]interface{})
 	}
+	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull jsonSchema is nil: %v\n", jsonSchema == nil)
 	if jsonSchema != nil {
 		if err := ResolveLegacyGCPManagedFields(r, liveState, config); err != nil {
 			return nil, nil, fmt.Errorf("error resolving legacy GCP-managed fields: %w", err)
@@ -67,6 +69,31 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 		config, err = resolveUnmanagedFields(config, r, liveState, jsonSchema)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error resolving externally-managed fields: %w", err)
+		}
+
+		/*
+			Due to an existing TF limitation, KCC recommends against setting "remove-default-nodepool" alongside nodeConfig.
+			This field is only relevant to the default pool intended to be deleted, and should be managed in ContainerNodePool resource.
+
+			However, to unblock OrgPolicies/customer requirements when creating the ContainerCluster(b/489359646, b/491324027),
+			we introduced the opt-in "remove-default-node-pool-allow-node-config" annotation. This allows a ContainerCluster
+			to be created and reconciled with both "remove-default-node-pool" and nodeConfig specified.
+		*/
+		removeDefaultNodePoolDirective := "remove-default-node-pool"
+		removeDefaultNodePoolKey := k8s.FormatAnnotation(removeDefaultNodePoolDirective)
+		allowNodeConfigOverrideDirective := "remove-default-node-pool-allow-node-config"
+		allowNodeConfigOverrideKey := k8s.FormatAnnotation(allowNodeConfigOverrideDirective)
+		if r.GroupVersionKind().Kind == "ContainerCluster" {
+			if val, ok := k8s.GetAnnotation(removeDefaultNodePoolKey, r); ok && val == "true" {
+				// Check liveState to determine if it's initial creation or reconcile. If the resource is being created,
+				// we MUST NOT modify the desired configuration. We should assume all user specified values are required
+				// during cluster provisioning.
+				if liveState != nil && liveState.ID != "" {
+					if override, ok := k8s.GetAnnotation(allowNodeConfigOverrideKey, r); ok && override == "true" {
+						unstructured.RemoveNestedField(config, "nodeConfig")
+					}
+				}
+			}
 		}
 	}
 	if err := handleUserSpecifiedID(config, r, smLoader, c); err != nil {
@@ -146,8 +173,10 @@ func KRMResourceToTFResourceConfigFull(r *Resource, c client.Client, smLoader *s
 	state := InstanceStateToMap(r.TFResource, liveState)
 	config, err = withResourceCustomResolvers(config, state, r.Kind, r.TFResource)
 	if err != nil {
+		fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull custom resolver error: %v\n", err)
 		return nil, nil, fmt.Errorf("error running resource custom resolver: %w", err)
 	}
+	fmt.Printf("DEBUG: KRMResourceToTFResourceConfigFull success for %v, generation %v\n", r.GetName(), r.GetGeneration())
 	return MapToResourceConfig(r.TFResource, config), secretVersions, nil
 }
 

--- a/pkg/krmtotf/legacygcpmanagedfields.go
+++ b/pkg/krmtotf/legacygcpmanagedfields.go
@@ -317,7 +317,7 @@ func removeFromConfigIfNotApplied(r *Resource, config map[string]interface{}, pa
 	// in the KRM camelCase format.
 	_, found, err := getLastAppliedValue(r, path...)
 	if err != nil {
-		return fmt.Errorf("error finding last applied value for disk size: %w", err)
+		return fmt.Errorf("error finding last applied value for %s: %w", path, err)
 	}
 	if !found {
 		// The value was not found in the last applied configuration. Delegate

--- a/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_http.log
+++ b/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_http.log
@@ -191,7 +191,7 @@ X-Xss-Protection: 0
   "operationType": "DELETE_NODE_POOL",
   "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "RUNNING",
+  "status": "PENDING",
   "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}/nodePools/default-pool",
   "zone": "us-central1-a"
 }
@@ -239,6 +239,9 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -247,10 +250,11 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    }
+    },
+    "nodeReadinessConfig": {}
   },
   "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
+    "mode": "LIMITED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -277,11 +281,15 @@ X-Xss-Protection: 0
   "clusterTelemetry": {
     "type": "ENABLED"
   },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-d9cca5b6872648c0ada619b00fd020ab81a7-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -289,15 +297,14 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
-      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentMasterVersion": "1.35.3-gke.1389000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
+  "currentNodeVersion": "1.35.3-gke.1389000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -311,21 +318,22 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialClusterVersion": "1.35.3-gke.1389000",
   "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-sample-${uniqueId}-pods-d9cca5b6",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "abcdef0123A=",
+  "labelFingerprint": "161f8d3b",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
@@ -343,9 +351,10 @@ X-Xss-Protection: 0
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
+  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRQzNoeEpZWEQxUGVkbGZvTDJaTlgyREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRMVpEY3pZbUV6TWkwMlkyRmlMVFEwT1dNdE9HSTJZUzB5WW1Fek1qY3hZVEUyWkRjdwpJQmNOTWpZd05USTJNVGN5TnpRMldoZ1BNakExTmpBMU1UZ3hPREkzTkRaYU1DOHhMVEFyQmdOVkJBTVRKRFZrCk56TmlZVE15TFRaallXSXRORFE1WXkwNFlqWmhMVEppWVRNeU56RmhNVFprTnpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUpXOTdDcWc3M2NPMHNIVlBRSXlmOE9sZUs0NHdyU3dDRThJRGY2SQpVTUI5N0ZYMktjUmVxNktsaGErTE9Xb0lKbFVrd0FXaTJnS3ljVXplaU1Hb1RjSEUxNVJacDBEQkMwWXMrZFl4CkVONGQ1aVNobncyS3VYYXFrbWFrVStDREc3RmJNZVdQcVlBckRzWkVLNUVKWkN0MGc5QVc2M09BNWpiaXpVOE4KdGJoejZSbk5lZmR2eFUvNXNYajNaKzlrTXJ2L2w2QUV0S1doZmxUTWphNTkwOWI0RVFnQUIxRVRxVXROenhTQwp0UDJRUWw2eEIydzd4cWVQTEhZZ2txcW55VjZ4ZFJyaHFrUWxBU3B6R2FaRjlYb05DNVdoS0N1MTVpd3k4aktHCm5GK01taSsxVStiaE5OcWpQSkkrVWNCV0ZyZ3JUMDUrTjJuZzl5alBGV1BSRDM5SXpBSmpCbXZFcFZEZnZlN2UKclBOZXBEMmorVUpMTDF2WjE2T2FHclRTV3N3Nng4UVowODZnakVGbGZ0a1ZoTG9tQXhNUWhXWE5UTlNBbEQyWAp4Q3I1MGltRklWTU0yU0pPVURWM1g1VTNjMmtCU052NVlpNmNmZlJYOVdyME53U2xjMVRpNFdBUjVXVDVDZVJHCm5idHRuWXF2YnFXcUpQUU15L0VUT1RJSjVRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVYUHB5OHo0UHNsZ25oNHM1RmhkRFhNYjhjY0l3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFBSklkc2I1REFFSGgwTmtGR1RJZ2cwMkNSNVMxeWRiODJ4WXpRYURXazhzCjdLODZnS0hBUDJaM0FRbm9vN1pUWncyUkFmSEljZlg5UWg0cFArWVplVFNSSnZCczVaTmpwMUpTMUg0VDdxRTYKS2F4a2FHQmxvcXBDVy9JcDJOWTcxdk9FYXFjZ2RKM2oyeFVKR1I3UVAxeFBsUTNEOWQyK3Z0dDFEY0g5UWRMMQpjdG1sTFc0YkczcjRsY3htOUdnazFiT2FsK2xWNTZCeHgyeHQ4VnUxNzlncEhXNTB5QnhGUjdHbGhVNWtpdGZWCjkyZWk1N0dwUVBrZWhCY3dlTVFneUVYYnRuM25FM2NqOEU5dUxxVVFLRXJIQklzZnp2ZEtBRU9pR2pXcThrQzUKZ1ZmNkRSU2l3dFNYQXJlS3cyWDY3WTdOcmJsQnY3ZmthMlRXbWVDTTJPeEtTR2RmQTRBa1RMMjZaYWFNRkkxUApHK1U0WXNLNGZUKzVDeW50eG9tWXpYL0VVVjR2Zi96eHRQM0lBR09lQXd2QnBkY1ZhTXFsWkRLeC84bVVEQTVoCkJJVEhGKytZeDRZWGpYcUxDdjZWMUZGZ1BJc2hTT0Z4ZEtGODZsSnlHSlNVVGN1SjBGcmdueHVyK0pHZno0Z2UKRVdaMFQ1M1V5SHhEb0F0UWlGbFYrUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -355,16 +364,16 @@ X-Xss-Protection: 0
     "componentConfig": {
       "enableComponents": [
         "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
         "STORAGE",
         "HPA",
         "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
         "CADVISOR",
         "KUBELET",
-        "DCGM"
+        "DCGM",
+        "JOBSET"
       ]
     },
     "managedPrometheusConfig": {
@@ -375,43 +384,13 @@ X-Xss-Protection: 0
   "name": "cluster-sample-${uniqueId}",
   "network": "default",
   "networkConfig": {
+    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
   },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -430,1116 +409,13 @@ X-Xss-Protection: 0
       }
     }
   },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
   "notificationConfig": {
     "pubsub": {}
   },
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "cnrm-test": "true",
-    "label-one": "value-one",
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found"
-  }
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-sample-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    }
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "globalAccess": false,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
-  "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "abcdef0123A=",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "logging.googleapis.com/kubernetes",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "cluster-sample-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "cnrm-test": "true",
-    "label-one": "value-one",
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found"
-  }
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-sample-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    }
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "globalAccess": false,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
-  "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "abcdef0123A=",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "logging.googleapis.com/kubernetes",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "cluster-sample-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "cnrm-test": "true",
-    "label-one": "value-one",
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found"
-  }
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-sample-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    }
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "globalAccess": false,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
-  "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "abcdef0123A=",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "logging.googleapis.com/kubernetes",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "cluster-sample-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
+  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"
@@ -1653,6 +529,9 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -1661,10 +540,11 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    }
+    },
+    "nodeReadinessConfig": {}
   },
   "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
+    "mode": "LIMITED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -1689,13 +569,17 @@ X-Xss-Protection: 0
   "binaryAuthorization": {},
   "clusterIpv4Cidr": "10.112.0.0/14",
   "clusterTelemetry": {
-    "type": "ENABLED"
+    "type": "DISABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
   },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-d9cca5b6872648c0ada619b00fd020ab81a7-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -1703,15 +587,13 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
-      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
+  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.35.3-gke.1389000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -1725,41 +607,38 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialClusterVersion": "1.35.3-gke.1389000",
   "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-sample-${uniqueId}-pods-d9cca5b6",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "abcdef0123A=",
+  "labelFingerprint": "161f8d3b",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
     "us-central1-a"
   ],
   "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
+    "componentConfig": {}
   },
   "loggingService": "none",
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
+  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRQzNoeEpZWEQxUGVkbGZvTDJaTlgyREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRMVpEY3pZbUV6TWkwMlkyRmlMVFEwT1dNdE9HSTJZUzB5WW1Fek1qY3hZVEUyWkRjdwpJQmNOTWpZd05USTJNVGN5TnpRMldoZ1BNakExTmpBMU1UZ3hPREkzTkRaYU1DOHhMVEFyQmdOVkJBTVRKRFZrCk56TmlZVE15TFRaallXSXRORFE1WXkwNFlqWmhMVEppWVRNeU56RmhNVFprTnpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUpXOTdDcWc3M2NPMHNIVlBRSXlmOE9sZUs0NHdyU3dDRThJRGY2SQpVTUI5N0ZYMktjUmVxNktsaGErTE9Xb0lKbFVrd0FXaTJnS3ljVXplaU1Hb1RjSEUxNVJacDBEQkMwWXMrZFl4CkVONGQ1aVNobncyS3VYYXFrbWFrVStDREc3RmJNZVdQcVlBckRzWkVLNUVKWkN0MGc5QVc2M09BNWpiaXpVOE4KdGJoejZSbk5lZmR2eFUvNXNYajNaKzlrTXJ2L2w2QUV0S1doZmxUTWphNTkwOWI0RVFnQUIxRVRxVXROenhTQwp0UDJRUWw2eEIydzd4cWVQTEhZZ2txcW55VjZ4ZFJyaHFrUWxBU3B6R2FaRjlYb05DNVdoS0N1MTVpd3k4aktHCm5GK01taSsxVStiaE5OcWpQSkkrVWNCV0ZyZ3JUMDUrTjJuZzl5alBGV1BSRDM5SXpBSmpCbXZFcFZEZnZlN2UKclBOZXBEMmorVUpMTDF2WjE2T2FHclRTV3N3Nng4UVowODZnakVGbGZ0a1ZoTG9tQXhNUWhXWE5UTlNBbEQyWAp4Q3I1MGltRklWTU0yU0pPVURWM1g1VTNjMmtCU052NVlpNmNmZlJYOVdyME53U2xjMVRpNFdBUjVXVDVDZVJHCm5idHRuWXF2YnFXcUpQUU15L0VUT1RJSjVRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVYUHB5OHo0UHNsZ25oNHM1RmhkRFhNYjhjY0l3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFBSklkc2I1REFFSGgwTmtGR1RJZ2cwMkNSNVMxeWRiODJ4WXpRYURXazhzCjdLODZnS0hBUDJaM0FRbm9vN1pUWncyUkFmSEljZlg5UWg0cFArWVplVFNSSnZCczVaTmpwMUpTMUg0VDdxRTYKS2F4a2FHQmxvcXBDVy9JcDJOWTcxdk9FYXFjZ2RKM2oyeFVKR1I3UVAxeFBsUTNEOWQyK3Z0dDFEY0g5UWRMMQpjdG1sTFc0YkczcjRsY3htOUdnazFiT2FsK2xWNTZCeHgyeHQ4VnUxNzlncEhXNTB5QnhGUjdHbGhVNWtpdGZWCjkyZWk1N0dwUVBrZWhCY3dlTVFneUVYYnRuM25FM2NqOEU5dUxxVVFLRXJIQklzZnp2ZEtBRU9pR2pXcThrQzUKZ1ZmNkRSU2l3dFNYQXJlS3cyWDY3WTdOcmJsQnY3ZmthMlRXbWVDTTJPeEtTR2RmQTRBa1RMMjZaYWFNRkkxUApHK1U0WXNLNGZUKzVDeW50eG9tWXpYL0VVVjR2Zi96eHRQM0lBR09lQXd2QnBkY1ZhTXFsWkRLeC84bVVEQTVoCkJJVEhGKytZeDRZWGpYcUxDdjZWMUZGZ1BJc2hTT0Z4ZEtGODZsSnlHSlNVVGN1SjBGcmdueHVyK0pHZno0Z2UKRVdaMFQ1M1V5SHhEb0F0UWlGbFYrUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -1768,17 +647,16 @@ X-Xss-Protection: 0
     "advancedDatapathObservabilityConfig": {},
     "componentConfig": {
       "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
         "STORAGE",
         "HPA",
         "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
         "CADVISOR",
         "KUBELET",
-        "DCGM"
+        "DCGM",
+        "JOBSET"
       ]
     },
     "managedPrometheusConfig": {
@@ -1789,43 +667,13 @@ X-Xss-Protection: 0
   "name": "cluster-sample-${uniqueId}",
   "network": "default",
   "networkConfig": {
+    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
   },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -1844,770 +692,13 @@ X-Xss-Protection: 0
       }
     }
   },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
   "notificationConfig": {
     "pubsub": {}
   },
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "cnrm-test": "true",
-    "label-one": "value-one",
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found"
-  }
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-sample-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    }
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "globalAccess": false,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
-  "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "abcdef0123A=",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "none",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "none",
-  "name": "cluster-sample-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "cnrm-test": "true",
-    "label-one": "value-one",
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-404 Not Found
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "error": {
-    "code": 404,
-    "errors": [
-      {
-        "domain": "global",
-        "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found",
-        "reason": "notFound"
-      }
-    ],
-    "message": "instanceGroupManager \"projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp\" not found"
-  }
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-sample-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    }
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "ENABLED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "globalAccess": false,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.30.5-gke.1014001",
-  "currentNodeCount": 1,
-  "currentNodeVersion": "1.30.5-gke.1014001",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.30.5-gke.1014001",
-  "initialNodeCount": 1,
-  "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
-  ],
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "abcdef0123A=",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "none",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "1234567890abcdefghijklmn"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "JOBSET",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "none",
-  "name": "cluster-sample-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeConfig": {
-    "bootDisk": {
-      "diskType": "pd-balanced",
-      "sizeGb": "100"
-    },
-    "diskSizeGb": 100,
-    "diskType": "pd-balanced",
-    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-    "imageType": "COS_CONTAINERD",
-    "kubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false,
-      "maxParallelImagePulls": 2
-    },
-    "machineType": "e2-medium",
-    "metadata": {
-      "disable-legacy-endpoints": "true"
-    },
-    "oauthScopes": [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append"
-    ],
-    "resourceLabels": {
-      "goog-gke-node-pool-provisioning-model": "on-demand"
-    },
-    "serviceAccount": "default",
-    "shieldedInstanceConfig": {
-      "enableIntegrityMonitoring": true
-    },
-    "windowsNodeConfig": {}
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "nodePools": [
-    {
-      "config": {
-        "bootDisk": {
-          "diskType": "pd-balanced",
-          "sizeGb": "100"
-        },
-        "diskSizeGb": 100,
-        "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
-        "imageType": "COS_CONTAINERD",
-        "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": false,
-          "maxParallelImagePulls": 2
-        },
-        "machineType": "e2-medium",
-        "metadata": {
-          "disable-legacy-endpoints": "true"
-        },
-        "oauthScopes": [
-          "https://www.googleapis.com/auth/devstorage.read_only",
-          "https://www.googleapis.com/auth/logging.write",
-          "https://www.googleapis.com/auth/monitoring",
-          "https://www.googleapis.com/auth/service.management.readonly",
-          "https://www.googleapis.com/auth/servicecontrol",
-          "https://www.googleapis.com/auth/trace.append"
-        ],
-        "resourceLabels": {
-          "goog-gke-node-pool-provisioning-model": "on-demand"
-        },
-        "serviceAccount": "default",
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": true
-        },
-        "windowsNodeConfig": {}
-      },
-      "initialNodeCount": 1,
-      "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
-      ],
-      "locations": [
-        "us-central1-a"
-      ],
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "maxPodsConstraint": {
-        "maxPodsPerNode": "110"
-      },
-      "name": "default-pool",
-      "networkConfig": {
-        "podIpv4CidrBlock": "10.92.0.0/14",
-        "podIpv4RangeUtilization": 0.001,
-        "podRange": "default-pool-pods-12345678",
-        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-      },
-      "podIpv4CidrSize": 24,
-      "status": "RUNNING",
-      "upgradeSettings": {
-        "maxSurge": 1,
-        "strategy": "SURGE"
-      },
-      "version": "1.30.5-gke.1014001"
-    }
-  ],
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
+  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"

--- a/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_http.log
+++ b/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool/_http.log
@@ -191,7 +191,7 @@ X-Xss-Protection: 0
   "operationType": "DELETE_NODE_POOL",
   "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "PENDING",
+  "status": "RUNNING",
   "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-sample-${uniqueId}/nodePools/default-pool",
   "zone": "us-central1-a"
 }
@@ -239,9 +239,6 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -250,11 +247,10 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    },
-    "nodeReadinessConfig": {}
+    }
   },
   "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
+    "mode": "ENABLED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -281,15 +277,11 @@ X-Xss-Protection: 0
   "clusterTelemetry": {
     "type": "ENABLED"
   },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
-  },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-d9cca5b6872648c0ada619b00fd020ab81a7-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -297,14 +289,15 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
+      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentMasterVersion": "1.30.5-gke.1014001",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.30.5-gke.1014001",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -318,22 +311,21 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
   "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-sample-${uniqueId}-pods-d9cca5b6",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "161f8d3b",
+  "labelFingerprint": "abcdef0123A=",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
@@ -351,10 +343,9 @@ X-Xss-Protection: 0
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
-  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRQzNoeEpZWEQxUGVkbGZvTDJaTlgyREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRMVpEY3pZbUV6TWkwMlkyRmlMVFEwT1dNdE9HSTJZUzB5WW1Fek1qY3hZVEUyWkRjdwpJQmNOTWpZd05USTJNVGN5TnpRMldoZ1BNakExTmpBMU1UZ3hPREkzTkRaYU1DOHhMVEFyQmdOVkJBTVRKRFZrCk56TmlZVE15TFRaallXSXRORFE1WXkwNFlqWmhMVEppWVRNeU56RmhNVFprTnpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUpXOTdDcWc3M2NPMHNIVlBRSXlmOE9sZUs0NHdyU3dDRThJRGY2SQpVTUI5N0ZYMktjUmVxNktsaGErTE9Xb0lKbFVrd0FXaTJnS3ljVXplaU1Hb1RjSEUxNVJacDBEQkMwWXMrZFl4CkVONGQ1aVNobncyS3VYYXFrbWFrVStDREc3RmJNZVdQcVlBckRzWkVLNUVKWkN0MGc5QVc2M09BNWpiaXpVOE4KdGJoejZSbk5lZmR2eFUvNXNYajNaKzlrTXJ2L2w2QUV0S1doZmxUTWphNTkwOWI0RVFnQUIxRVRxVXROenhTQwp0UDJRUWw2eEIydzd4cWVQTEhZZ2txcW55VjZ4ZFJyaHFrUWxBU3B6R2FaRjlYb05DNVdoS0N1MTVpd3k4aktHCm5GK01taSsxVStiaE5OcWpQSkkrVWNCV0ZyZ3JUMDUrTjJuZzl5alBGV1BSRDM5SXpBSmpCbXZFcFZEZnZlN2UKclBOZXBEMmorVUpMTDF2WjE2T2FHclRTV3N3Nng4UVowODZnakVGbGZ0a1ZoTG9tQXhNUWhXWE5UTlNBbEQyWAp4Q3I1MGltRklWTU0yU0pPVURWM1g1VTNjMmtCU052NVlpNmNmZlJYOVdyME53U2xjMVRpNFdBUjVXVDVDZVJHCm5idHRuWXF2YnFXcUpQUU15L0VUT1RJSjVRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVYUHB5OHo0UHNsZ25oNHM1RmhkRFhNYjhjY0l3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFBSklkc2I1REFFSGgwTmtGR1RJZ2cwMkNSNVMxeWRiODJ4WXpRYURXazhzCjdLODZnS0hBUDJaM0FRbm9vN1pUWncyUkFmSEljZlg5UWg0cFArWVplVFNSSnZCczVaTmpwMUpTMUg0VDdxRTYKS2F4a2FHQmxvcXBDVy9JcDJOWTcxdk9FYXFjZ2RKM2oyeFVKR1I3UVAxeFBsUTNEOWQyK3Z0dDFEY0g5UWRMMQpjdG1sTFc0YkczcjRsY3htOUdnazFiT2FsK2xWNTZCeHgyeHQ4VnUxNzlncEhXNTB5QnhGUjdHbGhVNWtpdGZWCjkyZWk1N0dwUVBrZWhCY3dlTVFneUVYYnRuM25FM2NqOEU5dUxxVVFLRXJIQklzZnp2ZEtBRU9pR2pXcThrQzUKZ1ZmNkRSU2l3dFNYQXJlS3cyWDY3WTdOcmJsQnY3ZmthMlRXbWVDTTJPeEtTR2RmQTRBa1RMMjZaYWFNRkkxUApHK1U0WXNLNGZUKzVDeW50eG9tWXpYL0VVVjR2Zi96eHRQM0lBR09lQXd2QnBkY1ZhTXFsWkRLeC84bVVEQTVoCkJJVEhGKytZeDRZWGpYcUxDdjZWMUZGZ1BJc2hTT0Z4ZEtGODZsSnlHSlNVVGN1SjBGcmdueHVyK0pHZno0Z2UKRVdaMFQ1M1V5SHhEb0F0UWlGbFYrUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -364,16 +355,16 @@ X-Xss-Protection: 0
     "componentConfig": {
       "enableComponents": [
         "SYSTEM_COMPONENTS",
-        "STORAGE",
-        "HPA",
-        "POD",
         "DAEMONSET",
         "DEPLOYMENT",
         "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
         "CADVISOR",
         "KUBELET",
-        "DCGM",
-        "JOBSET"
+        "DCGM"
       ]
     },
     "managedPrometheusConfig": {
@@ -384,13 +375,9 @@ X-Xss-Protection: 0
   "name": "cluster-sample-${uniqueId}",
   "network": "default",
   "networkConfig": {
-    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -415,7 +402,6 @@ X-Xss-Protection: 0
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"
@@ -529,9 +515,6 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -540,11 +523,10 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    },
-    "nodeReadinessConfig": {}
+    }
   },
   "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
+    "mode": "ENABLED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -569,17 +551,13 @@ X-Xss-Protection: 0
   "binaryAuthorization": {},
   "clusterIpv4Cidr": "10.112.0.0/14",
   "clusterTelemetry": {
-    "type": "DISABLED"
-  },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
+    "type": "ENABLED"
   },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-d9cca5b6872648c0ada619b00fd020ab81a7-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -587,13 +565,15 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
+      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
-  "currentNodeVersion": "1.35.3-gke.1389000",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -607,38 +587,41 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
   "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-sample-${uniqueId}-pods-d9cca5b6",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "161f8d3b",
+  "labelFingerprint": "abcdef0123A=",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
     "us-central1-a"
   ],
   "loggingConfig": {
-    "componentConfig": {}
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
   },
   "loggingService": "none",
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
-  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRQzNoeEpZWEQxUGVkbGZvTDJaTlgyREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRMVpEY3pZbUV6TWkwMlkyRmlMVFEwT1dNdE9HSTJZUzB5WW1Fek1qY3hZVEUyWkRjdwpJQmNOTWpZd05USTJNVGN5TnpRMldoZ1BNakExTmpBMU1UZ3hPREkzTkRaYU1DOHhMVEFyQmdOVkJBTVRKRFZrCk56TmlZVE15TFRaallXSXRORFE1WXkwNFlqWmhMVEppWVRNeU56RmhNVFprTnpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUpXOTdDcWc3M2NPMHNIVlBRSXlmOE9sZUs0NHdyU3dDRThJRGY2SQpVTUI5N0ZYMktjUmVxNktsaGErTE9Xb0lKbFVrd0FXaTJnS3ljVXplaU1Hb1RjSEUxNVJacDBEQkMwWXMrZFl4CkVONGQ1aVNobncyS3VYYXFrbWFrVStDREc3RmJNZVdQcVlBckRzWkVLNUVKWkN0MGc5QVc2M09BNWpiaXpVOE4KdGJoejZSbk5lZmR2eFUvNXNYajNaKzlrTXJ2L2w2QUV0S1doZmxUTWphNTkwOWI0RVFnQUIxRVRxVXROenhTQwp0UDJRUWw2eEIydzd4cWVQTEhZZ2txcW55VjZ4ZFJyaHFrUWxBU3B6R2FaRjlYb05DNVdoS0N1MTVpd3k4aktHCm5GK01taSsxVStiaE5OcWpQSkkrVWNCV0ZyZ3JUMDUrTjJuZzl5alBGV1BSRDM5SXpBSmpCbXZFcFZEZnZlN2UKclBOZXBEMmorVUpMTDF2WjE2T2FHclRTV3N3Nng4UVowODZnakVGbGZ0a1ZoTG9tQXhNUWhXWE5UTlNBbEQyWAp4Q3I1MGltRklWTU0yU0pPVURWM1g1VTNjMmtCU052NVlpNmNmZlJYOVdyME53U2xjMVRpNFdBUjVXVDVDZVJHCm5idHRuWXF2YnFXcUpQUU15L0VUT1RJSjVRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVYUHB5OHo0UHNsZ25oNHM1RmhkRFhNYjhjY0l3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFBSklkc2I1REFFSGgwTmtGR1RJZ2cwMkNSNVMxeWRiODJ4WXpRYURXazhzCjdLODZnS0hBUDJaM0FRbm9vN1pUWncyUkFmSEljZlg5UWg0cFArWVplVFNSSnZCczVaTmpwMUpTMUg0VDdxRTYKS2F4a2FHQmxvcXBDVy9JcDJOWTcxdk9FYXFjZ2RKM2oyeFVKR1I3UVAxeFBsUTNEOWQyK3Z0dDFEY0g5UWRMMQpjdG1sTFc0YkczcjRsY3htOUdnazFiT2FsK2xWNTZCeHgyeHQ4VnUxNzlncEhXNTB5QnhGUjdHbGhVNWtpdGZWCjkyZWk1N0dwUVBrZWhCY3dlTVFneUVYYnRuM25FM2NqOEU5dUxxVVFLRXJIQklzZnp2ZEtBRU9pR2pXcThrQzUKZ1ZmNkRSU2l3dFNYQXJlS3cyWDY3WTdOcmJsQnY3ZmthMlRXbWVDTTJPeEtTR2RmQTRBa1RMMjZaYWFNRkkxUApHK1U0WXNLNGZUKzVDeW50eG9tWXpYL0VVVjR2Zi96eHRQM0lBR09lQXd2QnBkY1ZhTXFsWkRLeC84bVVEQTVoCkJJVEhGKytZeDRZWGpYcUxDdjZWMUZGZ1BJc2hTT0Z4ZEtGODZsSnlHSlNVVGN1SjBGcmdueHVyK0pHZno0Z2UKRVdaMFQ1M1V5SHhEb0F0UWlGbFYrUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -647,16 +630,17 @@ X-Xss-Protection: 0
     "advancedDatapathObservabilityConfig": {},
     "componentConfig": {
       "enableComponents": [
-        "STORAGE",
-        "HPA",
-        "POD",
+        "SYSTEM_COMPONENTS",
         "DAEMONSET",
         "DEPLOYMENT",
         "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
         "CADVISOR",
         "KUBELET",
-        "DCGM",
-        "JOBSET"
+        "DCGM"
       ]
     },
     "managedPrometheusConfig": {
@@ -667,13 +651,9 @@ X-Xss-Protection: 0
   "name": "cluster-sample-${uniqueId}",
   "network": "default",
   "networkConfig": {
-    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -698,7 +678,6 @@ X-Xss-Protection: 0
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http00.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http00.log
@@ -1,0 +1,448 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}.",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "cluster": {
+    "autopilot": {
+      "enabled": false
+    },
+    "autoscaling": {
+      "enableNodeAutoprovisioning": false
+    },
+    "binaryAuthorization": {
+      "enabled": false
+    },
+    "controlPlaneEndpointsConfig": {
+      "dnsEndpointConfig": {
+        "allowExternalTraffic": false,
+        "enableK8sTokensViaDns": false
+      },
+      "ipEndpointsConfig": {
+        "authorizedNetworksConfig": {},
+        "enablePublicEndpoint": true,
+        "enabled": true,
+        "globalAccess": false,
+        "privateEndpointSubnetwork": ""
+      }
+    },
+    "initialNodeCount": 1,
+    "ipAllocationPolicy": {
+      "stackType": "IPV4",
+      "useIpAliases": false
+    },
+    "legacyAbac": {
+      "enabled": false
+    },
+    "maintenancePolicy": {
+      "window": {}
+    },
+    "name": "cluster-${uniqueId}",
+    "network": "projects/${projectId}/global/networks/default",
+    "networkConfig": {},
+    "networkPolicy": {},
+    "nodeConfig": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "metadata": {
+        "disable-legacy-endpoints": "true"
+      }
+    },
+    "notificationConfig": {
+      "pubsub": {}
+    },
+    "resourceLabels": {
+      "managed-by-cnrm": "true"
+    },
+    "shieldedNodes": {
+      "enabled": true
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "progress": {
+    "metrics": [
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING"
+      },
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING_TOTAL"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING_TOTAL"
+      },
+      {
+        "intValue": "1",
+        "name": "CLUSTER_HEALTHCHECKING"
+      },
+      {
+        "intValue": "2",
+        "name": "CLUSTER_HEALTHCHECKING_TOTAL"
+      }
+    ]
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+DELETE https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}/nodePools/default-pool?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "DELETE_NODE_POOL",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "PENDING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}/nodePools/default-pool",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "DELETE_NODE_POOL",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}/nodePools/default-pool",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.3-gke.1389000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialNodeCount": 1,
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "837da224",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "cluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "defaultSnatStatus": {},
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http00.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http00.log
@@ -187,7 +187,7 @@ X-Xss-Protection: 0
   "operationType": "DELETE_NODE_POOL",
   "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
   "startTime": "2024-04-01T12:34:56.123456Z",
-  "status": "PENDING",
+  "status": "RUNNING",
   "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/cluster-${uniqueId}/nodePools/default-pool",
   "zone": "us-central1-a"
 }
@@ -235,9 +235,6 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -246,11 +243,10 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    },
-    "nodeReadinessConfig": {}
+    }
   },
   "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
+    "mode": "ENABLED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -277,15 +273,11 @@ X-Xss-Protection: 0
   "clusterTelemetry": {
     "type": "ENABLED"
   },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
-  },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -293,14 +285,15 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
+      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentMasterVersion": "1.30.5-gke.1014001",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.30.5-gke.1014001",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -314,22 +307,21 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
   "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "837da224",
+  "labelFingerprint": "abcdef0123A=",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
@@ -347,10 +339,9 @@ X-Xss-Protection: 0
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
-  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -360,16 +351,16 @@ X-Xss-Protection: 0
     "componentConfig": {
       "enableComponents": [
         "SYSTEM_COMPONENTS",
-        "STORAGE",
-        "HPA",
-        "POD",
         "DAEMONSET",
         "DEPLOYMENT",
         "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
         "CADVISOR",
         "KUBELET",
-        "DCGM",
-        "JOBSET"
+        "DCGM"
       ]
     },
     "managedPrometheusConfig": {
@@ -380,13 +371,9 @@ X-Xss-Protection: 0
   "name": "cluster-${uniqueId}",
   "network": "default",
   "networkConfig": {
-    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -411,7 +398,6 @@ X-Xss-Protection: 0
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http01.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http01.log
@@ -1,0 +1,454 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.3-gke.1389000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialNodeCount": 1,
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "837da224",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "cluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "defaultSnatStatus": {},
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.35.3-gke.1389000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialNodeCount": 1,
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "837da224",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "cluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "defaultSnatStatus": {},
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http01.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http01.log
@@ -13,9 +13,6 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -24,11 +21,10 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    },
-    "nodeReadinessConfig": {}
+    }
   },
   "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
+    "mode": "ENABLED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -55,15 +51,11 @@ X-Xss-Protection: 0
   "clusterTelemetry": {
     "type": "ENABLED"
   },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
-  },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -71,14 +63,15 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
+      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentMasterVersion": "1.30.5-gke.1014001",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.30.5-gke.1014001",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -92,22 +85,21 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
   "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "837da224",
+  "labelFingerprint": "abcdef0123A=",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
@@ -125,10 +117,9 @@ X-Xss-Protection: 0
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
-  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -138,16 +129,16 @@ X-Xss-Protection: 0
     "componentConfig": {
       "enableComponents": [
         "SYSTEM_COMPONENTS",
-        "STORAGE",
-        "HPA",
-        "POD",
         "DAEMONSET",
         "DEPLOYMENT",
         "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
         "CADVISOR",
         "KUBELET",
-        "DCGM",
-        "JOBSET"
+        "DCGM"
       ]
     },
     "managedPrometheusConfig": {
@@ -158,13 +149,9 @@ X-Xss-Protection: 0
   "name": "cluster-${uniqueId}",
   "network": "default",
   "networkConfig": {
-    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -189,235 +176,6 @@ X-Xss-Protection: 0
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateCluster": true,
-  "privateClusterConfig": {
-    "privateEndpoint": "${privateEndpointIPV4}",
-    "publicEndpoint": "${publicEndpointIPV4}"
-  },
-  "protectConfig": {
-    "workloadConfig": {
-      "auditMode": "BASIC"
-    },
-    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "rbacBindingConfig": {
-    "enableInsecureBindingSystemAuthenticated": true,
-    "enableInsecureBindingSystemUnauthenticated": true
-  },
-  "releaseChannel": {
-    "channel": "REGULAR"
-  },
-  "resourceLabels": {
-    "managed-by-cnrm": "true"
-  },
-  "securityPostureConfig": {
-    "mode": "BASIC",
-    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
-  },
-  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
-  "servicesIpv4Cidr": "34.118.224.0/20",
-  "shieldedNodes": {
-    "enabled": true
-  },
-  "status": "RUNNING",
-  "subnetwork": "default",
-  "userManagedKeysConfig": {},
-  "zone": "us-central1-a"
-}
-
----
-
-GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
-User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
-
-200 OK
-Content-Type: application/json; charset=UTF-8
-Server: ESF
-Vary: Origin
-Vary: X-Origin
-Vary: Referer
-X-Content-Type-Options: nosniff
-X-Frame-Options: SAMEORIGIN
-X-Xss-Protection: 0
-
-{
-  "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
-    "gcePersistentDiskCsiDriverConfig": {
-      "enabled": true
-    },
-    "kubernetesDashboard": {
-      "disabled": true
-    },
-    "networkPolicyConfig": {
-      "disabled": true
-    },
-    "nodeReadinessConfig": {}
-  },
-  "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
-  },
-  "autopilot": {},
-  "autoscaling": {
-    "autoprovisioningNodePoolDefaults": {
-      "imageType": "COS_CONTAINERD",
-      "management": {
-        "autoRepair": true,
-        "autoUpgrade": true
-      },
-      "oauthScopes": [
-        "https://www.googleapis.com/auth/devstorage.read_only",
-        "https://www.googleapis.com/auth/logging.write",
-        "https://www.googleapis.com/auth/monitoring",
-        "https://www.googleapis.com/auth/service.management.readonly",
-        "https://www.googleapis.com/auth/servicecontrol",
-        "https://www.googleapis.com/auth/trace.append"
-      ],
-      "serviceAccount": "default"
-    },
-    "autoscalingProfile": "BALANCED"
-  },
-  "binaryAuthorization": {},
-  "clusterIpv4Cidr": "10.112.0.0/14",
-  "clusterTelemetry": {
-    "type": "ENABLED"
-  },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
-  },
-  "controlPlaneEndpointsConfig": {
-    "dnsEndpointConfig": {
-      "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
-      "enableK8sTokensViaDns": false,
-      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
-    },
-    "ipEndpointsConfig": {
-      "authorizedNetworksConfig": {
-        "gcpPublicCidrsAccessEnabled": true
-      },
-      "enablePublicEndpoint": true,
-      "enabled": true,
-      "privateEndpoint": "${privateEndpointIPV4}",
-      "publicEndpoint": "${publicEndpointIPV4}"
-    }
-  },
-  "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
-  "currentNodeVersion": "1.35.3-gke.1389000",
-  "databaseEncryption": {
-    "currentState": "CURRENT_STATE_DECRYPTED",
-    "state": "DECRYPTED"
-  },
-  "defaultMaxPodsConstraint": {
-    "maxPodsPerNode": "110"
-  },
-  "endpoint": "${publicEndpointIPV4}",
-  "enterpriseConfig": {
-    "clusterTier": "STANDARD"
-  },
-  "etag": "abcdef0123A=",
-  "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
-  "initialNodeCount": 1,
-  "ipAllocationPolicy": {
-    "clusterIpv4Cidr": "10.112.0.0/14",
-    "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
-    "podCidrOverprovisionConfig": {},
-    "servicesIpv4Cidr": "34.118.224.0/20",
-    "servicesIpv4CidrBlock": "34.118.224.0/20",
-    "stackType": "IPV4",
-    "useIpAliases": true
-  },
-  "labelFingerprint": "837da224",
-  "legacyAbac": {},
-  "location": "us-central1-a",
-  "locations": [
-    "us-central1-a"
-  ],
-  "loggingConfig": {
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
-    }
-  },
-  "loggingService": "logging.googleapis.com/kubernetes",
-  "maintenancePolicy": {
-    "resourceVersion": "abcd1234"
-  },
-  "master": {},
-  "masterAuth": {
-    "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
-  },
-  "masterAuthorizedNetworksConfig": {
-    "gcpPublicCidrsAccessEnabled": true
-  },
-  "monitoringConfig": {
-    "advancedDatapathObservabilityConfig": {},
-    "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "STORAGE",
-        "HPA",
-        "POD",
-        "DAEMONSET",
-        "DEPLOYMENT",
-        "STATEFULSET",
-        "CADVISOR",
-        "KUBELET",
-        "DCGM",
-        "JOBSET"
-      ]
-    },
-    "managedPrometheusConfig": {
-      "enabled": true
-    }
-  },
-  "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "cluster-${uniqueId}",
-  "network": "default",
-  "networkConfig": {
-    "defaultSnatStatus": {},
-    "network": "projects/${projectId}/global/networks/default",
-    "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
-  },
-  "nodePoolAutoConfig": {
-    "nodeKubeletConfig": {
-      "insecureKubeletReadonlyPortEnabled": false
-    }
-  },
-  "nodePoolDefaults": {
-    "nodeConfigDefaults": {
-      "loggingConfig": {
-        "variantConfig": {
-          "variant": "DEFAULT"
-        }
-      },
-      "nodeKubeletConfig": {
-        "insecureKubeletReadonlyPortEnabled": false
-      }
-    }
-  },
-  "notificationConfig": {
-    "pubsub": {}
-  },
-  "podAutoscaling": {
-    "hpaProfile": "PERFORMANCE"
-  },
-  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http02.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http02.log
@@ -1,0 +1,225 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/cluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.3-gke.1389000",
+  "currentNodeVersion": "1.35.3-gke.1389000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialNodeCount": 1,
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "837da224",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "cluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "defaultSnatStatus": {},
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http02.log
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_http02.log
@@ -13,9 +13,6 @@ X-Xss-Protection: 0
 
 {
   "addonsConfig": {
-    "dnsCacheConfig": {
-      "enabled": true
-    },
     "gcePersistentDiskCsiDriverConfig": {
       "enabled": true
     },
@@ -24,11 +21,10 @@ X-Xss-Protection: 0
     },
     "networkPolicyConfig": {
       "disabled": true
-    },
-    "nodeReadinessConfig": {}
+    }
   },
   "anonymousAuthenticationConfig": {
-    "mode": "LIMITED"
+    "mode": "ENABLED"
   },
   "autopilot": {},
   "autoscaling": {
@@ -55,15 +51,11 @@ X-Xss-Protection: 0
   "clusterTelemetry": {
     "type": "ENABLED"
   },
-  "controlPlaneEgress": {
-    "mode": "VIA_CONTROL_PLANE"
-  },
   "controlPlaneEndpointsConfig": {
     "dnsEndpointConfig": {
       "allowExternalTraffic": false,
-      "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-bd52d0e407b441ea94f38a82131ac9e336e4-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -71,13 +63,15 @@ X-Xss-Protection: 0
       },
       "enablePublicEndpoint": true,
       "enabled": true,
+      "globalAccess": false,
       "privateEndpoint": "${privateEndpointIPV4}",
       "publicEndpoint": "${publicEndpointIPV4}"
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.3-gke.1389000",
-  "currentNodeVersion": "1.35.3-gke.1389000",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -91,22 +85,21 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.3-gke.1389000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
   "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-cluster-${uniqueId}-pods-bd52d0e4",
-    "networkTierConfig": {
-      "networkTier": "NETWORK_TIER_DEFAULT"
-    },
     "podCidrOverprovisionConfig": {},
     "servicesIpv4Cidr": "34.118.224.0/20",
     "servicesIpv4CidrBlock": "34.118.224.0/20",
     "stackType": "IPV4",
     "useIpAliases": true
   },
-  "labelFingerprint": "837da224",
+  "labelFingerprint": "abcdef0123A=",
   "legacyAbac": {},
   "location": "us-central1-a",
   "locations": [
@@ -124,10 +117,9 @@ X-Xss-Protection: 0
   "maintenancePolicy": {
     "resourceVersion": "abcd1234"
   },
-  "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUxyQU5UM0ppZ1NPK0F4TjVpMjluY1F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa016QmhZakkyTnpVdE5UVXhNUzAwTW1NeExUa3pPVGd0WkdFM01URmxaV1F6WXpkbApNQ0FYRFRJMk1EVXlOekF3TkRrd05Wb1lEekl3TlRZd05URTVNREUwT1RBMVdqQXZNUzB3S3dZRFZRUURFeVF6Ck1HRmlNalkzTlMwMU5URXhMVFF5WXpFdE9UTTVPQzFrWVRjeE1XVmxaRE5qTjJVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FEREc5akpLNkZrRjBITC91UnhsQTlZSUNQNzRkVDNFZHl1dHNwLwpQZHoxY3RsdjBzTUJqdHJ4RGljbnBQK3lhVXdtUjdSMnZva2dVMkVGVXdqaElSWGFqZmJxSWlHblJwN2w5NnQxCklzeFdGbDVMeEZIT3NYMWwzUlM4ZXVKUWtXU3RXTUQ2UWVQbkx2Ty8zQVZOZllxZ29KV1NsNEN5Sk9kNmZuanUKZTBXYll4WlFTYzZBRDhtU01sYVBucnd6QmlkR2lSdHYxK29NM0RnNzhtM1RiQUoxMTZ5ZGROL0J5cXFnVC9nMQpkcS8vM2Zja0djQkd3cGFESTJNQm13bmdIb2pnMTdZWjl1Ymw2MmdSeVlCYjRvK2RqTjNpeGtSb0tuQ1hmRk8wCndoYVpoL3hzNkZQSzFyZ3hTMWtVczJRcHJ6VFE0aUh5emloS0hyUkZWcldDVXdNQnUyUnFSMkNFdis2UjhKSGUKb0R2MjhIUmlyQ2ZRK2w5dWZrME11Ym41TlR4aEdmQjBmQ0ZVeHlIMno0MHVtOURjSVZTbVF3c2VmVzEwN3lENwo3bnZheUJPaUtpQU9neU1Kbm1RcCtob2xFM1YySlBTRENHOC9tOE5wa2ZnUEdwNlVJMVg2TlBGeExNbTQxVXk0Cm9GOWtwUFFWeFR2Rm8zTHlnT2YrVFJwRW40TUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGT2szc3Ryb1NGYW9FQVNCRDJSSWZwN0h3NTRnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ0IyYlRGSm4yRllKU2JkYk1RU2NVWUVzbzIzNXR3VGdHcS83WnRadUZNCmk5RFIwelJQT2ZJSzRRQU9zcEs1c0FnckthUHQyV0twZ3MwdVkwelJUV3BYVXFZSmpoc29ZZzF0ZGxNb1U1d0QKeFlYcFpmQ3FROUN4ZzlNdkdrSFVaOHY4UUUvQ1F5N2FqODk2SlE4WWVUb1RWVERJOStvK0NhemdVOXhxbDNUeQordzJLamV1Rnh3VzdjVVJzUG9SSkN6L1dSaDhtZ1lmYmhvUEZmNUVMODd3RkpCSE52Yk04ei9DK3pOVVdaYmdUCkxUeHdsVHU2bzNqY2xmKzU3NllyZlp4UDc5S3dkeFVhSzh5QmRKSXhnd1hjQmRaR2U2ZXAzOVVESU1RaE1OUU0KeWJyTlBHdDhVNWhLRUdDMXJjbU5adXpMT2NuanJGYmVKQ1VTRlliaTY1Mm1jWGhheE9HeXZpTC9PeVJGN2lDWApCb0wwM0pjYU9rZUdDNlBBQTB1Ukc5OXE4YnIyYlhoVGtxSjdudTZCejFtM0tvZjkvKzc3SWhXWWFzd3g0cVY4CmdPVUd5WFByMGliUU53RlBqdHl2c1BiQVhrbktEc1B5ZUZOQi9PRTlTWjJXWEFxK0NtWTFFbW5LSTNrSFRYVHgKNFpJRm5yanBXcWhGUnB3SG9keUIwWnc9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -137,16 +129,16 @@ X-Xss-Protection: 0
     "componentConfig": {
       "enableComponents": [
         "SYSTEM_COMPONENTS",
-        "STORAGE",
-        "HPA",
-        "POD",
         "DAEMONSET",
         "DEPLOYMENT",
         "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
         "CADVISOR",
         "KUBELET",
-        "DCGM",
-        "JOBSET"
+        "DCGM"
       ]
     },
     "managedPrometheusConfig": {
@@ -157,13 +149,9 @@ X-Xss-Protection: 0
   "name": "cluster-${uniqueId}",
   "network": "default",
   "networkConfig": {
-    "defaultSnatStatus": {},
     "network": "projects/${projectId}/global/networks/default",
     "serviceExternalIpsConfig": {},
     "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
-  },
-  "nodeCreationConfig": {
-    "nodeCreationMode": "VIA_KUBELET"
   },
   "nodePoolAutoConfig": {
     "nodeKubeletConfig": {
@@ -188,7 +176,6 @@ X-Xss-Protection: 0
   "podAutoscaling": {
     "hpaProfile": "PERFORMANCE"
   },
-  "privateCluster": true,
   "privateClusterConfig": {
     "privateEndpoint": "${privateEndpointIPV4}",
     "publicEndpoint": "${publicEndpointIPV4}"

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object00.yaml
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object00.yaml
@@ -1,0 +1,44 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: cluster-${uniqueId}
+  namespace: ${projectId}
+spec:
+  initialNodeCount: 1
+  location: us-central1-a
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"
+  resourceID: cluster-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  endpoint: 1.23.456.78
+  labelFingerprint: abcdef0123A=
+  masterVersion: 1.30.5-gke.1014001
+  observedGeneration: 2
+  observedState:
+    controlPlaneEndpointsConfig:
+      dnsEndpointConfig:
+        endpoint: gke-12345trewq-${projectNumber}.us-central1-a.gke.goog
+    masterAuth:
+      clusterCaCertificate: 1234567890abcdefghijklmn
+    privateClusterConfig:
+      privateEndpoint: 10.128.0.2
+      publicEndpoint: 8.8.8.8
+  selfLink: https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}
+  servicesIpv4Cidr: 34.118.224.0/20

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object01.yaml
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object01.yaml
@@ -1,0 +1,48 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/state-into-spec: absent
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"container.cnrm.cloud.google.com/v1beta1","kind":"ContainerCluster","spec":{"location":"us-central1-a","initialNodeCount":1,"nodeConfig":{"metadata":{"disable-legacy-endpoints": "true"}}}}
+    test.cnrm.cloud.google.com/reconcile-cookie: (removed)
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: cluster-${uniqueId}
+  namespace: ${projectId}
+spec:
+  initialNodeCount: 1
+  location: us-central1-a
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"
+  resourceID: cluster-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: "Update call failed: error calculating diff: 1 error occurred:\n\t* node_version
+      can only be specified if remove_default_node_pool is not true\n\n"
+    reason: UpdateFailed
+    status: "False"
+    type: Ready
+  endpoint: 1.23.456.78
+  labelFingerprint: abcdef0123A=
+  masterVersion: 1.30.5-gke.1014001
+  observedGeneration: 2
+  observedState:
+    controlPlaneEndpointsConfig:
+      dnsEndpointConfig:
+        endpoint: gke-12345trewq-${projectNumber}.us-central1-a.gke.goog
+    masterAuth:
+      clusterCaCertificate: 1234567890abcdefghijklmn
+    privateClusterConfig:
+      privateEndpoint: 10.128.0.2
+      publicEndpoint: 8.8.8.8
+  selfLink: https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}
+  servicesIpv4Cidr: 34.118.224.0/20

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object02.yaml
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/_object02.yaml
@@ -1,0 +1,47 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/remove-default-node-pool-allow-node-config: "true"
+    cnrm.cloud.google.com/state-into-spec: absent
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"container.cnrm.cloud.google.com/v1beta1","kind":"ContainerCluster","spec":{"location":"us-central1-a","initialNodeCount":1,"nodeConfig":{"metadata":{"disable-legacy-endpoints": "true"}}}}
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 2
+  name: cluster-${uniqueId}
+  namespace: ${projectId}
+spec:
+  initialNodeCount: 1
+  location: us-central1-a
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"
+  resourceID: cluster-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  endpoint: 1.23.456.78
+  labelFingerprint: abcdef0123A=
+  masterVersion: 1.30.5-gke.1014001
+  observedGeneration: 2
+  observedState:
+    controlPlaneEndpointsConfig:
+      dnsEndpointConfig:
+        endpoint: gke-12345trewq-${projectNumber}.us-central1-a.gke.goog
+    masterAuth:
+      clusterCaCertificate: 1234567890abcdefghijklmn
+    privateClusterConfig:
+      privateEndpoint: 10.128.0.2
+      publicEndpoint: 8.8.8.8
+  selfLink: https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/cluster-${uniqueId}
+  servicesIpv4Cidr: 34.118.224.0/20

--- a/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/script.yaml
+++ b/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool/script.yaml
@@ -1,0 +1,51 @@
+# step00: Create ContainerCluster with remove-default-node-pool: "true"
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+  name: cluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"
+---
+# step01: Trigger a reconcile.
+# Without the allow-node-config annotation, this should fail with the diff error.
+# We use APPLY-10-SEC to apply it and wait a bit, then it will be captured in golden file.
+TEST: APPLY-10-SEC
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    test.cnrm.cloud.google.com/reconcile-cookie: "v1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"container.cnrm.cloud.google.com/v1beta1","kind":"ContainerCluster","spec":{"location":"us-central1-a","initialNodeCount":1,"nodeConfig":{"metadata":{"disable-legacy-endpoints": "true"}}}}
+  name: cluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"
+---
+# step02: Add the fix annotation.
+# This should allow the resource to become Healthy again.
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+    cnrm.cloud.google.com/remove-default-node-pool-allow-node-config: "true"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"container.cnrm.cloud.google.com/v1beta1","kind":"ContainerCluster","spec":{"location":"us-central1-a","initialNodeCount":1,"nodeConfig":{"metadata":{"disable-legacy-endpoints": "true"}}}}
+  name: cluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  nodeConfig:
+    metadata:
+      disable-legacy-endpoints: "true"


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Fixes: #7274 

A Terraform validation error is triggered([code](https://github.com/gemmahou/terraform-provider-google-beta/blob/main/google-beta/services/container/resource_container_cluster.go#L8321-L8322)) when all three conditions are met: **1) the `cnrm.cloud.google.com/remove-default-node-pool: true` directive exists in the desired state, 2) `nodeVersion` exists in the desired state, and 3) TF treats the resource as a new resource.**

Based on a recent customer issue, we discovered that when both `remove-default-node-pool` and `nodeConfig` are specified, this same validation error occurs after the default node pool has been deleted. The breakdown of why this happens is as follows:

1. **the `cnrm.cloud.google.com/remove-default-node-pool: true` directive exists**: This is defined by the user in their configuration.
2. **`nodeVersion` exists**: KCC's automated GCP unmanaged fields logic([code](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/pkg/k8s/managedfields.go#L201-L205)) fetches the `nodeVersion` from GCP and overlays it onto the desired state during reconciliation.
3. **The resource is treated as "new"**: Once the default pool is deleted in GCP, `nodeConfig` also removed from the live state. resulting a diff between the desired state (still contains nodeConfig set by user) and the live state. Because `nodeConfig` is marked as `ForceNew` in the Terraform schema, the diff forces a resource replacement in TF, tricking it into thinking it is a brand-new resource.

#### WHY do we need this change?
KCC recommends against setting `remove-default-nodepool` alongside fields like `nodeVersion` and `nodeConfig`. These fields are only relevant to the default pool which is intended for deletion, specifying them is invalid and will likely result in errors. 

However, customers may require setting `nodeConfig` to satisfy system or policy requirements during initial cluster provisioning. To support this, we introduced the "remove-default-node-pool-allow-node-config" annotation. This allows customers to set a `nodeConfig` to successfully pass their requirements during cluster creation, while allowing KCC to subsequently remove it after removing the default pool to align with the recommended practice.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce "cnrm.cloud.google.com/remove-default-node-pool-allow-node-config" annotation in ContainerCluster to allow setting "nodeConfig" with "cnrm.cloud.google.com/remove-default-node-pool".
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->
Tried to apply a resource with "cnrm.cloud.google.com/remove-default-node-pool" and "nodeConfig" .
Before(Without new annotation):
```
  Normal   UpToDate      13m                   containercluster-controller  Update in progress
  Normal   UpToDate      8m20s (x2 over 13m)   containercluster-controller  The resource is up to date
  Warning  UpdateFailed  115s (x6 over 3m58s)  containercluster-controller  Update call failed: error calculating diff: 1 error occurred:
           * node_version can only be specified if remove_default_node_pool is not true
```
After(With new annotation):
```
Events:
  Type    Reason    Age               From                         Message
  ----    ------    ----              ----                         -------
  Normal  Updating  11m               containercluster-controller  Update in progress
  Normal  UpToDate  10m               containercluster-controller  The resource is up to date
  Normal  UpToDate  5m (x2 over 10m)  containercluster-controller  The resource is up to date
```

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
