### PR TITLE
ci: stop caching kubebuilder envtest assets to avoid permission issues on runners

### DIFF
--- a/dev/ci/presubmits/tests-e2e-fixtures-compute
+++ b/dev/ci/presubmits/tests-e2e-fixtures-compute
@@ -27,6 +27,8 @@ trap on_error ERR
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
+. "${REPO_ROOT}/dev/tasks/setup-envtest"
+
 export ONLY_TEST_APIGROUPS="compute.cnrm.cloud.google.com"
 export USE_FULL_TEST_NAMES=true
 export TEST_TIMEOUT=15m

--- a/dev/ci/presubmits/tests-e2e-fixtures-gkehub
+++ b/dev/ci/presubmits/tests-e2e-fixtures-gkehub
@@ -27,6 +27,8 @@ trap on_error ERR
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
+. "${REPO_ROOT}/dev/tasks/setup-envtest"
+
 export ONLY_TEST_APIGROUPS="gkehub.cnrm.cloud.google.com"
 export USE_FULL_TEST_NAMES=true
 export TEST_TIMEOUT=15m

--- a/dev/tasks/generate-ci-cd-jobs
+++ b/dev/tasks/generate-ci-cd-jobs
@@ -121,6 +121,8 @@ trap on_error ERR
 REPO_ROOT="\$(git rev-parse --show-toplevel)"
 cd "\${REPO_ROOT}"
 
+. "\${REPO_ROOT}/dev/tasks/setup-envtest"
+
 export ONLY_TEST_APIGROUPS="${group}"
 export USE_FULL_TEST_NAMES=true
 export TEST_TIMEOUT=15m


### PR DESCRIPTION
All merge queue PRs are getting kicked out.

Due to test failure
https://github.com/GoogleCloudPlatform/k8s-config-connector/actions/runs/28264832694/job/83751335488
https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/10914#issuecomment-4812413766