### PR TITLE
Fix spelling typo 'theresource' in MonitoringNotificationChannel CRD description

### DIFF
--- a/apis/monitoring/v1beta1/notificationchannel_types.go
+++ b/apis/monitoring/v1beta1/notificationchannel_types.go
@@ -25,7 +25,7 @@ var MonitoringNotificationChannelGVK = GroupVersion.WithKind("MonitoringNotifica
 // MonitoringNotificationChannelSpec defines the desired state of MonitoringNotificationChannel
 // +kcc:spec:proto=google.monitoring.v3.NotificationChannel
 type MonitoringNotificationChannelSpec struct {
-	// Immutable. Optional. The service-generated name of theresource. Used for acquisition only. Leave unset to create a new resource.
+	// Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource.
 	ResourceID *string `json:"resourceID,omitempty"`
 
 	// An optional human-readable description of this notification

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_monitoringnotificationchannels.monitoring.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_monitoringnotificationchannels.monitoring.cnrm.cloud.google.com.yaml
@@ -95,8 +95,9 @@ spec:
                   corresponding to the type field.
                 type: object
               resourceID:
-                description: Immutable. Optional. The service-generated name of theresource.
-                  Used for acquisition only. Leave unset to create a new resource.
+                description: Immutable. Optional. The service-generated name of the
+                  resource. Used for acquisition only. Leave unset to create a new
+                  resource.
                 type: string
               sensitiveLabels:
                 description: |-

--- a/pkg/clients/generated/apis/monitoring/v1beta1/monitoringnotificationchannel_types.go
+++ b/pkg/clients/generated/apis/monitoring/v1beta1/monitoringnotificationchannel_types.go
@@ -105,7 +105,7 @@ type MonitoringNotificationChannelSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
-	/* Immutable. Optional. The service-generated name of theresource. Used for acquisition only. Leave unset to create a new resource. */
+	/* Immutable. Optional. The service-generated name of the resource. Used for acquisition only. Leave unset to create a new resource. */
 	// +optional
 	ResourceID *string `json:"resourceID,omitempty"`
 


### PR DESCRIPTION
Fixes #9208