### PR TITLE
Update migration tracker for consistent direct resource naming

### DIFF
--- a/dev/migration-tracker/data.json
+++ b/dev/migration-tracker/data.json
@@ -22,7 +22,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 123,
+    "sortOrder": 125,
     "downstreamCount": 0
   },
   {
@@ -48,7 +48,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 124,
+    "sortOrder": 126,
     "downstreamCount": 0
   },
   {
@@ -75,7 +75,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 130,
+    "sortOrder": 133,
     "downstreamCount": 0
   },
   {
@@ -128,7 +128,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 133,
+    "sortOrder": 136,
     "downstreamCount": 0
   },
   {
@@ -176,7 +176,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 134,
+    "sortOrder": 137,
     "downstreamCount": 0
   },
   {
@@ -205,7 +205,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 135,
+    "sortOrder": 138,
     "downstreamCount": 0
   },
   {
@@ -229,7 +229,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 136,
+    "sortOrder": 139,
     "downstreamCount": 0
   },
   {
@@ -255,7 +255,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 137,
+    "sortOrder": 140,
     "downstreamCount": 0
   },
   {
@@ -310,7 +310,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 139,
+    "sortOrder": 142,
     "downstreamCount": 0
   },
   {
@@ -334,7 +334,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 141,
+    "sortOrder": 145,
     "downstreamCount": 0
   },
   {
@@ -384,7 +384,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 145,
+    "sortOrder": 149,
     "downstreamCount": 0
   },
   {
@@ -411,8 +411,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 23,
-    "downstreamCount": 6
+    "sortOrder": 20,
+    "downstreamCount": 7
   },
   {
     "group": "apigee",
@@ -435,7 +435,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 148,
+    "sortOrder": 153,
     "downstreamCount": 0
   },
   {
@@ -459,7 +459,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 149,
+    "sortOrder": 154,
     "downstreamCount": 0
   },
   {
@@ -483,7 +483,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 150,
+    "sortOrder": 155,
     "downstreamCount": 0
   },
   {
@@ -509,7 +509,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 151,
+    "sortOrder": 156,
     "downstreamCount": 0
   },
   {
@@ -533,7 +533,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 152,
+    "sortOrder": 157,
     "downstreamCount": 0
   },
   {
@@ -559,7 +559,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 153,
+    "sortOrder": 158,
     "downstreamCount": 0
   },
   {
@@ -586,7 +586,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 157,
+    "sortOrder": 163,
     "downstreamCount": 0
   },
   {
@@ -612,7 +612,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 166,
+    "sortOrder": 173,
     "downstreamCount": 0
   },
   {
@@ -638,7 +638,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 167,
+    "sortOrder": 174,
     "downstreamCount": 0
   },
   {
@@ -664,7 +664,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 168,
+    "sortOrder": 175,
     "downstreamCount": 0
   },
   {
@@ -690,7 +690,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 176,
+    "sortOrder": 183,
     "downstreamCount": 0
   },
   {
@@ -743,8 +743,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 178,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 185,
     "downstreamCount": 0
   },
   {
@@ -772,7 +772,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 179,
+    "sortOrder": 186,
     "downstreamCount": 0
   },
   {
@@ -798,7 +798,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 181,
+    "sortOrder": 189,
     "downstreamCount": 0
   },
   {
@@ -825,7 +825,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 182,
+    "sortOrder": 190,
     "downstreamCount": 0
   },
   {
@@ -880,7 +880,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 183,
+    "sortOrder": 191,
     "downstreamCount": 0
   },
   {
@@ -890,24 +890,25 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "BigtableInstance",
       "BigtableTable"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 186,
+    "sortOrder": 194,
     "downstreamCount": 0
   },
   {
@@ -985,7 +986,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 189,
+    "sortOrder": 197,
     "downstreamCount": 0
   },
   {
@@ -1011,7 +1012,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 190,
+    "sortOrder": 198,
     "downstreamCount": 0
   },
   {
@@ -1037,7 +1038,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 192,
+    "sortOrder": 200,
     "downstreamCount": 0
   },
   {
@@ -1064,7 +1065,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 197,
+    "sortOrder": 206,
     "downstreamCount": 0
   },
   {
@@ -1091,7 +1092,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 199,
+    "sortOrder": 208,
     "downstreamCount": 0
   },
   {
@@ -1101,23 +1102,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 200,
+    "notes": "",
+    "sortOrder": 209,
     "downstreamCount": 0
   },
   {
@@ -1143,7 +1145,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 202,
+    "sortOrder": 211,
     "downstreamCount": 0
   },
   {
@@ -1167,7 +1169,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 203,
+    "sortOrder": 212,
     "downstreamCount": 0
   },
   {
@@ -1193,7 +1195,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 204,
+    "sortOrder": 213,
     "downstreamCount": 0
   },
   {
@@ -1220,8 +1222,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 207,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 216,
     "downstreamCount": 0
   },
   {
@@ -1247,7 +1249,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 214,
+    "sortOrder": 223,
     "downstreamCount": 0
   },
   {
@@ -1274,7 +1276,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 215,
+    "sortOrder": 224,
     "downstreamCount": 0
   },
   {
@@ -1301,7 +1303,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 216,
+    "sortOrder": 225,
     "downstreamCount": 0
   },
   {
@@ -1325,7 +1327,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 217,
+    "sortOrder": 226,
     "downstreamCount": 0
   },
   {
@@ -1349,7 +1351,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 218,
+    "sortOrder": 227,
     "downstreamCount": 0
   },
   {
@@ -1375,7 +1377,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 220,
+    "sortOrder": 229,
     "downstreamCount": 0
   },
   {
@@ -1385,20 +1387,21 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork",
       "ComputeSubnetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -1412,23 +1415,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 224,
+    "sortOrder": 233,
     "downstreamCount": 0
   },
   {
@@ -1454,7 +1458,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 20,
+    "sortOrder": 21,
     "downstreamCount": 7
   },
   {
@@ -1481,7 +1485,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 225,
+    "sortOrder": 234,
     "downstreamCount": 0
   },
   {
@@ -1522,24 +1526,25 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeBackendService",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 226,
+    "sortOrder": 235,
     "downstreamCount": 0
   },
   {
@@ -1549,6 +1554,7 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
@@ -1557,18 +1563,18 @@
       "KMSCryptoKey",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 527,
+    "sortOrder": 552,
     "downstreamCount": 4
   },
   {
@@ -1578,24 +1584,25 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeDisk",
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 525,
+    "sortOrder": 551,
     "downstreamCount": 0
   },
   {
@@ -1619,7 +1626,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 227,
+    "sortOrder": 236,
     "downstreamCount": 0
   },
   {
@@ -1637,15 +1644,15 @@
     "state": "Not Started",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 228,
+    "notes": "",
+    "sortOrder": 237,
     "downstreamCount": 0
   },
   {
@@ -1662,8 +1669,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -1697,7 +1704,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 229,
+    "sortOrder": 238,
     "downstreamCount": 0
   },
   {
@@ -1760,7 +1767,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 232,
+    "sortOrder": 241,
     "downstreamCount": 0
   },
   {
@@ -1786,7 +1793,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 233,
+    "sortOrder": 242,
     "downstreamCount": 0
   },
   {
@@ -1796,20 +1803,21 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "In Progress",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 13,
     "downstreamCount": 11
   },
