### PR TITLE
fix: Fix permdiff caused by automatedbackupconfig default in RedisCluster

### DIFF
--- a/mockgcp/mockredis/cluster.go
+++ b/mockgcp/mockredis/cluster.go
@@ -206,6 +206,8 @@ func (s *clusterServer) populateDefaultsForCluster(name *clusterName, obj *pb.Cl
 			obj.AutomatedBackupConfig.Schedule = nil
 			obj.AutomatedBackupConfig.Retention = nil
 		}
+	} else {
+		obj.AutomatedBackupConfig = &pb.AutomatedBackupConfig{AutomatedBackupMode: pb.AutomatedBackupConfig_DISABLED}
 	}
 
 	if obj.GetKmsKey() != "" {

--- a/pkg/controller/direct/redis/cluster_controller.go
+++ b/pkg/controller/direct/redis/cluster_controller.go
@@ -363,6 +363,8 @@ func populateDefaults(cluster *pb.Cluster) *pb.Cluster {
 			cluster.AutomatedBackupConfig.Schedule = nil
 			cluster.AutomatedBackupConfig.Retention = nil
 		}
+	} else {
+		cluster.AutomatedBackupConfig = &pb.AutomatedBackupConfig{AutomatedBackupMode: pb.AutomatedBackupConfig_DISABLED}
 	}
 
 	// clear pscConfig as it's not included in the response

--- a/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_generated_object_basicrediscluster.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_generated_object_basicrediscluster.golden.yaml
@@ -42,13 +42,11 @@ status:
       network: projects/${projectId}/global/networks/${networkID}
       projectID: ${projectId}
       pscConnectionID: ${pscConnectionID}
-      serviceAttachment: projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa
     - address: 10.11.12.13
       forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}
       network: projects/${projectId}/global/networks/${networkID}
       projectID: ${projectId}
       pscConnectionID: ${pscConnectionID}
-      serviceAttachment: projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2
     sizeGb: 130
     state: ACTIVE
     uid: 0123456789abcdef

--- a/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_generated_object_basicrediscluster.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_generated_object_basicrediscluster.golden.yaml
@@ -42,11 +42,13 @@ status:
       network: projects/${projectId}/global/networks/${networkID}
       projectID: ${projectId}
       pscConnectionID: ${pscConnectionID}
+      serviceAttachment: projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa
     - address: 10.11.12.13
       forwardingRule: https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}
       network: projects/${projectId}/global/networks/${networkID}
       projectID: ${projectId}
       pscConnectionID: ${pscConnectionID}
+      serviceAttachment: projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2
     sizeGb: 130
     state: ACTIVE
     uid: 0123456789abcdef

--- a/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_http.log
@@ -119,6 +119,10 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -244,7 +248,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -260,8 +266,7 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY",
-  "state": "READY"
+  "stackType": "IPV4_ONLY"
 }
 
 ---
@@ -315,10 +320,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -347,6 +354,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -419,10 +427,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -451,6 +461,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -547,10 +558,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "create"
   },
@@ -581,6 +594,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "create"
   },
@@ -588,6 +602,38 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.Cluster",
     "authorizationMode": "AUTH_MODE_DISABLED",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
+    "clusterEndpoints": [
+      {
+        "connections": [
+          {
+            "pscAutoConnection": {
+              "address": "10.128.0.2",
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "projectId": "${projectId}",
+              "pscConnectionId": "${pscConnectionID}",
+              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
+              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "address": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "projectId": "${projectId}",
+              "pscConnectionId": "${pscConnectionID}",
+              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
+              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+            }
+          }
+        ]
+      }
+    ],
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "discoveryEndpoints": [
@@ -599,6 +645,7 @@ X-Xss-Protection: 0
         }
       }
     ],
+    "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
     "encryptionInfo": {
       "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
     },
@@ -614,17 +661,30 @@ X-Xss-Protection: 0
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}"
+        "pscConnectionId": "${pscConnectionID}",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
       },
       {
         "address": "10.11.12.13",
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}"
+        "pscConnectionId": "${pscConnectionID}",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+      }
+    ],
+    "pscServiceAttachments": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+      },
+      {
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
       }
     ],
     "replicaCount": 0,
