### PR TITLE
test: refine extractResourceKey to capture service prefixes and operation scopes

### DIFF
--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -393,6 +393,14 @@ func parseLog(content string) []httpEvent {
 
 func extractResourceKey(urlPath string) string {
 	u := strings.Split(urlPath, "?")[0]
+	var servicePrefix string
+	if protoIdx := strings.Index(u, "://"); protoIdx != -1 {
+		hostPath := u[protoIdx+3:]
+		if slashIdx := strings.Index(hostPath, "/"); slashIdx != -1 {
+			host := hostPath[:slashIdx]
+			servicePrefix = strings.Split(host, ".")[0] + "/"
+		}
+	}
 	u = cleanURL(u)
 	segments := strings.Split(strings.Trim(u, "/"), "/")
 	if len(segments) == 0 {
@@ -404,9 +412,13 @@ func extractResourceKey(urlPath string) string {
 	}
 	if len(segments) >= 2 {
 		prevSeg := segments[len(segments)-2]
-		return prevSeg + "/" + lastSeg
+		if prevSeg == "operations" && len(segments) >= 3 {
+			prevPrevSeg := segments[len(segments)-3]
+			return servicePrefix + prevPrevSeg + "/" + prevSeg + "/" + lastSeg
+		}
+		return servicePrefix + prevSeg + "/" + lastSeg
 	}
-	return lastSeg
+	return servicePrefix + lastSeg
 }
 
 func cleanURL(u string) string {

--- a/pkg/test/utils_test.go
+++ b/pkg/test/utils_test.go
@@ -25,19 +25,31 @@ func TestExtractResourceKey(t *testing.T) {
 	}{
 		{
 			url:  "https://container.googleapis.com/v1beta1/projects/mock-project/locations/us-central1-a/clusters/cluster-sample-123",
-			want: "clusters/cluster-sample-123",
+			want: "container/clusters/cluster-sample-123",
 		},
 		{
 			url:  "https://container.googleapis.com/v1beta1/projects/mock-project/locations/us-central1-a/clusters/cluster-sample-123/nodePools/nodepool-sample-123?alt=json",
-			want: "nodePools/nodepool-sample-123",
+			want: "container/nodePools/nodepool-sample-123",
 		},
 		{
 			url:  "https://compute.googleapis.com/compute/v1/projects/mock-project/global/networks/computenetwork-123",
-			want: "networks/computenetwork-123",
+			want: "compute/networks/computenetwork-123",
 		},
 		{
 			url:  "https://cloudkms.googleapis.com/v1/projects/mock-project/locations/us-central1/keyRings/keyring-123/cryptoKeys/cryptokey-123:getIamPolicy",
-			want: "cryptoKeys/cryptokey-123",
+			want: "cloudkms/cryptoKeys/cryptokey-123",
+		},
+		{
+			url:  "https://container.googleapis.com/v1beta1/projects/mock-project/locations/us-central1-a/operations/operation-123",
+			want: "container/us-central1-a/operations/operation-123",
+		},
+		{
+			url:  "https://compute.googleapis.com/compute/v1/projects/mock-project/regions/us-central1/operations/operation-456",
+			want: "compute/us-central1/operations/operation-456",
+		},
+		{
+			url:  "https://compute.googleapis.com/compute/v1/projects/mock-project/global/operations/operation-789",
+			want: "compute/global/operations/operation-789",
 		},
 	}
 


### PR DESCRIPTION
### Summary
Refines the HTTP log parsing utility `extractResourceKey` right inside `pkg/test/utils.go` to extract **service prefixes** from hostnames and accurately identify multi-segment **operation paths**.

### Changes
* **Service Prefix Extraction**: Captures the service hostname prefix (e.g., `container/` from `container.googleapis.com` or `compute/` from `compute.googleapis.com`) so resources with similar IDs across multiple APIs do not collide during HTTP log sorting and normalization in mock tests.
* **Operation Scope Support**: Recognizes operation endpoint segments (`.../operations/<op-id>`) across services and regions or global scopes and preserves the scope segment (`compute/us-central1-a/operations/...` or `compute/global/operations/...`).
