### PR TITLE
Fix spelling typo 'Subsequential' in StorageAnywhereCache CRD description

### DIFF
--- a/apis/storage/v1beta1/anywherecache_types.go
+++ b/apis/storage/v1beta1/anywherecache_types.go
@@ -91,7 +91,7 @@ type StorageAnywhereCacheObservedState struct {
 	UpdateTime *string `json:"updateTime,omitempty"`
 
 	// Output only. True if there is an active update operation against this cache
-	//  instance. Subsequential update requests will be rejected if this field is
+	//  instance. Subsequent update requests will be rejected if this field is
 	//  true. Output only.
 	// +kcc:proto:field=google.storage.control.v2.AnywhereCache.pending_update
 	PendingUpdate *bool `json:"pendingUpdate,omitempty"`

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_storageanywherecaches.storage.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_storageanywherecaches.storage.cnrm.cloud.google.com.yaml
@@ -183,7 +183,7 @@ spec:
                     type: string
                   pendingUpdate:
                     description: Output only. True if there is an active update operation
-                      against this cache instance. Subsequential update requests will
+                      against this cache instance. Subsequent update requests will
                       be rejected if this field is true. Output only.
                     type: boolean
                   state:
@@ -361,7 +361,7 @@ spec:
                     type: string
                   pendingUpdate:
                     description: Output only. True if there is an active update operation
-                      against this cache instance. Subsequential update requests will
+                      against this cache instance. Subsequent update requests will
                       be rejected if this field is true. Output only.
                     type: boolean
                   state:

--- a/pkg/clients/generated/apis/storage/v1beta1/storageanywherecache_types.go
+++ b/pkg/clients/generated/apis/storage/v1beta1/storageanywherecache_types.go
@@ -67,7 +67,7 @@ type AnywherecacheObservedStateStatus struct {
 	// +optional
 	CreateTime *string `json:"createTime,omitempty"`
 
-	/* Output only. True if there is an active update operation against this cache instance. Subsequential update requests will be rejected if this field is true. Output only. */
+	/* Output only. True if there is an active update operation against this cache instance. Subsequent update requests will be rejected if this field is true. Output only. */
 	// +optional
 	PendingUpdate *bool `json:"pendingUpdate,omitempty"`
 


### PR DESCRIPTION
Fixes #9213