### PR TITLE
Security: Incorrect string matching in ParseAccessPolicyExternal

### DIFF
--- a/apis/accesscontextmanager/v1beta1/accesspolicy_identity.go
+++ b/apis/accesscontextmanager/v1beta1/accesspolicy_identity.go
@@ -52,7 +52,7 @@ func NewAccessPolicyIdentity(ctx context.Context, reader client.Reader, obj *Acc
 func ParseAccessPolicyExternal(external string) (resourceID string, err error) {
 	// pattern: "accessPolicies/{access_policy}"
 	tokens := strings.Split(external, "/")
-	if len(tokens) != 2 || tokens[0] != "accesspolicys" {
+	if len(tokens) != 2 || tokens[0] != "accessPolicies" {
 		return "", fmt.Errorf("format of AccessContextManagerAccessPolicy external=%q was not known (use accessPolicies/{{access_policy}})", external)
 	}
 	resourceID = tokens[1]


### PR DESCRIPTION
## Summary

Security: Incorrect string matching in ParseAccessPolicyExternal

## Problem

**Severity**: `Medium` | **File**: `apis/accesscontextmanager/v1beta1/accesspolicy_identity.go:L56`

The `ParseAccessPolicyExternal` function checks for `tokens[0] != "accesspolicys"` but the error message and expected format suggest it should be `accessPolicies`. This typo causes valid input like `accessPolicies/123` to be rejected, while invalid input would be accepted.

## Solution

Fix the string comparison to use `accessPolicies` instead of `accesspolicys` to match the documented format and error message.

## Changes

- `apis/accesscontextmanager/v1beta1/accesspolicy_identity.go` (modified)