+    "satisfiesPzi": false,
+    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 3,
     "sizeGb": 39,
     "state": "ACTIVE",
@@ -655,6 +715,38 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 2,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
+  "clusterEndpoints": [
+    {
+      "connections": [
+        {
+          "pscAutoConnection": {
+            "address": "10.128.0.2",
+            "connectionType": 1,
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "projectId": "${projectId}",
+            "pscConnectionId": "${pscConnectionID}",
+            "pscConnectionStatus": 1,
+            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+          }
+        },
+        {
+          "pscAutoConnection": {
+            "address": "10.128.0.3",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "projectId": "${projectId}",
+            "pscConnectionId": "${pscConnectionID}",
+            "pscConnectionStatus": 1,
+            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+          }
+        }
+      ]
+    }
+  ],
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "discoveryEndpoints": [
@@ -666,6 +758,7 @@ X-Xss-Protection: 0
       }
     }
   ],
+  "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
   "encryptionInfo": {
     "encryptionType": 1
   },
@@ -681,17 +774,30 @@ X-Xss-Protection: 0
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}"
+      "pscConnectionId": "${pscConnectionID}",
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
     },
     {
       "address": "10.11.12.13",
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}"
+      "pscConnectionId": "${pscConnectionID}",
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+    }
+  ],
+  "pscServiceAttachments": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+    },
+    {
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
     }
   ],
   "replicaCount": 0,
+  "satisfiesPzi": false,
+  "serverCaMode": 0,
   "shardCount": 3,
   "sizeGb": 39,
   "state": 2,
@@ -730,10 +836,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "update"
   },
@@ -764,6 +872,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "update"
   },
@@ -771,6 +880,38 @@ X-Xss-Protection: 0
   "response": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.Cluster",
     "authorizationMode": "AUTH_MODE_DISABLED",
+    "automatedBackupConfig": {
+      "automatedBackupMode": "DISABLED"
+    },
+    "clusterEndpoints": [
+      {
+        "connections": [
+          {
+            "pscAutoConnection": {
+              "address": "10.128.0.2",
+              "connectionType": "CONNECTION_TYPE_DISCOVERY",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "projectId": "${projectId}",
+              "pscConnectionId": "${pscConnectionID}",
+              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
+              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+            }
+          },
+          {
+            "pscAutoConnection": {
+              "address": "10.128.0.3",
+              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+              "network": "projects/${projectId}/global/networks/${networkID}",
+              "projectId": "${projectId}",
+              "pscConnectionId": "${pscConnectionID}",
+              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
+              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+            }
+          }
+        ]
+      }
+    ],
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "discoveryEndpoints": [
@@ -782,6 +923,7 @@ X-Xss-Protection: 0
         }
       }
     ],
+    "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
     "encryptionInfo": {
       "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
     },
@@ -797,17 +939,30 @@ X-Xss-Protection: 0
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}"
+        "pscConnectionId": "${pscConnectionID}",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
       },
       {
         "address": "10.11.12.13",
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}"
+        "pscConnectionId": "${pscConnectionID}",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+      }
+    ],
+    "pscServiceAttachments": [
+      {
+        "connectionType": "CONNECTION_TYPE_DISCOVERY",
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+      },
+      {
+        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
       }
     ],
     "replicaCount": 0,
+    "satisfiesPzi": false,
+    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 10,
     "sizeGb": 130,
     "state": "ACTIVE",
