### PR TITLE
bigquery: ignore actual schema when desired schema is nil during direct takeover

### DIFF
--- a/pkg/controller/direct/bigquery/table_compare.go
+++ b/pkg/controller/direct/bigquery/table_compare.go
@@ -35,23 +35,23 @@ func checkFieldValid(fields []*bigquery.TableFieldSchema) error {
 	return nil
 }
 
-func policyTagsEqual(a, b *bigquery.TableFieldSchemaPolicyTags) bool {
-	aEmpty := (a == nil || len(a.Names) == 0)
-	bEmpty := (b == nil || len(b.Names) == 0)
-	if aEmpty && bEmpty {
+func policyTagsEqual(actual, desired *bigquery.TableFieldSchemaPolicyTags) bool {
+	actualEmpty := (actual == nil || len(actual.Names) == 0)
+	desiredEmpty := (desired == nil || len(desired.Names) == 0)
+	if actualEmpty && desiredEmpty {
 		return true
 	}
-	if aEmpty || bEmpty {
+	if actualEmpty || desiredEmpty {
 		return false
 	}
 
-	if len(a.Names) != len(b.Names) {
+	if len(actual.Names) != len(desired.Names) {
 		return false
 	}
-	sort.Strings(a.Names)
-	sort.Strings(b.Names)
-	for i := range a.Names {
-		if a.Names[i] != b.Names[i] {
+	sort.Strings(actual.Names)
+	sort.Strings(desired.Names)
+	for i := range actual.Names {
+		if actual.Names[i] != desired.Names[i] {
 			return false
 		}
 	}
@@ -65,85 +65,84 @@ func sortSchemaFields(fields []*bigquery.TableFieldSchema) {
 	})
 }
 
-func tableFieldsSchemaEqual(desired, actual []*bigquery.TableFieldSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if len(desired) == 0 && len(actual) == 0 {
+func tableFieldsSchemaEqual(actual, desired []*bigquery.TableFieldSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if len(actual) == 0 && len(desired) == 0 {
 		return true, nil
+	}
+	if err := checkFieldValid(actual); err != nil {
+		return false, err
 	}
 	if err := checkFieldValid(desired); err != nil {
 		return false, err
 	}
-	if err := checkFieldValid(actual); err != nil {
-		return false, err
-
-	}
-	if len(desired) != len(actual) {
-		diff.AddField(prefix, desired, actual)
+	if len(actual) != len(desired) {
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
 	// The fields from API can be in a different order.
 	// Sort by name before comparing.
-	sortSchemaFields(desired)
 	sortSchemaFields(actual)
-	for i := range desired {
-		fieldName := desired[i].Name
+	sortSchemaFields(desired)
+	for i := range actual {
+		fieldName := actual[i].Name
 		fieldPrefix := fmt.Sprintf("%s[%s]", prefix, fieldName)
-		if !reflect.DeepEqual(desired[i].Categories, actual[i].Categories) {
-			diff.AddField(fieldPrefix+".categories", desired[i].Categories, actual[i].Categories)
+		if !reflect.DeepEqual(actual[i].Categories, desired[i].Categories) {
+			diff.AddField(fieldPrefix+".categories", actual[i].Categories, desired[i].Categories)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Collation, actual[i].Collation) {
-			diff.AddField(fieldPrefix+".collation", desired[i].Collation, actual[i].Collation)
+		if !reflect.DeepEqual(actual[i].Collation, desired[i].Collation) {
+			diff.AddField(fieldPrefix+".collation", actual[i].Collation, desired[i].Collation)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].DefaultValueExpression, actual[i].DefaultValueExpression) {
-			diff.AddField(fieldPrefix+".default_value_expression", desired[i].DefaultValueExpression, actual[i].DefaultValueExpression)
+		if !reflect.DeepEqual(actual[i].DefaultValueExpression, desired[i].DefaultValueExpression) {
+			diff.AddField(fieldPrefix+".default_value_expression", actual[i].DefaultValueExpression, desired[i].DefaultValueExpression)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Description, actual[i].Description) {
-			diff.AddField(fieldPrefix+".description", desired[i].Description, actual[i].Description)
+		if !reflect.DeepEqual(actual[i].Description, desired[i].Description) {
+			diff.AddField(fieldPrefix+".description", actual[i].Description, desired[i].Description)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].ForeignTypeDefinition, actual[i].ForeignTypeDefinition) {
-			diff.AddField(fieldPrefix+".foreign_type_definition", desired[i].ForeignTypeDefinition, actual[i].ForeignTypeDefinition)
+		if !reflect.DeepEqual(actual[i].ForeignTypeDefinition, desired[i].ForeignTypeDefinition) {
+			diff.AddField(fieldPrefix+".foreign_type_definition", actual[i].ForeignTypeDefinition, desired[i].ForeignTypeDefinition)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].MaxLength, actual[i].MaxLength) {
-			diff.AddField(fieldPrefix+".max_length", desired[i].MaxLength, actual[i].MaxLength)
+		if !reflect.DeepEqual(actual[i].MaxLength, desired[i].MaxLength) {
+			diff.AddField(fieldPrefix+".max_length", actual[i].MaxLength, desired[i].MaxLength)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Mode, actual[i].Mode) {
-			diff.AddField(fieldPrefix+".mode", desired[i].Mode, actual[i].Mode)
+		if !reflect.DeepEqual(actual[i].Mode, desired[i].Mode) {
+			diff.AddField(fieldPrefix+".mode", actual[i].Mode, desired[i].Mode)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Name, actual[i].Name) {
-			diff.AddField(fieldPrefix+".name", desired[i].Name, actual[i].Name)
+		if !reflect.DeepEqual(actual[i].Name, desired[i].Name) {
+			diff.AddField(fieldPrefix+".name", actual[i].Name, desired[i].Name)
 			return false, nil
 		}
-		if !policyTagsEqual(desired[i].PolicyTags, actual[i].PolicyTags) {
-			diff.AddField(fieldPrefix+".policy_tags", desired[i].PolicyTags, actual[i].PolicyTags)
+		if !policyTagsEqual(actual[i].PolicyTags, desired[i].PolicyTags) {
+			diff.AddField(fieldPrefix+".policy_tags", actual[i].PolicyTags, desired[i].PolicyTags)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Precision, actual[i].Precision) {
-			diff.AddField(fieldPrefix+".precision", desired[i].Precision, actual[i].Precision)
+		if !reflect.DeepEqual(actual[i].Precision, desired[i].Precision) {
+			diff.AddField(fieldPrefix+".precision", actual[i].Precision, desired[i].Precision)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].RangeElementType, actual[i].RangeElementType) {
-			diff.AddField(fieldPrefix+".range_element_type", desired[i].RangeElementType, actual[i].RangeElementType)
+		if !reflect.DeepEqual(actual[i].RangeElementType, desired[i].RangeElementType) {
+			diff.AddField(fieldPrefix+".range_element_type", actual[i].RangeElementType, desired[i].RangeElementType)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].RoundingMode, actual[i].RoundingMode) {
-			diff.AddField(fieldPrefix+".rounding_mode", desired[i].RoundingMode, actual[i].RoundingMode)
+		if !reflect.DeepEqual(actual[i].RoundingMode, desired[i].RoundingMode) {
+			diff.AddField(fieldPrefix+".rounding_mode", actual[i].RoundingMode, desired[i].RoundingMode)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Scale, actual[i].Scale) {
-			diff.AddField(fieldPrefix+".scale", desired[i].Scale, actual[i].Scale)
+		if !reflect.DeepEqual(actual[i].Scale, desired[i].Scale) {
+			diff.AddField(fieldPrefix+".scale", actual[i].Scale, desired[i].Scale)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Type, actual[i].Type) {
-			diff.AddField(fieldPrefix+".type", desired[i].Type, actual[i].Type)
+		if !reflect.DeepEqual(actual[i].Type, desired[i].Type) {
+			diff.AddField(fieldPrefix+".type", actual[i].Type, desired[i].Type)
 			return false, nil
 		}
-		eq, err := tableFieldsSchemaEqual(desired[i].Fields, actual[i].Fields, fieldPrefix+".fields", diff)
+		eq, err := tableFieldsSchemaEqual(actual[i].Fields, desired[i].Fields, fieldPrefix+".fields", diff)
 		if err != nil {
 			return false, err
 		}
@@ -154,196 +153,199 @@ func tableFieldsSchemaEqual(desired, actual []*bigquery.TableFieldSchema, prefix
 	return true, nil
 }
 
-func externalDataConfigurationEqual(a, b *bigquery.ExternalDataConfiguration, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func externalDataConfigurationEqual(actual, desired *bigquery.ExternalDataConfiguration, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if actual == nil && desired == nil {
 		return true, nil
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Autodetect, b.Autodetect) {
-		diff.AddField(prefix+".autodetect", a.Autodetect, b.Autodetect)
+	if !reflect.DeepEqual(actual.Autodetect, desired.Autodetect) {
+		diff.AddField(prefix+".autodetect", actual.Autodetect, desired.Autodetect)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.AvroOptions, b.AvroOptions) {
-		diff.AddField(prefix+".avro_options", a.AvroOptions, b.AvroOptions)
+	if !reflect.DeepEqual(actual.AvroOptions, desired.AvroOptions) {
+		diff.AddField(prefix+".avro_options", actual.AvroOptions, desired.AvroOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Compression, b.Compression) {
-		diff.AddField(prefix+".compression", a.Compression, b.Compression)
+	if !reflect.DeepEqual(actual.Compression, desired.Compression) {
+		diff.AddField(prefix+".compression", actual.Compression, desired.Compression)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ConnectionId, b.ConnectionId) {
-		diff.AddField(prefix+".connection_id", a.ConnectionId, b.ConnectionId)
+	if !reflect.DeepEqual(actual.ConnectionId, desired.ConnectionId) {
+		diff.AddField(prefix+".connection_id", actual.ConnectionId, desired.ConnectionId)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.CsvOptions, b.CsvOptions) {
-		diff.AddField(prefix+".csv_options", a.CsvOptions, b.CsvOptions)
+	if !reflect.DeepEqual(actual.CsvOptions, desired.CsvOptions) {
+		diff.AddField(prefix+".csv_options", actual.CsvOptions, desired.CsvOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.GoogleSheetsOptions, b.GoogleSheetsOptions) {
-		diff.AddField(prefix+".google_sheets_options", a.GoogleSheetsOptions, b.GoogleSheetsOptions)
+	if !reflect.DeepEqual(actual.GoogleSheetsOptions, desired.GoogleSheetsOptions) {
+		diff.AddField(prefix+".google_sheets_options", actual.GoogleSheetsOptions, desired.GoogleSheetsOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.HivePartitioningOptions, b.HivePartitioningOptions) {
-		diff.AddField(prefix+".hive_partitioning_options", a.HivePartitioningOptions, b.HivePartitioningOptions)
+	if !reflect.DeepEqual(actual.HivePartitioningOptions, desired.HivePartitioningOptions) {
+		diff.AddField(prefix+".hive_partitioning_options", actual.HivePartitioningOptions, desired.HivePartitioningOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.IgnoreUnknownValues, b.IgnoreUnknownValues) {
-		diff.AddField(prefix+".ignore_unknown_values", a.IgnoreUnknownValues, b.IgnoreUnknownValues)
+	if !reflect.DeepEqual(actual.IgnoreUnknownValues, desired.IgnoreUnknownValues) {
+		diff.AddField(prefix+".ignore_unknown_values", actual.IgnoreUnknownValues, desired.IgnoreUnknownValues)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.JsonOptions, b.JsonOptions) {
-		diff.AddField(prefix+".json_options", a.JsonOptions, b.JsonOptions)
+	if !reflect.DeepEqual(actual.JsonOptions, desired.JsonOptions) {
+		diff.AddField(prefix+".json_options", actual.JsonOptions, desired.JsonOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MaxBadRecords, b.MaxBadRecords) {
-		diff.AddField(prefix+".max_bad_records", a.MaxBadRecords, b.MaxBadRecords)
+	if !reflect.DeepEqual(actual.MaxBadRecords, desired.MaxBadRecords) {
+		diff.AddField(prefix+".max_bad_records", actual.MaxBadRecords, desired.MaxBadRecords)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MetadataCacheMode, b.MetadataCacheMode) {
-		diff.AddField(prefix+".metadata_cache_mode", a.MetadataCacheMode, b.MetadataCacheMode)
+	if !reflect.DeepEqual(actual.MetadataCacheMode, desired.MetadataCacheMode) {
+		diff.AddField(prefix+".metadata_cache_mode", actual.MetadataCacheMode, desired.MetadataCacheMode)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ParquetOptions, b.ParquetOptions) {
-		diff.AddField(prefix+".parquet_options", a.ParquetOptions, b.ParquetOptions)
+	if !reflect.DeepEqual(actual.ParquetOptions, desired.ParquetOptions) {
+		diff.AddField(prefix+".parquet_options", actual.ParquetOptions, desired.ParquetOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.SourceFormat, b.SourceFormat) {
-		diff.AddField(prefix+".source_format", a.SourceFormat, b.SourceFormat)
+	if !reflect.DeepEqual(actual.SourceFormat, desired.SourceFormat) {
+		diff.AddField(prefix+".source_format", actual.SourceFormat, desired.SourceFormat)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.SourceUris, b.SourceUris) {
-		diff.AddField(prefix+".source_uris", a.SourceUris, b.SourceUris)
+	if !reflect.DeepEqual(actual.SourceUris, desired.SourceUris) {
+		diff.AddField(prefix+".source_uris", actual.SourceUris, desired.SourceUris)
 		return false, nil
 	}
 
-	equal, err := tableSchemaEq(a.Schema, b.Schema, prefix+".schema", diff)
+	equal, err := tableSchemaEq(actual.Schema, desired.Schema, prefix+".schema", diff)
 	if err != nil {
 		return false, err
 	}
 	return equal, nil
 }
 
-func materializedViewEq(a, b *bigquery.MaterializedViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
-	if a == nil && b == nil {
+func materializedViewEq(actual, desired *bigquery.MaterializedViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
+	if actual == nil && desired == nil {
 		return true
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false
 	}
-	if !reflect.DeepEqual(a.AllowNonIncrementalDefinition, b.AllowNonIncrementalDefinition) {
-		diff.AddField(prefix+".allow_non_incremental_definition", a.AllowNonIncrementalDefinition, b.AllowNonIncrementalDefinition)
+	if !reflect.DeepEqual(actual.AllowNonIncrementalDefinition, desired.AllowNonIncrementalDefinition) {
+		diff.AddField(prefix+".allow_non_incremental_definition", actual.AllowNonIncrementalDefinition, desired.AllowNonIncrementalDefinition)
 		return false
 	}
-	if !reflect.DeepEqual(a.EnableRefresh, b.EnableRefresh) {
-		diff.AddField(prefix+".enable_refresh", a.EnableRefresh, b.EnableRefresh)
+	if !reflect.DeepEqual(actual.EnableRefresh, desired.EnableRefresh) {
+		diff.AddField(prefix+".enable_refresh", actual.EnableRefresh, desired.EnableRefresh)
 		return false
 	}
-	if !reflect.DeepEqual(a.Query, b.Query) {
-		diff.AddField(prefix+".query", a.Query, b.Query)
+	if !reflect.DeepEqual(actual.Query, desired.Query) {
+		diff.AddField(prefix+".query", actual.Query, desired.Query)
 		return false
 	}
-	if !reflect.DeepEqual(a.MaxStaleness, b.MaxStaleness) {
-		diff.AddField(prefix+".max_staleness", a.MaxStaleness, b.MaxStaleness)
+	if !reflect.DeepEqual(actual.MaxStaleness, desired.MaxStaleness) {
+		diff.AddField(prefix+".max_staleness", actual.MaxStaleness, desired.MaxStaleness)
 		return false
 	}
-	if !reflect.DeepEqual(a.RefreshIntervalMs, b.RefreshIntervalMs) {
-		diff.AddField(prefix+".refresh_interval_ms", a.RefreshIntervalMs, b.RefreshIntervalMs)
+	if !reflect.DeepEqual(actual.RefreshIntervalMs, desired.RefreshIntervalMs) {
+		diff.AddField(prefix+".refresh_interval_ms", actual.RefreshIntervalMs, desired.RefreshIntervalMs)
 		return false
 	}
 	return true
 }
 
-func tableSchemaEq(a, b *bigquery.TableSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func tableSchemaEq(actual, desired *bigquery.TableSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if desired == nil {
+		// If the desired schema is not specified in the KRM spec, we do not enforce it.
+		// This is common for Views, Materialized Views, and External Tables where the schema is derived or autodetected.
 		return true, nil
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil {
+		// Desired schema is specified, but actual is nil. This is a diff.
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
-	return tableFieldsSchemaEqual(a.Fields, b.Fields, prefix+".fields", diff)
+	return tableFieldsSchemaEqual(actual.Fields, desired.Fields, prefix+".fields", diff)
 }
 
-func viewEq(a, b *bigquery.ViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
-	if a == nil && b == nil {
+func viewEq(actual, desired *bigquery.ViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
+	if actual == nil && desired == nil {
 		return true
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false
 	}
-	if !reflect.DeepEqual(a.Query, b.Query) {
-		diff.AddField(prefix+".query", a.Query, b.Query)
+	if !reflect.DeepEqual(actual.Query, desired.Query) {
+		diff.AddField(prefix+".query", actual.Query, desired.Query)
 		return false
 	}
-	if !reflect.DeepEqual(a.UseLegacySql, b.UseLegacySql) {
-		diff.AddField(prefix+".use_legacy_sql", a.UseLegacySql, b.UseLegacySql)
+	if !reflect.DeepEqual(actual.UseLegacySql, desired.UseLegacySql) {
+		diff.AddField(prefix+".use_legacy_sql", actual.UseLegacySql, desired.UseLegacySql)
 		return false
 	}
 	return true
 }
 
-func TableEq(a, b *bigquery.Table, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func TableEq(actual, desired *bigquery.Table, diff *structuredreporting.Diff) (bool, error) {
+	if actual == nil && desired == nil {
 		return true, nil
 	}
-	if !reflect.DeepEqual(a.Clustering, b.Clustering) {
-		diff.AddField("clustering", a.Clustering, b.Clustering)
+	if !reflect.DeepEqual(actual.Clustering, desired.Clustering) {
+		diff.AddField("clustering", actual.Clustering, desired.Clustering)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Description, b.Description) {
-		diff.AddField("description", a.Description, b.Description)
+	if !reflect.DeepEqual(actual.Description, desired.Description) {
+		diff.AddField("description", actual.Description, desired.Description)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.EncryptionConfiguration, b.EncryptionConfiguration) {
-		diff.AddField("encryption_configuration", a.EncryptionConfiguration, b.EncryptionConfiguration)
+	if !reflect.DeepEqual(actual.EncryptionConfiguration, desired.EncryptionConfiguration) {
+		diff.AddField("encryption_configuration", actual.EncryptionConfiguration, desired.EncryptionConfiguration)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ExpirationTime, b.ExpirationTime) {
-		diff.AddField("expiration_time", a.ExpirationTime, b.ExpirationTime)
+	if !reflect.DeepEqual(actual.ExpirationTime, desired.ExpirationTime) {
+		diff.AddField("expiration_time", actual.ExpirationTime, desired.ExpirationTime)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.FriendlyName, b.FriendlyName) {
-		diff.AddField("friendly_name", a.FriendlyName, b.FriendlyName)
+	if !reflect.DeepEqual(actual.FriendlyName, desired.FriendlyName) {
+		diff.AddField("friendly_name", actual.FriendlyName, desired.FriendlyName)
 		return false, nil
 	}
-	if !materializedViewEq(a.MaterializedView, b.MaterializedView, "materialized_view", diff) {
+	if !materializedViewEq(actual.MaterializedView, desired.MaterializedView, "materialized_view", diff) {
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MaxStaleness, b.MaxStaleness) {
-		diff.AddField("max_staleness", a.MaxStaleness, b.MaxStaleness)
+	if !reflect.DeepEqual(actual.MaxStaleness, desired.MaxStaleness) {
+		diff.AddField("max_staleness", actual.MaxStaleness, desired.MaxStaleness)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.RangePartitioning, b.RangePartitioning) {
-		diff.AddField("range_partitioning", a.RangePartitioning, b.RangePartitioning)
+	if !reflect.DeepEqual(actual.RangePartitioning, desired.RangePartitioning) {
+		diff.AddField("range_partitioning", actual.RangePartitioning, desired.RangePartitioning)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.RequirePartitionFilter, b.RequirePartitionFilter) {
-		diff.AddField("require_partition_filter", a.RequirePartitionFilter, b.RequirePartitionFilter)
+	if !reflect.DeepEqual(actual.RequirePartitionFilter, desired.RequirePartitionFilter) {
+		diff.AddField("require_partition_filter", actual.RequirePartitionFilter, desired.RequirePartitionFilter)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.TableConstraints, b.TableConstraints) {
-		diff.AddField("table_constraints", a.TableConstraints, b.TableConstraints)
+	if !reflect.DeepEqual(actual.TableConstraints, desired.TableConstraints) {
+		diff.AddField("table_constraints", actual.TableConstraints, desired.TableConstraints)
 		return false, nil
 	}
 
-	if !viewEq(a.View, b.View, "view", diff) {
+	if !viewEq(actual.View, desired.View, "view", diff) {
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
-		diff.AddField("labels", a.Labels, b.Labels)
+	if !reflect.DeepEqual(actual.Labels, desired.Labels) {
+		diff.AddField("labels", actual.Labels, desired.Labels)
 		return false, nil
 	}
-	equal, err := tableSchemaEq(a.Schema, b.Schema, "schema", diff)
+	equal, err := tableSchemaEq(actual.Schema, desired.Schema, "schema", diff)
 	if err != nil {
 		return false, err
 	}
 	if !equal {
 		return false, nil
 	}
-	return externalDataConfigurationEqual(a.ExternalDataConfiguration, b.ExternalDataConfiguration, "external_data_configuration", diff)
+	return externalDataConfigurationEqual(actual.ExternalDataConfiguration, desired.ExternalDataConfiguration, "external_data_configuration", diff)
 }


### PR DESCRIPTION
This PR fixes a migration takeover issue for BigQueryTable resources (specifically Views and Materialized Views). 

### Problem
When a BigQueryTable view or materialized view is created, its schema is automatically derived by BigQuery from the query. Consequently, the KRM spec has a `nil` schema. During Direct controller takeover (Phase 2), the controller compared the desired `nil` schema with the actual derived schema returned by the GCP API. Since one was `nil` and the other was not, the controller detected a diff and wrongly attempted to clear/delete the schema on GCP, causing the takeover to fail.

### Solution
This PR updates the schema comparison function `tableSchemaEq` in `pkg/controller/direct/bigquery/table_compare.go` to ignore the actual schema returned by the GCP API if the desired schema is omitted in the KRM spec (`desired == nil`).

### Refactoring & Readability
* Refactored `table_compare.go` to consistently use `actual` and `desired` parameter names instead of `a` and `b` across all comparison functions. This eliminates a major source of parameter swap bugs.
* Aligned all `diff.AddField(path, old, new)` calls to consistently pass `actual` (old) as the second argument and `desired` (new) as the third argument, fixing a mismatch in `tableFieldsSchemaEqual` where they were previously passed backwards.
