### PR TITLE
compute: suppress diff for delete_default_routes_on_create in TF controller

### DIFF
--- a/config/servicemappings/compute.yaml
+++ b/config/servicemappings/compute.yaml
@@ -1285,6 +1285,8 @@ spec:
             group: resourcemanager.cnrm.cloud.google.com
     - name: google_compute_network
       kind: ComputeNetwork
+      mutableButUnreadableFields:
+        - delete_default_routes_on_create
       metadataMapping:
         name: name
       resourceID:

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_final_object.diff
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_final_object.diff
@@ -1,12 +1,14 @@
-7d6
+6d5
+<     cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+8d6
 <     cnrm.cloud.google.com/state-into-spec: absent
-11c10
+12c10
 <   generation: 3
 ---
 >   generation: 2
-20d18
+21d18
 <   resourceID: ${networkID}
-29c27
+30c27
 <   observedGeneration: 3
 ---
 >   observedGeneration: 2

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_final_object_old_controller.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkautocreatesubnets/_final_object_old_controller.golden.yaml
@@ -3,6 +3,7 @@ kind: ComputeNetwork
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkbasic/_final_object.diff
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkbasic/_final_object.diff
@@ -1,12 +1,14 @@
-7d6
+6d5
+<     cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+8d6
 <     cnrm.cloud.google.com/state-into-spec: absent
-11c10
+12c10
 <   generation: 3
 ---
 >   generation: 2
-20d18
+21d18
 <   resourceID: ${networkID}
-29c27
+30c27
 <   observedGeneration: 3
 ---
 >   observedGeneration: 2

--- a/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkbasic/_final_object_old_controller.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/compute/v1beta1/computenetwork/computenetworkbasic/_final_object_old_controller.golden.yaml
@@ -3,6 +3,7 @@ kind: ComputeNetwork
 metadata:
   annotations:
     cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
     cnrm.cloud.google.com/project-id: ${projectId}
     cnrm.cloud.google.com/state-into-spec: absent
   finalizers:


### PR DESCRIPTION
### BRIEF Change description

Suppress perpetual diffs on the virtual/create-only `delete_default_routes_on_create` field in `ComputeNetwork` by configuring it under `mutableButUnreadableFields` in the service mapping.

### Key Enhancements:
1. **Declarative Diff Suppression**:
   - Adds `delete_default_routes_on_create` to `mutableButUnreadableFields` under `google_compute_network` in `config/servicemappings/compute.yaml`.
   - When fetching live state from GCP/Terraform (where GCP's API does not return this create-only field), KCC automatically injects the stored spec value from the resource's annotation into the live state before diff comparison occurs.
   - Eliminates perpetual diffs cleanly and declaratively without requiring custom Go overrides.

Fixes #6195
