### PR TITLE
Fix WaitUntilControllersAreRegistered call in samples_test.go

### DIFF
--- a/config/tests/samples/create/samples_test.go
+++ b/config/tests/samples/create/samples_test.go
@@ -328,7 +328,7 @@ func setup(ctx context.Context, t *testing.T) {
 	// Wait for all controllers to register and their caches to sync before starting any tests
 	cacheSyncCtx, cacheSyncCancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cacheSyncCancel()
-	if err := WaitUntilControllersAreRegistered(cacheSyncCtx, t, mgr); err != nil {
+	if err := WaitUntilControllersAreRegistered(cacheSyncCtx, t, mgr, nil); err != nil {
 		logging.Fatal(fmt.Errorf("error waiting for controllers to register and cache to sync: %w", err), "error starting manager")
 	}
 }


### PR DESCRIPTION
Fixes #9067. Pass nil as the 4th parameter to WaitUntilControllersAreRegistered in samples_test.go.