### PR TITLE
Fix invalid update diffs for CertificateManagerCertificate direct controller

### DIFF
--- a/pkg/controller/direct/certificatemanager/certificatemanagercertificate_controller.go
+++ b/pkg/controller/direct/certificatemanager/certificatemanagercertificate_controller.go
@@ -275,5 +275,22 @@ func compareCertificate(ctx context.Context, actual, desired *pb.Certificate) (*
 	if err != nil {
 		return nil, nil, err
 	}
+
+	var filteredFields []structuredreporting.DiffField
+	for _, f := range diffs.Fields {
+		if f.ID != "managed" && f.ID != "self_managed" {
+			filteredFields = append(filteredFields, f)
+		}
+	}
+	diffs.Fields = filteredFields
+
+	var filteredPaths []string
+	for _, path := range updateMask.Paths {
+		if path != "managed" && path != "self_managed" {
+			filteredPaths = append(filteredPaths, path)
+		}
+	}
+	updateMask.Paths = filteredPaths
+
 	return diffs, updateMask, nil
 }


### PR DESCRIPTION
### Description
Fixes invalid update diffs during `CertificateManagerCertificate` direct controller update reconciliation (#10972):

- Filtered out `managed` and `self_managed` fields from `diffs.Fields` and `updateMask.Paths` in `compareCertificate()`, preventing invalid `PATCH` requests (`updateMask=managed`) on creation-only blocks.

Closes #10972