### PR TITLE
Exclude direct-only controllers from migration tracker

### DIFF
--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -93,7 +93,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -143,7 +143,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -196,7 +196,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -220,7 +220,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -246,7 +246,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -301,7 +301,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -351,7 +351,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -402,7 +402,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -735,7 +735,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -789,7 +789,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -924,7 +924,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -950,7 +950,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -976,7 +976,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1054,7 +1054,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1210,7 +1210,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1566,7 +1566,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 495,
+    "sortOrder": 493,
     "downstreamCount": 4
   },
   {
@@ -1883,7 +1883,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 494,
+    "sortOrder": 495,
     "downstreamCount": 4
   },
   {
@@ -2331,7 +2331,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2355,7 +2355,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2566,7 +2566,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 493,
+    "sortOrder": 494,
     "downstreamCount": 0
   },
   {
@@ -2688,7 +2688,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2895,7 +2895,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3023,7 +3023,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3102,7 +3102,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3422,7 +3422,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3450,7 +3450,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3746,7 +3746,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3772,7 +3772,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3856,7 +3856,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3882,7 +3882,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -4760,7 +4760,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -4982,7 +4982,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5058,7 +5058,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5085,7 +5085,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5135,7 +5135,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5592,7 +5592,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5695,7 +5695,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5726,7 +5726,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5931,7 +5931,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6011,7 +6011,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6090,7 +6090,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6116,7 +6116,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6458,7 +6458,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6803,7 +6803,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -7219,7 +7219,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -7245,7 +7245,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -7271,7 +7271,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -22,7 +22,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 121,
+    "sortOrder": 123,
     "downstreamCount": 0
   },
   {
@@ -48,7 +48,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 122,
+    "sortOrder": 124,
     "downstreamCount": 0
   },
   {
@@ -75,7 +75,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 126,
+    "sortOrder": 130,
     "downstreamCount": 0
   },
   {
@@ -102,7 +102,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 45,
+    "sortOrder": 46,
     "downstreamCount": 2
   },
   {
@@ -128,7 +128,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 129,
+    "sortOrder": 133,
     "downstreamCount": 0
   },
   {
@@ -176,7 +176,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 130,
+    "sortOrder": 134,
     "downstreamCount": 0
   },
   {
@@ -205,7 +205,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 131,
+    "sortOrder": 135,
     "downstreamCount": 0
   },
   {
@@ -229,7 +229,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 132,
+    "sortOrder": 136,
     "downstreamCount": 0
   },
   {
@@ -255,7 +255,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 133,
+    "sortOrder": 137,
     "downstreamCount": 0
   },
   {
@@ -284,7 +284,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 46,
+    "sortOrder": 47,
     "downstreamCount": 2
   },
   {
@@ -310,7 +310,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 135,
+    "sortOrder": 139,
     "downstreamCount": 0
   },
   {
@@ -334,7 +334,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 137,
+    "sortOrder": 141,
     "downstreamCount": 0
   },
   {
@@ -360,7 +360,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 47,
+    "sortOrder": 48,
     "downstreamCount": 2
   },
   {
@@ -384,7 +384,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 141,
+    "sortOrder": 145,
     "downstreamCount": 0
   },
   {
@@ -435,7 +435,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 142,
+    "sortOrder": 148,
     "downstreamCount": 0
   },
   {
@@ -459,7 +459,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 143,
+    "sortOrder": 149,
     "downstreamCount": 0
   },
   {
@@ -483,7 +483,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 144,
+    "sortOrder": 150,
     "downstreamCount": 0
   },
   {
@@ -509,7 +509,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 145,
+    "sortOrder": 151,
     "downstreamCount": 0
   },
   {
@@ -533,7 +533,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 146,
+    "sortOrder": 152,
     "downstreamCount": 0
   },
   {
@@ -559,7 +559,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 147,
+    "sortOrder": 153,
     "downstreamCount": 0
   },
   {
@@ -586,7 +586,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 151,
+    "sortOrder": 157,
     "downstreamCount": 0
   },
   {
@@ -612,7 +612,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 160,
+    "sortOrder": 166,
     "downstreamCount": 0
   },
   {
@@ -638,7 +638,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 161,
+    "sortOrder": 167,
     "downstreamCount": 0
   },
   {
@@ -664,7 +664,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 162,
+    "sortOrder": 168,
     "downstreamCount": 0
   },
   {
@@ -690,7 +690,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 169,
+    "sortOrder": 176,
     "downstreamCount": 0
   },
   {
@@ -744,7 +744,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 171,
+    "sortOrder": 178,
     "downstreamCount": 0
   },
   {
@@ -772,7 +772,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 172,
+    "sortOrder": 179,
     "downstreamCount": 0
   },
   {
@@ -798,7 +798,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 174,
+    "sortOrder": 181,
     "downstreamCount": 0
   },
   {
@@ -825,7 +825,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 175,
+    "sortOrder": 182,
     "downstreamCount": 0
   },
   {
@@ -853,7 +853,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 81,
+    "sortOrder": 82,
     "downstreamCount": 1
   },
   {
@@ -880,7 +880,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 176,
+    "sortOrder": 183,
     "downstreamCount": 0
   },
   {
@@ -907,7 +907,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 179,
+    "sortOrder": 186,
     "downstreamCount": 0
   },
   {
@@ -959,7 +959,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 50,
+    "sortOrder": 51,
     "downstreamCount": 2
   },
   {
@@ -985,7 +985,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 182,
+    "sortOrder": 189,
     "downstreamCount": 0
   },
   {
@@ -1011,7 +1011,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 183,
+    "sortOrder": 190,
     "downstreamCount": 0
   },
   {
@@ -1037,7 +1037,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 185,
+    "sortOrder": 192,
     "downstreamCount": 0
   },
   {
@@ -1047,23 +1047,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 187,
+    "sortOrder": 197,
     "downstreamCount": 0
   },
   {
@@ -1073,23 +1074,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 189,
+    "sortOrder": 199,
     "downstreamCount": 0
   },
   {
@@ -1106,7 +1108,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1114,8 +1116,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 190,
+    "notes": "Missing _reference.go",
+    "sortOrder": 200,
     "downstreamCount": 0
   },
   {
@@ -1141,7 +1143,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 192,
+    "sortOrder": 202,
     "downstreamCount": 0
   },
   {
@@ -1165,7 +1167,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 193,
+    "sortOrder": 203,
     "downstreamCount": 0
   },
   {
@@ -1191,7 +1193,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 194,
+    "sortOrder": 204,
     "downstreamCount": 0
   },
   {
@@ -1219,7 +1221,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 196,
+    "sortOrder": 207,
     "downstreamCount": 0
   },
   {
@@ -1245,7 +1247,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 203,
+    "sortOrder": 214,
     "downstreamCount": 0
   },
   {
@@ -1272,7 +1274,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 204,
+    "sortOrder": 215,
     "downstreamCount": 0
   },
   {
@@ -1299,7 +1301,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 205,
+    "sortOrder": 216,
     "downstreamCount": 0
   },
   {
@@ -1323,7 +1325,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 206,
+    "sortOrder": 217,
     "downstreamCount": 0
   },
   {
@@ -1347,7 +1349,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 207,
+    "sortOrder": 218,
     "downstreamCount": 0
   },
   {
@@ -1373,7 +1375,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 209,
+    "sortOrder": 220,
     "downstreamCount": 0
   },
   {
@@ -1391,8 +1393,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -1400,7 +1402,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 52,
+    "sortOrder": 53,
     "downstreamCount": 2
   },
   {
@@ -1426,7 +1428,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 213,
+    "sortOrder": 224,
     "downstreamCount": 0
   },
   {
@@ -1479,7 +1481,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 214,
+    "sortOrder": 225,
     "downstreamCount": 0
   },
   {
@@ -1537,7 +1539,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 215,
+    "sortOrder": 226,
     "downstreamCount": 0
   },
   {
@@ -1557,8 +1559,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -1566,7 +1568,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 493,
+    "sortOrder": 524,
     "downstreamCount": 4
   },
   {
@@ -1593,7 +1595,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 496,
+    "sortOrder": 525,
     "downstreamCount": 0
   },
   {
@@ -1617,7 +1619,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 216,
+    "sortOrder": 227,
     "downstreamCount": 0
   },
   {
@@ -1634,7 +1636,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1642,8 +1644,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 217,
+    "notes": "Missing _reference.go",
+    "sortOrder": 228,
     "downstreamCount": 0
   },
   {
@@ -1695,7 +1697,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 218,
+    "sortOrder": 229,
     "downstreamCount": 0
   },
   {
@@ -1732,7 +1734,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 86,
+    "sortOrder": 88,
     "downstreamCount": 1
   },
   {
@@ -1758,7 +1760,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 221,
+    "sortOrder": 232,
     "downstreamCount": 0
   },
   {
@@ -1784,7 +1786,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 222,
+    "sortOrder": 233,
     "downstreamCount": 0
   },
   {
@@ -1807,7 +1809,7 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
+    "notes": "Missing _reference.go",
     "sortOrder": 13,
     "downstreamCount": 11
   },
@@ -1832,7 +1834,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 223,
+    "sortOrder": 234,
     "downstreamCount": 0
   },
   {
@@ -1883,7 +1885,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 495,
+    "sortOrder": 526,
     "downstreamCount": 4
   },
   {
@@ -1904,8 +1906,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -1930,7 +1932,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -1938,7 +1940,7 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
+    "notes": "Missing _reference.go",
     "sortOrder": 15,
     "downstreamCount": 10
   },
@@ -1968,7 +1970,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 87,
+    "sortOrder": 89,
     "downstreamCount": 1
   },
   {
@@ -1994,7 +1996,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 224,
+    "sortOrder": 235,
     "downstreamCount": 0
   },
   {
@@ -2075,7 +2077,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 226,
+    "sortOrder": 237,
     "downstreamCount": 0
   },
   {
@@ -2101,7 +2103,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 227,
+    "sortOrder": 238,
     "downstreamCount": 0
   },
   {
@@ -2125,8 +2127,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 6,
-    "downstreamCount": 101
+    "sortOrder": 5,
+    "downstreamCount": 123
   },
   {
     "group": "compute",
@@ -2153,7 +2155,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 230,
+    "sortOrder": 241,
     "downstreamCount": 0
   },
   {
@@ -2206,7 +2208,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 231,
+    "sortOrder": 242,
     "downstreamCount": 0
   },
   {
@@ -2233,7 +2235,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 232,
+    "sortOrder": 243,
     "downstreamCount": 0
   },
   {
@@ -2260,7 +2262,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 233,
+    "sortOrder": 244,
     "downstreamCount": 0
   },
   {
@@ -2277,7 +2279,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2285,8 +2287,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 234,
+    "notes": "Missing _reference.go",
+    "sortOrder": 245,
     "downstreamCount": 0
   },
   {
@@ -2313,7 +2315,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 235,
+    "sortOrder": 246,
     "downstreamCount": 0
   },
   {
@@ -2340,7 +2342,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 236,
+    "sortOrder": 247,
     "downstreamCount": 0
   },
   {
@@ -2356,15 +2358,15 @@
     "state": "Not Started",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 88,
+    "notes": "",
+    "sortOrder": 90,
     "downstreamCount": 1
   },
   {
@@ -2388,7 +2390,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 237,
+    "sortOrder": 248,
     "downstreamCount": 0
   },
   {
@@ -2412,7 +2414,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 238,
+    "sortOrder": 249,
     "downstreamCount": 0
   },
   {
@@ -2436,7 +2438,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 239,
+    "sortOrder": 250,
     "downstreamCount": 0
   },
   {
@@ -2462,7 +2464,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 240,
+    "sortOrder": 251,
     "downstreamCount": 0
   },
   {
@@ -2489,7 +2491,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 241,
+    "sortOrder": 252,
     "downstreamCount": 0
   },
   {
@@ -2513,7 +2515,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 242,
+    "sortOrder": 253,
     "downstreamCount": 0
   },
   {
@@ -2539,7 +2541,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 243,
+    "sortOrder": 254,
     "downstreamCount": 0
   },
   {
@@ -2566,7 +2568,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 494,
+    "sortOrder": 527,
     "downstreamCount": 0
   },
   {
@@ -2594,7 +2596,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 244,
+    "sortOrder": 255,
     "downstreamCount": 0
   },
   {
@@ -2611,7 +2613,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2619,8 +2621,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 245,
+    "notes": "Missing _reference.go",
+    "sortOrder": 256,
     "downstreamCount": 0
   },
   {
@@ -2646,7 +2648,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 246,
+    "sortOrder": 257,
     "downstreamCount": 0
   },
   {
@@ -2673,7 +2675,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 247,
+    "sortOrder": 258,
     "downstreamCount": 0
   },
   {
@@ -2697,7 +2699,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 248,
+    "sortOrder": 259,
     "downstreamCount": 0
   },
   {
@@ -2723,7 +2725,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 249,
+    "sortOrder": 260,
     "downstreamCount": 0
   },
   {
@@ -2778,7 +2780,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 89,
+    "sortOrder": 91,
     "downstreamCount": 1
   },
   {
@@ -2805,7 +2807,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 250,
+    "sortOrder": 261,
     "downstreamCount": 0
   },
   {
@@ -2832,7 +2834,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 251,
+    "sortOrder": 262,
     "downstreamCount": 0
   },
   {
@@ -2856,7 +2858,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 252,
+    "sortOrder": 263,
     "downstreamCount": 0
   },
   {
@@ -2904,7 +2906,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 10,
+    "sortOrder": 11,
     "downstreamCount": 13
   },
   {
@@ -2930,7 +2932,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 53,
+    "sortOrder": 54,
     "downstreamCount": 2
   },
   {
@@ -2954,7 +2956,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 253,
+    "sortOrder": 264,
     "downstreamCount": 0
   },
   {
@@ -2980,7 +2982,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 254,
+    "sortOrder": 265,
     "downstreamCount": 0
   },
   {
@@ -2997,8 +2999,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3024,14 +3026,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 9,
     "downstreamCount": 23
   },
