### PR TITLE
Fix spelling typo 'timzeone' in SpannerBackupSchedule CRD description

### DIFF
--- a/apis/spanner/v1alpha1/types.generated.go
+++ b/apis/spanner/v1alpha1/types.generated.go
@@ -31,7 +31,7 @@ type BackupScheduleSpec struct {
 type CrontabSpec struct {
 	// Required. Textual representation of the crontab. User can customize the
 	//  backup frequency and the backup version time using the cron
-	//  expression. The version time must be in UTC timzeone.
+	//  expression. The version time must be in UTC timezone.
 	//
 	//  The backup will contain an externally consistent copy of the
 	//  database at the version time. Allowed frequencies are 12 hour, 1 day,

--- a/apis/spanner/v1beta1/types.generated.go
+++ b/apis/spanner/v1beta1/types.generated.go
@@ -90,7 +90,7 @@ type BackupScheduleSpec struct {
 type CrontabSpec struct {
 	// Required. Textual representation of the crontab. User can customize the
 	//  backup frequency and the backup version time using the cron
-	//  expression. The version time must be in UTC timzeone.
+	//  expression. The version time must be in UTC timezone.
 	//
 	//  The backup will contain an externally consistent copy of the
 	//  database at the version time. Allowed frequencies are 12 hour, 1 day,

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerbackupschedules.spanner.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_spannerbackupschedules.spanner.cnrm.cloud.google.com.yaml
@@ -201,7 +201,7 @@ spec:
                         description: |-
                           Required. Textual representation of the crontab. User can customize the
                            backup frequency and the backup version time using the cron
-                           expression. The version time must be in UTC timzeone.
+                           expression. The version time must be in UTC timezone.
 
                            The backup will contain an externally consistent copy of the
                            database at the version time. Allowed frequencies are 12 hour, 1 day,
@@ -469,7 +469,7 @@ spec:
                         description: |-
                           Required. Textual representation of the crontab. User can customize the
                            backup frequency and the backup version time using the cron
-                           expression. The version time must be in UTC timzeone.
+                           expression. The version time must be in UTC timezone.
 
                            The backup will contain an externally consistent copy of the
                            database at the version time. Allowed frequencies are 12 hour, 1 day,

--- a/pkg/clients/generated/apis/spanner/v1beta1/spannerbackupschedule_types.go
+++ b/pkg/clients/generated/apis/spanner/v1beta1/spannerbackupschedule_types.go
@@ -41,7 +41,7 @@ var _ = apiextensionsv1.JSON{}
 type BackupscheduleCronSpec struct {
 	/* Required. Textual representation of the crontab. User can customize the
 	backup frequency and the backup version time using the cron
-	expression. The version time must be in UTC timzeone.
+	expression. The version time must be in UTC timezone.
 
 	The backup will contain an externally consistent copy of the
 	database at the version time. Allowed frequencies are 12 hour, 1 day,


### PR DESCRIPTION
Fixes #9210