### PR TITLE
chore: register .gemini/skills in .agents/skills.json for automatic agent discovery

### DIFF
--- a/.agents/skills.json
+++ b/.agents/skills.json
@@ -1,0 +1,5 @@
+{
+  "entries": [
+    { "path": ".gemini/skills" }
+  ]
+}


### PR DESCRIPTION
Bridges the repository's .gemini/skills/ directory with the agent's default workspace customization root (.agents/skills.json) so that skills in .gemini/skills are automatically discovered and loaded into the agent's context.

Cloned from https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11561
