### PR TITLE
test(e2e): remove fallback from _http_mock.log to _http.log in MockGCP runs

### DIFF
--- a/tests/e2e/unified_test.go
+++ b/tests/e2e/unified_test.go
@@ -428,13 +428,6 @@ func createDiffs(t *testing.T, ctx context.Context, fixture resourcefixture.Reso
 			oldKey = "_http_old_controller.log"
 			newKey = "_http.log"
 			diffKey = "_http.diff"
-		} else {
-			mockPath := filepath.Join(dir, newKey)
-			if _, err := os.Stat(mockPath); err != nil && os.Getenv("WRITE_GOLDEN_OUTPUT") == "" {
-				oldKey = "_http_old_controller.log"
-				newKey = "_http.log"
-				diffKey = "_http.diff"
-			}
 		}
 
 		oldPath := filepath.Join(dir, oldKey)
@@ -870,14 +863,6 @@ func runScenario(ctx context.Context, t *testing.T, options ScenarioOptions, fix
 							key = "_http.log"
 							if options.FallbackToOldController {
 								key = "_http_old_controller.log"
-							}
-						} else {
-							mockPath := filepath.Join(fixture.AbsoluteSourceDir, key)
-							if _, err := os.Stat(mockPath); err != nil && os.Getenv("WRITE_GOLDEN_OUTPUT") == "" {
-								key = "_http.log"
-								if options.FallbackToOldController {
-									key = "_http_old_controller.log"
-								}
 							}
 						}
 						expectedPath := filepath.Join(fixture.AbsoluteSourceDir, key)


### PR DESCRIPTION
Removes silent fallback so that non-realGCP testing strictly mandates and compares against _http_mock.log. Ensures _http.log remains untouched as the immutable human-verified real GCP baseline.