@@ -838,6 +993,38 @@ X-Xss-Protection: 0
 
 {
   "authorizationMode": 2,
+  "automatedBackupConfig": {
+    "automatedBackupMode": 1
+  },
+  "clusterEndpoints": [
+    {
+      "connections": [
+        {
+          "pscAutoConnection": {
+            "address": "10.128.0.2",
+            "connectionType": 1,
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "projectId": "${projectId}",
+            "pscConnectionId": "${pscConnectionID}",
+            "pscConnectionStatus": 1,
+            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+          }
+        },
+        {
+          "pscAutoConnection": {
+            "address": "10.128.0.3",
+            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
+            "network": "projects/${projectId}/global/networks/${networkID}",
+            "projectId": "${projectId}",
+            "pscConnectionId": "${pscConnectionID}",
+            "pscConnectionStatus": 1,
+            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+          }
+        }
+      ]
+    }
+  ],
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "discoveryEndpoints": [
@@ -849,6 +1036,7 @@ X-Xss-Protection: 0
       }
     }
   ],
+  "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
   "encryptionInfo": {
     "encryptionType": 1
   },
@@ -864,17 +1052,30 @@ X-Xss-Protection: 0
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}"
+      "pscConnectionId": "${pscConnectionID}",
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
     },
     {
       "address": "10.11.12.13",
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}"
+      "pscConnectionId": "${pscConnectionID}",
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+    }
+  ],
+  "pscServiceAttachments": [
+    {
+      "connectionType": 1,
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+    },
+    {
+      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
     }
   ],
   "replicaCount": 0,
+  "satisfiesPzi": false,
+  "serverCaMode": 0,
   "shardCount": 10,
   "sizeGb": 130,
   "state": 2,
@@ -903,10 +1104,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "delete"
   },
@@ -937,6 +1140,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "delete"
   },
@@ -993,10 +1197,12 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -1025,6 +1231,7 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
+    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -1051,7 +1258,9 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
+  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -1067,8 +1276,7 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY",
-  "state": "READY"
+  "stackType": "IPV4_ONLY"
 }
 
 ---
@@ -1159,6 +1367,10 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
+  "routingConfig": {
+    "bgpBestPathSelectionMode": "LEGACY",
+    "routingMode": "REGIONAL"
+  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }

--- a/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/redis/v1beta1/rediscluster/basicrediscluster/_http.log
@@ -119,10 +119,6 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }
@@ -248,9 +244,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -266,7 +260,8 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY"
+  "stackType": "IPV4_ONLY",
+  "state": "READY"
 }
 
 ---
@@ -320,12 +315,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -354,7 +347,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "create"
   },
@@ -427,12 +419,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -461,7 +451,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "update"
   },
@@ -558,12 +547,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "create"
   },
@@ -594,7 +581,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "create"
   },
@@ -605,35 +591,6 @@ X-Xss-Protection: 0
     "automatedBackupConfig": {
       "automatedBackupMode": "DISABLED"
     },
-    "clusterEndpoints": [
-      {
-        "connections": [
-          {
-            "pscAutoConnection": {
-              "address": "10.128.0.2",
-              "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-              "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}",
-              "pscConnectionId": "${pscConnectionID}",
-              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
-              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-            }
-          },
-          {
-            "pscAutoConnection": {
-              "address": "10.128.0.3",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-              "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}",
-              "pscConnectionId": "${pscConnectionID}",
-              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
-              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-            }
-          }
-        ]
-      }
-    ],
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "discoveryEndpoints": [
@@ -645,7 +602,6 @@ X-Xss-Protection: 0
         }
       }
     ],
-    "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
     "encryptionInfo": {
       "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
     },
@@ -661,30 +617,17 @@ X-Xss-Protection: 0
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+        "pscConnectionId": "${pscConnectionID}"
       },
       {
         "address": "10.11.12.13",
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-      }
-    ],
-    "pscServiceAttachments": [
-      {
-        "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-      },
-      {
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+        "pscConnectionId": "${pscConnectionID}"
       }
     ],
     "replicaCount": 0,
-    "satisfiesPzi": false,
-    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 3,
     "sizeGb": 39,
     "state": "ACTIVE",
@@ -718,35 +661,6 @@ X-Xss-Protection: 0
   "automatedBackupConfig": {
     "automatedBackupMode": 1
   },
-  "clusterEndpoints": [
-    {
-      "connections": [
-        {
-          "pscAutoConnection": {
-            "address": "10.128.0.2",
-            "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-            "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}",
-            "pscConnectionId": "${pscConnectionID}",
-            "pscConnectionStatus": 1,
-            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-          }
-        },
-        {
-          "pscAutoConnection": {
-            "address": "10.128.0.3",
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-            "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}",
-            "pscConnectionId": "${pscConnectionID}",
-            "pscConnectionStatus": 1,
-            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-          }
-        }
-      ]
-    }
-  ],
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "discoveryEndpoints": [
@@ -758,7 +672,6 @@ X-Xss-Protection: 0
       }
     }
   ],