@@ -3058,7 +3060,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 54,
+    "sortOrder": 55,
     "downstreamCount": 2
   },
   {
@@ -3084,7 +3086,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 55,
+    "sortOrder": 56,
     "downstreamCount": 2
   },
   {
@@ -3111,7 +3113,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 56,
+    "sortOrder": 57,
     "downstreamCount": 2
   },
   {
@@ -3139,7 +3141,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 255,
+    "sortOrder": 266,
     "downstreamCount": 0
   },
   {
@@ -3166,7 +3168,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 256,
+    "sortOrder": 267,
     "downstreamCount": 0
   },
   {
@@ -3193,7 +3195,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 57,
+    "sortOrder": 58,
     "downstreamCount": 2
   },
   {
@@ -3220,7 +3222,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 58,
+    "sortOrder": 59,
     "downstreamCount": 2
   },
   {
@@ -3328,7 +3330,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 59,
+    "sortOrder": 60,
     "downstreamCount": 2
   },
   {
@@ -3355,7 +3357,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 257,
+    "sortOrder": 268,
     "downstreamCount": 0
   },
   {
@@ -3379,7 +3381,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 259,
+    "sortOrder": 270,
     "downstreamCount": 0
   },
   {
@@ -3405,7 +3407,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 260,
+    "sortOrder": 271,
     "downstreamCount": 0
   },
   {
@@ -3431,7 +3433,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 261,
+    "sortOrder": 272,
     "downstreamCount": 0
   },
   {
@@ -3459,7 +3461,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 60,
+    "sortOrder": 61,
     "downstreamCount": 2
   },
   {
@@ -3488,7 +3490,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 262,
+    "sortOrder": 273,
     "downstreamCount": 0
   },
   {
@@ -3515,7 +3517,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 263,
+    "sortOrder": 276,
     "downstreamCount": 0
   },
   {
@@ -3541,7 +3543,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 90,
+    "sortOrder": 93,
     "downstreamCount": 1
   },
   {
@@ -3569,7 +3571,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 264,
+    "sortOrder": 278,
     "downstreamCount": 0
   },
   {
@@ -3595,7 +3597,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 265,
+    "sortOrder": 279,
     "downstreamCount": 0
   },
   {
@@ -3622,7 +3624,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 91,
+    "sortOrder": 94,
     "downstreamCount": 1
   },
   {
@@ -3649,7 +3651,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 266,
+    "sortOrder": 280,
     "downstreamCount": 0
   },
   {
@@ -3668,8 +3670,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3677,7 +3679,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 267,
+    "sortOrder": 281,
     "downstreamCount": 0
   },
   {
@@ -3694,8 +3696,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3703,7 +3705,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 268,
+    "sortOrder": 282,
     "downstreamCount": 0
   },
   {
@@ -3720,7 +3722,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -3728,8 +3730,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 269,
+    "notes": "Missing _reference.go",
+    "sortOrder": 283,
     "downstreamCount": 0
   },
   {
@@ -3755,7 +3757,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 270,
+    "sortOrder": 284,
     "downstreamCount": 0
   },
   {
@@ -3781,7 +3783,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 93,
+    "sortOrder": 96,
     "downstreamCount": 1
   },
   {
@@ -3808,7 +3810,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 273,
+    "sortOrder": 287,
     "downstreamCount": 0
   },
   {
@@ -3837,7 +3839,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 276,
+    "sortOrder": 294,
     "downstreamCount": 0
   },
   {
@@ -3865,7 +3867,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 277,
+    "sortOrder": 295,
     "downstreamCount": 0
   },
   {
@@ -3891,7 +3893,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 283,
+    "sortOrder": 303,
     "downstreamCount": 0
   },
   {
@@ -3951,7 +3953,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 288,
+    "sortOrder": 308,
     "downstreamCount": 0
   },
   {
@@ -3977,7 +3979,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 289,
+    "sortOrder": 309,
     "downstreamCount": 0
   },
   {
@@ -4003,7 +4005,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 292,
+    "sortOrder": 312,
     "downstreamCount": 0
   },
   {
@@ -4029,7 +4031,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 293,
+    "sortOrder": 313,
     "downstreamCount": 0
   },
   {
@@ -4053,7 +4055,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 296,
+    "sortOrder": 318,
     "downstreamCount": 0
   },
   {
@@ -4079,7 +4081,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 297,
+    "sortOrder": 319,
     "downstreamCount": 0
   },
   {
@@ -4103,7 +4105,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 298,
+    "sortOrder": 320,
     "downstreamCount": 0
   },
   {
@@ -4127,7 +4129,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 299,
+    "sortOrder": 321,
     "downstreamCount": 0
   },
   {
@@ -4151,7 +4153,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 300,
+    "sortOrder": 322,
     "downstreamCount": 0
   },
   {
@@ -4175,7 +4177,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 301,
+    "sortOrder": 323,
     "downstreamCount": 0
   },
   {
@@ -4199,7 +4201,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 302,
+    "sortOrder": 324,
     "downstreamCount": 0
   },
   {
@@ -4225,7 +4227,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 303,
+    "sortOrder": 326,
     "downstreamCount": 0
   },
   {
@@ -4251,7 +4253,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 304,
+    "sortOrder": 327,
     "downstreamCount": 0
   },
   {
@@ -4277,7 +4279,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 305,
+    "sortOrder": 329,
     "downstreamCount": 0
   },
   {
@@ -4301,7 +4303,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 310,
+    "sortOrder": 336,
     "downstreamCount": 0
   },
   {
@@ -4328,7 +4330,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 64,
+    "sortOrder": 65,
     "downstreamCount": 2
   },
   {
@@ -4356,7 +4358,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 313,
+    "sortOrder": 339,
     "downstreamCount": 0
   },
   {
@@ -4383,7 +4385,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 314,
+    "sortOrder": 340,
     "downstreamCount": 0
   },
   {
@@ -4409,7 +4411,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 96,
+    "sortOrder": 98,
     "downstreamCount": 1
   },
   {
@@ -4436,7 +4438,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 315,
+    "sortOrder": 341,
     "downstreamCount": 0
   },
   {
@@ -4465,7 +4467,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 320,
+    "sortOrder": 346,
     "downstreamCount": 0
   },
   {
@@ -4491,7 +4493,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 321,
+    "sortOrder": 347,
     "downstreamCount": 0
   },
   {
@@ -4518,7 +4520,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 322,
+    "sortOrder": 348,
     "downstreamCount": 0
   },
   {
@@ -4544,7 +4546,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 323,
+    "sortOrder": 349,
     "downstreamCount": 0
   },
   {
@@ -4570,7 +4572,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 324,
+    "sortOrder": 350,
     "downstreamCount": 0
   },
   {
@@ -4596,7 +4598,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 325,
+    "sortOrder": 351,
     "downstreamCount": 0
   },
   {
@@ -4620,7 +4622,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 326,
+    "sortOrder": 352,
     "downstreamCount": 0
   },
   {
@@ -4646,7 +4648,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 327,
+    "sortOrder": 353,
     "downstreamCount": 0
   },
   {
@@ -4670,7 +4672,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 97,
+    "sortOrder": 99,
     "downstreamCount": 1
   },
   {
@@ -4696,7 +4698,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 328,
+    "sortOrder": 354,
     "downstreamCount": 0
   },
   {
@@ -4720,7 +4722,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 329,
+    "sortOrder": 355,
     "downstreamCount": 0
   },
   {
@@ -4745,7 +4747,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 333,
+    "sortOrder": 359,
     "downstreamCount": 0
   },
   {
@@ -4770,7 +4772,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 1,
-    "downstreamCount": 337
+    "downstreamCount": 367
   },
   {
     "group": "gkehub",
@@ -4795,7 +4797,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 100,
+    "sortOrder": 102,
     "downstreamCount": 1
   },
   {
@@ -4819,7 +4821,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 66,
+    "sortOrder": 67,
     "downstreamCount": 2
   },
   {
@@ -4843,7 +4845,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 339,
+    "sortOrder": 365,
     "downstreamCount": 0
   },
   {
@@ -4867,7 +4869,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 340,
+    "sortOrder": 366,
     "downstreamCount": 0
   },
   {
@@ -4893,7 +4895,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 341,
+    "sortOrder": 367,
     "downstreamCount": 0
   },
   {
@@ -4917,7 +4919,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 342,
+    "sortOrder": 368,
     "downstreamCount": 0
   },
   {
@@ -4941,7 +4943,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 343,
+    "sortOrder": 369,
     "downstreamCount": 0
   },
   {
@@ -4967,7 +4969,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 344,
+    "sortOrder": 370,
     "downstreamCount": 0
   },
   {
@@ -4991,7 +4993,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 345,
+    "sortOrder": 371,
     "downstreamCount": 0
   },
   {
@@ -5015,7 +5017,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 346,
+    "sortOrder": 372,
     "downstreamCount": 0
   },
   {
@@ -5043,7 +5045,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 348,
+    "sortOrder": 374,
     "downstreamCount": 0
   },
   {
@@ -5067,7 +5069,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 349,
+    "sortOrder": 375,
     "downstreamCount": 0
   },
   {
@@ -5094,7 +5096,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 350,
+    "sortOrder": 376,
     "downstreamCount": 0
   },
   {
@@ -5119,7 +5121,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 7,
-    "downstreamCount": 49
+    "downstreamCount": 51
   },
   {
     "group": "iam",
@@ -5144,7 +5146,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 351,
+    "sortOrder": 377,
     "downstreamCount": 0
   },
   {
@@ -5168,7 +5170,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 101,
+    "sortOrder": 103,
     "downstreamCount": 1
   },
   {
@@ -5194,7 +5196,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 352,
+    "sortOrder": 378,
     "downstreamCount": 0
   },
   {
@@ -5220,7 +5222,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 102,
+    "sortOrder": 104,
     "downstreamCount": 1
   },
   {
@@ -5247,7 +5249,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 353,
+    "sortOrder": 379,
     "downstreamCount": 0
   },
   {
@@ -5271,7 +5273,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 103,
+    "sortOrder": 105,
     "downstreamCount": 1
   },
   {
@@ -5297,7 +5299,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 354,
+    "sortOrder": 380,
     "downstreamCount": 0
   },
   {
@@ -5323,7 +5325,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 356,
+    "sortOrder": 382,
     "downstreamCount": 0
   },
   {
@@ -5349,7 +5351,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 357,
+    "sortOrder": 383,
     "downstreamCount": 0
   },
   {
@@ -5375,7 +5377,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 358,
+    "sortOrder": 384,
     "downstreamCount": 0
   },
   {
@@ -5399,7 +5401,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 359,
+    "sortOrder": 385,
     "downstreamCount": 0
   },
   {
@@ -5425,7 +5427,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 360,
+    "sortOrder": 386,
     "downstreamCount": 0
   },
   {
@@ -5449,7 +5451,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 104,
+    "sortOrder": 106,
     "downstreamCount": 1
   },
   {
@@ -5475,7 +5477,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 361,
+    "sortOrder": 387,
     "downstreamCount": 0
   },
   {
@@ -5501,7 +5503,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 362,
+    "sortOrder": 388,
     "downstreamCount": 0
   },
   {
@@ -5527,7 +5529,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 363,
+    "sortOrder": 389,
     "downstreamCount": 0
   },
   {
@@ -5537,23 +5539,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "KMSKeyRing"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 5,
+    "sortOrder": 6,
     "downstreamCount": 122
   },
   {
@@ -5568,7 +5571,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5576,8 +5579,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 365,
+    "notes": "Missing _reference.go",
+    "sortOrder": 391,
     "downstreamCount": 0
   },
   {
@@ -5587,17 +5590,18 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -5625,7 +5629,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 368,
+    "sortOrder": 394,
     "downstreamCount": 0
   },
   {
@@ -5649,7 +5653,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 369,
+    "sortOrder": 395,
     "downstreamCount": 0
   },
   {
@@ -5677,7 +5681,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 43,
+    "sortOrder": 44,
     "downstreamCount": 3
   },
   {
@@ -5687,24 +5691,25 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Folder",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 371,
+    "sortOrder": 397,
     "downstreamCount": 0
   },
   {
@@ -5714,6 +5719,7 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
@@ -5724,18 +5730,18 @@
       "PubSubTopic",
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 373,
+    "sortOrder": 399,
     "downstreamCount": 0
   },
   {
@@ -5764,7 +5770,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 374,
+    "sortOrder": 400,
     "downstreamCount": 0
   },
   {
@@ -5790,7 +5796,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 375,
+    "sortOrder": 401,
     "downstreamCount": 0
   },
   {
@@ -5816,7 +5822,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 378,
+    "sortOrder": 404,
     "downstreamCount": 0
   },
   {
@@ -5840,7 +5846,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 105,
+    "sortOrder": 107,
     "downstreamCount": 1
   },
   {
@@ -5857,8 +5863,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5866,7 +5872,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 106,
+    "sortOrder": 108,
     "downstreamCount": 1
   },
   {
@@ -5883,8 +5889,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5892,7 +5898,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 383,
+    "sortOrder": 410,
     "downstreamCount": 0
   },
   {
@@ -5907,8 +5913,8 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5916,7 +5922,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 384,
+    "sortOrder": 411,
     "downstreamCount": 0
   },
   {
@@ -5940,7 +5946,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 385,
+    "sortOrder": 412,
     "downstreamCount": 0
   },
   {
@@ -5957,8 +5963,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5966,7 +5972,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 107,
+    "sortOrder": 109,
     "downstreamCount": 1
   },
   {
@@ -5993,7 +5999,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 386,
+    "sortOrder": 413,
     "downstreamCount": 0
   },
   {
@@ -6020,7 +6026,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 387,
+    "sortOrder": 414,
     "downstreamCount": 0
   },
   {
@@ -6046,7 +6052,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 108,
+    "sortOrder": 110,
     "downstreamCount": 1
   },
   {
@@ -6073,7 +6079,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 393,
+    "sortOrder": 420,
     "downstreamCount": 0
   },
   {
@@ -6099,7 +6105,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 395,
+    "sortOrder": 422,
     "downstreamCount": 0
   },
   {
@@ -6125,7 +6131,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 397,
+    "sortOrder": 424,
     "downstreamCount": 0
   },
   {
@@ -6151,7 +6157,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 402,
+    "sortOrder": 430,
     "downstreamCount": 0
   },
   {
@@ -6177,7 +6183,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 403,
+    "sortOrder": 431,
     "downstreamCount": 0
   },
   {
@@ -6203,7 +6209,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 404,
+    "sortOrder": 432,
     "downstreamCount": 0
   },
   {
@@ -6229,7 +6235,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 405,
+    "sortOrder": 433,
     "downstreamCount": 0
   },
   {
@@ -6255,7 +6261,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 406,
+    "sortOrder": 434,
     "downstreamCount": 0
   },
   {
@@ -6282,7 +6288,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 407,
+    "sortOrder": 435,
     "downstreamCount": 0
   },
   {
@@ -6308,7 +6314,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 408,
+    "sortOrder": 436,
     "downstreamCount": 0
   },
   {
@@ -6335,7 +6341,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 409,
+    "sortOrder": 437,
     "downstreamCount": 0
   },
   {
@@ -6361,7 +6367,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 411,
+    "sortOrder": 439,
     "downstreamCount": 0
   },
   {
@@ -6388,7 +6394,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 413,
+    "sortOrder": 441,
     "downstreamCount": 0
   },
   {
@@ -6415,7 +6421,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 414,
+    "sortOrder": 442,
     "downstreamCount": 0
   },
   {
@@ -6441,7 +6447,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 417,
+    "sortOrder": 446,
     "downstreamCount": 0
   },
   {
@@ -6467,7 +6473,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 418,
+    "sortOrder": 447,
     "downstreamCount": 0
   },
   {
@@ -6493,7 +6499,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 419,
+    "sortOrder": 448,
     "downstreamCount": 0
   },
   {
@@ -6517,7 +6523,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 420,
+    "sortOrder": 449,
     "downstreamCount": 0
   },
   {
@@ -6544,7 +6550,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 68,
+    "sortOrder": 69,
     "downstreamCount": 2
   },
   {
@@ -6573,7 +6579,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 424,
+    "sortOrder": 453,
     "downstreamCount": 0
   },
   {
@@ -6602,7 +6608,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 111,
+    "sortOrder": 113,
     "downstreamCount": 1
   },
   {
@@ -6628,7 +6634,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 112,
+    "sortOrder": 114,
     "downstreamCount": 1
   },
   {
@@ -6655,7 +6661,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 3,
-    "downstreamCount": 332
+    "downstreamCount": 362
   },
   {
     "group": "pubsublite",
@@ -6680,7 +6686,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 426,
+    "sortOrder": 455,
     "downstreamCount": 0
   },
   {
@@ -6706,7 +6712,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 427,
+    "sortOrder": 456,
     "downstreamCount": 0
   },
   {
@@ -6732,7 +6738,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 428,
+    "sortOrder": 457,
     "downstreamCount": 0
   },
   {
@@ -6742,18 +6748,19 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "In Progress",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
-      "controller": false,
+      "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
@@ -6776,8 +6783,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6785,7 +6792,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 69,
+    "sortOrder": 70,
     "downstreamCount": 2
   },
   {
@@ -6795,20 +6802,21 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "KMSCryptoKey",
       "PubSubSchema"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -6838,7 +6846,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 431,
+    "sortOrder": 460,
     "downstreamCount": 0
   },
   {
@@ -6864,7 +6872,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 433,
+    "sortOrder": 462,
     "downstreamCount": 0
   },
   {
@@ -6890,7 +6898,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 434,
+    "sortOrder": 463,
     "downstreamCount": 0
   },
   {
@@ -6917,7 +6925,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 435,
+    "sortOrder": 464,
     "downstreamCount": 0
   },
   {
@@ -6947,7 +6955,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 436,
+    "sortOrder": 465,
     "downstreamCount": 0
   },
   {
@@ -6975,7 +6983,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 437,
+    "sortOrder": 466,
     "downstreamCount": 0
   },
   {
@@ -6999,7 +7007,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 438,
+    "sortOrder": 467,
     "downstreamCount": 0
   },
   {
@@ -7023,7 +7031,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 439,
+    "sortOrder": 468,
     "downstreamCount": 0
   },
   {
@@ -7047,7 +7055,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 440,
+    "sortOrder": 469,
     "downstreamCount": 0
   },
   {
@@ -7074,7 +7082,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 70,
+    "sortOrder": 71,
     "downstreamCount": 2
   },
   {
@@ -7101,7 +7109,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 441,
+    "sortOrder": 470,
     "downstreamCount": 0
   },
   {
@@ -7125,7 +7133,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 445,
+    "sortOrder": 474,
     "downstreamCount": 0
   },
   {
@@ -7149,7 +7157,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 446,
+    "sortOrder": 475,
     "downstreamCount": 0
   },
   {
@@ -7175,8 +7183,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 11,
-    "downstreamCount": 13
+    "sortOrder": 10,
+    "downstreamCount": 15
   },
   {
     "group": "servicedirectory",
@@ -7193,7 +7201,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -7201,8 +7209,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 447,
+    "notes": "Missing _reference.go",
+    "sortOrder": 476,
     "downstreamCount": 0
   },
   {
@@ -7228,7 +7236,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 114,
+    "sortOrder": 116,
     "downstreamCount": 1
   },
   {
@@ -7238,23 +7246,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ServiceDirectoryNamespace"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 448,
+    "sortOrder": 477,
     "downstreamCount": 0
   },
   {
@@ -7280,7 +7289,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 71,
+    "sortOrder": 72,
     "downstreamCount": 2
   },
   {
@@ -7306,7 +7315,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 449,
+    "sortOrder": 478,
     "downstreamCount": 0
   },
   {
@@ -7332,7 +7341,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 451,
+    "sortOrder": 480,
     "downstreamCount": 0
   },
   {
@@ -7358,7 +7367,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 452,
+    "sortOrder": 481,
     "downstreamCount": 0
   },
   {
@@ -7385,7 +7394,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 115,
+    "sortOrder": 117,
     "downstreamCount": 1
   },
   {
@@ -7410,7 +7419,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 72,
+    "sortOrder": 73,
     "downstreamCount": 2
   },
   {
@@ -7423,6 +7432,7 @@
       "Terraform"
     ],
     "dependencies": [
+      "ComputeNetwork",
       "KMSCryptoKey"
     ],
     "state": "In Progress",
