### PR TITLE
feat(ci): add pre-push presubmit validation script validate-and-push and enforce repo rules

### DIFF
--- a/.gemini/skills/send-pr/SKILL.md
+++ b/.gemini/skills/send-pr/SKILL.md
@@ -9,13 +9,19 @@ description: CRITICAL: MUST be used whenever sending a PR, updating an existing 
 
 This skill mandates strict pre-push presubmit validation (`dev/tasks/validate-and-push`) whenever creating or updating a Pull Request (PR) or pushing any commit to a remote branch in `k8s-config-connector`.
 
-## Workflow: Updating an Existing PR or Pushing to a Remote Branch
+## Workflow: Automated Git Hooks & Pre-Push Presubmit Checks
 
-Before pushing to any remote branch (`git push ...`), you MUST run the automated pre-push validation script:
+To ensure that even local terminal sessions running direct `git push` commands are protected against unvalidated pushes, configure repository git hooks once by running:
+```bash
+./dev/tasks/install-git-hooks   # or: make setup-hooks
+```
+Once installed, Git's `pre-push` hook (`dev/git-hooks/pre-push`) automatically intercepts any `git push` and runs canonical pre-push presubmits (`make fmt`, `go vet ./...`, `validate-generated-files`, and `unit-tests`).
+
+Alternatively, or in environments where hooks are not configured, explicitly push via the automated helper script:
 ```bash
 ./dev/tasks/validate-and-push origin <branch-name>
 ```
-`validate-and-push` sequentially runs `make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests`. It will only execute `git push` if all local authoritative presubmits exit cleanly (`0`).
+`validate-and-push` sequentially runs all presubmits and will only execute `git push` if all checks exit cleanly (`0`).
 
 1. **Write the PR Body**:
    Create a temporary markdown file containing the body/description of your PR. Make sure to reference the issue you are solving (e.g., `Fixes #1234`).

--- a/.gemini/skills/send-pr/SKILL.md
+++ b/.gemini/skills/send-pr/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: send-pr
-description: Provides tools and instructions for sending Pull Requests (PRs), particularly from automated agents like codebot-robot. Use this skill when you need to send or update a PR, format code before pushing, or interact with github via the `gh` tool.
+description: CRITICAL: MUST be used whenever sending a PR, updating an existing PR, or pushing any commit to a remote branch. Provides instructions and pre-push checks (`dev/tasks/validate-and-push`) before pushing or interacting with GitHub via `gh`.
 ---
 
-# Send PR
+# Send PR & Safe Remote Push
 
 ## Overview
 
-This skill simplifies the process of creating and updating Pull Requests (PRs) in the `k8s-config-connector` repository. It provides a standard script that handles formatting checks, git pushing, and the `gh` tool interaction to create or edit PRs safely.
+This skill mandates strict pre-push presubmit validation (`dev/tasks/validate-and-push`) whenever creating or updating a Pull Request (PR) or pushing any commit to a remote branch in `k8s-config-connector`.
 
-## Workflow: Creating or Updating a PR
+## Workflow: Updating an Existing PR or Pushing to a Remote Branch
 
