### PR TITLE
doc: Document Container Cluster remove-default-node-pool behavior

### DIFF
--- a/docs/design-decisions/container-cluster-directives.md
+++ b/docs/design-decisions/container-cluster-directives.md
@@ -1,0 +1,65 @@
+# Container Cluster Directives
+
+## Context
+
+The `ContainerCluster` resource supports specific annotations (directives) to
+control the behavior of the default node pool created by GKE during cluster
+creation.
+
+### `cnrm.cloud.google.com/remove-default-node-pool`
+
+If set to `true`, this directive removes the default node pool created by GKE
+immediately after cluster creation. This maps to Terraform's
+[`remove_default_node_pool`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#example-usage---using-a-separately-managed-node-pool-recommended)
+field.
+
+KCC recommends the following best practices:
+
+1.  To manage node settings, enable `remove-default-node-pool` during cluster
+    creation and define nodes using the `ContainerNodePool` resource instead.
+2.  If `remove-default-node-pool` is set to `true`, `nodeVersion` and
+    `nodeConfig` should generally be omitted from the `ContainerCluster` spec,
+    as they are associated with the default pool intended for deletion.
+    Including them can lead to reconciliation conflicts or Terraform errors.
+
+## Design Decision: `cnrm.cloud.google.com/remove-default-node-pool-allow-node-config`
+
+To accommodate users who need to remove the default pool while still including
+`nodeConfig` in their spec, e.g., due to Organization Policies that require
+specific configurations even on the default pool during its brief existence at
+creation
+(https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/7274), the
+opt-in annotation
+`cnrm.cloud.google.com/remove-default-node-pool-allow-node-config` was
+introduced in KCC
+[v1.153.0](https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.153.0).
+
+### Behavior
+
+1.  **Initial Creation**: If both `remove-default-node-pool` and
+    `remove-default-node-pool-allow-node-config` are set to `true`, KCC
+    preserves `nodeConfig` in the configuration sent to GKE.
+2.  **Subsequent Reconciliations**: Once the cluster exists and the default pool
+    is removed, KCC automatically removes `nodeConfig` from the desired state
+    during reconciliation. This prevents permanent diffs and errors that would
+    occur if KCC tried to manage a configuration for a deleted node pool.
+
+## Direct Controller Migration Checklist
+
+1.  **Maintain Backward Compatibility**: Ensure both `remove-default-node-pool`
+    and `remove-default-node-pool-allow-node-config` annotations remain fully
+    functional in the direct controller. Existing test cases should continue to
+    pass:
+
+    -   [removedefaultnodepool resource fixture](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/master/pkg/test/resourcefixture/testdata/directives/removedefaultnodepool)
+    -   [removedefaultnodepool e2e scenario](https://github.com/GoogleCloudPlatform/k8s-config-connector/tree/master/tests/e2e/testdata/scenarios/containercluster/removedefaultnodepool)
+
+2.  **Support Field Conflict Validation**: In alignment with KCC best practices
+    mentioned above, ensure that `nodeVersion` and `nodeConfig` still strictly
+    conflict with the `remove-default-node-pool` annotation (unless the
+    allow-node-config override is present) and cannot be set simultaneously in a
+    way that causes errors.
+
+3.  **Improve Error Logging**: Surface clear error messages when conflicts
+    occur. Currently, Terraform uses the same message for both `nodeVersion` and
+    `nodeConfig` conflicts, which can be confusing for users.

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -7,6 +7,10 @@ Note: The ContainerCluster annotation can include
 If set to <code>true</code>, the <code>remove-default-node-pool</code> directive
 removes the default node pool created during cluster creation.
 
+The <code>remove-default-node-pool-allow-node-config</code> is an opt-in directive that can be used alongside <code>remove-default-node-pool</code>.
+If set to <code>true</code>, it allows <code>nodeConfig</code> to be specified during initial creation (satisfying
+Organization Policies) while avoiding conflicts after the default node pool is removed.
+
 Note: In <code>maintenancePolicy</code>, specify <code>startTime</code> and
 <code>endTime</code> in RFC3339 Zulu date format. Specify <code>recurrence</code>
 in RFC5545 RRULE format. GKE may accept other formats, but will return values in UTC,

--- a/scripts/generate-google3-docs/resource-reference/templates/container_containercluster.tmpl
+++ b/scripts/generate-google3-docs/resource-reference/templates/container_containercluster.tmpl
@@ -11,6 +11,10 @@ Note: The {{ .Kind}} annotation can include
 If set to <code>true</code>, the <code>remove-default-node-pool</code> directive
 removes the default node pool created during cluster creation.
 
+The <code>remove-default-node-pool-allow-node-config</code> is an opt-in directive that can be used alongside <code>remove-default-node-pool</code>.
+If set to <code>true</code>, it allows <code>nodeConfig</code> to be specified during initial creation (satisfying
+Organization Policies) while avoiding conflicts after the default node pool is removed.
+
 Note: In <code>maintenancePolicy</code>, specify <code>startTime</code> and
 <code>endTime</code> in RFC3339 Zulu date format. Specify <code>recurrence</code>
 in RFC5545 RRULE format. GKE may accept other formats, but will return values in UTC,


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Document Container Cluster "remove-default-node-pool" and "remove-default-node-pool-allow-node-config" annotations.

Update the Container Cluster reference doc with the usage of the new "remove-default-node-pool-allow-node-config" annotation.

Make sure both behave the same after we migrate the resource to direct.

PR that introduced the new "remove-default-node-pool-allow-node-config" annotation: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8651

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

<!--

Make sure you have run "make ready-pr" to run required tests and ensure this PR is ready to review. 

Also if possible, share a bit more on the tests you have done. 

For example if you have updated the pubsubtopic sample, you can share the test logs from running the test case locally.

go test -v -tags=integration ./config/tests/samples/create -test.run TestAll -run-tests pubsubtopic

-->

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.