@@ -7462,7 +7472,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 459,
+    "sortOrder": 488,
     "downstreamCount": 0
   },
   {
@@ -7488,7 +7498,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 460,
+    "sortOrder": 489,
     "downstreamCount": 0
   },
   {
@@ -7514,7 +7524,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 462,
+    "sortOrder": 491,
     "downstreamCount": 0
   },
   {
@@ -7540,7 +7550,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 464,
+    "sortOrder": 493,
     "downstreamCount": 0
   },
   {
@@ -7566,7 +7576,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 465,
+    "sortOrder": 494,
     "downstreamCount": 0
   },
   {
@@ -7592,7 +7602,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 466,
+    "sortOrder": 495,
     "downstreamCount": 0
   },
   {
@@ -7618,7 +7628,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 467,
+    "sortOrder": 496,
     "downstreamCount": 0
   },
   {
@@ -7645,7 +7655,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 469,
+    "sortOrder": 498,
     "downstreamCount": 0
   },
   {
@@ -7672,7 +7682,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 470,
+    "sortOrder": 499,
     "downstreamCount": 0
   },
   {
@@ -7697,7 +7707,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 471,
+    "sortOrder": 500,
     "downstreamCount": 0
   },
   {
@@ -7722,7 +7732,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 73,
+    "sortOrder": 74,
     "downstreamCount": 2
   },
   {
@@ -7749,7 +7759,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 475,
+    "sortOrder": 504,
     "downstreamCount": 0
   },
   {
@@ -7767,8 +7777,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -7776,7 +7786,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 477,
+    "sortOrder": 506,
     "downstreamCount": 0
   },
   {
@@ -7804,7 +7814,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 479,
+    "sortOrder": 508,
     "downstreamCount": 0
   },
   {
@@ -7828,7 +7838,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 482,
+    "sortOrder": 512,
     "downstreamCount": 0
   },
   {
@@ -7852,7 +7862,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 483,
+    "sortOrder": 513,
     "downstreamCount": 0
   },
   {
@@ -7878,7 +7888,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 484,
+    "sortOrder": 514,
     "downstreamCount": 0
   },
   {
@@ -7904,7 +7914,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 485,
+    "sortOrder": 515,
     "downstreamCount": 0
   },
   {
@@ -7930,7 +7940,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 487,
+    "sortOrder": 518,
     "downstreamCount": 0
   }
 ]

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -1568,7 +1568,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 524,
+    "sortOrder": 527,
     "downstreamCount": 4
   },
   {
@@ -1885,7 +1885,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 526,
+    "sortOrder": 524,
     "downstreamCount": 4
   },
   {
@@ -2568,7 +2568,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 527,
+    "sortOrder": 526,
     "downstreamCount": 0
   },
   {

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -67,14 +67,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 126,
     "downstreamCount": 0
   },
@@ -94,7 +94,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -144,7 +144,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -197,14 +197,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 131,
     "downstreamCount": 0
   },
@@ -221,14 +221,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 132,
     "downstreamCount": 0
   },
@@ -247,14 +247,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 133,
     "downstreamCount": 0
   },
@@ -302,14 +302,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 135,
     "downstreamCount": 0
   },
@@ -352,7 +352,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -403,7 +403,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -578,14 +578,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 151,
     "downstreamCount": 0
   },
@@ -790,14 +790,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 174,
     "downstreamCount": 0
   },
@@ -845,14 +845,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 81,
     "downstreamCount": 1
   },
@@ -872,14 +872,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 176,
     "downstreamCount": 0
   },
