### PR TITLE
test: append '(mockgcp)' signature to User-Agent headers when normalizing mock HTTP traffic

### DIFF
--- a/tests/e2e/normalize.go
+++ b/tests/e2e/normalize.go
@@ -1124,6 +1124,15 @@ func NormalizeHTTPLog(t *testing.T, events test.LogEntries, services mockgcpregi
 	// Remove headers that just aren't very relevant to testing
 	// Remove headers in request.
 	events.RemoveHTTPRequestHeader("X-Goog-Api-Client")
+	if os.Getenv("E2E_GCP_TARGET") == "mock" {
+		for _, event := range events {
+			for i, ua := range event.Request.Header["User-Agent"] {
+				if !strings.HasSuffix(ua, "(mockgcp)") {
+					event.Request.Header["User-Agent"][i] = ua + " (mockgcp)"
+				}
+			}
+		}
+	}
 	// Remove header in response.
 	events.RemoveHTTPResponseHeader("Date")
 	events.RemoveHTTPResponseHeader("Alt-Svc")


### PR DESCRIPTION
### Description
Appends a distinct `(mockgcp)` signature suffix to all `User-Agent` request headers when recording or normalizing mock HTTP traffic (`E2E_GCP_TARGET=mock`).

This enables unambiguous programmatic differentiation between:
- **Mock GCP recordings (`_http_mock.log`)**: `User-Agent: ... (mockgcp)`
- **Real GCP recordings (`_http.log`)**: `User-Agent: ...`

Because `TestGoldenLogAlignment` skips comparing HTTP headers between real and mock logs, this signature does not disrupt unit test alignment while providing a clear signature for detecting/preventing mock traffic from ever being recorded into `_http.log`.