### PR TITLE
fix: path for instructions to update mock

### DIFF
--- a/.gemini/skills/match-mockgcp-with-realgcp/SKILL.md
+++ b/.gemini/skills/match-mockgcp-with-realgcp/SKILL.md
@@ -8,8 +8,8 @@ When the golden tests for K8s Config Connector mock output diverge from real GCP
 
 ### Align Mockgcp
 
-1.  Run `dev/tools/record-gcp "fixtures/^<testname>$"` to capture real GCP behavior.
-2.  Run `dev/tools/compare-mock "fixtures/^<testname>$"` to check mock behavior.
+1.  Run `hack/record-gcp "fixtures/^<testname>$"` to capture real GCP behavior.
+2.  Run `hack/compare-mock "fixtures/^<testname>$"` to check mock behavior.
 3.  Iteratively fix discrepancies in the mock implementation or `normalize.go`.
 
 #### Tips for fixing the discrepancies:
@@ -25,4 +25,3 @@ When the golden tests for K8s Config Connector mock output diverge from real GCP
 
 * It is important to commit the files modified by running realgcp tests in its own commit.
 * This is for the human reviewer to compare the diff in the test artifacts when running real and mockgcp.
-


### PR DESCRIPTION
Not sure how this merge missed the change !! 

https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9814/files#diff-873b9263ca2019b6e4f00bfc65280145b1d6fd249f0b654ad0b53aff893c3b0f