@@ -925,7 +925,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -951,7 +951,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -977,14 +977,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 182,
     "downstreamCount": 0
   },
@@ -1055,14 +1055,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 187,
     "downstreamCount": 0
   },
@@ -2117,7 +2117,7 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -2332,14 +2332,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 236,
     "downstreamCount": 0
   },
@@ -2689,14 +2689,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 248,
     "downstreamCount": 0
   },
@@ -2896,7 +2896,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3103,7 +3103,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3451,14 +3451,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 60,
     "downstreamCount": 2
   },
@@ -3614,14 +3614,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 91,
     "downstreamCount": 1
   },
@@ -3747,7 +3747,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3773,7 +3773,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3829,14 +3829,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 276,
     "downstreamCount": 0
   },
@@ -3857,14 +3857,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 277,
     "downstreamCount": 0
   },
@@ -4761,7 +4761,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5136,7 +5136,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5593,7 +5593,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5696,14 +5696,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 371,
     "downstreamCount": 0
   },
@@ -5727,14 +5727,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 373,
     "downstreamCount": 0
   },
@@ -5756,14 +5756,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 374,
     "downstreamCount": 0
   },
@@ -5932,7 +5932,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6012,14 +6012,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 387,
     "downstreamCount": 0
   },
@@ -6091,7 +6091,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6117,7 +6117,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6459,7 +6459,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6536,14 +6536,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 68,
     "downstreamCount": 2
   },
@@ -6646,7 +6646,7 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6750,14 +6750,14 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": false,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 19,
     "downstreamCount": 8
   },
@@ -6804,7 +6804,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -7167,7 +7167,7 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -7220,14 +7220,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 114,
     "downstreamCount": 1
   },
@@ -7246,14 +7246,14 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 448,
     "downstreamCount": 0
   },
@@ -7272,7 +7272,7 @@
     "state": "Not Started",
     "steps": {
       "gen-types": false,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -7402,14 +7402,14 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 72,
     "downstreamCount": 2
   },
@@ -7428,7 +7428,7 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,