@@ -1834,7 +1842,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 234,
+    "sortOrder": 243,
     "downstreamCount": 0
   },
   {
@@ -1857,7 +1865,7 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "Missing _reference.go or _identity.go",
     "sortOrder": 12,
     "downstreamCount": 12
   },
@@ -1868,24 +1876,25 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeDisk",
       "KMSCryptoKey"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 524,
+    "sortOrder": 554,
     "downstreamCount": 4
   },
   {
@@ -1895,6 +1904,7 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
@@ -1904,14 +1914,14 @@
       "IAMServiceAccount",
       "KMSCryptoKey"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -1925,22 +1935,23 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
+    "notes": "",
     "sortOrder": 15,
     "downstreamCount": 10
   },
@@ -1996,7 +2007,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 235,
+    "sortOrder": 244,
     "downstreamCount": 0
   },
   {
@@ -2025,7 +2036,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 21,
+    "sortOrder": 22,
     "downstreamCount": 7
   },
   {
@@ -2077,7 +2088,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 237,
+    "sortOrder": 246,
     "downstreamCount": 0
   },
   {
@@ -2103,7 +2114,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 238,
+    "sortOrder": 247,
     "downstreamCount": 0
   },
   {
@@ -2113,22 +2124,23 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "In Progress",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 5,
-    "downstreamCount": 123
+    "sortOrder": 4,
+    "downstreamCount": 126
   },
   {
     "group": "compute",
@@ -2155,7 +2167,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 241,
+    "sortOrder": 250,
     "downstreamCount": 0
   },
   {
@@ -2208,7 +2220,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 242,
+    "sortOrder": 251,
     "downstreamCount": 0
   },
   {
@@ -2235,7 +2247,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 243,
+    "sortOrder": 252,
     "downstreamCount": 0
   },
   {
@@ -2262,7 +2274,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 244,
+    "sortOrder": 253,
     "downstreamCount": 0
   },
   {
@@ -2287,8 +2299,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 245,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 254,
     "downstreamCount": 0
   },
   {
@@ -2315,7 +2327,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 246,
+    "sortOrder": 255,
     "downstreamCount": 0
   },
   {
@@ -2342,7 +2354,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 247,
+    "sortOrder": 256,
     "downstreamCount": 0
   },
   {
@@ -2381,7 +2393,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -2389,8 +2401,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 248,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 257,
     "downstreamCount": 0
   },
   {
@@ -2414,7 +2426,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 249,
+    "sortOrder": 258,
     "downstreamCount": 0
   },
   {
@@ -2438,7 +2450,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 250,
+    "sortOrder": 259,
     "downstreamCount": 0
   },
   {
@@ -2464,7 +2476,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 251,
+    "sortOrder": 260,
     "downstreamCount": 0
   },
   {
@@ -2491,7 +2503,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 252,
+    "sortOrder": 261,
     "downstreamCount": 0
   },
   {
@@ -2515,7 +2527,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 253,
+    "sortOrder": 262,
     "downstreamCount": 0
   },
   {
@@ -2532,16 +2544,16 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
-      "controller": false,
+      "controller": true,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 254,
+    "sortOrder": 263,
     "downstreamCount": 0
   },
   {
@@ -2568,7 +2580,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 526,
+    "sortOrder": 553,
     "downstreamCount": 0
   },
   {
@@ -2596,7 +2608,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 255,
+    "sortOrder": 264,
     "downstreamCount": 0
   },
   {
@@ -2621,8 +2633,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 256,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 265,
     "downstreamCount": 0
   },
   {
@@ -2648,7 +2660,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 257,
+    "sortOrder": 266,
     "downstreamCount": 0
   },
   {
@@ -2675,7 +2687,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 258,
+    "sortOrder": 267,
     "downstreamCount": 0
   },
   {
@@ -2699,7 +2711,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 259,
+    "sortOrder": 268,
     "downstreamCount": 0
   },
   {
@@ -2716,8 +2728,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -2725,7 +2737,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 260,
+    "sortOrder": 269,
     "downstreamCount": 0
   },
   {
@@ -2735,19 +2747,20 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -2771,8 +2784,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -2807,7 +2820,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 261,
+    "sortOrder": 270,
     "downstreamCount": 0
   },
   {
@@ -2834,7 +2847,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 262,
+    "sortOrder": 271,
     "downstreamCount": 0
   },
   {
@@ -2858,7 +2871,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 263,
+    "sortOrder": 272,
     "downstreamCount": 0
   },
   {
@@ -2868,17 +2881,18 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -2892,17 +2906,18 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -2956,7 +2971,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 264,
+    "sortOrder": 273,
     "downstreamCount": 0
   },
   {
@@ -2982,7 +2997,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 265,
+    "sortOrder": 274,
     "downstreamCount": 0
   },
   {
@@ -3141,7 +3156,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 266,
+    "sortOrder": 275,
     "downstreamCount": 0
   },
   {
@@ -3168,7 +3183,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 267,
+    "sortOrder": 276,
     "downstreamCount": 0
   },
   {
@@ -3258,20 +3273,21 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeBackendBucket",
       "ComputeBackendService"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -3357,7 +3373,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 268,
+    "sortOrder": 277,
     "downstreamCount": 0
   },
   {
@@ -3381,7 +3397,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 270,
+    "sortOrder": 280,
     "downstreamCount": 0
   },
   {
@@ -3407,7 +3423,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 271,
+    "sortOrder": 281,
     "downstreamCount": 0
   },
   {
@@ -3432,8 +3448,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 272,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 282,
     "downstreamCount": 0
   },
   {
@@ -3481,8 +3497,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3490,7 +3506,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 273,
+    "sortOrder": 283,
     "downstreamCount": 0
   },
   {
@@ -3517,7 +3533,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 276,
+    "sortOrder": 288,
     "downstreamCount": 0
   },
   {
@@ -3571,7 +3587,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 278,
+    "sortOrder": 290,
     "downstreamCount": 0
   },
   {
@@ -3597,7 +3613,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 279,
+    "sortOrder": 291,
     "downstreamCount": 0
   },
   {
@@ -3651,7 +3667,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 280,
+    "sortOrder": 292,
     "downstreamCount": 0
   },
   {
@@ -3679,12 +3695,39 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 281,
+    "sortOrder": 293,
     "downstreamCount": 0
   },
   {
     "group": "dns",
     "kind": "DNSResponsePolicy",
+    "version": "v1beta1",
+    "controllerType": "Terraform",
+    "defaultController": "Terraform",
+    "supportedControllers": [
+      "Direct",
+      "Terraform"
+    ],
+    "dependencies": [
+      "Project"
+    ],
+    "state": "Completed",
+    "steps": {
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
+    },
+    "mocksLastRefreshed": "Never",
+    "notes": "",
+    "sortOrder": 294,
+    "downstreamCount": 0
+  },
+  {
+    "group": "dns",
+    "kind": "DNSResponsePolicyRule",
     "version": "v1beta1",
     "controllerType": "Terraform",
     "defaultController": "Terraform",
@@ -3705,33 +3748,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 282,
-    "downstreamCount": 0
-  },
-  {
-    "group": "dns",
-    "kind": "DNSResponsePolicyRule",
-    "version": "v1beta1",
-    "controllerType": "Terraform",
-    "defaultController": "Terraform",
-    "supportedControllers": [
-      "Terraform"
-    ],
-    "dependencies": [
-      "Project"
-    ],
-    "state": "Not Started",
-    "steps": {
-      "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
-    },
-    "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 283,
+    "sortOrder": 295,
     "downstreamCount": 0
   },
   {
@@ -3757,7 +3774,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 284,
+    "sortOrder": 296,
     "downstreamCount": 0
   },
   {
@@ -3810,7 +3827,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 287,
+    "sortOrder": 299,
     "downstreamCount": 0
   },
   {
@@ -3839,7 +3856,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 294,
+    "sortOrder": 308,
     "downstreamCount": 0
   },
   {
@@ -3867,7 +3884,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 295,
+    "sortOrder": 309,
     "downstreamCount": 0
   },
   {
@@ -3877,23 +3894,24 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 303,
+    "notes": "",
+    "sortOrder": 321,
     "downstreamCount": 0
   },
   {
@@ -3914,8 +3932,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -3953,7 +3971,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 308,
+    "sortOrder": 326,
     "downstreamCount": 0
   },
   {
@@ -3979,7 +3997,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 309,
+    "sortOrder": 327,
     "downstreamCount": 0
   },
   {
@@ -4005,7 +4023,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 312,
+    "sortOrder": 330,
     "downstreamCount": 0
   },
   {
@@ -4031,7 +4049,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 313,
+    "sortOrder": 331,
     "downstreamCount": 0
   },
   {
@@ -4055,7 +4073,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 318,
+    "sortOrder": 336,
     "downstreamCount": 0
   },
   {
@@ -4081,7 +4099,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 319,
+    "sortOrder": 337,
     "downstreamCount": 0
   },
   {
@@ -4105,7 +4123,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 320,
+    "sortOrder": 338,
     "downstreamCount": 0
   },
   {
@@ -4129,7 +4147,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 321,
+    "sortOrder": 339,
     "downstreamCount": 0
   },
   {
@@ -4153,7 +4171,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 322,
+    "sortOrder": 340,
     "downstreamCount": 0
   },
   {
@@ -4177,7 +4195,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 323,
+    "sortOrder": 341,
     "downstreamCount": 0
   },
   {
@@ -4201,7 +4219,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 324,
+    "sortOrder": 342,
     "downstreamCount": 0
   },
   {
@@ -4227,7 +4245,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 326,
+    "sortOrder": 344,
     "downstreamCount": 0
   },
   {
@@ -4253,7 +4271,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 327,
+    "sortOrder": 345,
     "downstreamCount": 0
   },
   {
@@ -4279,7 +4297,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 329,
+    "sortOrder": 347,
     "downstreamCount": 0
   },
   {
@@ -4303,7 +4321,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 336,
+    "sortOrder": 356,
     "downstreamCount": 0
   },
   {
@@ -4358,7 +4376,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 339,
+    "sortOrder": 359,
     "downstreamCount": 0
   },
   {
@@ -4385,7 +4403,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 340,
+    "sortOrder": 360,
     "downstreamCount": 0
   },
   {
@@ -4438,7 +4456,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 341,
+    "sortOrder": 361,
     "downstreamCount": 0
   },
   {
@@ -4467,7 +4485,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 346,
+    "sortOrder": 367,
     "downstreamCount": 0
   },
   {
@@ -4493,7 +4511,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 347,
+    "sortOrder": 368,
     "downstreamCount": 0
   },
   {
@@ -4511,7 +4529,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -4519,8 +4537,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 348,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 369,
     "downstreamCount": 0
   },
   {
@@ -4546,7 +4564,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 349,
+    "sortOrder": 370,
     "downstreamCount": 0
   },
   {
@@ -4572,7 +4590,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 350,
+    "sortOrder": 371,
     "downstreamCount": 0
   },
   {
@@ -4598,7 +4616,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 351,
+    "sortOrder": 372,
     "downstreamCount": 0
   },
   {
@@ -4622,7 +4640,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 352,
+    "sortOrder": 373,
     "downstreamCount": 0
   },
   {
@@ -4648,7 +4666,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 353,
+    "sortOrder": 374,
     "downstreamCount": 0
   },
   {
@@ -4698,7 +4716,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 354,
+    "sortOrder": 375,
     "downstreamCount": 0
   },
   {
@@ -4722,7 +4740,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 355,
+    "sortOrder": 376,
     "downstreamCount": 0
   },
   {
@@ -4747,7 +4765,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 359,
+    "sortOrder": 380,
     "downstreamCount": 0
   },
   {
@@ -4766,13 +4784,13 @@
       "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
-      "controller": false,
+      "controller": true,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 1,
-    "downstreamCount": 367
+    "downstreamCount": 394
   },
   {
     "group": "gkehub",
@@ -4845,7 +4863,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 365,
+    "sortOrder": 387,
     "downstreamCount": 0
   },
   {
@@ -4869,7 +4887,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 366,
+    "sortOrder": 388,
     "downstreamCount": 0
   },
   {
@@ -4895,7 +4913,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 367,
+    "sortOrder": 389,
     "downstreamCount": 0
   },
   {
@@ -4919,7 +4937,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 368,
+    "sortOrder": 390,
     "downstreamCount": 0
   },
   {
@@ -4943,7 +4961,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 369,
+    "sortOrder": 391,
     "downstreamCount": 0
   },
   {
@@ -4969,7 +4987,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 370,
+    "sortOrder": 392,
     "downstreamCount": 0
   },
   {
@@ -4992,8 +5010,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 371,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 393,
     "downstreamCount": 0
   },
   {
@@ -5017,7 +5035,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 372,
+    "sortOrder": 394,
     "downstreamCount": 0
   },
   {
@@ -5044,8 +5062,8 @@
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 374,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 396,
     "downstreamCount": 0
   },
   {
@@ -5064,12 +5082,12 @@
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
-      "controller": false,
+      "controller": true,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 375,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 397,
     "downstreamCount": 0
   },
   {
@@ -5095,8 +5113,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 376,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 398,
     "downstreamCount": 0
   },
   {
@@ -5111,7 +5129,7 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -5119,9 +5137,9 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
+    "notes": "Missing _reference.go or _identity.go",
     "sortOrder": 7,
-    "downstreamCount": 51
+    "downstreamCount": 53
   },
   {
     "group": "iam",
@@ -5146,7 +5164,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 377,
+    "sortOrder": 399,
     "downstreamCount": 0
   },
   {
@@ -5196,7 +5214,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 378,
+    "sortOrder": 400,
     "downstreamCount": 0
   },
   {
@@ -5249,7 +5267,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 379,
+    "sortOrder": 401,
     "downstreamCount": 0
   },
   {
@@ -5264,8 +5282,8 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5299,7 +5317,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 380,
+    "sortOrder": 402,
     "downstreamCount": 0
   },
   {
@@ -5325,7 +5343,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 382,
+    "sortOrder": 404,
     "downstreamCount": 0
   },
   {
@@ -5351,7 +5369,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 383,
+    "sortOrder": 405,
     "downstreamCount": 0
   },
   {
@@ -5377,7 +5395,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 384,
+    "sortOrder": 406,
     "downstreamCount": 0
   },
   {
@@ -5401,7 +5419,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 385,
+    "sortOrder": 407,
     "downstreamCount": 0
   },
   {
@@ -5427,7 +5445,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 386,
+    "sortOrder": 408,
     "downstreamCount": 0
   },
   {
@@ -5477,7 +5495,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 387,
+    "sortOrder": 409,
     "downstreamCount": 0
   },
   {
@@ -5503,7 +5521,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 388,
+    "sortOrder": 410,
     "downstreamCount": 0
   },
   {
@@ -5529,7 +5547,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 389,
+    "sortOrder": 411,
     "downstreamCount": 0
   },
   {
@@ -5557,7 +5575,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 6,
-    "downstreamCount": 122
+    "downstreamCount": 124
   },
   {
     "group": "kms",
@@ -5572,15 +5590,15 @@
     "state": "Not Started",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 391,
+    "notes": "",
+    "sortOrder": 413,
     "downstreamCount": 0
   },
   {
@@ -5605,8 +5623,8 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 4,
-    "downstreamCount": 124
+    "sortOrder": 5,
+    "downstreamCount": 126
   },
   {
     "group": "kms",
@@ -5620,8 +5638,8 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5629,7 +5647,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 394,
+    "sortOrder": 416,
     "downstreamCount": 0
   },
   {
@@ -5644,8 +5662,8 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5653,7 +5671,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 395,
+    "sortOrder": 417,
     "downstreamCount": 0
   },
   {
@@ -5709,7 +5727,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 397,
+    "sortOrder": 419,
     "downstreamCount": 0
   },
   {
@@ -5741,7 +5759,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 399,
+    "sortOrder": 421,
     "downstreamCount": 0
   },
   {
@@ -5770,7 +5788,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 400,
+    "sortOrder": 422,
     "downstreamCount": 0
   },
   {
@@ -5796,7 +5814,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 401,
+    "sortOrder": 423,
     "downstreamCount": 0
   },
   {
@@ -5822,7 +5840,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 404,
+    "sortOrder": 426,
     "downstreamCount": 0
   },
   {
@@ -5837,8 +5855,8 @@
     "dependencies": [],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -5898,7 +5916,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 410,
+    "sortOrder": 432,
     "downstreamCount": 0
   },
   {
@@ -5922,7 +5940,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 411,
+    "sortOrder": 433,
     "downstreamCount": 0
   },
   {
@@ -5946,7 +5964,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 412,
+    "sortOrder": 434,
     "downstreamCount": 0
   },
   {
@@ -5999,7 +6017,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 413,
+    "sortOrder": 435,
     "downstreamCount": 0
   },
   {
@@ -6026,7 +6044,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 414,
+    "sortOrder": 436,
     "downstreamCount": 0
   },
   {
@@ -6079,7 +6097,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 420,
+    "sortOrder": 442,
     "downstreamCount": 0
   },
   {
@@ -6105,7 +6123,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 422,
+    "sortOrder": 445,
     "downstreamCount": 0
   },
   {
@@ -6131,7 +6149,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 424,
+    "sortOrder": 447,
     "downstreamCount": 0
   },
   {
@@ -6157,7 +6175,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 430,
+    "sortOrder": 454,
     "downstreamCount": 0
   },
   {
@@ -6183,7 +6201,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 431,
+    "sortOrder": 455,
     "downstreamCount": 0
   },
   {
@@ -6209,7 +6227,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 432,
+    "sortOrder": 456,
     "downstreamCount": 0
   },
   {
@@ -6226,8 +6244,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6235,7 +6253,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 433,
+    "sortOrder": 457,
     "downstreamCount": 0
   },
   {
@@ -6261,7 +6279,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 434,
+    "sortOrder": 458,
     "downstreamCount": 0
   },
   {
@@ -6288,7 +6306,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 435,
+    "sortOrder": 459,
     "downstreamCount": 0
   },
   {
@@ -6298,23 +6316,24 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 436,
+    "sortOrder": 460,
     "downstreamCount": 0
   },
   {
@@ -6341,7 +6360,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 437,
+    "sortOrder": 461,
     "downstreamCount": 0
   },
   {
@@ -6367,7 +6386,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 439,
+    "sortOrder": 463,
     "downstreamCount": 0
   },
   {
@@ -6394,7 +6413,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 441,
+    "sortOrder": 465,
     "downstreamCount": 0
   },
   {
@@ -6421,7 +6440,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 442,
+    "sortOrder": 466,
     "downstreamCount": 0
   },
   {
@@ -6447,7 +6466,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 446,
+    "sortOrder": 470,
     "downstreamCount": 0
   },
   {
@@ -6473,7 +6492,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 447,
+    "sortOrder": 471,
     "downstreamCount": 0
   },
   {
@@ -6499,7 +6518,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 448,
+    "sortOrder": 472,
     "downstreamCount": 0
   },
   {
@@ -6523,7 +6542,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 449,
+    "sortOrder": 473,
     "downstreamCount": 0
   },
   {
@@ -6579,7 +6598,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 453,
+    "sortOrder": 477,
     "downstreamCount": 0
   },
   {
@@ -6599,7 +6618,7 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
+      "gen-types": true,
       "identity-reference": false,
       "mapper-fuzzer": false,
       "mocks": false,
@@ -6607,8 +6626,8 @@
       "tests": false
     },
     "mocksLastRefreshed": "Never",
