### PR TITLE
docs: correct resourceSettings mode in controlled-cr-reconciliation.md

### DIFF
--- a/docs/features/controlled-cr-reconciliation.md
+++ b/docs/features/controlled-cr-reconciliation.md
@@ -8,11 +8,11 @@ By defining `ResourceSettings` within the `ConfigConnector` and `ConfigConnector
 
 ### Valid Modes
 Resource lists can act in one of two modes:
-* **Exclusive (Deny-list)**: `Enabled: false`. The system reconciles everything EXCEPT the resources explicitly listed. This is the default mode.
-* **Inclusive (Allow-list)**: `Enabled: true`. The system reconciles ONLY the resources explicitly listed and ignores all others.
+* **Exclusive (Deny-list)**: `mode: exclude`. The system reconciles everything EXCEPT the resources explicitly listed. This is the default mode.
+* **Inclusive (Allow-list)**: `mode: include`. The system reconciles ONLY the resources explicitly listed and ignores all others.
 
 > [!WARNING]
-> **Mode Conflicts Forbidden**: To prevent unpredictable behaviors, you cannot mix inclusive and exclusive modes across configurations. The `ConfigConnector` (global) and `ConfigConnectorContext` (namespace) **must** utilize the same `Enabled` value. If they clash, the `ConfigConnectorContext` will report an error (`Healthy: False`) and the Manager pod for that namespace will refuse to start tracking reconciliation until the conflict is resolved.
+> **Mode Conflicts Forbidden**: To prevent unpredictable behaviors, you cannot mix inclusive and exclusive modes across configurations. The `ConfigConnector` (global) and `ConfigConnectorContext` (namespace) **must** utilize the same `mode` value. If they clash, the `ConfigConnectorContext` will report an error (`Healthy: False`) and the Manager pod for that namespace will refuse to start tracking reconciliation until the conflict is resolved.
 
 ### Additive Layering
 Because both global and local settings use the same mode, they combine **additively**:
@@ -32,7 +32,7 @@ spec:
   # ... other specs ...
   experiments:
     resourceSettings:
-      enabled: false  # (Optional) Defaults to false. `false` = Exclusive, `true` = Inclusive
+      mode: exclude  # (Optional) Defaults to "exclude". "exclude" = Exclusive, "include" = Inclusive
       resources:
         # Exclude/Include an entire Group
         - group: pubsub.cnrm.cloud.google.com
@@ -55,7 +55,7 @@ spec:
   mode: namespaced
   experiments:
     resourceSettings:
-      enabled: false
+      mode: exclude
       resources:
       - group: pubsub.cnrm.cloud.google.com
 ---
@@ -68,7 +68,7 @@ metadata:
 spec:
   experiments:
     resourceSettings:
-      enabled: false
+      mode: exclude
       resources:
       - group: storage.cnrm.cloud.google.com
         kind: StorageBucket
@@ -93,7 +93,7 @@ spec:
   mode: namespaced
   experiments:
     resourceSettings:
-      enabled: true
+      mode: include
       resources:
       - group: iam.cnrm.cloud.google.com
         kind: IAMServiceAccount
@@ -107,7 +107,7 @@ metadata:
 spec:
   experiments:
     resourceSettings:
-      enabled: true
+      mode: include
       resources:
       - group: pubsub.cnrm.cloud.google.com
         kind: PubSubTopic


### PR DESCRIPTION
### BRIEF Change description

in the example of how to setup the ConfigConnector, it references a enabled: true|false attribute, but this is not correct, since the ConfigConnector CRD in actual KCC is:

```
                 properties:
                    mode:
                      description: |-
                        Mode controls whether the resources are included or excluded.
                        Defaults to "exclude" (Exclusion mode).
```

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
