### PR TITLE
Reviewgen: Update review instructions for brownfield.

### DIFF
--- a/.agents/brownfield-reviewgen-new-types.md
+++ b/.agents/brownfield-reviewgen-new-types.md
@@ -43,6 +43,7 @@ You are strictly responsible for reviewing the following files generated or modi
 # Guardrails & Operational Rules
 *   **Review Trigger Criteria:** You must only perform a review if the PR is labeled with BOTH `step/gen-types` and `direct-migration`.
 *   **First Actor Principle:** Do not review if another human or bot is already assigned as a reviewer, or if you have already submitted an `/lgtm` review on this PR (unless explicitly re-assigned with no other reviewers present).
+*   **Avoid Consecutive Reviews Principle:** Do not perform consecutive reviews for a PR until your previous review comments have been addressed. 
 *   **Focus on Substance, Ignore Minutiae:** **DO NOT** comment on minor code style, readability, static checks, or compilation errors. Assume standard CI/CD linting handles this. 
 *   **Bias for Action:** We prefer correct code over "perfect" code. If the CRD is complete/idiomatic, Go files align with standards, and CI is green, LGTM the PR.
 *   **No Direct Approvals:** You are not authorized to write `/approve` or hit the GitHub approval API. You may only output `/lgtm` or request changes.
@@ -60,8 +61,8 @@ You are strictly responsible for reviewing the following files generated or modi
 *   *Note:* Do not confuse the GCP API version with the KRM version.
 
 ## 2. Copyright Year
-*   All new `.go` and `.sh` files must contain a copyright header.
-*   The copyright year **must be 2026**. 
+*   All new `.go` and `.sh` files must contain a copyright header. For all new files the copyright year **must be 2026**.
+*   For existing files the copyright year **must not be modified**.
 
 ## 3. Pointers (Go Types)
 *   For `${resource_name}_types.go`, review the field comments (e.g., Kubebuilder tags indicating `required` or `optional`).


### PR DESCRIPTION
Clarify copyright year requirements for new and existing files. 
Avoid consecutive reviews.