-  "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
   "encryptionInfo": {
     "encryptionType": 1
   },
@@ -774,30 +687,17 @@ X-Xss-Protection: 0
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}",
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+      "pscConnectionId": "${pscConnectionID}"
     },
     {
       "address": "10.11.12.13",
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}",
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-    }
-  ],
-  "pscServiceAttachments": [
-    {
-      "connectionType": 1,
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-    },
-    {
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+      "pscConnectionId": "${pscConnectionID}"
     }
   ],
   "replicaCount": 0,
-  "satisfiesPzi": false,
-  "serverCaMode": 0,
   "shardCount": 3,
   "sizeGb": 39,
   "state": 2,
@@ -836,12 +736,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "update"
   },
@@ -872,7 +770,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "update"
   },
@@ -883,35 +780,6 @@ X-Xss-Protection: 0
     "automatedBackupConfig": {
       "automatedBackupMode": "DISABLED"
     },
-    "clusterEndpoints": [
-      {
-        "connections": [
-          {
-            "pscAutoConnection": {
-              "address": "10.128.0.2",
-              "connectionType": "CONNECTION_TYPE_DISCOVERY",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-              "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}",
-              "pscConnectionId": "${pscConnectionID}",
-              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
-              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-            }
-          },
-          {
-            "pscAutoConnection": {
-              "address": "10.128.0.3",
-              "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-              "network": "projects/${projectId}/global/networks/${networkID}",
-              "projectId": "${projectId}",
-              "pscConnectionId": "${pscConnectionID}",
-              "pscConnectionStatus": "PSC_CONNECTION_STATUS_ACTIVE",
-              "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-            }
-          }
-        ]
-      }
-    ],
     "createTime": "2024-04-01T12:34:56.123456Z",
     "deletionProtectionEnabled": false,
     "discoveryEndpoints": [
@@ -923,7 +791,6 @@ X-Xss-Protection: 0
         }
       }
     ],
-    "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
     "encryptionInfo": {
       "encryptionType": "GOOGLE_DEFAULT_ENCRYPTION"
     },
@@ -939,30 +806,17 @@ X-Xss-Protection: 0
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+        "pscConnectionId": "${pscConnectionID}"
       },
       {
         "address": "10.11.12.13",
         "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
         "network": "projects/${projectId}/global/networks/${networkID}",
         "projectId": "${projectId}",
-        "pscConnectionId": "${pscConnectionID}",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-      }
-    ],
-    "pscServiceAttachments": [
-      {
-        "connectionType": "CONNECTION_TYPE_DISCOVERY",
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-      },
-      {
-        "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+        "pscConnectionId": "${pscConnectionID}"
       }
     ],
     "replicaCount": 0,
-    "satisfiesPzi": false,
-    "serverCaMode": "SERVER_CA_MODE_UNSPECIFIED",
     "shardCount": 10,
     "sizeGb": 130,
     "state": "ACTIVE",
@@ -996,35 +850,6 @@ X-Xss-Protection: 0
   "automatedBackupConfig": {
     "automatedBackupMode": 1
   },