-When you are ready to send your changes as a Pull Request, use the provided `send-pr.sh` script.
+Before pushing to any remote branch (`git push ...`), you MUST run the automated pre-push validation script:
+```bash
+./dev/tasks/validate-and-push origin <branch-name>
+```
+`validate-and-push` sequentially runs `make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests`. It will only execute `git push` if all local authoritative presubmits exit cleanly (`0`).
 
 1. **Write the PR Body**:
    Create a temporary markdown file containing the body/description of your PR. Make sure to reference the issue you are solving (e.g., `Fixes #1234`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -164,9 +164,12 @@ When asked to work with github issues, use the `gh issue` tool to read/update is
 # Github Pull Requests and Remote Pushes
 
 When asked to send or update a pull request, or push any commit to a remote branch, NEVER run raw `git push` directly without running full pre-push validations.
-You MUST either:
-1. Run `./dev/tasks/validate-and-push [remote] [branch]` which automatically executes `make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests` before safely executing `git push`; OR
-2. Please use the `send-pr` skill and verify clean exit codes (`0`) on `make fmt`, `./dev/ci/presubmits/unit-tests`, and `./dev/ci/presubmits/validate-generated-files` before pushing.
+
+To protect local terminal runs from unvalidated `git push` commands, configure repository git hooks by running `./dev/tasks/install-git-hooks` (or `make setup-hooks`). Once installed, Git's `pre-push` hook (`dev/git-hooks/pre-push`) automatically intercepts any `git push` and runs canonical pre-push validation (`make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests`) before allowing commits to be published.
+
+When automating or pushing manually, you MUST:
+1. Use `./dev/tasks/validate-and-push [remote] [branch]` (or `make validate`) to execute pre-push presubmit checks safely; OR
+2. Ensure repository git hooks (`make setup-hooks`) are active so standard `git push` commands automatically run the canonical pre-push checks.
 
 # Import Alias Convention
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -161,9 +161,12 @@ We have custom linters in `dev/linters`.
 
 When asked to work with github issues, use the `gh issue` tool to read/update issues.
 
-# Github Pull Requests
+# Github Pull Requests and Remote Pushes
 
-When asked to send or update a pull request, please use the `send-pr` skill. It provides a script that handles formatting and git pushing safely.
+When asked to send or update a pull request, or push any commit to a remote branch, NEVER run raw `git push` directly without running full pre-push validations.
+You MUST either:
+1. Run `./dev/tasks/validate-and-push [remote] [branch]` which automatically executes `make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests` before safely executing `git push`; OR
+2. Please use the `send-pr` skill and verify clean exit codes (`0`) on `make fmt`, `./dev/ci/presubmits/unit-tests`, and `./dev/ci/presubmits/validate-generated-files` before pushing.
 
 # Import Alias Convention
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,17 @@ test: generate fmt vet manifests
 	dev/ci/presubmits/unit-tests
 	dev/ci/presubmits/unit-tests-operator
 
+# Setup repository git hooks for automated pre-push presubmit validation
+.PHONY: setup-hooks
+setup-hooks:
+	dev/tasks/install-git-hooks
+
+# Run canonical presubmit / validation checks without pushing
+.PHONY: presubmit validate
+validate presubmit:
+	dev/tasks/validate-and-push --validate-only
+
+
 # Build config-connector binary
 .PHONY: config-connector
 config-connector: generate fmt vet

--- a/dev/git-hooks/pre-push
+++ b/dev/git-hooks/pre-push
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${SKIP_PRE_PUSH_VALIDATION:-0}" == "1" ]]; then
+  echo "WARNING: SKIP_PRE_PUSH_VALIDATION=1 is set; skipping pre-push validation hook."
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+echo "========================================================================"
+echo " [pre-push hook] Running pre-push presubmit validation..."
+echo "========================================================================"
+
+if ! ./dev/tasks/validate-and-push --validate-only; then
+  echo ""
+  echo "========================================================================"
+  echo " ERROR: Pre-push presubmit validation failed!"
+  echo "========================================================================"
+  echo "To protect repository health and CI pipelines, your git push has been aborted."
+  echo "Please inspect and resolve the errors above before pushing."
+  echo ""
+  echo "If you explicitly need to bypass this pre-push check (e.g. saving WIP branch), run:"
+  echo "  SKIP_PRE_PUSH_VALIDATION=1 git push ..."
+  echo "========================================================================"
+  exit 1
+fi

--- a/dev/tasks/install-git-hooks
+++ b/dev/tasks/install-git-hooks
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+chmod +x dev/git-hooks/* || true
+git config core.hooksPath dev/git-hooks
+
+echo "Successfully configured git hooks path to: dev/git-hooks"
+echo "Any 'git push' command in this repository will now automatically execute canonical pre-push validation."

--- a/dev/tasks/validate-and-push
+++ b/dev/tasks/validate-and-push
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+echo "=== Step 1/4: Running make fmt ==="
+make fmt
+
+echo "=== Step 2/4: Running go vet ./... ==="
+go vet ./...
+
+echo "=== Step 3/4: Running dev/ci/presubmits/validate-generated-files ==="
+./dev/ci/presubmits/validate-generated-files
+
+echo "=== Step 4/4: Running dev/ci/presubmits/unit-tests ==="
+./dev/ci/presubmits/unit-tests
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR: Working directory is not clean after validation steps. Uncommitted changes detected:"
+  git status --short
+  echo "Please commit or stage these changes before pushing."
+  exit 1
+fi
+
+echo "All presubmit checks passed cleanly!"
+
+if [[ $# -gt 0 ]]; then
+  echo "Pushing changes: git push $*"
+  git push "$@"
+else
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  echo "Pushing current branch ${BRANCH} to origin: git push origin ${BRANCH}"
+  git push origin "${BRANCH}"
+fi

--- a/dev/tasks/validate-and-push
+++ b/dev/tasks/validate-and-push
@@ -20,6 +20,12 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
+VALIDATE_ONLY=0
+if [[ "${1:-}" == "--validate-only" || "${1:-}" == "-v" ]]; then
+  VALIDATE_ONLY=1
+  shift
+fi
+
 echo "=== Step 1/4: Running make fmt ==="
 make fmt
 
@@ -41,6 +47,11 @@ fi
 
 echo "All presubmit checks passed cleanly!"
 
+if [[ "${VALIDATE_ONLY}" == "1" ]]; then
+  echo "Validation-only mode (--validate-only) requested. Skipping git push."
+  exit 0
+fi
+
 if [[ $# -gt 0 ]]; then
   echo "Pushing changes: git push $*"
   git push "$@"
@@ -49,3 +60,4 @@ else
   echo "Pushing current branch ${BRANCH} to origin: git push origin ${BRANCH}"
   git push origin "${BRANCH}"
 fi
+


### PR DESCRIPTION
This PR introduces systemic pre-push safeguards to prevent unvalidated commits from being pushed to remote branches or pull requests:

1. **New Script `dev/tasks/validate-and-push`**: Sequentially executes `make fmt`, `go vet ./...`, `./dev/ci/presubmits/validate-generated-files`, and `./dev/ci/presubmits/unit-tests` before safely pushing a branch.
2. **Updated `GEMINI.md`**: Strictly enforces pre-push presubmit validation for all agents and contributors before pushing to any remote branch or pull request.
3. **Updated `send-pr` Skill**: Expands workflow description to trigger on any PR update or remote branch push and route via `validate-and-push`.