### PR TITLE
Fix GKE ContainerNodePool reconcile 400 error

### DIFF
--- a/pkg/krmtotf/legacygcpmanagedfields.go
+++ b/pkg/krmtotf/legacygcpmanagedfields.go
@@ -55,6 +55,9 @@ func ResolveLegacyGCPManagedFields(r *Resource, liveState *terraform.InstanceSta
 		if err := resolveContainerNodePoolNodeCount(r, config); err != nil {
 			return err
 		}
+		if err := resolveContainerNodePoolNodeConfig(r, config); err != nil {
+			return err
+		}
 		return nil
 	case "ComputeBackendService":
 		return resolveComputeBackendServiceBackend(r, config)
@@ -324,6 +327,19 @@ func removeFromConfigIfNotApplied(r *Resource, config map[string]interface{}, pa
 		// instead to GCP by removing the field from the config. The live state's
 		// value will be substituted during the diff calculation.
 		unstructured.RemoveNestedField(config, path...)
+	}
+	return nil
+}
+
+func resolveContainerNodePoolNodeConfig(r *Resource, config map[string]interface{}) error {
+	if err := removeFromConfigIfNotApplied(r, config, "nodeConfig", "kubeletConfig"); err != nil {
+		return fmt.Errorf("error resolving kubeletConfig: %w", err)
+	}
+	if err := removeFromConfigIfNotApplied(r, config, "nodeConfig", "linuxNodeConfig"); err != nil {
+		return fmt.Errorf("error resolving linuxNodeConfig: %w", err)
+	}
+	if err := removeFromConfigIfNotApplied(r, config, "nodeConfig", "windowsNodeConfig"); err != nil {
+		return fmt.Errorf("error resolving windowsNodeConfig: %w", err)
 	}
 	return nil
 }

--- a/pkg/krmtotf/legacygcpmanagedfields_test.go
+++ b/pkg/krmtotf/legacygcpmanagedfields_test.go
@@ -233,6 +233,63 @@ func TestResolveGCPManagedFields(t *testing.T) {
 		},
 
 		{
+			name: "ContainerNodePool removes nodeConfig.kubeletConfig when not explicitly applied",
+			kind: "ContainerNodePool",
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"nodeConfig": map[string]interface{}{
+						"machineType": "e2-medium",
+					},
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"nodeConfig": map[string]interface{}{
+					"machineType": "e2-medium",
+					"kubeletConfig": map[string]interface{}{
+						"cpuManagerPolicy": "none",
+					},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"nodeConfig": map[string]interface{}{
+					"machineType": "e2-medium",
+				},
+			},
+		},
+		{
+			name: "ContainerNodePool preserves nodeConfig.kubeletConfig when explicitly applied",
+			kind: "ContainerNodePool",
+			lastAppliedConfig: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"nodeConfig": map[string]interface{}{
+						"machineType": "e2-medium",
+						"kubeletConfig": map[string]interface{}{
+							"cpuManagerPolicy": "none",
+						},
+					},
+				},
+			},
+			resourceExists: true,
+			inputConfig: map[string]interface{}{
+				"nodeConfig": map[string]interface{}{
+					"machineType": "e2-medium",
+					"kubeletConfig": map[string]interface{}{
+						"cpuManagerPolicy": "none",
+					},
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"nodeConfig": map[string]interface{}{
+					"machineType": "e2-medium",
+					"kubeletConfig": map[string]interface{}{
+						"cpuManagerPolicy": "none",
+					},
+				},
+			},
+		},
+
+		{
 			name: "ContainerNodePool uses user-supplied version when explicitly applied",
 			kind: "ContainerNodePool",
 			lastAppliedConfig: map[string]interface{}{


### PR DESCRIPTION
This PR fixes a bug where ContainerNodePool update reconciliation fails with a remote 400 error from GKE API when optional + computed nodeConfig fields (like kubeletConfig) are not explicitly applied in the KRM spec. We resolve it by removing them from the desired configuration in the GCP-managed fields resolver if they were not explicitly applied by the user.