--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -1,32 +1,6 @@
 [
   {
     "group": "apigateway",
-    "kind": "APIGatewayAPI",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 113,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apigateway",
     "kind": "APIGatewayAPIConfig",
     "version": "v1beta1",
     "controllerType": "Terraform",
@@ -48,7 +22,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 114,
+    "sortOrder": 121,
     "downstreamCount": 0
   },
   {
@@ -74,7 +48,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 115,
+    "sortOrder": 122,
     "downstreamCount": 0
   },
   {
@@ -93,68 +67,15 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": true,
+      "identity-reference": false,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 116,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudquota",
-    "kind": "APIQuotaAdjusterSettings",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 117,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudquota",
-    "kind": "APIQuotaPreference",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 118,
+    "notes": "Missing _reference.go",
+    "sortOrder": 126,
     "downstreamCount": 0
   },
   {
@@ -181,7 +102,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 42,
+    "sortOrder": 45,
     "downstreamCount": 2
   },
   {
@@ -207,7 +128,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 119,
+    "sortOrder": 129,
     "downstreamCount": 0
   },
   {
@@ -255,7 +176,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 120,
+    "sortOrder": 130,
     "downstreamCount": 0
   },
   {
@@ -284,7 +205,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 121,
+    "sortOrder": 131,
     "downstreamCount": 0
   },
   {
@@ -308,7 +229,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 122,
+    "sortOrder": 132,
     "downstreamCount": 0
   },
   {
@@ -333,8 +254,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 123,
+    "notes": "Missing _reference.go",
+    "sortOrder": 133,
     "downstreamCount": 0
   },
   {
@@ -363,34 +284,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 43,
+    "sortOrder": 46,
     "downstreamCount": 2
-  },
-  {
-    "group": "alloydb",
-    "kind": "AlloyDBInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "AlloyDBCluster"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 124,
-    "downstreamCount": 0
   },
   {
     "group": "alloydb",
@@ -415,7 +310,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 125,
+    "sortOrder": 135,
     "downstreamCount": 0
   },
   {
@@ -439,86 +334,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 127,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeEndpointAttachment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ApigeeOrganization"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 128,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeEnvgroup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ApigeeOrganization"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 69,
-    "downstreamCount": 1
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeEnvgroupAttachment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ApigeeEnvgroup",
-      "ApigeeEnvironment"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 129,
+    "sortOrder": 137,
     "downstreamCount": 0
   },
   {
@@ -544,62 +360,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 44,
+    "sortOrder": 47,
     "downstreamCount": 2
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ApigeeOrganization",
-      "KMSCryptoKey"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 70,
-    "downstreamCount": 1
-  },
-  {
-    "group": "apigee",
-    "kind": "ApigeeInstanceAttachment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ApigeeEnvironment",
-      "ApigeeInstance"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 130,
-    "downstreamCount": 0
   },
   {
     "group": "apigee",
@@ -622,7 +384,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 131,
+    "sortOrder": 141,
     "downstreamCount": 0
   },
   {
@@ -649,7 +411,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 21,
+    "sortOrder": 23,
     "downstreamCount": 6
   },
   {
@@ -673,7 +435,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 132,
+    "sortOrder": 142,
     "downstreamCount": 0
   },
   {
@@ -697,7 +459,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 133,
+    "sortOrder": 143,
     "downstreamCount": 0
   },
   {
@@ -721,7 +483,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 134,
+    "sortOrder": 144,
     "downstreamCount": 0
   },
   {
@@ -747,7 +509,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 135,
+    "sortOrder": 145,
     "downstreamCount": 0
   },
   {
@@ -771,7 +533,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 136,
+    "sortOrder": 146,
     "downstreamCount": 0
   },
   {
@@ -797,33 +559,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 137,
-    "downstreamCount": 0
-  },
-  {
-    "group": "apphub",
-    "kind": "AppHubApplication",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 138,
+    "sortOrder": 147,
     "downstreamCount": 0
   },
   {
@@ -833,215 +569,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "KMSCryptoKey"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 141,
-    "downstreamCount": 0
-  },
-  {
-    "group": "asset",
-    "kind": "AssetFeed",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 142,
-    "downstreamCount": 0
-  },
-  {
-    "group": "asset",
-    "kind": "AssetSavedQuery",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 143,
-    "downstreamCount": 0
-  },
-  {
-    "group": "backupdr",
-    "kind": "BackupDRBackupPlan",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BackupDRBackupVault",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 71,
-    "downstreamCount": 1
-  },
-  {
-    "group": "backupdr",
-    "kind": "BackupDRBackupPlanAssociation",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BackupDRBackupPlan",
-      "ComputeInstance",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 145,
-    "downstreamCount": 0
-  },
-  {
-    "group": "backupdr",
-    "kind": "BackupDRBackupVault",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 45,
-    "downstreamCount": 2
-  },
-  {
-    "group": "backupdr",
-    "kind": "BackupDRManagementServer",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 146,
-    "downstreamCount": 0
-  },
-  {
-    "group": "batch",
-    "kind": "BatchJob",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project",
-      "PubSubTopic"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 147,
+    "sortOrder": 151,
     "downstreamCount": 0
   },
   {
@@ -1067,7 +612,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 149,
+    "sortOrder": 160,
     "downstreamCount": 0
   },
   {
@@ -1093,7 +638,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 150,
+    "sortOrder": 161,
     "downstreamCount": 0
   },
   {
@@ -1119,113 +664,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 151,
+    "sortOrder": 162,
     "downstreamCount": 0
-  },
-  {
-    "group": "bigquerybiglake",
-    "kind": "BigLakeTable",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 154,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigqueryanalyticshub",
-    "kind": "BigQueryAnalyticsHubDataExchange",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 72,
-    "downstreamCount": 1
-  },
-  {
-    "group": "bigqueryanalyticshub",
-    "kind": "BigQueryAnalyticsHubListing",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BigQueryAnalyticsHubDataExchange",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 155,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigqueryconnection",
-    "kind": "BigQueryConnectionConnection",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataprocCluster",
-      "MetastoreService",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 46,
-    "downstreamCount": 2
   },
   {
     "group": "bigquerydatapolicy",
@@ -1250,37 +690,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 157,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigquerydatatransfer",
-    "kind": "BigQueryDataTransferConfig",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project",
-      "PubSubSubscription",
-      "PubSubTopic"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 158,
+    "sortOrder": 169,
     "downstreamCount": 0
   },
   {
@@ -1308,7 +718,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 29,
+    "sortOrder": 30,
     "downstreamCount": 4
   },
   {
@@ -1333,8 +743,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 159,
+    "notes": "Missing _reference.go",
+    "sortOrder": 171,
     "downstreamCount": 0
   },
   {
@@ -1362,35 +772,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 160,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigqueryreservation",
-    "kind": "BigQueryReservationAssignment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BigQueryReservationReservation",
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 161,
+    "sortOrder": 172,
     "downstreamCount": 0
   },
   {
@@ -1415,35 +797,9 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 162,
+    "notes": "Missing _reference.go",
+    "sortOrder": 174,
     "downstreamCount": 0
-  },
-  {
-    "group": "bigqueryreservation",
-    "kind": "BigQueryReservationReservation",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 73,
-    "downstreamCount": 1
   },
   {
     "group": "bigquery",
@@ -1469,7 +825,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 163,
+    "sortOrder": 175,
     "downstreamCount": 0
   },
   {
@@ -1497,7 +853,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 74,
+    "sortOrder": 81,
     "downstreamCount": 1
   },
   {
@@ -1516,15 +872,15 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": true,
+      "identity-reference": false,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 164,
+    "notes": "Missing _reference.go",
+    "sortOrder": 176,
     "downstreamCount": 0
   },
   {
@@ -1551,7 +907,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 167,
+    "sortOrder": 179,
     "downstreamCount": 0
   },
   {
@@ -1582,58 +938,6 @@
   },
   {
     "group": "bigtable",
-    "kind": "BigtableLogicalView",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BigtableInstance"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 168,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigtable",
-    "kind": "BigtableMaterializedView",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "BigtableInstance"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 169,
-    "downstreamCount": 0
-  },
-  {
-    "group": "bigtable",
     "kind": "BigtableTable",
     "version": "v1beta1",
     "controllerType": "Terraform",
@@ -1655,7 +959,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 47,
+    "sortOrder": 50,
     "downstreamCount": 2
   },
   {
@@ -1680,8 +984,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 170,
+    "notes": "Missing _reference.go",
+    "sortOrder": 182,
     "downstreamCount": 0
   },
   {
@@ -1707,7 +1011,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 171,
+    "sortOrder": 183,
     "downstreamCount": 0
   },
   {
@@ -1733,7 +1037,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 172,
+    "sortOrder": 185,
     "downstreamCount": 0
   },
   {
@@ -1758,8 +1062,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 173,
+    "notes": "Missing _reference.go",
+    "sortOrder": 187,
     "downstreamCount": 0
   },
   {
@@ -1785,7 +1089,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 175,
+    "sortOrder": 189,
     "downstreamCount": 0
   },
   {
@@ -1811,33 +1115,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 176,
-    "downstreamCount": 0
-  },
-  {
-    "group": "certificatemanager",
-    "kind": "CertificateManagerDNSAuthorization",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 177,
+    "sortOrder": 190,
     "downstreamCount": 0
   },
   {
@@ -1863,7 +1141,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 178,
+    "sortOrder": 192,
     "downstreamCount": 0
   },
   {
@@ -1887,7 +1165,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 179,
+    "sortOrder": 193,
     "downstreamCount": 0
   },
   {
@@ -1913,7 +1191,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 180,
+    "sortOrder": 194,
     "downstreamCount": 0
   },
   {
@@ -1941,60 +1219,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 181,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudbuild",
-    "kind": "CloudBuildWorkerPool",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 182,
-    "downstreamCount": 0
-  },
-  {
-    "group": "clouddeploy",
-    "kind": "CloudDeployDeliveryPipeline",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 186,
+    "sortOrder": 196,
     "downstreamCount": 0
   },
   {
@@ -2020,7 +1245,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 189,
+    "sortOrder": 203,
     "downstreamCount": 0
   },
   {
@@ -2047,7 +1272,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 190,
+    "sortOrder": 204,
     "downstreamCount": 0
   },
   {
@@ -2074,7 +1299,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 191,
+    "sortOrder": 205,
     "downstreamCount": 0
   },
   {
@@ -2098,7 +1323,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 192,
+    "sortOrder": 206,
     "downstreamCount": 0
   },
   {
@@ -2122,57 +1347,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 193,
-    "downstreamCount": 0
-  },
-  {
-    "group": "cloudidentity",
-    "kind": "CloudIdentityGroup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 77,
-    "downstreamCount": 1
-  },
-  {
-    "group": "cloudidentity",
-    "kind": "CloudIdentityMembership",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "CloudIdentityGroup"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 194,
+    "sortOrder": 207,
     "downstreamCount": 0
   },
   {
@@ -2198,93 +1373,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 195,
-    "downstreamCount": 0
-  },
-  {
-    "group": "colab",
-    "kind": "ColabRuntime",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ColabRuntimeTemplate",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 196,
-    "downstreamCount": 0
-  },
-  {
-    "group": "colab",
-    "kind": "ColabRuntimeTemplate",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 78,
-    "downstreamCount": 1
-  },
-  {
-    "group": "composer",
-    "kind": "ComposerEnvironment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project",
-      "StorageBucket"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 197,
+    "sortOrder": 209,
     "downstreamCount": 0
   },
   {
@@ -2311,7 +1400,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 48,
+    "sortOrder": 52,
     "downstreamCount": 2
   },
   {
@@ -2337,7 +1426,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 198,
+    "sortOrder": 213,
     "downstreamCount": 0
   },
   {
@@ -2363,7 +1452,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 18,
+    "sortOrder": 20,
     "downstreamCount": 7
   },
   {
@@ -2390,7 +1479,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 199,
+    "sortOrder": 214,
     "downstreamCount": 0
   },
   {
@@ -2448,7 +1537,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 200,
+    "sortOrder": 215,
     "downstreamCount": 0
   },
   {
@@ -2477,7 +1566,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 456,
+    "sortOrder": 495,
     "downstreamCount": 4
   },
   {
@@ -2504,7 +1593,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 453,
+    "sortOrder": 496,
     "downstreamCount": 0
   },
   {
@@ -2528,7 +1617,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 201,
+    "sortOrder": 216,
     "downstreamCount": 0
   },
   {
@@ -2554,7 +1643,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 202,
+    "sortOrder": 217,
     "downstreamCount": 0
   },
   {
@@ -2580,7 +1669,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 30,
+    "sortOrder": 31,
     "downstreamCount": 4
   },
   {
@@ -2606,33 +1695,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 203,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeFirewallPolicyRule",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeFirewallPolicy"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 204,
+    "sortOrder": 218,
     "downstreamCount": 0
   },
   {
@@ -2669,7 +1732,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 79,
+    "sortOrder": 86,
     "downstreamCount": 1
   },
   {
@@ -2695,7 +1758,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 205,
+    "sortOrder": 221,
     "downstreamCount": 0
   },
   {
@@ -2721,7 +1784,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 206,
+    "sortOrder": 222,
     "downstreamCount": 0
   },
   {
@@ -2769,7 +1832,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 207,
+    "sortOrder": 223,
     "downstreamCount": 0
   },
   {
@@ -2792,7 +1855,7 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
+    "notes": "Missing _reference.go",
     "sortOrder": 12,
     "downstreamCount": 12
   },
@@ -2820,7 +1883,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 454,
+    "sortOrder": 494,
     "downstreamCount": 4
   },
   {
@@ -2850,7 +1913,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 31,
+    "sortOrder": 32,
     "downstreamCount": 4
   },
   {
@@ -2905,7 +1968,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 80,
+    "sortOrder": 87,
     "downstreamCount": 1
   },
   {
@@ -2931,7 +1994,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 208,
+    "sortOrder": 224,
     "downstreamCount": 0
   },
   {
@@ -2960,7 +2023,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 19,
+    "sortOrder": 21,
     "downstreamCount": 7
   },
   {
@@ -2986,7 +2049,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 32,
+    "sortOrder": 33,
     "downstreamCount": 4
   },
   {
@@ -3012,7 +2075,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 210,
+    "sortOrder": 226,
     "downstreamCount": 0
   },
   {
@@ -3038,7 +2101,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 211,
+    "sortOrder": 227,
     "downstreamCount": 0
   },
   {
@@ -3063,60 +2126,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 6,
-    "downstreamCount": 97
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeNetworkAttachment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 212,
-    "downstreamCount": 0
-  },
-  {
-    "group": "compute",
-    "kind": "ComputeNetworkEdgeSecurityService",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeSecurityPolicy",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 213,
-    "downstreamCount": 0
+    "downstreamCount": 101
   },
   {
     "group": "compute",
@@ -3143,7 +2153,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 214,
+    "sortOrder": 230,
     "downstreamCount": 0
   },
   {
@@ -3196,7 +2206,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 215,
+    "sortOrder": 231,
     "downstreamCount": 0
   },
   {
@@ -3223,7 +2233,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 216,
+    "sortOrder": 232,
     "downstreamCount": 0
   },
   {
@@ -3250,7 +2260,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 217,
+    "sortOrder": 233,
     "downstreamCount": 0
   },
   {
@@ -3276,7 +2286,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 218,
+    "sortOrder": 234,
     "downstreamCount": 0
   },
   {
@@ -3303,7 +2313,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 219,
+    "sortOrder": 235,
     "downstreamCount": 0
   },
   {
@@ -3329,8 +2339,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 220,
+    "notes": "Missing _reference.go",
+    "sortOrder": 236,
     "downstreamCount": 0
   },
   {
@@ -3354,7 +2364,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 81,
+    "sortOrder": 88,
     "downstreamCount": 1
   },
   {
@@ -3378,7 +2388,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 221,
+    "sortOrder": 237,
     "downstreamCount": 0
   },
   {
@@ -3402,7 +2412,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 222,
+    "sortOrder": 238,
     "downstreamCount": 0
   },
   {
@@ -3426,7 +2436,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 223,
+    "sortOrder": 239,
     "downstreamCount": 0
   },
   {
@@ -3452,7 +2462,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 224,
+    "sortOrder": 240,
     "downstreamCount": 0
   },
   {
@@ -3479,7 +2489,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 225,
+    "sortOrder": 241,
     "downstreamCount": 0
   },
   {
@@ -3503,7 +2513,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 226,
+    "sortOrder": 242,
     "downstreamCount": 0
   },
   {
@@ -3529,7 +2539,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 227,
+    "sortOrder": 243,
     "downstreamCount": 0
   },
   {
@@ -3556,7 +2566,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 455,
+    "sortOrder": 493,
     "downstreamCount": 0
   },
   {
@@ -3584,7 +2594,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 228,
+    "sortOrder": 244,
     "downstreamCount": 0
   },
   {
@@ -3610,7 +2620,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 229,
+    "sortOrder": 245,
     "downstreamCount": 0
   },
   {
@@ -3636,7 +2646,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 230,
+    "sortOrder": 246,
     "downstreamCount": 0
   },
   {
@@ -3646,21 +2656,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
-    "dependencies": [],
-    "state": "Not Started",
+    "dependencies": [
+      "Project"
+    ],
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 231,
+    "sortOrder": 247,
     "downstreamCount": 0
   },
   {
@@ -3684,7 +2697,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 232,
+    "sortOrder": 248,
     "downstreamCount": 0
   },
   {
@@ -3710,7 +2723,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 233,
+    "sortOrder": 249,
     "downstreamCount": 0
   },
   {
@@ -3736,7 +2749,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 22,
+    "sortOrder": 24,
     "downstreamCount": 6
   },
   {
@@ -3765,7 +2778,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 82,
+    "sortOrder": 89,
     "downstreamCount": 1
   },
   {
@@ -3792,7 +2805,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 234,
+    "sortOrder": 250,
     "downstreamCount": 0
   },
   {
@@ -3819,7 +2832,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 235,
+    "sortOrder": 251,
     "downstreamCount": 0
   },
   {
@@ -3843,7 +2856,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 236,
+    "sortOrder": 252,
     "downstreamCount": 0
   },
   {
@@ -3867,7 +2880,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 33,
+    "sortOrder": 34,
     "downstreamCount": 4
   },
   {
@@ -3917,7 +2930,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 49,
+    "sortOrder": 53,
     "downstreamCount": 2
   },
   {
@@ -3941,7 +2954,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 237,
+    "sortOrder": 253,
     "downstreamCount": 0
   },
   {
@@ -3967,7 +2980,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 238,
+    "sortOrder": 254,
     "downstreamCount": 0
   },
   {
@@ -3993,7 +3006,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 34,
+    "sortOrder": 35,
     "downstreamCount": 4
   },
   {
@@ -4045,7 +3058,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 50,
+    "sortOrder": 54,
     "downstreamCount": 2
   },
   {
@@ -4071,7 +3084,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 51,
+    "sortOrder": 55,
     "downstreamCount": 2
   },
   {
@@ -4098,7 +3111,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 52,
+    "sortOrder": 56,
     "downstreamCount": 2
   },
   {
@@ -4126,7 +3139,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 239,
+    "sortOrder": 255,
     "downstreamCount": 0
   },
   {
@@ -4153,7 +3166,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 240,
+    "sortOrder": 256,
     "downstreamCount": 0
   },
   {
@@ -4180,7 +3193,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 53,
+    "sortOrder": 57,
     "downstreamCount": 2
   },
   {
@@ -4207,7 +3220,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 54,
+    "sortOrder": 58,
     "downstreamCount": 2
   },
   {
@@ -4233,7 +3246,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 25,
+    "sortOrder": 26,
     "downstreamCount": 5
   },
   {
@@ -4260,7 +3273,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 26,
+    "sortOrder": 27,
     "downstreamCount": 5
   },
   {
@@ -4287,7 +3300,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 38,
+    "sortOrder": 39,
     "downstreamCount": 3
   },
   {
@@ -4315,7 +3328,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 55,
+    "sortOrder": 59,
     "downstreamCount": 2
   },
   {
@@ -4342,7 +3355,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 241,
+    "sortOrder": 257,
     "downstreamCount": 0
   },
   {
@@ -4366,7 +3379,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 243,
+    "sortOrder": 259,
     "downstreamCount": 0
   },
   {
@@ -4392,7 +3405,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 244,
+    "sortOrder": 260,
     "downstreamCount": 0
   },
   {
@@ -4418,7 +3431,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 245,
+    "sortOrder": 261,
     "downstreamCount": 0
   },
   {
@@ -4445,8 +3458,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 56,
+    "notes": "Missing _reference.go",
+    "sortOrder": 60,
     "downstreamCount": 2
   },
   {
@@ -4475,7 +3488,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 246,
+    "sortOrder": 262,
     "downstreamCount": 0
   },
   {
@@ -4502,7 +3515,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 247,
+    "sortOrder": 263,
     "downstreamCount": 0
   },
   {
@@ -4528,7 +3541,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 83,
+    "sortOrder": 90,
     "downstreamCount": 1
   },
   {
@@ -4556,7 +3569,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 248,
+    "sortOrder": 264,
     "downstreamCount": 0
   },
   {
@@ -4582,7 +3595,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 249,
+    "sortOrder": 265,
     "downstreamCount": 0
   },
   {
@@ -4592,23 +3605,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 84,
+    "notes": "Missing _reference.go",
+    "sortOrder": 91,
     "downstreamCount": 1
   },
   {
@@ -4618,23 +3632,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 250,
+    "sortOrder": 266,
     "downstreamCount": 0
   },
   {
@@ -4662,7 +3677,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 251,
+    "sortOrder": 267,
     "downstreamCount": 0
   },
   {
@@ -4688,7 +3703,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 252,
+    "sortOrder": 268,
     "downstreamCount": 0
   },
   {
@@ -4714,60 +3729,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 253,
+    "sortOrder": 269,
     "downstreamCount": 0
-  },
-  {
-    "group": "datacatalog",
-    "kind": "DataCatalogEntry",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataCatalogEntryGroup"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 85,
-    "downstreamCount": 1
-  },
-  {
-    "group": "datacatalog",
-    "kind": "DataCatalogEntryGroup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 57,
-    "downstreamCount": 2
   },
   {
     "group": "datacatalog",
@@ -4792,59 +3755,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 254,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datacatalog",
-    "kind": "DataCatalogTag",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataCatalogEntry"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 255,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datacatalog",
-    "kind": "DataCatalogTagTemplate",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 256,
+    "sortOrder": 270,
     "downstreamCount": 0
   },
   {
@@ -4870,7 +3781,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 86,
+    "sortOrder": 93,
     "downstreamCount": 1
   },
   {
@@ -4897,7 +3808,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 257,
+    "sortOrder": 273,
     "downstreamCount": 0
   },
   {
@@ -4926,7 +3837,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 258,
+    "sortOrder": 276,
     "downstreamCount": 0
   },
   {
@@ -4953,169 +3864,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 259,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataform",
-    "kind": "DataformRepository",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "IAMServiceAccount",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 260,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataplex",
-    "kind": "DataplexEntryGroup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 261,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataplex",
-    "kind": "DataplexEntryType",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 262,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataplex",
-    "kind": "DataplexLake",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "Service"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 58,
-    "downstreamCount": 2
-  },
-  {
-    "group": "dataplex",
-    "kind": "DataplexTask",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataplexLake",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 263,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataplex",
-    "kind": "DataplexZone",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataplexLake"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 264,
+    "sortOrder": 277,
     "downstreamCount": 0
   },
   {
@@ -5141,37 +3891,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 265,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dataproc",
-    "kind": "DataprocBatch",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DataprocCluster",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project",
-      "StorageBucket"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 266,
+    "sortOrder": 283,
     "downstreamCount": 0
   },
   {
@@ -5201,34 +3921,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 35,
-    "downstreamCount": 4
-  },
-  {
-    "group": "dataproc",
-    "kind": "DataprocJob",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 267,
-    "downstreamCount": 0
+    "sortOrder": 25,
+    "downstreamCount": 6
   },
   {
     "group": "dataproc",
@@ -5257,7 +3951,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 268,
+    "sortOrder": 288,
     "downstreamCount": 0
   },
   {
@@ -5283,88 +3977,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 269,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datastream",
-    "kind": "DatastreamConnectionProfile",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DatastreamPrivateConnection",
-      "Project",
-      "SecretManagerSecret"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 270,
-    "downstreamCount": 0
-  },
-  {
-    "group": "datastream",
-    "kind": "DatastreamPrivateConnection",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 59,
-    "downstreamCount": 2
-  },
-  {
-    "group": "datastream",
-    "kind": "DatastreamRoute",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DatastreamPrivateConnection"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 271,
+    "sortOrder": 289,
     "downstreamCount": 0
   },
   {
@@ -5390,7 +4003,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 272,
+    "sortOrder": 292,
     "downstreamCount": 0
   },
   {
@@ -5416,7 +4029,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 273,
+    "sortOrder": 293,
     "downstreamCount": 0
   },
   {
@@ -5440,7 +4053,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 274,
+    "sortOrder": 296,
     "downstreamCount": 0
   },
   {
@@ -5466,7 +4079,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 275,
+    "sortOrder": 297,
     "downstreamCount": 0
   },
   {
@@ -5490,7 +4103,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 276,
+    "sortOrder": 298,
     "downstreamCount": 0
   },
   {
@@ -5514,7 +4127,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 277,
+    "sortOrder": 299,
     "downstreamCount": 0
   },
   {
@@ -5538,7 +4151,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 278,
+    "sortOrder": 300,
     "downstreamCount": 0
   },
   {
@@ -5562,7 +4175,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 279,
+    "sortOrder": 301,
     "downstreamCount": 0
   },
   {
@@ -5586,7 +4199,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 280,
+    "sortOrder": 302,
     "downstreamCount": 0
   },
   {
@@ -5612,7 +4225,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 281,
+    "sortOrder": 303,
     "downstreamCount": 0
   },
   {
@@ -5638,7 +4251,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 282,
+    "sortOrder": 304,
     "downstreamCount": 0
   },
   {
@@ -5664,61 +4277,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 283,
+    "sortOrder": 305,
     "downstreamCount": 0
-  },
-  {
-    "group": "discoveryengine",
-    "kind": "DiscoveryEngineDataStore",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 87,
-    "downstreamCount": 1
-  },
-  {
-    "group": "documentai",
-    "kind": "DocumentAIProcessor",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 88,
-    "downstreamCount": 1
   },
   {
     "group": "documentai",
@@ -5741,34 +4301,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 286,
-    "downstreamCount": 0
-  },
-  {
-    "group": "documentai",
-    "kind": "DocumentAIProcessorVersion",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "DocumentAIProcessor",
-      "KMSCryptoKey"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 287,
+    "sortOrder": 310,
     "downstreamCount": 0
   },
   {
@@ -5795,7 +4328,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 60,
+    "sortOrder": 64,
     "downstreamCount": 2
   },
   {
@@ -5823,7 +4356,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 289,
+    "sortOrder": 313,
     "downstreamCount": 0
   },
   {
@@ -5850,7 +4383,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 290,
+    "sortOrder": 314,
     "downstreamCount": 0
   },
   {
@@ -5876,7 +4409,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 89,
+    "sortOrder": 96,
     "downstreamCount": 1
   },
   {
@@ -5903,88 +4436,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 291,
-    "downstreamCount": 0
-  },
-  {
-    "group": "essentialcontacts",
-    "kind": "EssentialContactsContact",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 292,
-    "downstreamCount": 0
-  },
-  {
-    "group": "eventarc",
-    "kind": "EventarcChannel",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 90,
-    "downstreamCount": 1
-  },
-  {
-    "group": "eventarc",
-    "kind": "EventarcGoogleChannelConfig",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 293,
+    "sortOrder": 315,
     "downstreamCount": 0
   },
   {
@@ -5998,7 +4450,6 @@
     ],
     "dependencies": [
       "ComputeNetwork",
-      "EventarcChannel",
       "IAMServiceAccount",
       "Project",
       "Service"
@@ -6014,7 +4465,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 294,
+    "sortOrder": 320,
     "downstreamCount": 0
   },
   {
@@ -6040,7 +4491,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 295,
+    "sortOrder": 321,
     "downstreamCount": 0
   },
   {
@@ -6067,7 +4518,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 296,
+    "sortOrder": 322,
     "downstreamCount": 0
   },
   {
@@ -6093,7 +4544,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 297,
+    "sortOrder": 323,
     "downstreamCount": 0
   },
   {
@@ -6119,7 +4570,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 298,
+    "sortOrder": 324,
     "downstreamCount": 0
   },
   {
@@ -6145,7 +4596,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 299,
+    "sortOrder": 325,
     "downstreamCount": 0
   },
   {
@@ -6169,7 +4620,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 300,
+    "sortOrder": 326,
     "downstreamCount": 0
   },
   {
@@ -6195,7 +4646,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 301,
+    "sortOrder": 327,
     "downstreamCount": 0
   },
   {
@@ -6219,7 +4670,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 91,
+    "sortOrder": 97,
     "downstreamCount": 1
   },
   {
@@ -6245,7 +4696,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 302,
+    "sortOrder": 328,
     "downstreamCount": 0
   },
   {
@@ -6269,85 +4720,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 303,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firestore",
-    "kind": "FirestoreDatabase",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 39,
-    "downstreamCount": 3
-  },
-  {
-    "group": "firestore",
-    "kind": "FirestoreDocument",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "FirestoreDatabase"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 305,
-    "downstreamCount": 0
-  },
-  {
-    "group": "firestore",
-    "kind": "FirestoreField",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "FirestoreDatabase"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 306,
+    "sortOrder": 329,
     "downstreamCount": 0
   },
   {
@@ -6357,21 +4730,22 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 307,
+    "sortOrder": 333,
     "downstreamCount": 0
   },
   {
@@ -6396,114 +4770,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 1,
-    "downstreamCount": 298
-  },
-  {
-    "group": "gkebackup",
-    "kind": "GKEBackupBackup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "GKEBackupBackupPlan"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 92,
-    "downstreamCount": 1
-  },
-  {
-    "group": "gkebackup",
-    "kind": "GKEBackupBackupPlan",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 40,
-    "downstreamCount": 3
-  },
-  {
-    "group": "gkebackup",
-    "kind": "GKEBackupRestore",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "GKEBackupBackup",
-      "GKEBackupRestorePlan"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 308,
-    "downstreamCount": 0
-  },
-  {
-    "group": "gkebackup",
-    "kind": "GKEBackupRestorePlan",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "GKEBackupBackupPlan",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 93,
-    "downstreamCount": 1
+    "downstreamCount": 337
   },
   {
     "group": "gkehub",
@@ -6528,37 +4795,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 94,
+    "sortOrder": 100,
     "downstreamCount": 1
-  },
-  {
-    "group": "gkehub",
-    "kind": "GKEHubFeatureMembership",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "GKEHubFeature",
-      "GKEHubMembership",
-      "IAMServiceAccount",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 309,
-    "downstreamCount": 0
   },
   {
     "group": "gkehub",
@@ -6581,8 +4819,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 95,
-    "downstreamCount": 1
+    "sortOrder": 66,
+    "downstreamCount": 2
   },
   {
     "group": "healthcare",
@@ -6605,7 +4843,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 310,
+    "sortOrder": 339,
     "downstreamCount": 0
   },
   {
@@ -6629,7 +4867,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 311,
+    "sortOrder": 340,
     "downstreamCount": 0
   },
   {
@@ -6655,7 +4893,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 312,
+    "sortOrder": 341,
     "downstreamCount": 0
   },
   {
@@ -6679,7 +4917,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 313,
+    "sortOrder": 342,
     "downstreamCount": 0
   },
   {
@@ -6703,7 +4941,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 314,
+    "sortOrder": 343,
     "downstreamCount": 0
   },
   {
@@ -6729,7 +4967,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 315,
+    "sortOrder": 344,
     "downstreamCount": 0
   },
   {
@@ -6753,7 +4991,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 316,
+    "sortOrder": 345,
     "downstreamCount": 0
   },
   {
@@ -6777,7 +5015,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 317,
+    "sortOrder": 346,
     "downstreamCount": 0
   },
   {
@@ -6791,9 +5029,7 @@
       "IAMPartialPolicy"
     ],
     "dependencies": [
-      "BigQueryConnectionConnection",
       "IAMServiceAccount",
-      "SQLInstance",
       "ServiceIdentity"
     ],
     "state": "Completed",