-    "notes": "",
-    "sortOrder": 113,
+    "notes": "Missing _reference.go or _identity.go",
+    "sortOrder": 115,
     "downstreamCount": 1
   },
   {
@@ -6618,23 +6637,24 @@
     "controllerType": "DCL",
     "defaultController": "DCL",
     "supportedControllers": [
-      "DCL"
+      "DCL",
+      "Direct"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 114,
+    "sortOrder": 116,
     "downstreamCount": 1
   },
   {
@@ -6661,7 +6681,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 3,
-    "downstreamCount": 362
+    "downstreamCount": 389
   },
   {
     "group": "pubsublite",
@@ -6686,7 +6706,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 455,
+    "sortOrder": 479,
     "downstreamCount": 0
   },
   {
@@ -6712,7 +6732,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 456,
+    "sortOrder": 480,
     "downstreamCount": 0
   },
   {
@@ -6738,7 +6758,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 457,
+    "sortOrder": 481,
     "downstreamCount": 0
   },
   {
@@ -6775,20 +6795,21 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "PubSubTopic",
       "StorageBucket"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -6820,7 +6841,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 22,
+    "sortOrder": 23,
     "downstreamCount": 7
   },
   {
@@ -6837,8 +6858,8 @@
     ],
     "state": "Not Started",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
+      "gen-types": true,
+      "identity-reference": true,
       "mapper-fuzzer": false,
       "mocks": false,
       "controller": false,
@@ -6846,7 +6867,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 460,
+    "sortOrder": 484,
     "downstreamCount": 0
   },
   {
@@ -6856,23 +6877,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
-      "gen-types": false,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "gen-types": true,
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 462,
+    "sortOrder": 486,
     "downstreamCount": 0
   },
   {
@@ -6898,7 +6920,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 463,
+    "sortOrder": 487,
     "downstreamCount": 0
   },
   {
@@ -6925,7 +6947,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 464,
+    "sortOrder": 488,
     "downstreamCount": 0
   },
   {
@@ -6955,7 +6977,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 465,
+    "sortOrder": 489,
     "downstreamCount": 0
   },
   {
@@ -6983,7 +7005,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 466,
+    "sortOrder": 490,
     "downstreamCount": 0
   },
   {
@@ -7007,7 +7029,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 467,
+    "sortOrder": 492,
     "downstreamCount": 0
   },
   {
@@ -7031,7 +7053,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 468,
+    "sortOrder": 493,
     "downstreamCount": 0
   },
   {
@@ -7055,7 +7077,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 469,
+    "sortOrder": 494,
     "downstreamCount": 0
   },
   {
@@ -7109,7 +7131,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 470,
+    "sortOrder": 495,
     "downstreamCount": 0
   },
   {
@@ -7133,7 +7155,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 474,
+    "sortOrder": 499,
     "downstreamCount": 0
   },
   {
@@ -7157,7 +7179,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 475,
+    "sortOrder": 500,
     "downstreamCount": 0
   },
   {
@@ -7167,19 +7189,20 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "In Progress",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
@@ -7193,24 +7216,25 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "ComputeNetwork",
       "Service"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "identity-reference": true,
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 476,
+    "notes": "",
+    "sortOrder": 501,
     "downstreamCount": 0
   },
   {
@@ -7220,23 +7244,24 @@
     "controllerType": "Terraform",
     "defaultController": "Terraform",
     "supportedControllers": [
+      "Direct",
       "Terraform"
     ],
     "dependencies": [
       "Project"
     ],
-    "state": "Not Started",
+    "state": "Completed",
     "steps": {
       "gen-types": true,
       "identity-reference": true,
-      "mapper-fuzzer": false,
-      "mocks": false,
-      "controller": false,
-      "tests": false
+      "mapper-fuzzer": true,
+      "mocks": true,
+      "controller": true,
+      "tests": true
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 116,
+    "sortOrder": 118,
     "downstreamCount": 1
   },
   {
@@ -7263,7 +7288,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 477,
+    "sortOrder": 502,
     "downstreamCount": 0
   },
   {
@@ -7315,7 +7340,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 478,
+    "sortOrder": 503,
     "downstreamCount": 0
   },
   {
@@ -7341,7 +7366,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 480,
+    "sortOrder": 505,
     "downstreamCount": 0
   },
   {
@@ -7367,7 +7392,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 481,
+    "sortOrder": 506,
     "downstreamCount": 0
   },
   {
@@ -7394,7 +7419,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 117,
+    "sortOrder": 119,
     "downstreamCount": 1
   },
   {
@@ -7447,7 +7472,7 @@
     "mocksLastRefreshed": "Never",
     "notes": "",
     "sortOrder": 8,
-    "downstreamCount": 39
+    "downstreamCount": 40
   },
   {
     "group": "storage",
@@ -7472,7 +7497,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 488,
+    "sortOrder": 513,
     "downstreamCount": 0
   },
   {
@@ -7498,7 +7523,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 489,
+    "sortOrder": 514,
     "downstreamCount": 0
   },
   {
@@ -7524,7 +7549,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 491,
+    "sortOrder": 516,
     "downstreamCount": 0
   },
   {
@@ -7550,7 +7575,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 493,
+    "sortOrder": 518,
     "downstreamCount": 0
   },
   {
@@ -7576,7 +7601,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 494,
+    "sortOrder": 519,
     "downstreamCount": 0
   },
   {
@@ -7602,7 +7627,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 495,
+    "sortOrder": 520,
     "downstreamCount": 0
   },
   {
@@ -7628,7 +7653,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 496,
+    "sortOrder": 521,
     "downstreamCount": 0
   },
   {
@@ -7647,15 +7672,15 @@
     "state": "Completed",
     "steps": {
       "gen-types": true,
-      "identity-reference": false,
+      "identity-reference": true,
       "mapper-fuzzer": true,
       "mocks": true,
       "controller": true,
       "tests": true
     },
     "mocksLastRefreshed": "Never",
-    "notes": "Missing _reference.go",
-    "sortOrder": 498,
+    "notes": "",
+    "sortOrder": 523,
     "downstreamCount": 0
   },
   {
@@ -7682,7 +7707,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 499,
+    "sortOrder": 524,
     "downstreamCount": 0
   },
   {
@@ -7707,7 +7732,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 500,
+    "sortOrder": 525,
     "downstreamCount": 0
   },
   {
@@ -7759,7 +7784,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 504,
+    "sortOrder": 529,
     "downstreamCount": 0
   },
   {
@@ -7786,7 +7811,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 506,
+    "sortOrder": 532,
     "downstreamCount": 0
   },
   {
@@ -7814,7 +7839,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 508,
+    "sortOrder": 534,
     "downstreamCount": 0
   },
   {
@@ -7838,7 +7863,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 512,
+    "sortOrder": 539,
     "downstreamCount": 0
   },
   {
@@ -7862,7 +7887,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 513,
+    "sortOrder": 540,
     "downstreamCount": 0
   },
   {
@@ -7888,7 +7913,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 514,
+    "sortOrder": 541,
     "downstreamCount": 0
   },
   {
@@ -7914,7 +7939,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 515,
+    "sortOrder": 542,
     "downstreamCount": 0
   },
   {
@@ -7940,7 +7965,7 @@
     },
     "mocksLastRefreshed": "Never",
     "notes": "",
-    "sortOrder": 518,
+    "sortOrder": 545,
     "downstreamCount": 0
   }
 ]

