### PR TITLE
Fix markdown table header separator formatting in CRD report

### DIFF
--- a/dev/tasks/generate-resource-report
+++ b/dev/tasks/generate-resource-report
@@ -144,7 +144,7 @@ def write_markdown_report(results, fieldnames, mdfile):
     header_line = "| " + " | ".join([h.ljust(col_widths[h]) for h in fieldnames]) + " |"
     mdfile.write(header_line + '\n')
 
-    separator_line = "|-" + "-|- ".join([ "-" * col_widths[h] for h in fieldnames]) + "-|"
+    separator_line = "|-" + "-|-".join([ "-" * col_widths[h] for h in fieldnames]) + "-|"
     mdfile.write(separator_line + '\n')
 
     for res in results:

--- a/docs/reports/crd_report.md
+++ b/docs/reports/crd_report.md
@@ -1,7 +1,7 @@
 # CRD Analysis Report
 
 | group                                         | kind                                            | has_v1alpha1 | has_v1beta1 | has_v1 | reconciler | has_go_type |
-|-----------------------------------------------|- ------------------------------------------------|- -------------|- ------------|- -------|- -----------|- ------------|
+|-----------------------------------------------|-------------------------------------------------|--------------|-------------|--------|------------|-------------|
 | accesscontextmanager.cnrm.cloud.google.com    | AccessContextManagerAccessLevelCondition        | True         | False       | False  | Terraform  | False       |
 | accesscontextmanager.cnrm.cloud.google.com    | AccessContextManagerAccessLevel                 | False        | True        | False  | Terraform  | True        |
 | accesscontextmanager.cnrm.cloud.google.com    | AccessContextManagerAccessPolicy                | False        | True        | False  | Terraform  | True        |


### PR DESCRIPTION
### BRIEF Change description

No bug for this.

#### WHY do we need this change?

The markdown table format is currently broken. It looks like [this](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/docs/reports/crd_report.md)



### Tests you have done

The fixed version is like [this](https://github.com/anfernee/k8s-config-connector/blob/fix/crd-report-markdown-formatting/docs/reports/crd_report.md)
