### PR TITLE
e2e: add direct migration test runner and custom gemini skill

### DIFF
--- a/.gemini/skills/solve-migration-diff-issues/SKILL.md
+++ b/.gemini/skills/solve-migration-diff-issues/SKILL.md
@@ -1,0 +1,72 @@
+# Skill: Solve Migration Diff Issues for Direct Takeover
+
+This skill guides an automated agent through diagnosing, explaining, and fixing "takeover diff" issues when migrating a Kubernetes controller in KCC from Terraform/DCL to the Direct approach. 
+
+During a takeover, the Direct controller must be able to adopt an existing resource created by the old controller with a clean **0-write no-op reconciliation**. Any diff detected during this phase is considered a bug.
+
+---
+
+## Steps & Best Practices
+
+### 1. Diagnose the Takeover Diff
+1. Run the E2E migration test suite for the specific fixture:
+   ```bash
+   ./hack/record-gcp TestMigrationToDirect/fixtures/<fixture-name>$
+   ```
+2. Open the recorded structured diff file:
+   `pkg/test/resourcefixture/testdata/basic/<service>/<version>/<resource>/<fixture-name>/_migration_diffs.json`
+3. Look for blocks containing `"isNewObject": false`. This indicates a diff detected during the Direct takeover phase (Phase 2).
+4. Analyze the diff. A diff of the form `"old": <value>, "new": null` (or vice-versa) indicates a mismatch where a field is populated in one state but not the other.
+
+---
+
+### 2. Identify the Root Cause
+* **Derived/Computed Fields:** In GCP, some fields (e.g., a BigQuery view's `schema`, default database settings, or server-generated metadata) are automatically computed/derived by the server. These are omitted in the KRM spec (desired is `nil`) but populated by GCP (actual is non-nil).
+* **Casing & Aliases:** Strings returned by the GCP API might have different casing (e.g. `INT64` vs `INTEGER`, `true` vs `TRUE`) or format (e.g. fully-qualified URIs vs relative paths).
+* **Default Values:** The old controller might have applied a default value that the new Direct controller does not apply, or vice-versa.
+
+---
+
+### 3. Formulate the Fix in the Direct Controller
+1. Locate the comparison logic for the resource:
+   * For most resources, the comparison is done directly inside the `Update` method (or helper functions) in the controller file: `pkg/controller/direct/<service>/<resource>_controller.go`.
+   * For extremely large or complex resources (like BigQuery Table), it may be split out into a separate file: `pkg/controller/direct/<service>/<resource>_compare.go`.
+2. **Prevent Parameter Swap Bugs:** When writing or editing comparison functions, **always** explicitly name the parameters `actual` and `desired` instead of `a` and `b`. This prevents accidentally swapping them during comparison and diff reporting.
+3. **Ignore Undesired Optional Fields:** If a field is optional in KRM and is omitted from the spec (desired is `nil`), the comparison logic should **ignore** the actual value returned by GCP rather than attempting to delete it.
+   * *Implementation Pattern:*
+     ```go
+     func compareFieldEq(actual, desired *Type, prefix string, diff *structuredreporting.Diff) (bool, error) {
+         if desired == nil {
+             // If the desired state is not specified in the KRM spec, we do not enforce it.
+             return true, nil
+         }
+         if actual == nil {
+             // Desired is specified, but actual is nil. This is a diff.
+             diff.AddField(prefix, actual, desired)
+             return false, nil
+         }
+         // Perform deep comparison...
+     }
+     ```
+4. **Normalize Values before Comparison:** If the diff is due to formatting or casing differences, implement normalization helpers to format both `actual` and `desired` identically before calling `reflect.DeepEqual`.
+
+---
+
+### 4. Validate the Fix
+1. Run the E2E migration test with `WRITE_GOLDEN_OUTPUT=1` to update the recorded traffic and diffs:
+   ```bash
+   E2E_KUBE_TARGET=envtest E2E_GCP_TARGET=mock GOLDEN_REQUEST_CHECKS=1 GOLDEN_OBJECT_CHECKS=1 WRITE_GOLDEN_OUTPUT=1 RUN_E2E=1 go test ./tests/e2e -v -run TestMigrationToDirect/fixtures/<fixture-name>$
+   ```
+2. Verify that the `"isNewObject": false` block in `_migration_diffs.json` is **completely gone**, indicating a clean 0-write takeover.
+3. **Iterate If Diffs Persist:** If a diff block with `"isNewObject": false` still exists in `_migration_diffs.json`, analyze the remaining/new diff fields, loop back to **Step 2 (Identify Root Cause)** and **Step 3 (Formulate Fix)**, and refine or add fixes until no takeover diffs remain.
+4. Run the E2E migration test one final time without `WRITE_GOLDEN_OUTPUT=1` to ensure the test passes with a perfect green status.
+
+---
+
+### 5. Format and Clean Up
+1. Run `make fmt` and `go vet ./pkg/controller/direct/...` to ensure formatting and compilation are perfect.
+2. Clean up any accidentally generated untracked `.log` and `.json` files in other fixture directories:
+   ```bash
+   rm -f pkg/test/resourcefixture/testdata/basic/<service>/v1beta1/<resource>/*/_http_migration_phase*.log
+   rm -f pkg/test/resourcefixture/testdata/basic/<service>/v1beta1/<resource>/*/_migration_diffs.json
+   ```

--- a/.gemini/skills/solve-migration-diff-issues/journal.md
+++ b/.gemini/skills/solve-migration-diff-issues/journal.md
@@ -1,0 +1,7 @@
+# Journal for Solve Migration Diff Issues for Direct Takeover
+
+## 2026-06-12 - BigQueryTable View Schema Diff
+- When migrating resources with derived/computed fields (e.g., a BigQuery view or materialized view's `schema`), the field is typically omitted in the KRM spec but returned by the GCP API.
+- Unlike Terraform (which automatically handles this by storing the fetched value in the state file because the field is `Computed`), Kubernetes/KCC is strictly declarative based on the KRM spec. If the spec has a `nil` schema, the controller will attempt to clear/delete the schema on GCP during reconciliation.
+- To fix this, you must write a custom comparison function (e.g., `tableSchemaEq`) that returns `true` (no diff) if the `desired` schema is `nil`, regardless of the `actual` schema returned by GCP.
+- **Gotcha (Parameter Swap):** In comparison files, parameter names like `a` and `b` are extremely error-prone. They are easily swapped between caller and callee, causing diffs to be reported backwards or checks to be bypassed. Always name them `actual` and `desired` consistently throughout the file.

--- a/config/tests/samples/create/harness.go
+++ b/config/tests/samples/create/harness.go
@@ -405,7 +405,9 @@ func NewHarness(ctx context.Context, t *testing.T, opts ...HarnessOption) *Harne
 
 	// Log structuredreporting messages
 	{
-		ctx = structuredreporting.ContextWithListener(ctx, &structuredreporting.DebugLogListener{})
+		if _, ok := structuredreporting.GetListenerFromContext(ctx); !ok {
+			ctx = structuredreporting.ContextWithListener(ctx, &structuredreporting.DebugLogListener{})
+		}
 		h.Ctx = ctx
 	}
 

--- a/hack/record-gcp
+++ b/hack/record-gcp
@@ -31,6 +31,9 @@ if [[ $1 =~ TestE2EScript.* ]]; then
 elif [[ $1 =~ TestAllInSeries.* ]]; then
   # Prefix looks good
   RUN_TESTS=$1
+elif [[ $1 =~ TestMigrationToDirect.* ]]; then
+  # Prefix looks good
+  RUN_TESTS=$1
 elif [[ $1 =~ pkg.* ]]; then
   # Prefix looks good, but we need to add TestAllInSeries/ and opt-in to full paths
   export USE_FULL_TEST_NAMES=true

--- a/pkg/controller/direct/bigquery/table_compare.go
+++ b/pkg/controller/direct/bigquery/table_compare.go
@@ -35,23 +35,23 @@ func checkFieldValid(fields []*bigquery.TableFieldSchema) error {
 	return nil
 }
 
-func policyTagsEqual(a, b *bigquery.TableFieldSchemaPolicyTags) bool {
-	aEmpty := (a == nil || len(a.Names) == 0)
-	bEmpty := (b == nil || len(b.Names) == 0)
-	if aEmpty && bEmpty {
+func policyTagsEqual(actual, desired *bigquery.TableFieldSchemaPolicyTags) bool {
+	actualEmpty := (actual == nil || len(actual.Names) == 0)
+	desiredEmpty := (desired == nil || len(desired.Names) == 0)
+	if actualEmpty && desiredEmpty {
 		return true
 	}
-	if aEmpty || bEmpty {
+	if actualEmpty || desiredEmpty {
 		return false
 	}
 
-	if len(a.Names) != len(b.Names) {
+	if len(actual.Names) != len(desired.Names) {
 		return false
 	}
-	sort.Strings(a.Names)
-	sort.Strings(b.Names)
-	for i := range a.Names {
-		if a.Names[i] != b.Names[i] {
+	sort.Strings(actual.Names)
+	sort.Strings(desired.Names)
+	for i := range actual.Names {
+		if actual.Names[i] != desired.Names[i] {
 			return false
 		}
 	}
@@ -65,85 +65,84 @@ func sortSchemaFields(fields []*bigquery.TableFieldSchema) {
 	})
 }
 
-func tableFieldsSchemaEqual(desired, actual []*bigquery.TableFieldSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if len(desired) == 0 && len(actual) == 0 {
+func tableFieldsSchemaEqual(actual, desired []*bigquery.TableFieldSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if len(actual) == 0 && len(desired) == 0 {
 		return true, nil
+	}
+	if err := checkFieldValid(actual); err != nil {
+		return false, err
 	}
 	if err := checkFieldValid(desired); err != nil {
 		return false, err
 	}
-	if err := checkFieldValid(actual); err != nil {
-		return false, err
-
-	}
-	if len(desired) != len(actual) {
-		diff.AddField(prefix, desired, actual)
+	if len(actual) != len(desired) {
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
 	// The fields from API can be in a different order.
 	// Sort by name before comparing.
-	sortSchemaFields(desired)
 	sortSchemaFields(actual)
-	for i := range desired {
-		fieldName := desired[i].Name
+	sortSchemaFields(desired)
+	for i := range actual {
+		fieldName := actual[i].Name
 		fieldPrefix := fmt.Sprintf("%s[%s]", prefix, fieldName)
-		if !reflect.DeepEqual(desired[i].Categories, actual[i].Categories) {
-			diff.AddField(fieldPrefix+".categories", desired[i].Categories, actual[i].Categories)
+		if !reflect.DeepEqual(actual[i].Categories, desired[i].Categories) {
+			diff.AddField(fieldPrefix+".categories", actual[i].Categories, desired[i].Categories)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Collation, actual[i].Collation) {
-			diff.AddField(fieldPrefix+".collation", desired[i].Collation, actual[i].Collation)
+		if !reflect.DeepEqual(actual[i].Collation, desired[i].Collation) {
+			diff.AddField(fieldPrefix+".collation", actual[i].Collation, desired[i].Collation)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].DefaultValueExpression, actual[i].DefaultValueExpression) {
-			diff.AddField(fieldPrefix+".default_value_expression", desired[i].DefaultValueExpression, actual[i].DefaultValueExpression)
+		if !reflect.DeepEqual(actual[i].DefaultValueExpression, desired[i].DefaultValueExpression) {
+			diff.AddField(fieldPrefix+".default_value_expression", actual[i].DefaultValueExpression, desired[i].DefaultValueExpression)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Description, actual[i].Description) {
-			diff.AddField(fieldPrefix+".description", desired[i].Description, actual[i].Description)
+		if !reflect.DeepEqual(actual[i].Description, desired[i].Description) {
+			diff.AddField(fieldPrefix+".description", actual[i].Description, desired[i].Description)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].ForeignTypeDefinition, actual[i].ForeignTypeDefinition) {
-			diff.AddField(fieldPrefix+".foreign_type_definition", desired[i].ForeignTypeDefinition, actual[i].ForeignTypeDefinition)
+		if !reflect.DeepEqual(actual[i].ForeignTypeDefinition, desired[i].ForeignTypeDefinition) {
+			diff.AddField(fieldPrefix+".foreign_type_definition", actual[i].ForeignTypeDefinition, desired[i].ForeignTypeDefinition)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].MaxLength, actual[i].MaxLength) {
-			diff.AddField(fieldPrefix+".max_length", desired[i].MaxLength, actual[i].MaxLength)
+		if !reflect.DeepEqual(actual[i].MaxLength, desired[i].MaxLength) {
+			diff.AddField(fieldPrefix+".max_length", actual[i].MaxLength, desired[i].MaxLength)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Mode, actual[i].Mode) {
-			diff.AddField(fieldPrefix+".mode", desired[i].Mode, actual[i].Mode)
+		if !reflect.DeepEqual(actual[i].Mode, desired[i].Mode) {
+			diff.AddField(fieldPrefix+".mode", actual[i].Mode, desired[i].Mode)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Name, actual[i].Name) {
-			diff.AddField(fieldPrefix+".name", desired[i].Name, actual[i].Name)
+		if !reflect.DeepEqual(actual[i].Name, desired[i].Name) {
+			diff.AddField(fieldPrefix+".name", actual[i].Name, desired[i].Name)
 			return false, nil
 		}
-		if !policyTagsEqual(desired[i].PolicyTags, actual[i].PolicyTags) {
-			diff.AddField(fieldPrefix+".policy_tags", desired[i].PolicyTags, actual[i].PolicyTags)
+		if !policyTagsEqual(actual[i].PolicyTags, desired[i].PolicyTags) {
+			diff.AddField(fieldPrefix+".policy_tags", actual[i].PolicyTags, desired[i].PolicyTags)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Precision, actual[i].Precision) {
-			diff.AddField(fieldPrefix+".precision", desired[i].Precision, actual[i].Precision)
+		if !reflect.DeepEqual(actual[i].Precision, desired[i].Precision) {
+			diff.AddField(fieldPrefix+".precision", actual[i].Precision, desired[i].Precision)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].RangeElementType, actual[i].RangeElementType) {
-			diff.AddField(fieldPrefix+".range_element_type", desired[i].RangeElementType, actual[i].RangeElementType)
+		if !reflect.DeepEqual(actual[i].RangeElementType, desired[i].RangeElementType) {
+			diff.AddField(fieldPrefix+".range_element_type", actual[i].RangeElementType, desired[i].RangeElementType)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].RoundingMode, actual[i].RoundingMode) {
-			diff.AddField(fieldPrefix+".rounding_mode", desired[i].RoundingMode, actual[i].RoundingMode)
+		if !reflect.DeepEqual(actual[i].RoundingMode, desired[i].RoundingMode) {
+			diff.AddField(fieldPrefix+".rounding_mode", actual[i].RoundingMode, desired[i].RoundingMode)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Scale, actual[i].Scale) {
-			diff.AddField(fieldPrefix+".scale", desired[i].Scale, actual[i].Scale)
+		if !reflect.DeepEqual(actual[i].Scale, desired[i].Scale) {
+			diff.AddField(fieldPrefix+".scale", actual[i].Scale, desired[i].Scale)
 			return false, nil
 		}
-		if !reflect.DeepEqual(desired[i].Type, actual[i].Type) {
-			diff.AddField(fieldPrefix+".type", desired[i].Type, actual[i].Type)
+		if !reflect.DeepEqual(actual[i].Type, desired[i].Type) {
+			diff.AddField(fieldPrefix+".type", actual[i].Type, desired[i].Type)
 			return false, nil
 		}
-		eq, err := tableFieldsSchemaEqual(desired[i].Fields, actual[i].Fields, fieldPrefix+".fields", diff)
+		eq, err := tableFieldsSchemaEqual(actual[i].Fields, desired[i].Fields, fieldPrefix+".fields", diff)
 		if err != nil {
 			return false, err
 		}
@@ -154,196 +153,199 @@ func tableFieldsSchemaEqual(desired, actual []*bigquery.TableFieldSchema, prefix
 	return true, nil
 }
 
-func externalDataConfigurationEqual(a, b *bigquery.ExternalDataConfiguration, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func externalDataConfigurationEqual(actual, desired *bigquery.ExternalDataConfiguration, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if actual == nil && desired == nil {
 		return true, nil
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Autodetect, b.Autodetect) {
-		diff.AddField(prefix+".autodetect", a.Autodetect, b.Autodetect)
+	if !reflect.DeepEqual(actual.Autodetect, desired.Autodetect) {
+		diff.AddField(prefix+".autodetect", actual.Autodetect, desired.Autodetect)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.AvroOptions, b.AvroOptions) {
-		diff.AddField(prefix+".avro_options", a.AvroOptions, b.AvroOptions)
+	if !reflect.DeepEqual(actual.AvroOptions, desired.AvroOptions) {
+		diff.AddField(prefix+".avro_options", actual.AvroOptions, desired.AvroOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Compression, b.Compression) {
-		diff.AddField(prefix+".compression", a.Compression, b.Compression)
+	if !reflect.DeepEqual(actual.Compression, desired.Compression) {
+		diff.AddField(prefix+".compression", actual.Compression, desired.Compression)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ConnectionId, b.ConnectionId) {
-		diff.AddField(prefix+".connection_id", a.ConnectionId, b.ConnectionId)
+	if !reflect.DeepEqual(actual.ConnectionId, desired.ConnectionId) {
+		diff.AddField(prefix+".connection_id", actual.ConnectionId, desired.ConnectionId)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.CsvOptions, b.CsvOptions) {
-		diff.AddField(prefix+".csv_options", a.CsvOptions, b.CsvOptions)
+	if !reflect.DeepEqual(actual.CsvOptions, desired.CsvOptions) {
+		diff.AddField(prefix+".csv_options", actual.CsvOptions, desired.CsvOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.GoogleSheetsOptions, b.GoogleSheetsOptions) {
-		diff.AddField(prefix+".google_sheets_options", a.GoogleSheetsOptions, b.GoogleSheetsOptions)
+	if !reflect.DeepEqual(actual.GoogleSheetsOptions, desired.GoogleSheetsOptions) {
+		diff.AddField(prefix+".google_sheets_options", actual.GoogleSheetsOptions, desired.GoogleSheetsOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.HivePartitioningOptions, b.HivePartitioningOptions) {
-		diff.AddField(prefix+".hive_partitioning_options", a.HivePartitioningOptions, b.HivePartitioningOptions)
+	if !reflect.DeepEqual(actual.HivePartitioningOptions, desired.HivePartitioningOptions) {
+		diff.AddField(prefix+".hive_partitioning_options", actual.HivePartitioningOptions, desired.HivePartitioningOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.IgnoreUnknownValues, b.IgnoreUnknownValues) {
-		diff.AddField(prefix+".ignore_unknown_values", a.IgnoreUnknownValues, b.IgnoreUnknownValues)
+	if !reflect.DeepEqual(actual.IgnoreUnknownValues, desired.IgnoreUnknownValues) {
+		diff.AddField(prefix+".ignore_unknown_values", actual.IgnoreUnknownValues, desired.IgnoreUnknownValues)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.JsonOptions, b.JsonOptions) {
-		diff.AddField(prefix+".json_options", a.JsonOptions, b.JsonOptions)
+	if !reflect.DeepEqual(actual.JsonOptions, desired.JsonOptions) {
+		diff.AddField(prefix+".json_options", actual.JsonOptions, desired.JsonOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MaxBadRecords, b.MaxBadRecords) {
-		diff.AddField(prefix+".max_bad_records", a.MaxBadRecords, b.MaxBadRecords)
+	if !reflect.DeepEqual(actual.MaxBadRecords, desired.MaxBadRecords) {
+		diff.AddField(prefix+".max_bad_records", actual.MaxBadRecords, desired.MaxBadRecords)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MetadataCacheMode, b.MetadataCacheMode) {
-		diff.AddField(prefix+".metadata_cache_mode", a.MetadataCacheMode, b.MetadataCacheMode)
+	if !reflect.DeepEqual(actual.MetadataCacheMode, desired.MetadataCacheMode) {
+		diff.AddField(prefix+".metadata_cache_mode", actual.MetadataCacheMode, desired.MetadataCacheMode)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ParquetOptions, b.ParquetOptions) {
-		diff.AddField(prefix+".parquet_options", a.ParquetOptions, b.ParquetOptions)
+	if !reflect.DeepEqual(actual.ParquetOptions, desired.ParquetOptions) {
+		diff.AddField(prefix+".parquet_options", actual.ParquetOptions, desired.ParquetOptions)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.SourceFormat, b.SourceFormat) {
-		diff.AddField(prefix+".source_format", a.SourceFormat, b.SourceFormat)
+	if !reflect.DeepEqual(actual.SourceFormat, desired.SourceFormat) {
+		diff.AddField(prefix+".source_format", actual.SourceFormat, desired.SourceFormat)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.SourceUris, b.SourceUris) {
-		diff.AddField(prefix+".source_uris", a.SourceUris, b.SourceUris)
+	if !reflect.DeepEqual(actual.SourceUris, desired.SourceUris) {
+		diff.AddField(prefix+".source_uris", actual.SourceUris, desired.SourceUris)
 		return false, nil
 	}
 
-	equal, err := tableSchemaEq(a.Schema, b.Schema, prefix+".schema", diff)
+	equal, err := tableSchemaEq(actual.Schema, desired.Schema, prefix+".schema", diff)
 	if err != nil {
 		return false, err
 	}
 	return equal, nil
 }
 
-func materializedViewEq(a, b *bigquery.MaterializedViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
-	if a == nil && b == nil {
+func materializedViewEq(actual, desired *bigquery.MaterializedViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
+	if actual == nil && desired == nil {
 		return true
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false
 	}
-	if !reflect.DeepEqual(a.AllowNonIncrementalDefinition, b.AllowNonIncrementalDefinition) {
-		diff.AddField(prefix+".allow_non_incremental_definition", a.AllowNonIncrementalDefinition, b.AllowNonIncrementalDefinition)
+	if !reflect.DeepEqual(actual.AllowNonIncrementalDefinition, desired.AllowNonIncrementalDefinition) {
+		diff.AddField(prefix+".allow_non_incremental_definition", actual.AllowNonIncrementalDefinition, desired.AllowNonIncrementalDefinition)
 		return false
 	}
-	if !reflect.DeepEqual(a.EnableRefresh, b.EnableRefresh) {
-		diff.AddField(prefix+".enable_refresh", a.EnableRefresh, b.EnableRefresh)
+	if !reflect.DeepEqual(actual.EnableRefresh, desired.EnableRefresh) {
+		diff.AddField(prefix+".enable_refresh", actual.EnableRefresh, desired.EnableRefresh)
 		return false
 	}
-	if !reflect.DeepEqual(a.Query, b.Query) {
-		diff.AddField(prefix+".query", a.Query, b.Query)
+	if !reflect.DeepEqual(actual.Query, desired.Query) {
+		diff.AddField(prefix+".query", actual.Query, desired.Query)
 		return false
 	}
-	if !reflect.DeepEqual(a.MaxStaleness, b.MaxStaleness) {
-		diff.AddField(prefix+".max_staleness", a.MaxStaleness, b.MaxStaleness)
+	if !reflect.DeepEqual(actual.MaxStaleness, desired.MaxStaleness) {
+		diff.AddField(prefix+".max_staleness", actual.MaxStaleness, desired.MaxStaleness)
 		return false
 	}
-	if !reflect.DeepEqual(a.RefreshIntervalMs, b.RefreshIntervalMs) {
-		diff.AddField(prefix+".refresh_interval_ms", a.RefreshIntervalMs, b.RefreshIntervalMs)
+	if !reflect.DeepEqual(actual.RefreshIntervalMs, desired.RefreshIntervalMs) {
+		diff.AddField(prefix+".refresh_interval_ms", actual.RefreshIntervalMs, desired.RefreshIntervalMs)
 		return false
 	}
 	return true
 }
 
-func tableSchemaEq(a, b *bigquery.TableSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func tableSchemaEq(actual, desired *bigquery.TableSchema, prefix string, diff *structuredreporting.Diff) (bool, error) {
+	if desired == nil {
+		// If the desired schema is not specified in the KRM spec, we do not enforce it.
+		// This is common for Views, Materialized Views, and External Tables where the schema is derived or autodetected.
 		return true, nil
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil {
+		// Desired schema is specified, but actual is nil. This is a diff.
+		diff.AddField(prefix, actual, desired)
 		return false, nil
 	}
-	return tableFieldsSchemaEqual(a.Fields, b.Fields, prefix+".fields", diff)
+	return tableFieldsSchemaEqual(actual.Fields, desired.Fields, prefix+".fields", diff)
 }
 
-func viewEq(a, b *bigquery.ViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
-	if a == nil && b == nil {
+func viewEq(actual, desired *bigquery.ViewDefinition, prefix string, diff *structuredreporting.Diff) bool {
+	if actual == nil && desired == nil {
 		return true
 	}
-	if a == nil || b == nil {
-		diff.AddField(prefix, a, b)
+	if actual == nil || desired == nil {
+		diff.AddField(prefix, actual, desired)
 		return false
 	}
-	if !reflect.DeepEqual(a.Query, b.Query) {
-		diff.AddField(prefix+".query", a.Query, b.Query)
+	if !reflect.DeepEqual(actual.Query, desired.Query) {
+		diff.AddField(prefix+".query", actual.Query, desired.Query)
 		return false
 	}
-	if !reflect.DeepEqual(a.UseLegacySql, b.UseLegacySql) {
-		diff.AddField(prefix+".use_legacy_sql", a.UseLegacySql, b.UseLegacySql)
+	if !reflect.DeepEqual(actual.UseLegacySql, desired.UseLegacySql) {
+		diff.AddField(prefix+".use_legacy_sql", actual.UseLegacySql, desired.UseLegacySql)
 		return false
 	}
 	return true
 }
 
-func TableEq(a, b *bigquery.Table, diff *structuredreporting.Diff) (bool, error) {
-	if a == nil && b == nil {
+func TableEq(actual, desired *bigquery.Table, diff *structuredreporting.Diff) (bool, error) {
+	if actual == nil && desired == nil {
 		return true, nil
 	}
-	if !reflect.DeepEqual(a.Clustering, b.Clustering) {
-		diff.AddField("clustering", a.Clustering, b.Clustering)
+	if !reflect.DeepEqual(actual.Clustering, desired.Clustering) {
+		diff.AddField("clustering", actual.Clustering, desired.Clustering)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Description, b.Description) {
-		diff.AddField("description", a.Description, b.Description)
+	if !reflect.DeepEqual(actual.Description, desired.Description) {
+		diff.AddField("description", actual.Description, desired.Description)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.EncryptionConfiguration, b.EncryptionConfiguration) {
-		diff.AddField("encryption_configuration", a.EncryptionConfiguration, b.EncryptionConfiguration)
+	if !reflect.DeepEqual(actual.EncryptionConfiguration, desired.EncryptionConfiguration) {
+		diff.AddField("encryption_configuration", actual.EncryptionConfiguration, desired.EncryptionConfiguration)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.ExpirationTime, b.ExpirationTime) {
-		diff.AddField("expiration_time", a.ExpirationTime, b.ExpirationTime)
+	if !reflect.DeepEqual(actual.ExpirationTime, desired.ExpirationTime) {
+		diff.AddField("expiration_time", actual.ExpirationTime, desired.ExpirationTime)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.FriendlyName, b.FriendlyName) {
-		diff.AddField("friendly_name", a.FriendlyName, b.FriendlyName)
+	if !reflect.DeepEqual(actual.FriendlyName, desired.FriendlyName) {
+		diff.AddField("friendly_name", actual.FriendlyName, desired.FriendlyName)
 		return false, nil
 	}
-	if !materializedViewEq(a.MaterializedView, b.MaterializedView, "materialized_view", diff) {
+	if !materializedViewEq(actual.MaterializedView, desired.MaterializedView, "materialized_view", diff) {
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.MaxStaleness, b.MaxStaleness) {
-		diff.AddField("max_staleness", a.MaxStaleness, b.MaxStaleness)
+	if !reflect.DeepEqual(actual.MaxStaleness, desired.MaxStaleness) {
+		diff.AddField("max_staleness", actual.MaxStaleness, desired.MaxStaleness)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.RangePartitioning, b.RangePartitioning) {
-		diff.AddField("range_partitioning", a.RangePartitioning, b.RangePartitioning)
+	if !reflect.DeepEqual(actual.RangePartitioning, desired.RangePartitioning) {
+		diff.AddField("range_partitioning", actual.RangePartitioning, desired.RangePartitioning)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.RequirePartitionFilter, b.RequirePartitionFilter) {
-		diff.AddField("require_partition_filter", a.RequirePartitionFilter, b.RequirePartitionFilter)
+	if !reflect.DeepEqual(actual.RequirePartitionFilter, desired.RequirePartitionFilter) {
+		diff.AddField("require_partition_filter", actual.RequirePartitionFilter, desired.RequirePartitionFilter)
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.TableConstraints, b.TableConstraints) {
-		diff.AddField("table_constraints", a.TableConstraints, b.TableConstraints)
+	if !reflect.DeepEqual(actual.TableConstraints, desired.TableConstraints) {
+		diff.AddField("table_constraints", actual.TableConstraints, desired.TableConstraints)
 		return false, nil
 	}
 
-	if !viewEq(a.View, b.View, "view", diff) {
+	if !viewEq(actual.View, desired.View, "view", diff) {
 		return false, nil
 	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
-		diff.AddField("labels", a.Labels, b.Labels)
+	if !reflect.DeepEqual(actual.Labels, desired.Labels) {
+		diff.AddField("labels", actual.Labels, desired.Labels)
 		return false, nil
 	}
-	equal, err := tableSchemaEq(a.Schema, b.Schema, "schema", diff)
+	equal, err := tableSchemaEq(actual.Schema, desired.Schema, "schema", diff)
 	if err != nil {
 		return false, err
 	}
 	if !equal {
 		return false, nil
 	}
-	return externalDataConfigurationEqual(a.ExternalDataConfiguration, b.ExternalDataConfiguration, "external_data_configuration", diff)
+	return externalDataConfigurationEqual(actual.ExternalDataConfiguration, desired.ExternalDataConfiguration, "external_data_configuration", diff)
 }

--- a/tests/e2e/migration_test.go
+++ b/tests/e2e/migration_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-config-connector/config/tests/samples/create"
+	opcorev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/operator/pkg/apis/core/v1beta1"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/resourceconfig"
+	k8scontrollertype "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/k8s"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/structuredreporting"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test"
+	testgcp "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/gcp"
+	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture"
+	testvariable "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/resourcefixture/variable"
+	testyaml "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/test/yaml"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// TestMigrationToDirect tests the transition/migration of a resource from being
+// managed by the legacy (TF or DCL) controller to the Direct controller.
+// It first provisions the resource using the legacy controller, then applies the
+// `alpha.cnrm.cloud.google.com/reconciler: direct` annotation to force the Direct
+// controller to take over. It verifies that the takeover is smooth and does not
+// trigger any unexpected updates (i.e., a no-op reconciliation).
+func TestMigrationToDirect(t *testing.T) {
+	if os.Getenv("RUN_E2E") == "" {
+		t.Skip("RUN_E2E not set; skipping")
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	subtestTimeout := time.Hour
+	if targetGCP := os.Getenv("E2E_GCP_TARGET"); targetGCP == "mock" {
+		subtestTimeout = 3 * time.Minute
+	}
+
+	t.Run("fixtures", func(t *testing.T) {
+		// Load all fixtures using the same filters as TestAllInSeries
+		lightFilter := func(name string, testType resourcefixture.TestType) bool {
+			return !strings.Contains(name, "iam-bigqueryconnectionconnectionref") &&
+				!strings.Contains(name, "iam-logsinkref") &&
+				!strings.Contains(name, "iam-serviceaccountref") &&
+				!strings.Contains(name, "iam-serviceidentityref") &&
+				!strings.Contains(name, "iam-sqlinstanceref")
+		}
+		pathFilter := func(path string) bool {
+			return !strings.Contains(path, "testdata/iam/iampartialpolicy")
+		}
+
+		fixtures := resourcefixture.LoadWithPathFilter(t, pathFilter, lightFilter, nil)
+		for _, fixture := range fixtures {
+			fixture := fixture
+			group := fixture.GVK.Group
+
+			if s := os.Getenv("SKIP_TEST_APIGROUP"); s != "" {
+				skippedGroups := strings.Split(s, ",")
+				if slices.Contains(skippedGroups, group) {
+					continue
+				}
+			}
+			if s := os.Getenv("ONLY_TEST_APIGROUPS"); s != "" {
+				groups := strings.Split(s, ",")
+				if !slices.Contains(groups, group) {
+					continue
+				}
+			}
+
+			// We only want to test migration if the default controller is TF/DCL, but Direct is supported.
+			config, err := resourceconfig.LoadConfig().GetControllersForGVK(fixture.GVK)
+			if err != nil {
+				t.Logf("skipping GVK %v: %v", fixture.GVK, err)
+				continue
+			}
+
+			hasDirect := false
+			var oldController k8scontrollertype.ReconcilerType
+			for _, c := range config.SupportedControllers {
+				if c == k8scontrollertype.ReconcilerTypeDirect {
+					hasDirect = true
+				} else {
+					oldController = c
+				}
+			}
+			if !hasDirect || oldController == "" {
+				// Skip because we can't migrate from TF/DCL to Direct (or Direct is already the only/default controller)
+				continue
+			}
+
+			testName := fixture.Name
+			if os.Getenv("USE_FULL_TEST_NAMES") == "true" {
+				testName = "pkg/test/resourcefixture/testdata/" + fixture.TestKey
+			}
+
+			t.Run(testName, func(t *testing.T) {
+				if os.Getenv("SKIP_ALL") != "" {
+					t.Skip("SKIP_ALL is set")
+				}
+
+				subCtx := addTestTimeout(ctx, t, subtestTimeout, fixture.TestKey)
+				runMigrationScenario(subCtx, t, fixture, oldController)
+			})
+		}
+	})
+}
+
+func runMigrationScenario(ctx context.Context, t *testing.T, fixture resourcefixture.ResourceFixture, oldController k8scontrollertype.ReconcilerType) {
+	uniqueID := testvariable.NewUniqueID()
+
+	// Load fixture data
+	loadFixture := func(project testgcp.GCPProject, uniqueID string) (*unstructured.Unstructured, create.CreateDeleteTestOptions) {
+		primaryResource := bytesToUnstructured(t, fixture.Create, uniqueID, project)
+		opt := create.CreateDeleteTestOptions{CleanupResources: false}
+
+		if fixture.Dependencies != nil {
+			dependencyYamls := testyaml.SplitYAML(t, fixture.Dependencies)
+			for _, dependBytes := range dependencyYamls {
+				depUnstruct := bytesToUnstructured(t, dependBytes, uniqueID, project)
+				opt.Create = append(opt.Create, depUnstruct)
+			}
+		}
+		opt.Create = append(opt.Create, primaryResource)
+		opt.PrimaryResource = primaryResource
+		return primaryResource, opt
+	}
+
+	// Build harness options (filter CRDs)
+	_, dummyOpt := loadFixture(testgcp.GCPProject{ProjectID: "test-skip", ProjectNumber: 123456789}, uniqueID)
+	keepCRDs := map[schema.GroupKind]bool{}
+	for _, obj := range dummyOpt.Create {
+		keepCRDs[obj.GroupVersionKind().GroupKind()] = true
+	}
+	harnessOptions := []create.HarnessOption{buildCRDFilter(keepCRDs)}
+
+	// Create custom structured reporting listener to capture diffs
+	diffListener := &migrationDiffListener{}
+	ctx = structuredreporting.ContextWithListener(ctx, diffListener)
+
+	// Create harness
+	h := create.NewHarness(ctx, t, harnessOptions...)
+	project := h.Project
+
+	primaryResource, opt := loadFixture(project, uniqueID)
+
+	// Setup namespaces
+	create.SetupNamespacesAndApplyDefaults(h, opt.Create, project)
+
+	// Create ConfigConnector
+	cc := &opcorev1beta1.ConfigConnector{}
+	cc.Name = "configconnector.core.cnrm.cloud.google.com"
+	cc.Spec.Mode = "namespaced"
+	if err := h.GetClient().Create(ctx, cc); err != nil {
+		t.Fatalf("FAIL: error creating CC: %v", err)
+	}
+
+	// Create ConfigConnectorContext with controllerOverride to force old controller
+	ccc := &opcorev1beta1.ConfigConnectorContext{}
+	ccc.Name = "configconnectorcontext.core.cnrm.cloud.google.com"
+	ccc.Namespace = primaryResource.GetNamespace()
+
+	primaryGK := primaryResource.GroupVersionKind().GroupKind()
+	controllerOverrides := map[string]k8scontrollertype.ReconcilerType{
+		fmt.Sprintf("%s.%s", primaryGK.Kind, primaryGK.Group): oldController,
+	}
+	ccc.Spec.Experiments = &opcorev1beta1.Experiments{
+		ControllerOverrides: controllerOverrides,
+	}
+	if err := h.GetClient().Create(ctx, ccc); err != nil {
+		t.Fatalf("FAIL: error creating CCC: %v", err)
+	}
+
+	t.Logf("Phase 1: Creating resource using %v...", oldController)
+	// Create resources (dependencies + primary)
+	for _, u := range opt.Create {
+		t.Log("creating object", "GVK", u.GroupVersionKind().String(), "name", u.GetName())
+		if err := h.GetClient().Patch(ctx, u, client.Apply, client.FieldOwner("kcc-tests")); err != nil {
+			t.Fatalf("error creating resource: %v", err)
+		}
+	}
+	// Wait for them to be ready
+	create.WaitForReady(h, create.DefaultWaitForReadyTimeout, opt.Create...)
+
+	// Record HTTP log for Phase 1
+	eventsPhase1 := h.Events.HTTPEvents
+	if os.Getenv("GOLDEN_REQUEST_CHECKS") != "" || os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
+		got, normalizers := LegacyNormalize(t, h, project, uniqueID, test.LogEntries(eventsPhase1))
+		h.CompareGoldenFile(filepath.Join(fixture.AbsoluteSourceDir, "_http_migration_phase1.log"), got, normalizers...)
+	}
+
+	t.Log("Phase 2: Migrating to Direct controller...")
+	// Get pre-patch resource version to wait for reconciliation
+	prePatchRV := getResourceVersion(h, primaryResource)
+
+	// Update primary resource with direct reconciler annotation and touch it
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(primaryResource.GroupVersionKind())
+	u.SetName(primaryResource.GetName())
+	u.SetNamespace(primaryResource.GetNamespace())
+
+	// Get existing annotations
+	existing := readObject(h, primaryResource.GroupVersionKind(), primaryResource.GetNamespace(), primaryResource.GetName())
+	annotations := existing.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["alpha.cnrm.cloud.google.com/reconciler"] = "direct"
+	annotations["test.cnrm.cloud.google.com/reconcile-cookie"] = "migration-v1"
+	u.SetAnnotations(annotations)
+
+	t.Logf("Applying direct reconciler annotation to %s/%s", u.GetNamespace(), u.GetName())
+	if err := h.GetClient().Patch(ctx, u, client.Apply, client.FieldOwner("kcc-test-migration-touch")); err != nil {
+		t.Fatalf("error applying direct reconciler annotation: %v", err)
+	}
+
+	// Wait for direct controller to reconcile it
+	waitForReconciliationAfterPatch(h, primaryResource, prePatchRV)
+
+	// Verify HTTP events during Phase 2 (Direct take over)
+	eventsPhase2 := h.Events.HTTPEvents[len(eventsPhase1):]
+
+	// The direct controller should not perform any updates (no-op reconciliation)
+	for _, event := range eventsPhase2 {
+		isReadOnly := false
+		switch event.Request.Method {
+		case "GET":
+			isReadOnly = true
+		case "GRPC":
+			if strings.Contains(event.Request.URL, "/Get") || strings.Contains(event.Request.URL, "/List") {
+				isReadOnly = true
+			}
+		}
+		if !isReadOnly {
+			t.Errorf("FAIL: unexpected write request during migration reconciliation: %v %v", event.Request.Method, event.Request.URL)
+		}
+	}
+
+	// Record HTTP log for Phase 2
+	if os.Getenv("GOLDEN_REQUEST_CHECKS") != "" || os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
+		got, normalizers := LegacyNormalize(t, h, project, uniqueID, test.LogEntries(eventsPhase2))
+		h.CompareGoldenFile(filepath.Join(fixture.AbsoluteSourceDir, "_http_migration_phase2.log"), got, normalizers...)
+	}
+
+	// Record raw structured diffs (only written when recording golden output for inspection)
+	if os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
+		rawDiffsStr := formatDiffsRaw(t, diffListener)
+		diffPath := filepath.Join(fixture.AbsoluteSourceDir, "_migration_diffs.json")
+		if err := os.WriteFile(diffPath, []byte(rawDiffsStr), 0644); err != nil {
+			t.Fatalf("FAIL: error writing _migration_diffs.json: %v", err)
+		}
+		t.Logf("wrote raw structured diff to %s", diffPath)
+	}
+
+	// Cleanup
+	t.Log("Cleaning up resources...")
+	opt.CleanupResources = true
+	create.DeleteResources(h, opt)
+}
+
+func getResourceVersion(h *create.Harness, obj *unstructured.Unstructured) string {
+	existing := readObject(h, obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	return existing.GetResourceVersion()
+}
+
+type migrationDiffListener struct {
+	mu    sync.Mutex
+	diffs []*structuredreporting.Diff
+}
+
+func (l *migrationDiffListener) OnDiff(ctx context.Context, diff *structuredreporting.Diff) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Clone the diff because the underlying object might be modified
+	clone := &structuredreporting.Diff{
+		IsNewObject: diff.IsNewObject,
+	}
+	if diff.Object != nil {
+		clone.Object = diff.Object.DeepCopy()
+	}
+	for _, f := range diff.Fields {
+		clone.Fields = append(clone.Fields, structuredreporting.DiffField{
+			ID:                   f.ID,
+			ProtoFieldDescriptor: f.ProtoFieldDescriptor,
+			Old:                  f.Old,
+			New:                  f.New,
+		})
+	}
+	l.diffs = append(l.diffs, clone)
+}
+
+func (l *migrationDiffListener) OnError(ctx context.Context, err error, args ...any) {}
+func (l *migrationDiffListener) OnReconcileStart(ctx context.Context, u *unstructured.Unstructured, t k8scontrollertype.ReconcilerType) {
+}
+func (l *migrationDiffListener) OnReconcileEnd(ctx context.Context, u *unstructured.Unstructured, result reconcile.Result, err error, t k8scontrollertype.ReconcilerType) {
+}
+
+type rawDiffField struct {
+	ID  string `json:"id"`
+	Old any    `json:"old,omitempty"`
+	New any    `json:"new,omitempty"`
+}
+
+type rawDiff struct {
+	IsNewObject bool           `json:"isNewObject"`
+	Resource    string         `json:"resource"`
+	Fields      []rawDiffField `json:"fields,omitempty"`
+}
+
+func formatDiffsRaw(t *testing.T, listener *migrationDiffListener) string {
+	var rawDiffs []rawDiff
+	for _, diff := range listener.diffs {
+		rd := rawDiff{
+			IsNewObject: diff.IsNewObject,
+		}
+		if diff.Object != nil {
+			rd.Resource = fmt.Sprintf("%s/%s", diff.Object.GetKind(), diff.Object.GetName())
+		}
+
+		// Sort fields by ID to ensure deterministic output
+		fields := append([]structuredreporting.DiffField{}, diff.Fields...)
+		sort.Slice(fields, func(i, j int) bool {
+			return fields[i].ID < fields[j].ID
+		})
+
+		for _, f := range fields {
+			rd.Fields = append(rd.Fields, rawDiffField{
+				ID:  f.ID,
+				Old: f.Old,
+				New: f.New,
+			})
+		}
+		rawDiffs = append(rawDiffs, rd)
+	}
+
+	// Marshal to pretty JSON
+	bytes, err := json.MarshalIndent(rawDiffs, "", "  ")
+	if err != nil {
+		t.Fatalf("FAIL: error marshaling diffs to JSON: %v", err)
+	}
+	return string(bytes) + "\n"
+}


### PR DESCRIPTION
This PR introduces a new E2E migration test suite to KCC, along with a custom Gemini skill to help automated agents debug takeover diff issues during migration.

### 1. E2E Migration Test Suite (`TestMigrationToDirect`)
* Implements a generic runner in `tests/e2e/migration_test.go` that provisions resources using the legacy Terraform/DCL controller, switches the configuration to the Direct controller, and reconciles to assert that the takeover is a clean 0-write no-op.
* Integrates a raw structured diff reporter that writes to `_migration_diffs.json` when recording (`WRITE_GOLDEN_OUTPUT=1`) to help analyze diffs before committing.
* Modified the test harness (`config/tests/samples/create/harness.go`) to preserve pre-existing `structuredreporting.Listener` contexts.
* Modified `hack/record-gcp` to support running these migration tests.

### 2. Custom Gemini Skill (`solve-migration-diff-issues`)
* Adds a new, highly structured skill under `.gemini/skills/solve-migration-diff-issues/` consisting of:
  * `SKILL.md`: Detailed steps on how to diagnose, identify root causes, fix, and validate Direct controller takeover diffs.
  * `journal.md`: A log of lessons learned, including BigQuery view schema diffs, parameter swap gotchas, and the contrast between KCC's strict declarative model and Terraform's `Computed` behavior.
