### PR TITLE
Fix ComposerEnvironment storageConfig.bucketRef mapping

### DIFF
--- a/mockgcp/mockcomposer/environment.go
+++ b/mockgcp/mockcomposer/environment.go
@@ -74,6 +74,10 @@ func (s *ComposerV1) CreateEnvironment(ctx context.Context, req *pb.CreateEnviro
 		return nil, err
 	}
 
+	if bucket := req.GetEnvironment().GetStorageConfig().GetBucket(); strings.Contains(bucket, "/") {
+		return nil, status.Errorf(codes.InvalidArgument, "Composer doesn't have permission to read the requested Cloud Storage bucket: gs://%s", bucket)
+	}
+
 	fqn := name.String()
 	now := time.Now()
 
@@ -110,6 +114,9 @@ func (s *ComposerV1) UpdateEnvironment(ctx context.Context, req *pb.UpdateEnviro
 	name, err := s.parseEnvironmentName(req.GetName())
 	if err != nil {
 		return nil, err
+	}
+	if bucket := req.GetEnvironment().GetStorageConfig().GetBucket(); strings.Contains(bucket, "/") {
+		return nil, status.Errorf(codes.InvalidArgument, "Composer doesn't have permission to read the requested Cloud Storage bucket: gs://%s", bucket)
 	}
 	fqn := name.String()
 

--- a/pkg/controller/direct/composer/environment_mappings.go
+++ b/pkg/controller/direct/composer/environment_mappings.go
@@ -21,6 +21,7 @@ import (
 	computev1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/compute/v1alpha1"
 	computev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/compute/v1beta1"
 	refs "github.com/GoogleCloudPlatform/k8s-config-connector/apis/refs/v1beta1"
+	storagev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/storage/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
@@ -364,6 +365,35 @@ func EncryptionConfig_ToProto(mapCtx *direct.MapContext, in *krm.EncryptionConfi
 	out := &pb.EncryptionConfig{}
 	if in.KMSKeyRef != nil {
 		out.KmsKeyName = in.KMSKeyRef.External
+	}
+	return out
+}
+
+func StorageConfig_ToProto(mapCtx *direct.MapContext, in *krm.StorageConfig) *pb.StorageConfig {
+	if in == nil {
+		return nil
+	}
+	out := &pb.StorageConfig{}
+	if in.BucketRef != nil {
+		id := &storagev1beta1.StorageBucketIdentity{}
+		if err := id.FromExternal(in.BucketRef.External); err != nil {
+			mapCtx.Errorf("storageConfig.bucketRef: %v", err)
+		} else {
+			out.Bucket = id.Bucket
+		}
+	}
+	return out
+}
+
+func StorageConfig_FromProto(mapCtx *direct.MapContext, in *pb.StorageConfig) *krm.StorageConfig {
+	if in == nil {
+		return nil
+	}
+	out := &krm.StorageConfig{}
+	if in.GetBucket() != "" {
+		out.BucketRef = &storagev1beta1.StorageBucketRef{
+			External: "gs://" + in.GetBucket(),
+		}
 	}
 	return out
 }

--- a/pkg/controller/direct/composer/mapper.generated.go
+++ b/pkg/controller/direct/composer/mapper.generated.go
@@ -26,7 +26,6 @@ package composer
 import (
 	pb "cloud.google.com/go/orchestration/airflow/service/apiv1/servicepb"
 	krm "github.com/GoogleCloudPlatform/k8s-config-connector/apis/composer/v1beta1"
-	krmstoragev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/apis/storage/v1beta1"
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct"
 )
 
@@ -444,26 +443,6 @@ func SoftwareConfig_ToProto(mapCtx *direct.MapContext, in *krm.SoftwareConfig) *
 	out.SchedulerCount = direct.ValueOf(in.SchedulerCount)
 	out.CloudDataLineageIntegration = CloudDataLineageIntegration_ToProto(mapCtx, in.CloudDataLineageIntegration)
 	out.WebServerPluginsMode = direct.Enum_ToProto[pb.SoftwareConfig_WebServerPluginsMode](mapCtx, in.WebServerPluginsMode)
-	return out
-}
-func StorageConfig_FromProto(mapCtx *direct.MapContext, in *pb.StorageConfig) *krm.StorageConfig {
-	if in == nil {
-		return nil
-	}
-	out := &krm.StorageConfig{}
-	if in.GetBucket() != "" {
-		out.BucketRef = &krmstoragev1beta1.StorageBucketRef{External: in.GetBucket()}
-	}
-	return out
-}
-func StorageConfig_ToProto(mapCtx *direct.MapContext, in *krm.StorageConfig) *pb.StorageConfig {
-	if in == nil {
-		return nil
-	}
-	out := &pb.StorageConfig{}
-	if in.BucketRef != nil {
-		out.Bucket = in.BucketRef.External
-	}
 	return out
 }
 func TaskLogsRetentionConfig_FromProto(mapCtx *direct.MapContext, in *pb.TaskLogsRetentionConfig) *krm.TaskLogsRetentionConfig {

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironment/composerenvironmentwithrefs/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironment/composerenvironmentwithrefs/_http.log
@@ -1042,7 +1042,7 @@ X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
   },
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   }
 }
 
