### PR TITLE
Fix unexpected diffs for AlloyDBCluster direct controller

### DIFF
--- a/pkg/controller/direct/alloydb/alloydbcluster_controller.go
+++ b/pkg/controller/direct/alloydb/alloydbcluster_controller.go
@@ -504,6 +504,9 @@ func (a *ClusterAdapter) resolveGCPDefaults(desired *alloydbpb.Cluster, actual *
 		desired.SubscriptionType = alloydbpb.SubscriptionType_STANDARD
 	}
 	desired.DatabaseVersion = actual.DatabaseVersion
+	if desired.DataplexConfig == nil {
+		desired.DataplexConfig = actual.DataplexConfig
+	}
 
 	desired.Source = actual.Source
 }
@@ -573,6 +576,16 @@ func (a *ClusterAdapter) Update(ctx context.Context, updateOp *directbase.Update
 	// applied value under status.observedState).
 	paths.Delete("network_config.network")
 	paths.Delete("network")
+	// display_name is unreadable on GET for alloydb cluster. Ignore diffs during update.
+	paths.Delete("display_name")
+
+	// initial_user and deletion_policy are write-only / unreadable fields not returned on GET. Ignore diffs during update.
+	for path := range paths {
+		if path == "initial_user" || strings.HasPrefix(path, "initial_user.") ||
+			path == "deletion_policy" || strings.HasPrefix(path, "deletion_policy.") {
+			paths.Delete(path)
+		}
+	}
 
 	if len(paths) == 0 {
 		log.V(2).Info("no field needs update", "name", a.id)


### PR DESCRIPTION
### Description
Fixes unexpected reconciliation diffs during AlloyDBCluster direct controller update reconciliation (#10968):

1. **`dataplexConfig`**: Populated `desired.DataplexConfig` from `actual.DataplexConfig` in `resolveGCPDefaults()` when omitted in spec, ensuring optional server-side defaults don't trigger drift.
2. **Unreadable / Write-Only fields**: Ignored readback diffs for `initial_user`, `deletion_policy`, and `display_name` during `Update()` diff path filtering as these fields are unreadable or creation-only on GCP `GET` responses.

Closes #10968