### PR TITLE
test: add guardrails to CompareGoldenFile ensuring _http.log is only recorded against real GCP

### DIFF
--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -91,7 +91,8 @@ func extractEventsWithURLPrefix(allEvents, urlPrefix string) string {
 // CompareGoldenFile performs a file comparison for a golden test.
 func CompareGoldenFile(t *testing.T, p, fullGot string, normalizers ...func(s string) string) {
 	writeGoldenOutput := os.Getenv("WRITE_GOLDEN_OUTPUT") != ""
-	if writeGoldenOutput && filepath.Base(p) == "_http.log" && os.Getenv("E2E_GCP_TARGET") != "real" {
+	isResourceFixture := strings.Contains(p, "pkg/test/resourcefixture/testdata")
+	if writeGoldenOutput && isResourceFixture && filepath.Base(p) == "_http.log" && os.Getenv("E2E_GCP_TARGET") != "real" {
 		t.Fatalf("FAIL: attempted to write/update %q while E2E_GCP_TARGET=%q. _http.log must only be recorded when running against real GCP (E2E_GCP_TARGET=real).", p, os.Getenv("E2E_GCP_TARGET"))
 	}
 
@@ -114,7 +115,7 @@ func CompareGoldenFile(t *testing.T, p, fullGot string, normalizers ...func(s st
 		}
 	}
 	want := string(wantBytes)
-	if filepath.Base(p) == "_http.log" && strings.Contains(want, "(mockgcp)") {
+	if isResourceFixture && filepath.Base(p) == "_http.log" && strings.Contains(want, "(mockgcp)") {
 		t.Fatalf("FAIL: golden file %q contains mock traffic signature '(mockgcp)'. _http.log must only be recorded against real GCP (E2E_GCP_TARGET=real).", p)
 	}
 	for _, normalizer := range normalizers {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -91,6 +91,9 @@ func extractEventsWithURLPrefix(allEvents, urlPrefix string) string {
 // CompareGoldenFile performs a file comparison for a golden test.
 func CompareGoldenFile(t *testing.T, p, fullGot string, normalizers ...func(s string) string) {
 	writeGoldenOutput := os.Getenv("WRITE_GOLDEN_OUTPUT") != ""
+	if writeGoldenOutput && filepath.Base(p) == "_http.log" && os.Getenv("E2E_GCP_TARGET") != "real" {
+		t.Fatalf("FAIL: attempted to write/update %q while E2E_GCP_TARGET=%q. _http.log must only be recorded when running against real GCP (E2E_GCP_TARGET=real).", p, os.Getenv("E2E_GCP_TARGET"))
+	}
 
 	for _, normalizer := range normalizers {
 		fullGot = normalizer(fullGot)
@@ -111,6 +114,9 @@ func CompareGoldenFile(t *testing.T, p, fullGot string, normalizers ...func(s st
 		}
 	}
 	want := string(wantBytes)
+	if filepath.Base(p) == "_http.log" && strings.Contains(want, "(mockgcp)") {
+		t.Fatalf("FAIL: golden file %q contains mock traffic signature '(mockgcp)'. _http.log must only be recorded against real GCP (E2E_GCP_TARGET=real).", p)
+	}
 	for _, normalizer := range normalizers {
 		want = normalizer(want)
 	}


### PR DESCRIPTION
### Description
Enforces strict separation between real GCP golden logs (`_http.log`) and mock GCP golden logs (`_http_mock.log`):

1. **Write/Creation Guardrail**: When `WRITE_GOLDEN_OUTPUT=1`, attempting to write or update `_http.log` while `E2E_GCP_TARGET != real` (e.g. `mock`) instantly aborts the test with a clear failure message.
2. **Signature Read Guardrail**: Prevents reading any `_http.log` file containing mock traffic signatures (`(mockgcp)`).