@@ -6807,7 +5043,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 319,
+    "sortOrder": 348,
     "downstreamCount": 0
   },
   {
@@ -6831,7 +5067,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 320,
+    "sortOrder": 349,
     "downstreamCount": 0
   },
   {
@@ -6844,9 +5080,7 @@
       "IAMPolicyMember"
     ],
     "dependencies": [
-      "BigQueryConnectionConnection",
       "IAMServiceAccount",
-      "SQLInstance",
       "ServiceIdentity"
     ],
     "state": "Not Started",
@@ -6860,7 +5094,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 321,
+    "sortOrder": 350,
     "downstreamCount": 0
   },
   {
@@ -6885,7 +5119,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 7,
-    "downstreamCount": 43
+    "downstreamCount": 49
   },
   {
     "group": "iam",
@@ -6910,7 +5144,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 322,
+    "sortOrder": 351,
     "downstreamCount": 0
   },
   {
@@ -6934,7 +5168,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 96,
+    "sortOrder": 101,
     "downstreamCount": 1
   },
   {
@@ -6960,7 +5194,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 323,
+    "sortOrder": 352,
     "downstreamCount": 0
   },
   {
@@ -6986,7 +5220,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 97,
+    "sortOrder": 102,
     "downstreamCount": 1
   },
   {
@@ -7013,7 +5247,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 324,
+    "sortOrder": 353,
     "downstreamCount": 0
   },
   {
@@ -7037,7 +5271,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 98,
+    "sortOrder": 103,
     "downstreamCount": 1
   },
   {
@@ -7063,34 +5297,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 325,
-    "downstreamCount": 0
-  },
-  {
-    "group": "iap",
-    "kind": "IAPSettings",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 326,
+    "sortOrder": 354,
     "downstreamCount": 0
   },
   {
@@ -7116,7 +5323,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 327,
+    "sortOrder": 356,
     "downstreamCount": 0
   },
   {
@@ -7142,7 +5349,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 328,
+    "sortOrder": 357,
     "downstreamCount": 0
   },
   {
@@ -7168,7 +5375,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 329,
+    "sortOrder": 358,
     "downstreamCount": 0
   },
   {
@@ -7192,7 +5399,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 330,
+    "sortOrder": 359,
     "downstreamCount": 0
   },
   {
@@ -7218,7 +5425,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 331,
+    "sortOrder": 360,
     "downstreamCount": 0
   },
   {
@@ -7242,7 +5449,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 99,
+    "sortOrder": 104,
     "downstreamCount": 1
   },
   {
@@ -7268,7 +5475,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 332,
+    "sortOrder": 361,
     "downstreamCount": 0
   },
   {
@@ -7294,7 +5501,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 333,
+    "sortOrder": 362,
     "downstreamCount": 0
   },
   {
@@ -7320,33 +5527,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 334,
-    "downstreamCount": 0
-  },
-  {
-    "group": "kms",
-    "kind": "KMSAutokeyConfig",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 335,
+    "sortOrder": 363,
     "downstreamCount": 0
   },
   {
@@ -7373,7 +5554,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 5,
-    "downstreamCount": 113
+    "downstreamCount": 122
   },
   {
     "group": "kms",
@@ -7396,59 +5577,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 336,
-    "downstreamCount": 0
-  },
-  {
-    "group": "kms",
-    "kind": "KMSImportJob",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSKeyRing"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 337,
-    "downstreamCount": 0
-  },
-  {
-    "group": "kms",
-    "kind": "KMSKeyHandle",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 338,
+    "sortOrder": 365,
     "downstreamCount": 0
   },
   {
@@ -7473,7 +5602,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 4,
-    "downstreamCount": 115
+    "downstreamCount": 124
   },
   {
     "group": "kms",
@@ -7496,7 +5625,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 339,
+    "sortOrder": 368,
     "downstreamCount": 0
   },
   {
@@ -7520,20 +5649,22 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 340,
+    "sortOrder": 369,
     "downstreamCount": 0
   },
   {
     "group": "logging",
-    "kind": "LoggingLink",
+    "kind": "LoggingLogBucket",
     "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
+    "controllerType": "DCL",
+    "defaultController": "DCL",
     "supportedControllers": [
+      "DCL",
       "Direct"
     ],
     "dependencies": [
-      "LoggingLogBucket"
+      "Folder",
+      "Project"
     ],
     "state": "Completed",
     "steps": {
@@ -7546,34 +5677,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 341,
-    "downstreamCount": 0
-  },
-  {
-    "group": "logging",
-    "kind": "LoggingLogBucket",
-    "version": "v1beta1",
-    "controllerType": "DCL",
-    "defaultController": "DCL",
-    "supportedControllers": [
-      "DCL"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 41,
+    "sortOrder": 43,
     "downstreamCount": 3
   },
   {
@@ -7599,35 +5703,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 342,
-    "downstreamCount": 0
-  },
-  {
-    "group": "logging",
-    "kind": "LoggingLogMetric",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "LoggingLogBucket",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 343,
+    "sortOrder": 371,
     "downstreamCount": 0
   },
   {
@@ -7657,8 +5734,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 344,
+    "notes": "Missing _reference.go",
+    "sortOrder": 373,
     "downstreamCount": 0
   },
   {
@@ -7668,25 +5745,26 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Folder",
       "Project",
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 345,
+    "notes": "Missing _reference.go",
+    "sortOrder": 374,
     "downstreamCount": 0
   },
   {
@@ -7712,62 +5790,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 346,
-    "downstreamCount": 0
-  },
-  {
-    "group": "managedkafka",
-    "kind": "ManagedKafkaCluster",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 61,
-    "downstreamCount": 2
-  },
-  {
-    "group": "managedkafka",
-    "kind": "ManagedKafkaTopic",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ManagedKafkaCluster",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 348,
+    "sortOrder": 375,
     "downstreamCount": 0
   },
   {
@@ -7793,115 +5816,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 349,
+    "sortOrder": 378,
     "downstreamCount": 0
-  },
-  {
-    "group": "memorystore",
-    "kind": "MemorystoreInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 350,
-    "downstreamCount": 0
-  },
-  {
-    "group": "metastore",
-    "kind": "MetastoreBackup",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "MetastoreService"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 351,
-    "downstreamCount": 0
-  },
-  {
-    "group": "metastore",
-    "kind": "MetastoreFederation",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 352,
-    "downstreamCount": 0
-  },
-  {
-    "group": "metastore",
-    "kind": "MetastoreService",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 36,
-    "downstreamCount": 4
   },
   {
     "group": "monitoring",
@@ -7924,35 +5840,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 100,
+    "sortOrder": 105,
     "downstreamCount": 1
-  },
-  {
-    "group": "monitoring",
-    "kind": "MonitoringDashboard",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "MonitoringAlertPolicy",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 353,
-    "downstreamCount": 0
   },
   {
     "group": "monitoring",
@@ -7977,7 +5866,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 101,
+    "sortOrder": 106,
     "downstreamCount": 1
   },
   {
@@ -8003,7 +5892,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 354,
+    "sortOrder": 383,
     "downstreamCount": 0
   },
   {
@@ -8027,7 +5916,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 355,
+    "sortOrder": 384,
     "downstreamCount": 0
   },
   {
@@ -8051,7 +5940,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 356,
+    "sortOrder": 385,
     "downstreamCount": 0
   },
   {
@@ -8077,7 +5966,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 102,
+    "sortOrder": 107,
     "downstreamCount": 1
   },
   {
@@ -8104,7 +5993,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 357,
+    "sortOrder": 386,
     "downstreamCount": 0
   },
   {
@@ -8130,34 +6019,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 358,
-    "downstreamCount": 0
-  },
-  {
-    "group": "netapp",
-    "kind": "NetAppBackupPolicy",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 359,
+    "notes": "Missing _reference.go",
+    "sortOrder": 387,
     "downstreamCount": 0
   },
   {
@@ -8183,62 +6046,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 103,
+    "sortOrder": 108,
     "downstreamCount": 1
-  },
-  {
-    "group": "networkconnectivity",
-    "kind": "NetworkConnectivityInternalRange",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 361,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkconnectivity",
-    "kind": "NetworkConnectivityServiceConnectionPolicy",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 362,
-    "downstreamCount": 0
   },
   {
     "group": "networkconnectivity",
@@ -8264,37 +6073,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 363,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkmanagement",
-    "kind": "NetworkManagementConnectivityTest",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeForwardingRule",
-      "ComputeInstance",
-      "ComputeNetwork",
-      "ContainerCluster",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 364,
+    "sortOrder": 393,
     "downstreamCount": 0
   },
   {
@@ -8320,7 +6099,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 365,
+    "sortOrder": 395,
     "downstreamCount": 0
   },
   {
@@ -8346,7 +6125,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 366,
+    "sortOrder": 397,
     "downstreamCount": 0
   },
   {
@@ -8372,7 +6151,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 367,
+    "sortOrder": 402,
     "downstreamCount": 0
   },
   {
@@ -8398,7 +6177,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 368,
+    "sortOrder": 403,
     "downstreamCount": 0
   },
   {
@@ -8424,7 +6203,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 369,
+    "sortOrder": 404,
     "downstreamCount": 0
   },
   {
@@ -8450,7 +6229,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 370,
+    "sortOrder": 405,
     "downstreamCount": 0
   },
   {
@@ -8476,7 +6255,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 371,
+    "sortOrder": 406,
     "downstreamCount": 0
   },
   {
@@ -8503,7 +6282,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 372,
+    "sortOrder": 407,
     "downstreamCount": 0
   },
   {
@@ -8529,7 +6308,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 373,
+    "sortOrder": 408,
     "downstreamCount": 0
   },
   {
@@ -8556,7 +6335,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 374,
+    "sortOrder": 409,
     "downstreamCount": 0
   },
   {
@@ -8582,34 +6361,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 376,
-    "downstreamCount": 0
-  },
-  {
-    "group": "networkservices",
-    "kind": "NetworkServicesServiceBinding",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "Service"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 377,
+    "sortOrder": 411,
     "downstreamCount": 0
   },
   {
@@ -8636,7 +6388,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 378,
+    "sortOrder": 413,
     "downstreamCount": 0
   },
   {
@@ -8663,62 +6415,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 379,
-    "downstreamCount": 0
-  },
-  {
-    "group": "notebooks",
-    "kind": "NotebookInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 380,
-    "downstreamCount": 0
-  },
-  {
-    "group": "notebooks",
-    "kind": "NotebooksEnvironment",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 381,
+    "sortOrder": 414,
     "downstreamCount": 0
   },
   {
@@ -8744,7 +6441,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 382,
+    "sortOrder": 417,
     "downstreamCount": 0
   },
   {
@@ -8770,7 +6467,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 383,
+    "sortOrder": 418,
     "downstreamCount": 0
   },
   {
@@ -8796,7 +6493,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 384,
+    "sortOrder": 419,
     "downstreamCount": 0
   },
   {
@@ -8820,86 +6517,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 385,
+    "sortOrder": 420,
     "downstreamCount": 0
-  },
-  {
-    "group": "orgpolicy",
-    "kind": "OrgPolicyCustomConstraint",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 386,
-    "downstreamCount": 0
-  },
-  {
-    "group": "orgpolicy",
-    "kind": "OrgPolicyPolicy",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 387,
-    "downstreamCount": 0
-  },
-  {
-    "group": "parametermanager",
-    "kind": "ParameterManagerParameter",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 104,
-    "downstreamCount": 1
   },
   {
     "group": "privateca",
@@ -8925,7 +6544,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 62,
+    "sortOrder": 68,
     "downstreamCount": 2
   },
   {
@@ -8954,7 +6573,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 389,
+    "sortOrder": 424,
     "downstreamCount": 0
   },
   {
@@ -8983,7 +6602,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 105,
+    "sortOrder": 111,
     "downstreamCount": 1
   },
   {
@@ -9009,35 +6628,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 106,
+    "sortOrder": 112,
     "downstreamCount": 1
-  },
-  {
-    "group": "privilegedaccessmanager",
-    "kind": "PrivilegedAccessManagerEntitlement",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Folder",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 390,
-    "downstreamCount": 0
   },
   {
     "group": "resourcemanager",
@@ -9063,7 +6655,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 3,
-    "downstreamCount": 292
+    "downstreamCount": 332
   },
   {
     "group": "pubsublite",
@@ -9088,7 +6680,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 391,
+    "sortOrder": 426,
     "downstreamCount": 0
   },
   {
@@ -9114,7 +6706,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 392,
+    "sortOrder": 427,
     "downstreamCount": 0
   },
   {
@@ -9140,7 +6732,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 393,
+    "sortOrder": 428,
     "downstreamCount": 0
   },
   {
@@ -9158,44 +6750,16 @@
     "state": "In Progress",
     "steps": {
       "gen-types": true,
-      "identity-reference": true,
+      "identity-reference": false,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": false,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 20,
-    "downstreamCount": 7
-  },
-  {
-    "group": "pubsub",
-    "kind": "PubSubSnapshot",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "PubSubSubscription",
-      "PubSubTopic"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 394,
-    "downstreamCount": 0
+    "notes": "Missing _reference.go",
+    "sortOrder": 19,
+    "downstreamCount": 8
   },
   {
     "group": "pubsub",
@@ -9221,7 +6785,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 63,
+    "sortOrder": 69,
     "downstreamCount": 2
   },
   {
@@ -9248,34 +6812,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 24,
-    "downstreamCount": 6
-  },
-  {
-    "group": "recaptchaenterprise",
-    "kind": "ReCAPTCHAEnterpriseFirewallPolicy",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 395,
-    "downstreamCount": 0
+    "sortOrder": 22,
+    "downstreamCount": 7
   },
   {
     "group": "recaptchaenterprise",
@@ -9300,34 +6838,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 396,
-    "downstreamCount": 0
-  },
-  {
-    "group": "redis",
-    "kind": "RedisCluster",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 397,
+    "sortOrder": 431,
     "downstreamCount": 0
   },
   {
@@ -9353,7 +6864,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 398,
+    "sortOrder": 433,
     "downstreamCount": 0
   },
   {
@@ -9379,7 +6890,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 399,
+    "sortOrder": 434,
     "downstreamCount": 0
   },
   {
@@ -9406,7 +6917,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 400,
+    "sortOrder": 435,
     "downstreamCount": 0
   },
   {
@@ -9436,7 +6947,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 401,
+    "sortOrder": 436,
     "downstreamCount": 0
   },
   {
@@ -9464,7 +6975,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 402,
+    "sortOrder": 437,
     "downstreamCount": 0
   },
   {
@@ -9476,9 +6987,7 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [
-      "SQLInstance"
-    ],
+    "dependencies": [],
     "state": "Not Started",
     "steps": {
       "gen-types": false,
@@ -9490,36 +6999,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 403,
+    "sortOrder": 438,
     "downstreamCount": 0
-  },
-  {
-    "group": "sql",
-    "kind": "SQLInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "KMSCryptoKey",
-      "StorageBucket"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 27,
-    "downstreamCount": 5
   },
   {
     "group": "sql",
@@ -9530,9 +7011,7 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [
-      "SQLInstance"
-    ],
+    "dependencies": [],
     "state": "Not Started",
     "steps": {
       "gen-types": false,
@@ -9544,7 +7023,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 404,
+    "sortOrder": 439,
     "downstreamCount": 0
   },
   {
@@ -9556,9 +7035,7 @@
     "supportedControllers": [
       "Terraform"
     ],
-    "dependencies": [
-      "SQLInstance"
-    ],
+    "dependencies": [],
     "state": "Not Started",
     "steps": {
       "gen-types": false,
@@ -9570,7 +7047,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 405,
+    "sortOrder": 440,
     "downstreamCount": 0
   },
   {
@@ -9597,7 +7074,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 64,
+    "sortOrder": 70,
     "downstreamCount": 2
   },
   {
@@ -9624,61 +7101,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 406,
-    "downstreamCount": 0
-  },
-  {
-    "group": "securesourcemanager",
-    "kind": "SecureSourceManagerInstance",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 107,
-    "downstreamCount": 1
-  },
-  {
-    "group": "securesourcemanager",
-    "kind": "SecureSourceManagerRepository",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "SecureSourceManagerInstance"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 407,
+    "sortOrder": 441,
     "downstreamCount": 0
   },
   {
@@ -9702,7 +7125,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 408,
+    "sortOrder": 445,
     "downstreamCount": 0
   },
   {
@@ -9726,7 +7149,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 409,
+    "sortOrder": 446,
     "downstreamCount": 0
   },
   {
@@ -9779,7 +7202,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 410,
+    "sortOrder": 447,
     "downstreamCount": 0
   },
   {
@@ -9804,8 +7227,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 108,
+    "notes": "Missing _reference.go",
+    "sortOrder": 114,
     "downstreamCount": 1
   },
   {
@@ -9830,8 +7253,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 411,
+    "notes": "Missing _reference.go",
+    "sortOrder": 448,
     "downstreamCount": 0
   },
   {
@@ -9857,7 +7280,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 65,
+    "sortOrder": 71,
     "downstreamCount": 2
   },
   {
@@ -9883,33 +7306,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 412,
-    "downstreamCount": 0
-  },
-  {
-    "group": "servicenetworking",
-    "kind": "ServiceNetworkingPeeredDNSDomain",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 413,
+    "sortOrder": 449,
     "downstreamCount": 0
   },
   {
@@ -9935,7 +7332,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 414,
+    "sortOrder": 451,
     "downstreamCount": 0
   },
   {
@@ -9961,34 +7358,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 415,
-    "downstreamCount": 0
-  },
-  {
-    "group": "spanner",
-    "kind": "SpannerBackupSchedule",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "SpannerDatabase"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 416,
+    "sortOrder": 452,
     "downstreamCount": 0
   },
   {
@@ -10015,7 +7385,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 109,
+    "sortOrder": 115,
     "downstreamCount": 1
   },
   {
@@ -10040,138 +7410,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 66,
+    "sortOrder": 72,
     "downstreamCount": 2
-  },
-  {
-    "group": "spanner",
-    "kind": "SpannerInstanceConfig",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 417,
-    "downstreamCount": 0
-  },
-  {
-    "group": "speech",
-    "kind": "SpeechCustomClass",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 418,
-    "downstreamCount": 0
-  },
-  {
-    "group": "speech",
-    "kind": "SpeechPhraseSet",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 419,
-    "downstreamCount": 0
-  },
-  {
-    "group": "speech",
-    "kind": "SpeechRecognizer",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 420,
-    "downstreamCount": 0
-  },
-  {
-    "group": "storage",
-    "kind": "StorageAnywhereCache",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "StorageBucket"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 421,
-    "downstreamCount": 0
   },
   {
     "group": "storage",
@@ -10197,7 +7437,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 8,
-    "downstreamCount": 37
+    "downstreamCount": 39
   },
   {
     "group": "storage",
@@ -10222,7 +7462,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 422,
+    "sortOrder": 459,
     "downstreamCount": 0
   },
   {
@@ -10248,34 +7488,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 423,
-    "downstreamCount": 0
-  },
-  {
-    "group": "storage",
-    "kind": "StorageFolder",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "StorageBucket"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 424,
+    "sortOrder": 460,
     "downstreamCount": 0
   },
   {
@@ -10301,7 +7514,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 425,
+    "sortOrder": 462,
     "downstreamCount": 0
   },
   {
@@ -10327,7 +7540,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 427,
+    "sortOrder": 464,
     "downstreamCount": 0
   },
   {
@@ -10353,7 +7566,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 428,
+    "sortOrder": 465,
     "downstreamCount": 0
   },
   {
@@ -10379,7 +7592,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 429,
+    "sortOrder": 466,
     "downstreamCount": 0
   },
   {
@@ -10405,7 +7618,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 430,
+    "sortOrder": 467,
     "downstreamCount": 0
   },
   {
@@ -10432,7 +7645,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "Missing _reference.go",
-    "sortOrder": 432,
+    "sortOrder": 469,
     "downstreamCount": 0
   },
   {
@@ -10459,7 +7672,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 433,
+    "sortOrder": 470,
     "downstreamCount": 0
   },
   {
@@ -10484,7 +7697,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 434,
+    "sortOrder": 471,
     "downstreamCount": 0
   },
   {
@@ -10509,194 +7722,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 67,
-    "downstreamCount": 2
-  },
-  {
-    "group": "cloudtasks",
-    "kind": "TasksQueue",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 435,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEngineExternalAccessRule",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "VMwareEngineExternalAddress",
-      "VMwareEngineNetworkPolicy"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 436,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEngineExternalAddress",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "VMwareEnginePrivateCloud"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 110,
-    "downstreamCount": 1
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEngineNetwork",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 28,
-    "downstreamCount": 5
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEngineNetworkPeering",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project",
-      "VMwareEngineNetwork"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 437,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEngineNetworkPolicy",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "VMwareEngineNetwork"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 111,
-    "downstreamCount": 1
-  },
-  {
-    "group": "vmwareengine",
-    "kind": "VMwareEnginePrivateCloud",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project",
-      "VMwareEngineNetwork"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 68,
+    "sortOrder": 73,
     "downstreamCount": 2
   },
   {
@@ -10723,7 +7749,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 438,
+    "sortOrder": 475,
     "downstreamCount": 0
   },
   {
@@ -10750,7 +7776,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 439,
+    "sortOrder": 477,
     "downstreamCount": 0
   },
   {
@@ -10778,34 +7804,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 440,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAIFeaturestore",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 441,
+    "sortOrder": 479,
     "downstreamCount": 0
   },
   {
@@ -10829,7 +7828,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 442,
+    "sortOrder": 482,
     "downstreamCount": 0
   },
   {
@@ -10853,7 +7852,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 443,
+    "sortOrder": 483,
     "downstreamCount": 0
   },
   {
@@ -10879,7 +7878,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 444,
+    "sortOrder": 484,
     "downstreamCount": 0
   },
   {
@@ -10905,34 +7904,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 445,
-    "downstreamCount": 0
-  },
-  {
-    "group": "vertexai",
-    "kind": "VertexAIMetadataStore",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 446,
+    "sortOrder": 485,
     "downstreamCount": 0
   },
   {
@@ -10958,139 +7930,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 447,
-    "downstreamCount": 0
-  },
-  {
-    "group": "workflowexecutions",
-    "kind": "WorkflowsExecution",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 448,
-    "downstreamCount": 0
-  },
-  {
-    "group": "workflows",
-    "kind": "WorkflowsWorkflow",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "IAMServiceAccount",
-      "KMSCryptoKey",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 449,
-    "downstreamCount": 0
-  },
-  {
-    "group": "workstations",
-    "kind": "Workstation",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 450,
-    "downstreamCount": 0
-  },
-  {
-    "group": "workstations",
-    "kind": "WorkstationCluster",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "ComputeNetwork",
-      "Project"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 451,
-    "downstreamCount": 0
-  },
-  {
-    "group": "workstations",
-    "kind": "WorkstationConfig",
-    "version": "v1beta1",
-    "controllerType": "Direct",
-    "defaultController": "Direct",
-    "supportedControllers": [
-      "Direct"
-    ],
-    "dependencies": [
-      "IAMServiceAccount",
-      "KMSCryptoKey"
-    ],
-    "state": "Completed",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": true,
-      "mapper-fuzzer": true,
-      "mocks": true,
-      "controller": true,
-      "tests": true
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 452,
+    "sortOrder": 487,
     "downstreamCount": 0
   }
 ]

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -243,12 +243,27 @@ def parse_data(config_file_path, apis_dir, crds_dir):
         if kind in implemented_types:
             has_reference = False
             for filepath in implemented_types[kind]:
-                ref_filepath = filepath.replace("_types.go", "_reference.go")
-                if os.path.exists(ref_filepath):
-                    has_reference = True
+                dirpath = os.path.dirname(filepath)
+                filename = os.path.basename(filepath)
+                prefix = filename.replace("_types.go", "")
+                
+                possible_names = [
+                    f"{prefix}_reference.go",
+                    f"{kind.lower()}_reference.go",
+                ]
+                
+                for name in possible_names:
+                    if os.path.exists(os.path.join(dirpath, name)):
+                        has_reference = True
+                        break
+                if has_reference:
                     break
             
-            if not has_reference:
+            if has_reference:
+                res['steps']['identity-reference'] = True
+                if res.get('notes') == 'Missing _reference.go':
+                    res['notes'] = ''
+            else:
                 res['notes'] = 'Missing _reference.go'
                 res['steps']['identity-reference'] = False
 

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -241,6 +241,7 @@ def parse_data(config_file_path, apis_dir, crds_dir):
             res['dependencies'] = sorted(valid_deps)
 
         if kind in implemented_types:
+            res['steps']['gen-types'] = True
             has_reference = False
             for filepath in implemented_types[kind]:
                 dirpath = os.path.dirname(filepath)

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -115,6 +115,17 @@ def build_dependency_graph(crds_dir="../../config/crds/resources"):
 def parse_data(config_file_path, apis_dir, crds_dir):
     resources = {}
     
+    # Load existing data to preserve manual updates
+    existing_resources = {}
+    data_json_path = 'data.json'
+    if os.path.exists(data_json_path):
+        try:
+            with open(data_json_path, 'r') as f:
+                existing_list = json.load(f)
+                existing_resources = {res['kind']: res for res in existing_list}
+        except Exception as e:
+            print(f"Warning: Could not load existing data.json: {e}", file=sys.stderr)
+            
     with open(config_file_path, 'r') as f:
         config_lines = f.readlines()
         
@@ -133,26 +144,42 @@ def parse_data(config_file_path, apis_dir, crds_dir):
             group = group_full.split('.')[0]
             kind = kind_match.group(1)
             
+            supported = []
+            if supported_ctrls_match:
+                ctrls_raw = supported_ctrls_match.group(1)
+                supported = re.findall(r'k8s\.ReconcilerType([A-Za-z]+)', ctrls_raw)
+            
+            # Skip if it only supports Direct (born direct or fully migrated and old controllers removed)
+            if len(supported) == 1 and supported[0] == 'Direct':
+                continue
+                
             resources[kind] = create_default_resource(kind, group)
+            resources[kind]['supportedControllers'] = supported
+            
+            # Restore existing manual fields if they exist
+            if kind in existing_resources:
+                existing = existing_resources[kind]
+                resources[kind]['state'] = existing.get('state', resources[kind]['state'])
+                resources[kind]['notes'] = existing.get('notes', resources[kind]['notes'])
+                resources[kind]['mocksLastRefreshed'] = existing.get('mocksLastRefreshed', resources[kind]['mocksLastRefreshed'])
+                if 'steps' in existing:
+                    for step, val in existing['steps'].items():
+                        resources[kind]['steps'][step] = val
             
             if default_ctrl_match:
                 resources[kind]['defaultController'] = default_ctrl_match.group(1)
                 resources[kind]['controllerType'] = default_ctrl_match.group(1)
                 
-            if supported_ctrls_match:
-                ctrls_raw = supported_ctrls_match.group(1)
-                supported = re.findall(r'k8s\.ReconcilerType([A-Za-z]+)', ctrls_raw)
-                resources[kind]['supportedControllers'] = supported
-                if 'Direct' in supported:
-                    resources[kind]['state'] = 'Completed'
-                    resources[kind]['steps'] = {
-                        "gen-types": True,
-                        "identity-reference": True,
-                        "mapper-fuzzer": True,
-                        "mocks": True,
-                        "controller": True,
-                        "tests": True
-                    }
+            if 'Direct' in supported:
+                resources[kind]['state'] = 'Completed'
+                resources[kind]['steps'] = {
+                    "gen-types": True,
+                    "identity-reference": True,
+                    "mapper-fuzzer": True,
+                    "mocks": True,
+                    "controller": True,
+                    "tests": True
+                }
 
     dependencies, known_kinds = build_dependency_graph(crds_dir)
     implemented_types = get_implemented_types(apis_dir)

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Closes #9607.

This PR implements a general rule to exclude resources that only support the `Direct` reconciler from the migration tracker. 

### Changes
*   Modified `dev/migration-tracker/generate_data.py` to skip resources where `SupportedControllers` in `static_config.go` contains only `Direct`.
*   Regenerated `dev/migration-tracker/data.json` to apply the new logic, reducing the tracked resources from 451 to 304.

This removes noise (like `AIStreamsCluster` and `AlloyDBInstance`) and focuses the tracker on active migrations.