### PR TITLE
Improve the CRD equivalence check

### DIFF
--- a/dev/tools/crd-mcp-server/compare.go
+++ b/dev/tools/crd-mcp-server/compare.go
@@ -132,6 +132,8 @@ func walkDepth(s *apiextensionsv1.JSONSchemaProps, depth int) any {
 		} else {
 			res = "map[string]any"
 		}
+	} else if s.Type == "object" {
+		res = "empty-object"
 	} else {
 		t := s.Type
 		if t == "" {
@@ -169,7 +171,7 @@ func walkDepth(s *apiextensionsv1.JSONSchemaProps, depth int) any {
 		}
 	}
 
-	if len(s.XValidations) > 0 {
+	if len(s.XValidations) > 0 || len(s.Required) > 0 {
 		m := make(map[string]any)
 		if mExisting, ok := res.(map[string]any); ok {
 			for k, v := range mExisting {
@@ -198,6 +200,9 @@ func walkDepth(s *apiextensionsv1.JSONSchemaProps, depth int) any {
 				val["optionalOldSelf"] = *v.OptionalOldSelf
 			}
 			m[fmt.Sprintf(":validation[%d]", i)] = val
+		}
+		for _, name := range s.Required {
+			m[fmt.Sprintf(":required.%s", name)] = "required"
 		}
 		return m
 	}
@@ -262,7 +267,7 @@ func isUnderStatus(path string) bool {
 
 // isValidationPath returns true if the path is within a validation rule.
 func isValidationPath(path string) bool {
-	return strings.Contains(path, ":validation[")
+	return strings.Contains(path, ":validation[") || strings.Contains(path, ":required.")
 }
 
 // CompareResult holds the outcome of a CRD comparison.
@@ -282,6 +287,35 @@ type CompareResult struct {
 //   - Adding spec.names.listKind is fine
 func compareEquivalence(oldCRD, newCRD *apiextensionsv1.CustomResourceDefinition) CompareResult {
 	var r CompareResult
+
+	// Check labels
+	const stabilityLabel = "cnrm.cloud.google.com/stability-level"
+	oldStability := oldCRD.Labels[stabilityLabel]
+	newStability := newCRD.Labels[stabilityLabel]
+
+	newHasV1Beta1 := false
+	newOnlyV1Alpha1 := true
+	for _, v := range newCRD.Spec.Versions {
+		if v.Name == "v1beta1" {
+			newHasV1Beta1 = true
+		}
+		if v.Name != "v1alpha1" {
+			newOnlyV1Alpha1 = false
+		}
+	}
+
+	if oldStability != newStability {
+		// Allow alpha -> stable promotion if v1beta1 is now supported.
+		if oldStability == "alpha" && newStability == "stable" && newHasV1Beta1 {
+			r.Notes = append(r.Notes, fmt.Sprintf("label %q promoted: %q -> %q (allowed with v1beta1)", stabilityLabel, oldStability, newStability))
+		} else {
+			r.Diffs = append(r.Diffs, fmt.Sprintf("label %q changed: %q -> %q", stabilityLabel, oldStability, newStability))
+		}
+	}
+
+	if newOnlyV1Alpha1 && newStability != "alpha" {
+		r.Diffs = append(r.Diffs, fmt.Sprintf("label %q must be \"alpha\" when only v1alpha1 is supported (got %q)", stabilityLabel, newStability))
+	}
 
 	// spec.names.listKind: adding is fine, changing is not.
 	oldListKind := oldCRD.Spec.Names.ListKind
@@ -326,6 +360,7 @@ func schemaEquivalenceDiff(version string, oldPaths, newPaths map[string]string)
 	if version != "" {
 		prefix = fmt.Sprintf("[%s] ", version)
 	}
+	isAlpha := version == "v1alpha1"
 
 	lastRemovedPrefix := ""
 	for _, path := range slices.Sorted(maps.Keys(oldPaths)) {
@@ -335,7 +370,11 @@ func schemaEquivalenceDiff(version string, oldPaths, newPaths map[string]string)
 			if lastRemovedPrefix != "" && (strings.HasPrefix(path, lastRemovedPrefix+".") || strings.HasPrefix(path, lastRemovedPrefix+"[")) {
 				continue
 			}
-			diffs = append(diffs, fmt.Sprintf("%sfield removed: %s (was %s)", prefix, path, oldType))
+			if isAlpha {
+				notes = append(notes, fmt.Sprintf("%sfield removed: %s (was %s) (allowed for alpha)", prefix, path, oldType))
+			} else {
+				diffs = append(diffs, fmt.Sprintf("%sfield removed: %s (was %s)", prefix, path, oldType))
+			}
 			lastRemovedPrefix = path
 			continue
 		}
@@ -343,6 +382,8 @@ func schemaEquivalenceDiff(version string, oldPaths, newPaths map[string]string)
 		if oldType != newType {
 			if isAllowedTypeChange(path, oldType, newType) {
 				notes = append(notes, fmt.Sprintf("%sfield type changed: %s (%s -> %s) (allowed)", prefix, path, oldType, newType))
+			} else if isAlpha {
+				notes = append(notes, fmt.Sprintf("%sfield type changed: %s (%s -> %s) (allowed for alpha)", prefix, path, oldType, newType))
 			} else {
 				diffs = append(diffs, fmt.Sprintf("%sfield type changed: %s (%s -> %s)", prefix, path, oldType, newType))
 			}
@@ -357,19 +398,35 @@ func schemaEquivalenceDiff(version string, oldPaths, newPaths map[string]string)
 		if lastDiffPrefix != "" && (strings.HasPrefix(path, lastDiffPrefix+".") || strings.HasPrefix(path, lastDiffPrefix+"[")) {
 			continue
 		}
+		newType := newPaths[path]
 		if isUnderStatus(path) {
 			if isAllowedNewStatusField(path) {
 				if path == "status" {
 					notes = append(notes, fmt.Sprintf("%sstatus block added (allowed)", prefix))
+				} else if newType == "empty-object" {
+					diffs = append(diffs, fmt.Sprintf("%sfield added under status is an empty object: %s", prefix, path))
+					lastDiffPrefix = path
 				} else {
-					notes = append(notes, fmt.Sprintf("%sfield added under status: %s (type: %s, allowed)", prefix, path, newPaths[path]))
+					notes = append(notes, fmt.Sprintf("%sfield added under status: %s (type: %s, allowed)", prefix, path, newType))
 				}
 			} else {
-				diffs = append(diffs, fmt.Sprintf("%sfield added under status: %s (type: %s)", prefix, path, newPaths[path]))
+				if newType == "empty-object" {
+					diffs = append(diffs, fmt.Sprintf("%sfield added under status is an empty object: %s", prefix, path))
+				} else if isAlpha {
+					notes = append(notes, fmt.Sprintf("%sfield added under status: %s (type: %s, allowed for alpha)", prefix, path, newType))
+				} else {
+					diffs = append(diffs, fmt.Sprintf("%sfield added under status: %s (type: %s)", prefix, path, newType))
+				}
 				lastDiffPrefix = path
 			}
 		} else {
-			diffs = append(diffs, fmt.Sprintf("%sfield added: %s (type: %s)", prefix, path, newPaths[path]))
+			if newType == "empty-object" {
+				diffs = append(diffs, fmt.Sprintf("%sfield added is an empty object: %s", prefix, path))
+			} else if isAlpha {
+				notes = append(notes, fmt.Sprintf("%sfield added: %s (type: %s, allowed for alpha)", prefix, path, newType))
+			} else {
+				diffs = append(diffs, fmt.Sprintf("%sfield added: %s (type: %s)", prefix, path, newType))
+			}
 			lastDiffPrefix = path
 		}
 	}
@@ -391,14 +448,24 @@ func isAllowedNewStatusField(path string) bool {
 }
 
 func isAllowedTypeChange(path, oldType, newType string) bool {
-	// If it is changed from integer to int32, then it should always be allowed.
-	if oldType == "integer" && newType == "int32" {
+	// We only allow certain safe "cleanup" changes in the status section.
+	if !isUnderStatus(path) {
+		return false
+	}
+
+	isInteger := func(t string) bool {
+		return t == "integer" || t == "int32" || t == "int64"
+	}
+
+	// In status, allow conversions between integer types (integer, int32, int64).
+	if isInteger(oldType) && isInteger(newType) {
+		// Specific disallowed case: narrowing from 64-bit to 32-bit.
+		if oldType == "int64" && newType == "int32" {
+			return false
+		}
 		return true
 	}
-	// If it is changed from integer to int64, it should be an allowed change.
-	if oldType == "integer" && newType == "int64" {
-		return true
-	}
+
 	return false
 }
 
@@ -410,6 +477,35 @@ func isAllowedTypeChange(path, oldType, newType string) bool {
 //   - New fields may be added anywhere
 func compareBackwardCompatibility(oldCRD, newCRD *apiextensionsv1.CustomResourceDefinition) CompareResult {
 	var r CompareResult
+
+	// Check labels
+	const stabilityLabel = "cnrm.cloud.google.com/stability-level"
+	oldStability := oldCRD.Labels[stabilityLabel]
+	newStability := newCRD.Labels[stabilityLabel]
+
+	newHasV1Beta1 := false
+	newOnlyV1Alpha1 := true
+	for _, v := range newCRD.Spec.Versions {
+		if v.Name == "v1beta1" {
+			newHasV1Beta1 = true
+		}
+		if v.Name != "v1alpha1" {
+			newOnlyV1Alpha1 = false
+		}
+	}
+
+	if oldStability != newStability {
+		// Allow alpha -> stable promotion if v1beta1 is now supported.
+		if oldStability == "alpha" && newStability == "stable" && newHasV1Beta1 {
+			r.Notes = append(r.Notes, fmt.Sprintf("label %q promoted: %q -> %q (allowed with v1beta1)", stabilityLabel, oldStability, newStability))
+		} else {
+			r.Diffs = append(r.Diffs, fmt.Sprintf("label %q changed: %q -> %q", stabilityLabel, oldStability, newStability))
+		}
+	}
+
+	if newOnlyV1Alpha1 && newStability != "alpha" {
+		r.Diffs = append(r.Diffs, fmt.Sprintf("label %q must be \"alpha\" when only v1alpha1 is supported (got %q)", stabilityLabel, newStability))
+	}
 
 	oldVersions := getVersionSchemas(oldCRD)
 	newVersions := getVersionSchemas(newCRD)
@@ -479,7 +575,11 @@ func schemaBackwardCompatDiff(version string, oldPaths, newPaths map[string]stri
 			continue
 		}
 		if _, ok := oldPaths[path]; !ok {
-			notes = append(notes, fmt.Sprintf("%sfield added: %s (type: %s, allowed)", prefix, path, newPaths[path]))
+			if newPaths[path] == "empty-object" {
+				diffs = append(diffs, fmt.Sprintf("%sfield added is an empty object: %s", prefix, path))
+			} else {
+				notes = append(notes, fmt.Sprintf("%sfield added: %s (type: %s, allowed)", prefix, path, newPaths[path]))
+			}
 		}
 	}
 

--- a/dev/tools/crd-mcp-server/compare_test.go
+++ b/dev/tools/crd-mcp-server/compare_test.go
@@ -15,10 +15,73 @@
 package main
 
 import (
-	"slices"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+// crdTemplate is a base CRD with a placeholder for the version name.
+const crdTemplate = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: {{STABILITY}}
+spec:
+  group: example.com
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced
+  versions:
+  - name: {{VERSION}}
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "The spec"
+            properties:
+              projectRef:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: "Project name"
+              region:
+                type: string
+                description: "Region"
+              count:
+                type: integer
+              httpKeepAliveTimeoutSec:
+                type: integer
+                format: int64
+          status:
+            type: object
+            description: "The status"
+            properties:
+              observedGeneration:
+                type: integer
+                description: "Observed generation"
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+              proxyId:
+                type: integer
+                format: int64
+`
 
 // baseCRD is a minimal CRD for testing.
 const baseCRD = `
@@ -26,6 +89,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -72,919 +137,377 @@ spec:
                       type: string
 `
 
-func TestEquivalence_DescriptionChange(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            description: "The spec - updated description"
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: "Project name - updated"
-              region:
-                type: string
-                description: "Region - updated"
-          status:
-            type: object
-            description: "The status - updated"
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-                description: "Observed generation - updated"
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 0 {
-		t.Fatalf("expected 0 diffs for description-only change, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for description-only change, got %d: %v", len(result.Notes), result.Notes)
-	}
+func getCRD(version string, stability string) string {
+	res := strings.ReplaceAll(crdTemplate, "{{VERSION}}", version)
+	return strings.ReplaceAll(res, "{{STABILITY}}", stability)
 }
 
-func TestEquivalence_AddListKind(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    listKind: FooList
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
+// TestEquivalence_SharedBehavior tests scenarios where v1alpha1 and v1beta1 behave identically.
+func TestEquivalence_SharedBehavior(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(string) string
+	}{
+		{
+			name: "Description Change (Pass)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "The spec", "Updated spec description")
+			},
+		},
+		{
+			name: "Add listKind (Pass with Note)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "kind: Foo", "kind: Foo\n    listKind: FooList")
+			},
+		},
+		{
+			name: "Add status.externalRef (Pass with Note)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "observedGeneration:", "externalRef:\n                type: string\n              observedGeneration:")
+			},
+		},
+		{
+			name: "Add Empty Object (Fail/Difference)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "projectRef:", "emptyObj:\n                type: object\n              projectRef:")
+			},
+		},
 	}
 
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 0 {
-		t.Fatalf("expected 0 diffs for listKind addition, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 1 {
-		t.Fatalf("expected 1 note about listKind addition, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_AllowedExternalRef(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-              externalRef:
-                type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 0 {
-		t.Fatalf("expected 0 diffs for allowed status field addition, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 1 {
-		t.Fatalf("expected 1 note for allowed status field addition, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_AddSpecField(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: string
-              newSpecField:
-                type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for spec field addition, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for spec field addition, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_RemoveField(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for removed spec field, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for removed spec field, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_RemoveStatusField(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for removed status field, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for removed status field, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_TypeChange(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: integer
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for type change, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for type change, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
-func TestEquivalence_IntegerTypeChange(t *testing.T) {
-	oldCRDStr := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              httpKeepAliveTimeoutSec:
-                type: integer
-              count:
-                type: integer
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-              proxyId:
-                type: integer
-              nodePort:
-                type: integer
-`
-
-	newCRDStr := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              httpKeepAliveTimeoutSec:
-                type: integer
-                format: int32
-              count:
-                type: integer
-                format: int64
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              proxyId:
-                type: integer
-                format: int64
-              nodePort:
-                type: integer
-                format: int32
-`
-
-	old, err := parseCRD([]byte(oldCRDStr))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(newCRDStr))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-
-	var expectedBlocked []string
-
-	if len(result.Diffs) != len(expectedBlocked) {
-		t.Fatalf("expected %d diffs, got %d: %v", len(expectedBlocked), len(result.Diffs), result.Diffs)
-	}
-	for i, d := range result.Diffs {
-		if d != expectedBlocked[i] {
-			t.Errorf("diff mismatch at %d: expected %q, got %q", i, expectedBlocked[i], d)
+	for _, version := range []string{"v1alpha1", "v1beta1"} {
+		stability := "alpha"
+		if version == "v1beta1" {
+			stability = "stable"
 		}
-	}
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s/%s", version, tt.name), func(t *testing.T) {
+				oldStr := getCRD(version, stability)
+				newStr := tt.modifier(oldStr)
 
-	expectedNotes := []string{
-		"[v1beta1] field type changed: spec.count (integer -> int64) (allowed)",
-		"[v1beta1] field type changed: spec.httpKeepAliveTimeoutSec (integer -> int32) (allowed)",
-		"[v1beta1] field type changed: status.nodePort (integer -> int32) (allowed)",
-		"[v1beta1] field type changed: status.observedGeneration (integer -> int64) (allowed)",
-		"[v1beta1] field type changed: status.proxyId (integer -> int64) (allowed)",
-	}
+				old, err := parseCRD([]byte(oldStr))
+				if err != nil {
+					t.Fatalf("failed to parse old CRD: %v", err)
+				}
+				newCRD, err := parseCRD([]byte(newStr))
+				if err != nil {
+					t.Fatalf("failed to parse new CRD: %v\nYAML:\n%s", err, newStr)
+				}
+				result := compareEquivalence(old, newCRD)
 
-	if len(result.Notes) != len(expectedNotes) {
-		t.Fatalf("expected %d notes, got %d: %v", len(expectedNotes), len(result.Notes), result.Notes)
-	}
-	for i, n := range result.Notes {
-		if n != expectedNotes[i] {
-			t.Errorf("note mismatch at %d: expected %q, got %q", i, expectedNotes[i], n)
+				if strings.Contains(tt.name, "Empty Object") {
+					// Should fail for both
+					if len(result.Diffs) == 0 {
+						t.Errorf("expected blocking diff for empty object, but got none")
+					}
+				} else {
+					// Should pass for both
+					if len(result.Diffs) != 0 {
+						t.Errorf("expected no diffs, but got %v", result.Diffs)
+					}
+				}
+			})
 		}
 	}
 }
 
-const testOldCRDData = `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              foo:
-                type: string
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-
-func TestEquivalence_NewStatusField(t *testing.T) {
-	newCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              foo:
-                type: string
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-                    newField:
-                      type: string
-              externalRef:
-                type: object
-                properties:
-                  subField:
-                    type: string
-              externalRefFoo:
-                type: string
-              externalRefName:
-                type: string
-              observedState:
-                type: object
-                properties:
-                  bar:
-                    type: string
-              observedStateFoo:
-                type: string
-              unallowedObject:
-                type: object
-                properties:
-                  child:
-                    type: string
-`
-
-	old, err := parseCRD([]byte(testOldCRDData))
-	if err != nil {
-		t.Fatalf("parseCRD old: %v", err)
-	}
-	new, err := parseCRD([]byte(newCRDData))
-	if err != nil {
-		t.Fatalf("parseCRD new: %v", err)
+// TestEquivalence_DivergentBehavior illustrates differences between v1alpha1 (relaxed) and v1beta1 (strict).
+func TestEquivalence_DivergentBehavior(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(string) string
+	}{
+		{
+			name: "Add Spec Field",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "region:", "region:\n                type: string\n              newField:\n                type: string")
+			},
+		},
+		{
+			name: "Remove Spec Field",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "region:", "removedField:")
+			},
+		},
+		{
+			name: "Type Change (string -> integer)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "type: string\n                description: \"Region\"", "type: integer")
+			},
+		},
+		// Removal of certain Status fields should also be allowed in v1alpha1 but not allowed in v1beta1.
+		// E.g. observedGeneration, conditions should not be removed in both versions, but other fields can be removed in v1alpha1.
 	}
 
-	result := compareEquivalence(old, new)
+	for _, tt := range tests {
+		// v1alpha1: Expected to be EQUIVALENT (Notes instead of Diffs)
+		t.Run(fmt.Sprintf("v1alpha1/%s", tt.name), func(t *testing.T) {
+			oldStr := getCRD("v1alpha1", "alpha")
+			newStr := tt.modifier(oldStr)
+			old, err := parseCRD([]byte(oldStr))
+			if err != nil {
+				t.Fatalf("failed to parse old: %v", err)
+			}
+			newCRD, err := parseCRD([]byte(newStr))
+			if err != nil {
+				t.Fatalf("failed to parse new: %v", err)
+			}
 
-	t.Run("Check diffs", func(t *testing.T) {
-		// Diffs expected for:
-		// 1. status.conditions[].newField
-		// 2. status.externalRefFoo
-		// 3. status.externalRefName
-		// 4. status.externalRef.subField (externalRef is string pointer, no subfields allowed)
-		// 5. status.observedStateFoo
-		// 6. status.unallowedObject
-		if len(result.Diffs) != 6 {
-			t.Fatalf("Expected 6 diffs, but got %d: %v", len(result.Diffs), result.Diffs)
+			result := compareEquivalence(old, newCRD)
+			if len(result.Diffs) != 0 {
+				t.Errorf("v1alpha1 should allow changes as notes, but got diffs: %v", result.Diffs)
+			}
+			if len(result.Notes) == 0 {
+				t.Error("v1alpha1 should have generated informational notes for the change")
+			}
+		})
+
+		// v1beta1: Expected to be NOT EQUIVALENT (Blocking Diffs)
+		t.Run(fmt.Sprintf("v1beta1/%s", tt.name), func(t *testing.T) {
+			oldStr := getCRD("v1beta1", "stable")
+			newStr := tt.modifier(oldStr)
+			old, err := parseCRD([]byte(oldStr))
+			if err != nil {
+				t.Fatalf("failed to parse old: %v", err)
+			}
+			newCRD, err := parseCRD([]byte(newStr))
+			if err != nil {
+				t.Fatalf("failed to parse new: %v", err)
+			}
+
+			result := compareEquivalence(old, newCRD)
+			if len(result.Diffs) == 0 {
+				t.Errorf("v1beta1 should block %s, but got no diffs", tt.name)
+			}
+		})
+	}
+}
+
+// TestEquivalence_RequiredFieldBehavior tests the 'required' constraint detection.
+func TestEquivalence_RequiredFieldBehavior(t *testing.T) {
+	modifier := func(in string) string {
+		// Insert 'required' block right before 'properties' inside 'spec'
+		return strings.ReplaceAll(in, "description: \"The spec\"", "description: \"The spec\"\n            required:\n            - region")
+	}
+
+	// v1alpha1: Note only
+	t.Run("v1alpha1/Add Required", func(t *testing.T) {
+		oldStr := getCRD("v1alpha1", "alpha")
+		newStr := modifier(oldStr)
+		old, err := parseCRD([]byte(oldStr))
+		if err != nil {
+			t.Fatalf("failed to parse old: %v", err)
 		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.conditions[].newField") }) {
-			t.Errorf("Expected diff for status.conditions[].newField, but it was not found. Result diffs: %v", result.Diffs)
+		newCRD, err := parseCRD([]byte(newStr))
+		if err != nil {
+			t.Fatalf("failed to parse new: %v\nYAML:\n%s", err, newStr)
 		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.externalRefFoo") }) {
-			t.Errorf("Expected diff for status.externalRefFoo, but it was not found. Result diffs: %v", result.Diffs)
-		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.externalRefName") }) {
-			t.Errorf("Expected diff for status.externalRefName, but it was not found. Result diffs: %v", result.Diffs)
-		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.externalRef.subField") }) {
-			t.Errorf("Expected diff for status.externalRef.subField, but it was not found. Result diffs: %v", result.Diffs)
-		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.unallowedObject") }) {
-			t.Errorf("Expected diff for status.unallowedObject, but it was not found. Result diffs: %v", result.Diffs)
-		}
-		if !slices.ContainsFunc(result.Diffs, func(diff string) bool { return strings.Contains(diff, "status.observedStateFoo") }) {
-			t.Errorf("Expected diff for status.observedStateFoo, but it was not found. Result diffs: %v", result.Diffs)
+		result := compareEquivalence(old, newCRD)
+		if len(result.Diffs) != 0 {
+			t.Errorf("v1alpha1 should allow required field addition as note, got diffs: %v", result.Diffs)
 		}
 	})
 
-	t.Run("Check notes", func(t *testing.T) {
-		if len(result.Notes) != 3 {
-			t.Fatalf("Expected 3 notes (externalRef, observedState, observedState.bar), but got %d: %v", len(result.Notes), result.Notes)
+	// v1beta1: Blocking Diff
+	t.Run("v1beta1/Add Required", func(t *testing.T) {
+		oldStr := getCRD("v1beta1", "stable")
+		newStr := modifier(oldStr)
+		old, err := parseCRD([]byte(oldStr))
+		if err != nil {
+			t.Fatalf("failed to parse old: %v", err)
 		}
-		if !slices.ContainsFunc(result.Notes, func(note string) bool { return strings.Contains(note, " status.externalRef ") }) {
-			t.Errorf("Expected note for status.externalRef, but it was not found. Result notes: %v", result.Notes)
+		newCRD, err := parseCRD([]byte(newStr))
+		if err != nil {
+			t.Fatalf("failed to parse new: %v\nYAML:\n%s", err, newStr)
 		}
-		if !slices.ContainsFunc(result.Notes, func(note string) bool { return strings.Contains(note, " status.observedState ") }) {
-			t.Errorf("Expected note for status.observedState (parent), but it was not found. Result notes: %v", result.Notes)
-		}
-		if !slices.ContainsFunc(result.Notes, func(note string) bool { return strings.Contains(note, "status.observedState.bar") }) {
-			t.Errorf("Expected note for status.observedState.bar, but it was not found. Result notes: %v", result.Notes)
+		result := compareEquivalence(old, newCRD)
+		if len(result.Diffs) == 0 {
+			t.Error("v1beta1 should block adding required fields")
 		}
 	})
 }
 
-func TestEquivalence_EmptyObservedState(t *testing.T) {
-	newCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              foo:
-                type: string
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-              observedState:
-                type: object
-`
+// TestEquivalence_StabilityLevelBehavior tests the cnrm.cloud.google.com/stability-level rules.
+func TestEquivalence_StabilityLevelBehavior(t *testing.T) {
+	// 1. v1alpha1 must be alpha
+	t.Run("v1alpha1/MustBeAlpha", func(t *testing.T) {
+		oldStr := getCRD("v1alpha1", "alpha")
+		newStr := strings.ReplaceAll(oldStr, "stability-level: alpha", "stability-level: stable")
+		old, err := parseCRD([]byte(oldStr))
+		if err != nil {
+			t.Fatalf("failed to parse old: %v", err)
+		}
+		newCRD, err := parseCRD([]byte(newStr))
+		if err != nil {
+			t.Fatalf("failed to parse new: %v", err)
+		}
+		result := compareEquivalence(old, newCRD)
+		if len(result.Diffs) == 0 {
+			t.Error("should have blocked stable label on v1alpha1-only resource")
+		}
+	})
 
-	old, err := parseCRD([]byte(testOldCRDData))
-	if err != nil {
-		t.Fatalf("parseCRD old: %v", err)
-	}
-	new, err := parseCRD([]byte(newCRDData))
-	if err != nil {
-		t.Fatalf("parseCRD new: %v", err)
+	// 2. Promotion alpha -> stable allowed if v1beta1 is added
+	t.Run("Promotion/AlphaToStableWithV1Beta1", func(t *testing.T) {
+		oldStr := getCRD("v1alpha1", "alpha")
+		newStr := strings.ReplaceAll(oldStr, "v1alpha1", "v1beta1")
+		newStr = strings.ReplaceAll(newStr, "stability-level: alpha", "stability-level: stable")
+		// Add v1alpha1 back so it has both
+		newStr = strings.ReplaceAll(newStr, "versions:", "versions:\n  - name: v1alpha1\n    served: true\n    storage: true\n    schema:\n      openAPIV3Schema:\n        type: object")
+		
+		old, _ := parseCRD([]byte(oldStr))
+		newCRD, _ := parseCRD([]byte(newStr))
+		result := compareEquivalence(old, newCRD)
+		
+		foundPromotionNote := false
+		for _, n := range result.Notes {
+			if strings.Contains(n, "promoted") {
+				foundPromotionNote = true
+				break
+			}
+		}
+		if !foundPromotionNote {
+			t.Errorf("expected promotion note, but got none. Diffs: %v, Notes: %v", result.Diffs, result.Notes)
+		}
+	})
+}
+
+// TestEquivalence_IntegerConversions tests safe vs unsafe integer type changes.
+func TestEquivalence_IntegerConversions(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(string) string
+		v1alpha1Result CompareResult
+		v1beta1Result CompareResult
+	}{
+		{
+			name: "Shared behavior: integer -> int64 in STATUS (Allowed with Note)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "observedGeneration:\n                type: integer", "observedGeneration:\n                type: integer\n                format: int64")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: status.observedGeneration (integer -> int64) (allowed)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1beta1] field type changed: status.observedGeneration (integer -> int64) (allowed)"},
+			},
+		},
+		{
+			name: "Shared behavior: integer -> int32 in STATUS (Allowed with Note)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "observedGeneration:\n                type: integer", "observedGeneration:\n                type: integer\n                format: int32")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: status.observedGeneration (integer -> int32) (allowed)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1beta1] field type changed: status.observedGeneration (integer -> int32) (allowed)"},
+			},
+		},
+		{
+			name: "Diverged behavior: int64 -> int32 in STATUS (v1beta1: Blocked; v1alpha1: Allowed with Note)",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "proxyId:\n                type: integer\n                format: int64", "proxyId:\n                type: integer\n                format: int32")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: status.proxyId (int64 -> int32) (allowed for alpha)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: []string{"[v1beta1] field type changed: status.proxyId (int64 -> int32)"},
+				Notes: nil,
+			},
+		},
+		{
+			name: "Diverged behavior: integer -> int64 in SPEC (v1beta1: Blocked; v1alpha1: Allowed with Note)\"",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "count:\n                type: integer", "count:\n                type: integer\n                format: int64")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: spec.count (integer -> int64) (allowed for alpha)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: []string{"[v1beta1] field type changed: spec.count (integer -> int64)"},
+				Notes: nil,
+			},
+		},
+		{
+			name: "Diverged behavior: integer -> int32 in SPEC (v1beta1: Blocked; v1alpha1: Allowed with Note)\"",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "count:\n                type: integer", "count:\n                type: integer\n                format: int32")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: spec.count (integer -> int32) (allowed for alpha)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: []string{"[v1beta1] field type changed: spec.count (integer -> int32)"},
+				Notes: nil,
+			},
+		},
+		{
+			name: "Diverged behavior: int64 -> int32 in SPEC (v1beta1: Blocked; v1alpha1: Allowed with Note)\"",
+			modifier: func(in string) string {
+				return strings.ReplaceAll(in, "httpKeepAliveTimeoutSec:\n                type: integer\n                format: int64", "httpKeepAliveTimeoutSec:\n                type: integer\n                format: int32")
+			},
+			v1alpha1Result: CompareResult{
+				Diffs: nil,
+				Notes: []string{"[v1alpha1] field type changed: spec.httpKeepAliveTimeoutSec (int64 -> int32) (allowed for alpha)"},
+			},
+			v1beta1Result: CompareResult{
+				Diffs: []string{"[v1beta1] field type changed: spec.httpKeepAliveTimeoutSec (int64 -> int32)"},
+				Notes: nil,
+			},
+		},
 	}
 
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 0 {
-		t.Fatalf("expected 0 diffs, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 1 {
-		t.Fatalf("expected 1 note, got %d: %v", len(result.Notes), result.Notes)
-	}
-	if !slices.ContainsFunc(result.Notes, func(note string) bool { return strings.Contains(note, " status.observedState ") }) {
-		t.Errorf("Expected note for status.observedState, but it was not found. Result notes: %v", result.Notes)
+	for _, tt := range tests {
+		// v1alpha1
+		t.Run(fmt.Sprintf("v1alpha1/%s", tt.name), func(t *testing.T) {
+			oldStr := getCRD("v1alpha1", "alpha")
+			newStr := tt.modifier(oldStr)
+			old, err := parseCRD([]byte(oldStr))
+			if err != nil {
+				t.Fatalf("failed to parse old: %v", err)
+			}
+			newCRD, err := parseCRD([]byte(newStr))
+			if err != nil {
+				t.Fatalf("failed to parse new: %v", err)
+			}
+
+			result := compareEquivalence(old, newCRD)
+			if diff := cmp.Diff(tt.v1alpha1Result, result); diff != "" {
+				t.Errorf("compare result mismatch (-want +got):\n%s", diff)
+			}
+		})
+
+		// v1beta1
+		t.Run(fmt.Sprintf("v1beta1/%s", tt.name), func(t *testing.T) {
+			oldStr := getCRD("v1beta1", "stable")
+			newStr := tt.modifier(oldStr)
+			old, err := parseCRD([]byte(oldStr))
+			if err != nil {
+				t.Fatalf("failed to parse old: %v", err)
+			}
+			newCRD, err := parseCRD([]byte(newStr))
+			if err != nil {
+				t.Fatalf("failed to parse new: %v", err)
+			}
+
+			result := compareEquivalence(old, newCRD)
+			if diff := cmp.Diff(tt.v1beta1Result, result); diff != "" {
+				t.Errorf("compare result mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
-func TestEquivalence_DisallowedStatusFieldTypeChange(t *testing.T) {
-	oldCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          status:
-            type: object
-            properties:
-              externalRef:
-                type: string
-`
-	newCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          status:
-            type: object
-            properties:
-              externalRef:
-                type: integer
-`
-	old, err := parseCRD([]byte(oldCRDData))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(newCRDData))
-	if err != nil {
-		t.Fatal(err)
-	}
+func matchGotAndExpected(t *testing.T, got CompareResult, expectedNotes, expectedDiffs []string) {
 
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for type change, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if result.Diffs[0] != "[v1alpha1] field type changed: status.externalRef (string -> integer)" {
-		t.Errorf("unexpected diff: %q", result.Diffs[0])
-	}
-}
-
-func TestEquivalence_ChangeListKind(t *testing.T) {
-	oldCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    listKind: OldList
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-`
-	newCRDData := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    listKind: NewList
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-`
-	old, err := parseCRD([]byte(oldCRDData))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(newCRDData))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for listKind change, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if result.Diffs[0] != `spec.names.listKind changed: "OldList" -> "NewList"` {
-		t.Errorf("unexpected diff: %q", result.Diffs[0])
-	}
 }
 
 func TestBackwardCompat_AddField(t *testing.T) {
@@ -997,6 +520,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1053,68 +578,6 @@ spec:
 	}
 }
 
-func TestBackwardCompat_RemoveField(t *testing.T) {
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareBackwardCompatibility(old, new)
-	if len(result.Diffs) != 1 {
-		t.Fatalf("expected 1 diff for removed field, got %d: %v", len(result.Diffs), result.Diffs)
-	}
-	if len(result.Notes) != 0 {
-		t.Fatalf("expected 0 notes for removed field, got %d: %v", len(result.Notes), result.Notes)
-	}
-}
-
 func TestBackwardCompat_TypeChange(t *testing.T) {
 	old, err := parseCRD([]byte(baseCRD))
 	if err != nil {
@@ -1125,6 +588,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1185,6 +650,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1220,6 +687,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1265,7 +734,10 @@ spec:
 
 	result := compareBackwardCompatibility(old, new)
 
-	var expectedBlocked []string
+	expectedBlocked := []string{
+		"[v1beta1] field type changed: spec.count (integer -> int64)",
+		"[v1beta1] field type changed: spec.httpKeepAliveTimeoutSec (integer -> int32)",
+	}
 
 	if len(result.Diffs) != len(expectedBlocked) {
 		t.Fatalf("expected %d diffs, got %d: %v", len(expectedBlocked), len(result.Diffs), result.Diffs)
@@ -1277,8 +749,6 @@ spec:
 	}
 
 	expectedNotes := []string{
-		"[v1beta1] field type changed: spec.count (integer -> int64) (allowed)",
-		"[v1beta1] field type changed: spec.httpKeepAliveTimeoutSec (integer -> int32) (allowed)",
 		"[v1beta1] field type changed: status.observedGeneration (integer -> int64) (allowed)",
 		"[v1beta1] field type changed: status.proxyId (integer -> int64) (allowed)",
 	}
@@ -1293,223 +763,6 @@ spec:
 	}
 }
 
-func TestGitShow_InvalidRef(t *testing.T) {
-	// An invalid ref should return an error, not silently report "file is new".
-	_, isNew, err := gitShow("nonexistent-ref-xyz123", "compare_test.go")
-	if err == nil {
-		t.Fatal("expected an error for an invalid git ref, got nil")
-	}
-	if isNew {
-		t.Fatal("an invalid git ref should return an error, not 'file is new'")
-	}
-}
-
-func TestEquivalence_AddValidation(t *testing.T) {
-	modified := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              projectRef:
-                type: object
-                properties:
-                  name:
-                    type: string
-              region:
-                type: string
-                x-kubernetes-validations:
-                - rule: 'self == "us-central1"'
-                  message: "only us-central1 is allowed"
-          status:
-            type: object
-            properties:
-              observedGeneration:
-                type: integer
-                format: int64
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                    status:
-                      type: string
-`
-	old, err := parseCRD([]byte(baseCRD))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(modified))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) == 0 {
-		t.Error("expected diffs for x-kubernetes-validations addition, but got none")
-	}
-}
-
-func TestEquivalence_ChangeValidation(t *testing.T) {
-	oldYaml := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              region:
-                type: string
-                x-kubernetes-validations:
-                - rule: 'self == "us-central1"'
-`
-	newYaml := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              region:
-                type: string
-                x-kubernetes-validations:
-                - rule: 'self == "us-west1"'
-`
-	old, err := parseCRD([]byte(oldYaml))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(newYaml))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) == 0 {
-		t.Error("expected diffs for validation rule change")
-	}
-}
-
-func TestEquivalence_ChangeValidationMessage(t *testing.T) {
-	oldYaml := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              region:
-                type: string
-                x-kubernetes-validations:
-                - rule: 'self == "us-central1"'
-                  message: "old message"
-`
-	newYaml := `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foos.example.com
-spec:
-  group: example.com
-  names:
-    kind: Foo
-    plural: foos
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              region:
-                type: string
-                x-kubernetes-validations:
-                - rule: 'self == "us-central1"'
-                  message: "new message"
-`
-	old, err := parseCRD([]byte(oldYaml))
-	if err != nil {
-		t.Fatal(err)
-	}
-	new, err := parseCRD([]byte(newYaml))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	result := compareEquivalence(old, new)
-	if len(result.Diffs) == 0 {
-		t.Error("expected diffs for validation message change")
-	}
-}
-
 func TestBackwardCompat_ValidationSkipped(t *testing.T) {
 	// Note: we skip validations in the backward compatibility check for now,
 	// as changes to validations may be determined on a case-by-case basis.
@@ -1518,6 +771,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1545,6 +800,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: foos.example.com
+  labels:
+    cnrm.cloud.google.com/stability-level: alpha
 spec:
   group: example.com
   names:
@@ -1579,5 +836,16 @@ spec:
 	result := compareBackwardCompatibility(old, new)
 	if len(result.Diffs) != 0 {
 		t.Errorf("expected no diffs for validation rule change as they are skipped for backward compatibility, got: %v", result.Diffs)
+	}
+}
+
+func TestGitShow_InvalidRef(t *testing.T) {
+	// An invalid ref should return an error, not silently report "file is new".
+	_, isNew, err := gitShow("nonexistent-ref-xyz123", "compare_test.go")
+	if err == nil {
+		t.Fatal("expected an error for an invalid git ref, got nil")
+	}
+	if isNew {
+		t.Fatal("an invalid git ref should return an error, not 'file is new'")
 	}
 }


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
The core comparison logic has been enhanced to handle version-specific rules and stricter schema safety:
* Version-Aware Rules: Added logic to relax equivalence requirements for v1alpha1 versions (treating most changes as informational notes) while maintaining strict enforcement for v1beta1.
* Stability Enforcement: Implemented checks for the `cnrm.cloud.google.com/stability-level` label. It now enforces alpha for v1alpha1-only resources and explicitly allows promotion to stable only when v1beta1 is present.
* Empty Object Detection: Updated the schema walker to identify and block the addition of objects with no properties (e.g., an empty status.observedState), which are invalid in KCC CRDs.
* Required Field Validation: The tool now tracks and validates changes to the required section of OpenAPI schemas.
* Strict Type Conversions: 
   * Spec: Strictly forbids all type conversions to prevent breaking client-side contracts.
   * Status: Allows safe cleanups (like integer <-> int64) while still blocking narrowing (like int64 -> int32).

The test suite for equivalence check has been completely refactored for clarity and better version coverage:
* Template-Based Testing: Introduced a crdTemplate and helper functions to test scenarios (additions, removals, type changes) across both v1alpha1 and v1beta1 side-by-side.
* Divergent Behavior Documentation: Added separate test groups to illustrate where alpha and beta behaviors differ (e.g., allowed vs. blocked spec changes).
* Documentation: Added detailed comments to every test case explaining the specific scenario, the expected result (Pass/Fail), and the engineering rationale.
* Stability: Improved reliability by adding proper error checking for CRD parsing and using more robust string-manipulation logic for YAML modifications.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