@@ -1183,7 +1183,7 @@ X-Xss-Protection: 0
     "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
     "state": "RUNNING",
     "storageConfig": {
-      "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+      "bucket": "bucket-${uniqueId}"
     },
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "uuid": "test-uuid"
@@ -1287,7 +1287,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"
@@ -1382,7 +1382,7 @@ X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2F
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"
@@ -1528,7 +1528,7 @@ X-Xss-Protection: 0
     "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
     "state": "RUNNING",
     "storageConfig": {
-      "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+      "bucket": "bucket-${uniqueId}"
     },
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "uuid": "test-uuid"
@@ -1635,7 +1635,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"

--- a/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironment/composerenvironmentwithrefs/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/composer/v1beta1/composerenvironment/composerenvironmentwithrefs/_http_mock.log
@@ -1042,7 +1042,7 @@ X-Goog-Request-Params: parent=projects%2F${projectId}%2Flocations%2Fus-central1
   },
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   }
 }
 
@@ -1183,7 +1183,7 @@ X-Xss-Protection: 0
     "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
     "state": "RUNNING",
     "storageConfig": {
-      "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+      "bucket": "bucket-${uniqueId}"
     },
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "uuid": "test-uuid"
@@ -1287,7 +1287,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"
@@ -1382,7 +1382,7 @@ X-Goog-Request-Params: name=projects%2F${projectId}%2Flocations%2Fus-central1%2F
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"
@@ -1528,7 +1528,7 @@ X-Xss-Protection: 0
     "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
     "state": "RUNNING",
     "storageConfig": {
-      "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+      "bucket": "bucket-${uniqueId}"
     },
     "updateTime": "2024-04-01T12:34:56.123456Z",
     "uuid": "test-uuid"
@@ -1635,7 +1635,7 @@ X-Xss-Protection: 0
   "name": "projects/${projectId}/locations/us-central1/environments/composerenvironment-${uniqueId}",
   "state": 2,
   "storageConfig": {
-    "bucket": "projects/${projectId}/buckets/bucket-${uniqueId}"
+    "bucket": "bucket-${uniqueId}"
   },
   "updateTime": "2024-04-01T12:34:56.123456Z",
   "uuid": "test-uuid"


### PR DESCRIPTION
Fixes b/528060386

In ComposerEnvironment direct reconciler, override autogenerated `StorageConfig_ToProto` and `StorageConfig_FromProto` mappers so that `storageConfig.bucketRef` maps to just the GCS bucket name without full resource path (`projects/../buckets/..`). This resolves API error 400 during `ComposerEnvironment` creation and updates.

### Changes
* **Direct Controller Mappers**: Override autogenerated `StorageConfig` mappers in `pkg/controller/direct/composer/environment_mappings.go` to use `StorageBucketIdentity.FromExternal(...)`.
* **Mock Validation**: Update `mockgcp/mockcomposer/environment.go` to validate and reject storage bucket strings containing slashes (`/`), matching real Google Cloud Composer frontend validation.
* **Golden Tests**: Update golden traffic log for `composerenvironmentwithrefs`. Verified all 4 composer basic test fixtures pass cleanly via `hack/compare-mock`.