### PR TITLE
Release Notes 1.152.0

### DIFF
--- a/docs/releasenotes/release-1.152.md
+++ b/docs/releasenotes/release-1.152.md
@@ -15,11 +15,11 @@
 
 ## New Fields:
 
-*   [`ComputeForwardingRule`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeforwardingrule)
-    *   Added `status.target` field.
-
 *   [`ComputeReservation`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computereservation)
     *   Added `spec.shareSettings` field.
+
+*   [`ComputeForwardingRule`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeforwardingrule)
+    *   Added `status.target` field.
 
 ## Reconciliation Improvements
 
@@ -30,7 +30,7 @@ We have added support for direct reconciliation to more resources, with opt-in b
 
 ## Bug Fixes:
 
-*   [SQLInstance](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8025) Fix case sensitivity in SQLInstance `availabilityType`.
-*   [Preview Tool](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7743) Fix crash on typed resources and hang on defaulting in preview mode.
-*   [ComputeForwardingRule](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7371) Fix target field matching in ComputeForwardingRule.
-*   [ComputeFutureReservation](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8479) Fix future reservation times validation.
+*   [SQLInstance](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8025): Fix case sensitivity in SQLInstance `availabilityType`.
+*   [Preview Tool](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7743): Fix crash on typed resources and hang on defaulting in preview mode.
+*   [ComputeForwardingRule](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7371): Fix target field matching in ComputeForwardingRule.
+*   [ComputeFutureReservation](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8479): Fix future reservation times validation.

--- a/docs/releasenotes/release-1.152.md
+++ b/docs/releasenotes/release-1.152.md
@@ -2,16 +2,8 @@
 
 ## New Alpha Resources (Direct Reconciler):
 
-*   `AIStreamsCluster`
-*   `APIHubDeployment`
-*   `AppHubServiceProjectAttachment`
-*   `BeyondCorpClientConnectorService`
 *   `BinaryAuthorizationPlatformPolicy`
-*   `DeviceStreamingSession`
-*   `EventarcEnrollment`
-*   `NetworkConnectivityRegionalEndpoint`
 *   `VertexAIDeploymentResourcePool`
-*   `VertexAIExampleStore`
 
 ## New Fields:
 

--- a/docs/releasenotes/release-1.152.md
+++ b/docs/releasenotes/release-1.152.md
@@ -1,10 +1,5 @@
 *   Special shout-outs to @acpana, @anhdle-sso, @barney-s, @codebot-robot, @gemmahou, @himanigulati01, @justinsb, @katrielt, @ldanielmadariaga, @maqiuyujoyce, @suwandim, @xiaoweim for their contributions to this release.
 
-## New Alpha Resources (Direct Reconciler):
-
-*   `BinaryAuthorizationPlatformPolicy`
-*   `VertexAIDeploymentResourcePool`
-
 ## New Fields:
 
 *   [`ComputeReservation`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computereservation)

--- a/docs/releasenotes/release-1.152.md
+++ b/docs/releasenotes/release-1.152.md
@@ -1,0 +1,36 @@
+*   Special shout-outs to @acpana, @anhdle-sso, @barney-s, @codebot-robot, @gemmahou, @himanigulati01, @justinsb, @katrielt, @ldanielmadariaga, @maqiuyujoyce, @suwandim, @xiaoweim for their contributions to this release.
+
+## New Alpha Resources (Direct Reconciler):
+
+*   `AIStreamsCluster`
+*   `APIHubDeployment`
+*   `AppHubServiceProjectAttachment`
+*   `BeyondCorpClientConnectorService`
+*   `BinaryAuthorizationPlatformPolicy`
+*   `DeviceStreamingSession`
+*   `EventarcEnrollment`
+*   `NetworkConnectivityRegionalEndpoint`
+*   `VertexAIDeploymentResourcePool`
+*   `VertexAIExampleStore`
+
+## New Fields:
+
+*   [`ComputeForwardingRule`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeforwardingrule)
+    *   Added `status.target` field.
+
+*   [`ComputeReservation`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computereservation)
+    *   Added `spec.shareSettings` field.
+
+## Reconciliation Improvements
+
+We have added support for direct reconciliation to more resources, with opt-in behaviour. The API is unchanged. To use the direct reconciler, add the `cnrm.cloud.google.com/reconciler: direct` annotation to the corresponding Config Connector object.
+
+*   [`ComputeReservation`](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computereservation)
+*   [`FirestoreIndex`](https://cloud.google.com/config-connector/docs/reference/resource-docs/firestore/firestoreindex)
+
+## Bug Fixes:
+
+*   [SQLInstance](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8025) Fix case sensitivity in SQLInstance `availabilityType`.
+*   [Preview Tool](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7743) Fix crash on typed resources and hang on defaulting in preview mode.
+*   [ComputeForwardingRule](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7371) Fix target field matching in ComputeForwardingRule.
+*   [ComputeFutureReservation](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8479) Fix future reservation times validation.


### PR DESCRIPTION
Automated draft of release notes for version 1.152.0 comparing v1.151.0 to v1.152.0.

Triggered by chore: `.agents/kcc-release.md`

Fixes #8706

This PR was generated by **Overseer** (powered by the gemini-3.5-flash model).
