### PR TITLE
Allow addition of status.externalRef field in the crd-equivalence-check

### DIFF
--- a/dev/ci/presubmits/crd-equivalence-check
+++ b/dev/ci/presubmits/crd-equivalence-check
@@ -48,7 +48,9 @@ fi
 FAILED=0
 
 echo "Running equivalence check..."
-CMD="dev/tasks/diff-crds --base ${COMPARISON_REF}"
+# We explicitly allow the addition of status.externalRef because it is a
+# required structural change when migrating resources to the Direct controller.
+CMD="dev/tasks/diff-crds --base ${COMPARISON_REF} --allow-status-external-ref-addition"
 echo "Running: ${CMD}"
 
 # We capture output to check for differences

--- a/dev/tasks/diff-crds
+++ b/dev/tasks/diff-crds
@@ -26,6 +26,11 @@ def main():
         default=None,
         help="The base revision to compare against (default: upstream/master, resolved to merge-base with HEAD)",
     )
+    parser.add_argument(
+        "--allow-status-external-ref-addition",
+        action="store_true",
+        help="Ignore additions of status.externalRef=string",
+    )
     args = parser.parse_args()
 
     # Get repo root
@@ -94,6 +99,9 @@ def main():
             "--flatten",
             "--ignore-integer-type-differences",
         ]
+
+        if args.allow_status_external_ref_addition:
+            go_run_cmd.append("--allow-status-external-ref-addition")
 
         try:
             # Create the git show process

--- a/dev/tools/crd-to-simple-schema/main.go
+++ b/dev/tools/crd-to-simple-schema/main.go
@@ -41,6 +41,7 @@ func main() {
 	flag.StringVar(&opt.DiffCRDFile, "diff-crd-file", "", "CRD file to compare against; if empty, no comparison is done")
 	flag.BoolVar(&opt.Flatten, "flatten", false, "Flatten output to path=type lines (easier for diffing)")
 	flag.BoolVar(&opt.IgnoreIntegerTypeDifferences, "ignore-integer-type-differences", opt.IgnoreIntegerTypeDifferences, "Treat int32 and int64 as equivalent to integer when diffing.")
+	flag.BoolVar(&opt.AllowStatusExternalRefAddition, "allow-status-external-ref-addition", opt.AllowStatusExternalRefAddition, "Ignore additions of status.externalRef=string.")
 
 	flag.Parse()
 
@@ -65,6 +66,9 @@ type ConvertOptions struct {
 
 	// IgnoreIntegerTypeDifferences treats int32 and int64 as equivalent to integer when diffing.
 	IgnoreIntegerTypeDifferences bool
+
+	// AllowStatusExternalRefAddition ignores additions of status.externalRef=string.
+	AllowStatusExternalRefAddition bool
 }
 
 func Run(ctx context.Context, opt ConvertOptions, out io.Writer) error {
@@ -248,16 +252,16 @@ func printMapDiff(out io.Writer, prefix string, m1, m2 map[string]string) {
 }
 
 func diffSchema(out io.Writer, schema1, schema2 any, opt ConvertOptions) {
-	lines1 := make(map[string]string)
-	flatten("", schema1, lines1)
+	basePaths := make(map[string]string)
+	flatten("", schema1, basePaths)
 
-	lines2 := make(map[string]string)
-	flatten("", schema2, lines2)
+	newPaths := make(map[string]string)
+	flatten("", schema2, newPaths)
 
 	var diff []string
 
-	for k, v1 := range lines1 {
-		v2, ok := lines2[k]
+	for k, v1 := range basePaths {
+		v2, ok := newPaths[k]
 		if !ok {
 			diff = append(diff, fmt.Sprintf("- %s=%s", k, v1))
 			continue
@@ -279,9 +283,12 @@ func diffSchema(out io.Writer, schema1, schema2 any, opt ConvertOptions) {
 			diff = append(diff, fmt.Sprintf("+ %s=%s", k, v2))
 		}
 	}
-	for k, v2 := range lines2 {
-		_, ok := lines1[k]
+	for k, v2 := range newPaths {
+		_, ok := basePaths[k]
 		if !ok {
+			if opt.AllowStatusExternalRefAddition && k == "status.externalRef" && v2 == "string" {
+				continue
+			}
 			diff = append(diff, fmt.Sprintf("+ %s=%s", k, v2))
 		}
 	}


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Adding `status.externalRef` during brownfield resource migration should be allowed.

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