--- a/dev/migration-tracker/generate_data.py
+++ b/dev/migration-tracker/generate_data.py
@@ -54,6 +54,16 @@ def get_implemented_types(apis_dir="../../apis"):
                         implemented_kinds[kind].append(filepath)
     return implemented_kinds
 
+def get_implemented_controllers(direct_dir="../../pkg/controller/direct"):
+    implemented_controllers = set()
+    if not os.path.exists(direct_dir):
+        return implemented_controllers
+    for root, _, files in os.walk(direct_dir):
+        for file in files:
+            if file.endswith("_controller.go"):
+                implemented_controllers.add(file)
+    return implemented_controllers
+
 def build_dependency_graph(crds_dir="../../config/crds/resources"):
     known_kinds = {}
     dependencies = defaultdict(set)
@@ -113,7 +123,7 @@ def build_dependency_graph(crds_dir="../../config/crds/resources"):
 
     return dependencies, known_kinds
 
-def parse_data(config_file_path, apis_dir, crds_dir):
+def parse_data(config_file_path, apis_dir, crds_dir, direct_dir="../../pkg/controller/direct"):
     resources = {}
     
     # Load existing data to preserve manual updates
@@ -184,6 +194,7 @@ def parse_data(config_file_path, apis_dir, crds_dir):
 
     dependencies, known_kinds = build_dependency_graph(crds_dir)
     implemented_types = get_implemented_types(apis_dir)
