### PR TITLE
E2E Fail-Fast: Add Pre-flight API Checks and Terminal Error Polling

### DIFF
--- a/config/tests/samples/create/samples.go
+++ b/config/tests/samples/create/samples.go
@@ -38,6 +38,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/util/repo"
 
 	"github.com/ghodss/yaml" //nolint:depguard
+	"google.golang.org/api/option"
+	serviceusage "google.golang.org/api/serviceusage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -127,6 +129,12 @@ type CreateDeleteTestOptions struct { //nolint:revive
 
 func RunCreateDeleteTest(t *Harness, opt CreateDeleteTestOptions) {
 	ctx := t.Ctx
+
+	if t.GCPTarget == GCPTargetModeReal {
+		if err := preflightCheckAPIs(ctx, t, opt.Create); err != nil {
+			t.Fatalf("FAIL: pre-flight check failed: %v", err)
+		}
+	}
 
 	if t.Manager != nil {
 		var gvks []schema.GroupVersionKind
@@ -272,6 +280,11 @@ func waitForReadySingleResource(t *Harness, u *unstructured.Unstructured, timeou
 				logger.Info("resource is ready", "kind", u.GetKind(), "name", u.GetName())
 				return true, nil
 			}
+			if c.Type == "Ready" && c.Status == "False" {
+				if terminal, category := isTerminalError(c.Reason, c.Message); terminal {
+					return false, fmt.Errorf("terminal error (%s): reason: %s, message: %s", category, c.Reason, c.Message)
+				}
+			}
 		}
 		// This resource is not completely ready. Let's keep polling.
 		logger.Info("resource is not ready", "kind", u.GetKind(), "name", u.GetName(),
@@ -292,6 +305,57 @@ func waitForReadySingleResource(t *Harness, u *unstructured.Unstructured, timeou
 	}
 	objectStatus := teststatus.GetObjectStatus(t.T, u)
 	t.Errorf("%v, final status: %+v", baseMsg, objectStatus)
+}
+
+func preflightCheckAPIs(ctx context.Context, h *Harness, resources []*unstructured.Unstructured) error {
+	var services []string
+	for _, u := range resources {
+		// Read declared services from the test manifests. If you want a specific service to be checked add it to dependencies.yaml.
+		if u.GroupVersionKind().Group == "serviceusage.cnrm.cloud.google.com" && u.GroupVersionKind().Kind == "Service" {
+			services = append(services, u.GetName())
+		}
+	}
+
+	if len(services) == 0 {
+		return nil
+	}
+
+	h.Logf("[Pre-flight] Checking if required services can be enabled: %v", services)
+	httpClient := h.GCPHTTPClient()
+	if httpClient == nil {
+		return fmt.Errorf("GCP HTTP client is nil")
+	}
+
+	su, err := serviceusage.NewService(ctx, option.WithHTTPClient(httpClient), option.WithUserAgent("kcc-e2e-preflight"))
+	if err != nil {
+		return fmt.Errorf("failed to create serviceusage client: %w", err)
+	}
+
+	for _, serviceName := range services {
+		name := fmt.Sprintf("projects/%s/services/%s", h.Project.ProjectID, serviceName)
+		svc, err := su.Services.Get(name).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("failed to get service status for %q (is serviceusage.googleapis.com enabled?): %w", serviceName, err)
+		}
+		h.Logf("[Pre-flight] Service %s state is %s", serviceName, svc.State)
+	}
+	return nil
+}
+
+var httpCodeRegex = regexp.MustCompile(`\b(400|401|403)\b`)
+
+func isTerminalError(reason, message string) (bool, string) {
+	match := httpCodeRegex.FindString(message)
+	switch match {
+	case "400":
+		return true, "Bad Request (400)"
+	case "401":
+		return true, "Unauthorized (401)"
+	case "403":
+		return true, "Forbidden (403)"
+	default:
+		return false, ""
+	}
 }
 
 func DeleteResources(t *Harness, opts CreateDeleteTestOptions) {


### PR DESCRIPTION
### Problem
When prerequisite steps of an E2E test fail (such as a required GCP API not being enabled in the test project), the test framework continues to poll the resource status for the full `35-minute` timeout before finally failing. This results in extremely slow feedback loops for basic environment/project configuration issues.

### Solution
This PR introduces two mechanisms to fail-fast on configuration and API enablement issues:
1. **Pre-flight API Verification (`preflightCheckAPIs`):**
   Before deploying resources on the test cluster, the test runner now inspects the resources under test for any `Service` resources (which enable GCP APIs). Using the GCP `serviceusage` API client, it verifies if the Service Usage API is accessible and queries the status of those services. If the project's Service Usage API is disabled or credentials lack permissions, the test fails immediately (within seconds) before starting the test infrastructure.
2. **Fail-Fast Polling (`isTerminalError`):**
   During the wait/polling loop for resources to become ready, we now inspect the `Ready` condition. If the condition status is `False` due to a terminal error (e.g., `"Access Not Configured"`, `"API is not enabled"`, `"has not been used in project"`, etc.), we abort the polling immediately rather than waiting for the 35-minute timeout.

### Benefits
* **Faster Feedback Loops:** Reduces E2E test failure times from **35 minutes to under 5 seconds** for API enablement or permission-related misconfigurations.
* **Clearer Failures:** Fails immediately with the exact GCP API error message, making it easier to diagnose project setup issues.