-  "clusterEndpoints": [
-    {
-      "connections": [
-        {
-          "pscAutoConnection": {
-            "address": "10.128.0.2",
-            "connectionType": 1,
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-            "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}",
-            "pscConnectionId": "${pscConnectionID}",
-            "pscConnectionStatus": 1,
-            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-          }
-        },
-        {
-          "pscAutoConnection": {
-            "address": "10.128.0.3",
-            "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
-            "network": "projects/${projectId}/global/networks/${networkID}",
-            "projectId": "${projectId}",
-            "pscConnectionId": "${pscConnectionID}",
-            "pscConnectionStatus": 1,
-            "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-          }
-        }
-      ]
-    }
-  ],
   "createTime": "2024-04-01T12:34:56.123456Z",
   "deletionProtectionEnabled": false,
   "discoveryEndpoints": [
@@ -1036,7 +861,6 @@ X-Xss-Protection: 0
       }
     }
   ],
-  "effectiveMaintenanceVersion": "REDISCLUSTER_20260512_00_00",
   "encryptionInfo": {
     "encryptionType": 1
   },
@@ -1052,30 +876,17 @@ X-Xss-Protection: 0
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}",
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
+      "pscConnectionId": "${pscConnectionID}"
     },
     {
       "address": "10.11.12.13",
       "forwardingRule": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/forwardingRules/${forwardingRuleID}",
       "network": "projects/${projectId}/global/networks/${networkID}",
       "projectId": "${projectId}",
-      "pscConnectionId": "${pscConnectionID}",
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
-    }
-  ],
-  "pscServiceAttachments": [
-    {
-      "connectionType": 1,
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa"
-    },
-    {
-      "serviceAttachment": "projects/623628891916/regions/us-central1/serviceAttachments/gcp-memorystore-auto-e0c8f17a5fa55926-psc-sa-2"
+      "pscConnectionId": "${pscConnectionID}"
     }
   ],
   "replicaCount": 0,
-  "satisfiesPzi": false,
-  "serverCaMode": 0,
   "shardCount": 10,
   "sizeGb": 130,
   "state": 2,
@@ -1104,12 +915,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.redis.cluster.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "delete"
   },
@@ -1140,7 +949,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/clusters/rediscluster-${uniqueId}",
     "verb": "delete"
   },
@@ -1197,12 +1005,10 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "done": false,
   "metadata": {
     "@type": "type.googleapis.com/google.cloud.networkconnectivity.v1.OperationMetadata",
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -1231,7 +1037,6 @@ X-Xss-Protection: 0
     "apiVersion": "v1",
     "createTime": "2024-04-01T12:34:56.123456Z",
     "endTime": "2024-04-01T12:34:56.123456Z",
-    "requestedCancellation": false,
     "target": "projects/${projectId}/locations/us-central1/serviceConnectionPolicies/scp-${uniqueId}",
     "verb": "delete"
   },
@@ -1258,9 +1063,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "allowSubnetCidrRoutesOverlap": false,
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
-  "enableFlowLogs": false,
   "fingerprint": "abcdef0123A=",
   "gatewayAddress": "10.0.0.1",
   "id": "000000000000000000000",
@@ -1276,7 +1079,8 @@ X-Xss-Protection: 0
   "purpose": "PRIVATE",
   "region": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/regions/us-central1/subnetworks/${subnetworkID}",
-  "stackType": "IPV4_ONLY"
+  "stackType": "IPV4_ONLY",
+  "state": "READY"
 }
 
 ---
@@ -1367,10 +1171,6 @@ X-Xss-Protection: 0
   "kind": "compute#network",
   "name": "${networkID}",
   "networkFirewallPolicyEnforcementOrder": "AFTER_CLASSIC_FIREWALL",
-  "routingConfig": {
-    "bgpBestPathSelectionMode": "LEGACY",
-    "routingMode": "REGIONAL"
-  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}",
   "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/${projectId}/global/networks/${networkID}"
 }


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Followup of #9221 

- Assign API default value to this field if unspecified. 
- Update mockGCP to include this field with default value in response body to match realGCP behavior .

#### WHY do we need this change?
By default, GCP sets the "automatedBackupConfig" mode to "disabled" if it is unspecified. During reconcile, comparing the desired(nil) and actual state(disabled) results in a diff, causing unnecessary Patch calls every time. We must assign the default value to this spec field to match actual state and avoid triggering a diff on this field.

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