+    implemented_controllers = get_implemented_controllers(direct_dir)
 
     # Calculate topological sort order and downstream count
     nodes = set(known_kinds.keys())
@@ -243,31 +254,64 @@ def parse_data(config_file_path, apis_dir, crds_dir):
 
         if kind in implemented_types:
             res['steps']['gen-types'] = True
-            has_reference = False
+            has_identity_reference = False
+            has_mapper = False
             for filepath in implemented_types[kind]:
                 dirpath = os.path.dirname(filepath)
                 filename = os.path.basename(filepath)
                 prefix = filename.replace("_types.go", "")
                 
-                possible_names = [
+                possible_id_ref_names = [
                     f"{prefix}_reference.go",
+                    f"{prefix}_identity.go",
                     f"{kind.lower()}_reference.go",
+                    f"{kind.lower()}_identity.go",
                 ]
                 
-                for name in possible_names:
+                for name in possible_id_ref_names:
                     if os.path.exists(os.path.join(dirpath, name)):
-                        has_reference = True
+                        has_identity_reference = True
                         break
-                if has_reference:
+                
+                possible_mapper_names = [
+                    f"{prefix}_mapper.go",
+                    f"{prefix}_fuzzer.go",
+                    f"{kind.lower()}_mapper.go",
+                    f"{kind.lower()}_fuzzer.go",
+                ]
+                for name in possible_mapper_names:
+                    if os.path.exists(os.path.join(dirpath, name)):
+                        has_mapper = True
+                        break
+
+                if has_identity_reference and has_mapper:
                     break
             
-            if has_reference:
+            if has_identity_reference:
                 res['steps']['identity-reference'] = True
-                if res.get('notes') == 'Missing _reference.go':
+                if res.get('notes') in ('Missing _reference.go', 'Missing _reference.go or _identity.go'):
                     res['notes'] = ''
             else:
-                res['notes'] = 'Missing _reference.go'
+                res['notes'] = 'Missing _reference.go or _identity.go'
                 res['steps']['identity-reference'] = False
+            
+            if has_mapper:
+                res['steps']['mapper-fuzzer'] = True
+
+        possible_controller_names = [
+            f"{kind.lower()}_controller.go",
+            f"{res['group'].lower()}{kind.lower()}_controller.go",
+        ]
+        if kind in implemented_types:
+            for filepath in implemented_types[kind]:
+                filename = os.path.basename(filepath)
+                prefix = filename.replace("_types.go", "")
+                possible_controller_names.append(f"{prefix}_controller.go")
+        
+        for ctrl_name in possible_controller_names:
+            if ctrl_name in implemented_controllers:
+                res['steps']['controller'] = True
+                break
 
     return list(resources.values())
 


### PR DESCRIPTION
Updates `dev/migration-tracker/generate_data.py` to align with the consistent naming convention for direct resources (Issue #10790).

Specifically:
- Added `*_identity.go` detection for tracking `identity-reference` completion.
- Added `*_mapper.go` and `*_fuzzer.go` detection for tracking `mapper-fuzzer` completion.
- Added `get_implemented_controllers` to track `*_controller.go` completion under `pkg/controller/direct/`.
- Normalized file candidate matching to check both `<prefix>_...` and `<kind.lower()>_...`.

### Migration Step Progress (+Counts)
Comparing against the previous baseline, regenerating `data.json` detected the following newly tracked components and step completions:
- **New `gen-types`:** +27 resources
- **New `identity-reference`:** +32 resources
- **New `mapper-fuzzer`:** +25 resources
- **New `controller`:** +28 resources
- **Newly Completed Resources:** +25 resources