### PR TITLE
Add oneOf rule for secret fields back to ComputeInstance

### DIFF
--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeinstances.compute.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_computeinstances.compute.cnrm.cloud.google.com.yaml
@@ -106,6 +106,17 @@ spec:
                       description: A 256-bit customer-supplied encryption key, encoded
                         in RFC 4648 base64 to encrypt this disk. Only one of kms_key_self_link
                         and disk_encryption_key_raw may be set.
+                      oneOf:
+                      - not:
+                          required:
+                          - valueFrom
+                        required:
+                        - value
+                      - not:
+                          required:
+                          - value
+                        required:
+                        - valueFrom
                       properties:
                         value:
                           description: Value of the field. Cannot be used if 'valueFrom'
@@ -212,6 +223,17 @@ spec:
                     description: Immutable. A 256-bit customer-supplied encryption
                       key, encoded in RFC 4648 base64 to encrypt this disk. Only one
                       of kms_key_self_link and disk_encryption_key_raw may be set.
+                    oneOf:
+                    - not:
+                        required:
+                        - valueFrom
+                      required:
+                      - value
+                    - not:
+                        required:
+                        - value
+                      required:
+                      - valueFrom
                     properties:
                       value:
                         description: Value of the field. Cannot be used if 'valueFrom'

--- a/dev/tools/crd-to-simple-schema/main.go
+++ b/dev/tools/crd-to-simple-schema/main.go
@@ -387,6 +387,16 @@ func walk(s *apiextensionsv1.JSONSchemaProps) any {
 		for _, req := range s.Required {
 			m["_required."+req] = "true"
 		}
+		for _, oneOf := range s.OneOf {
+			req := strings.Join(oneOf.Required, ",")
+			notReq := ""
+			if oneOf.Not != nil {
+				notReq = strings.Join(oneOf.Not.Required, ",")
+			}
+			if (req == "value" && notReq == "valueFrom") || (req == "valueFrom" && notReq == "value") {
+				m[fmt.Sprintf("_validation.oneOf.required[%s].not.required[%s]", req, notReq)] = "true"
+			}
+		}
 		return m
 	}
 

--- a/dev/tools/crd-to-simple-schema/testdata/oneof-validation/_output.txt
+++ b/dev/tools/crd-to-simple-schema/testdata/oneof-validation/_output.txt
@@ -1,0 +1,3 @@
+schema:
+- spec.password._validation.oneOf.required[valueFrom].not.required[value]=true
+- spec.password._validation.oneOf.required[value].not.required[valueFrom]=true

--- a/dev/tools/crd-to-simple-schema/testdata/oneof-validation/crd1.yaml
+++ b/dev/tools/crd-to-simple-schema/testdata/oneof-validation/crd1.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.example.com
+spec:
+  group: example.com
+  names:
+    kind: Test
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              password:
+                type: object
+                properties:
+                  value:
+                    type: string
+                  valueFrom:
+                    type: object
+                oneOf:
+                - not:
+                    required:
+                    - valueFrom
+                  required:
+                  - value
+                - not:
+                    required:
+                    - value
+                  required:
+                  - valueFrom
+    served: true
+    storage: true

--- a/dev/tools/crd-to-simple-schema/testdata/oneof-validation/crd2.yaml
+++ b/dev/tools/crd-to-simple-schema/testdata/oneof-validation/crd2.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.example.com
+spec:
+  group: example.com
+  names:
+    kind: Test
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              password:
+                type: object
+                properties:
+                  value:
+                    type: string
+                  valueFrom:
+                    type: object
+    served: true
+    storage: true

--- a/scripts/add-validation-to-crds/parse-crds.go
+++ b/scripts/add-validation-to-crds/parse-crds.go
@@ -391,7 +391,7 @@ oneOf:
 			}
 		} else if signature == "external,name,namespace" {
 			ruleYAML = refRuleWithoutKind
-		} else if signature == "value,valueFrom" && (kind == "AlloyDBUser" || kind == "ContainerCluster" || kind == "MonitoringUptimeCheckConfig") {
+		} else if signature == "value,valueFrom" && (kind == "AlloyDBUser" || kind == "ComputeInstance" || kind == "ContainerCluster" || kind == "MonitoringUptimeCheckConfig") {
 			ruleYAML = legacyRefRule
 		} else {
 			if strings.HasPrefix(signature, "external,") {


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Add `oneOf` rule for secret fields back to ComputeInstance and ensure CRD equivalence check detects this edge case.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.



FIXES #10008 