### PR TITLE
release: add committed patch and pre-rendered operator manifests for GitOps (#11757)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,6 @@ config/installbundle/components/recorder/recorder_image_patch.yaml
 config/installbundle/components/webhook/webhook_image_patch.yaml
 config/installbundle/components/deletiondefender/deletiondefender_image_patch.yaml
 config/installbundle/components/unmanageddetector/unmanageddetector_image_patch.yaml
-operator/config/manager/manager_image_patch.yaml
-operator/config/autopilot-manager/manager_image_patch.yaml
 
 ### Go ###
 # Binaries for programs and plugins

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 tmp/_output
 tmp/_test
 .tmp
+.jetskicli/
 
 # build output
 bin/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ See https://cloud.google.com/config-connector/docs/overview.
 
 See [Config Connector CLI](./docs/cli/README.md) for documentation on the `config-connector` command-line tool.
 
+See [Managing Config Connector with GitOps (ArgoCD)](./docs/guides/gitops-argocd.md) for instructions on deploying and upgrading via GitOps.
+
 See
 [Choosing an installation type](https://cloud.google.com/config-connector/docs/concepts/installation-types)
 to decide how you want to install Config Connector.

--- a/config/installbundle/release-manifests/autopilot/autopilot-configconnector-operator.yaml
+++ b/config/installbundle/release-manifests/autopilot/autopilot-configconnector-operator.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/config/installbundle/release-manifests/autopilot/autopilot-configconnector-operator.yaml
+++ b/config/installbundle/release-manifests/autopilot/autopilot-configconnector-operator.yaml
@@ -1,0 +1,3383 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnectorcontexts.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ConfigConnectorContext
+    listKind: ConfigConnectorContextList
+    plural: configconnectorcontexts
+    singular: configconnectorcontext
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'true' the most recent reconcile of the ConfigConnectorContext
+        object succeeded
+      jsonPath: .status.healthy
+      name: Healthy
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ConfigConnectorContext is the Schema for the ConfigConnectorContexts
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext
+            properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
+              billingProject:
+                description: |-
+                  Specifies the project to use for preconditions, quota and billing.
+                  Should only be used when requestProjectPolicy is set to BILLING_PROJECT.
+                type: string
+              experiments:
+                properties:
+                  controllerOverrides:
+                    additionalProperties:
+                      description: ReconcilerType describes the type of reconciler
+                        (controller) being used
+                      type: string
+                    description: |-
+                      ControllerOverrides allows specifying which controller to use for a given
+                      resource kind within this namespace, overriding the system default.
+                      The format for the entries should follow the format as Kind.group :
+                      e.g. BigQueryDataset.bigquery.cnrm.cloud.google.com: direct
+                    type: object
+                  resourceSettings:
+                    description: |-
+                      ResourceSettings allows specifying which resources to enable or disable in this namespace.
+                      Validation likely enforces uniqueness, but if duplicates exist, behavior is undefined.
+                    properties:
+                      mode:
+                        description: |-
+                          Mode controls whether the resources are included or excluded.
+                          Defaults to "exclude" (Exclusion mode).
+                        type: string
+                      resources:
+                        description: Resources is the list of resources to include
+                          or exclude.
+                        items:
+                          properties:
+                            group:
+                              description: Group is the API group of the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                          required:
+                          - group
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              googleServiceAccount:
+                description: |-
+                  The Google Service Account to be used by Config Connector to
+                  authenticate with Google Cloud APIs in the associated namespace.
+                type: string
+              managerNamespace:
+                description: |-
+                  ManagerNamespace instructs Config Connector to deploy
+                  controller managers and related resources in the namespace
+                  specified as 'ManagerNamespace' instead of standard 'cnrm-system'
+                  The specified manager namespace may exist before the corresponding
+                  ConfigConnectorContext is created.
+                  If the specified namespace does not exist then it will be created
+                  by Config Connector. The field is immutable.
+                type: string
+                x-kubernetes-validations:
+                - message: ManagerNamespace field is immutable
+                  rule: self == oldSelf
+              requestProjectPolicy:
+                description: |-
+                  Specifies which project to use for preconditions, quota, and billing for
+                  requests made to Google Cloud APIs for resources in the associated
+                  namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
+                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to
+                  'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service
+                  Account belongs to. If set to 'RESOURCE_PROJECT', uses the project that
+                  the resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.
+                enum:
+                - SERVICE_ACCOUNT_PROJECT
+                - RESOURCE_PROJECT
+                - BILLING_PROJECT
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
+                type: string
+              version:
+                description: |-
+                  Version specifies the exact addon version to be deployed, eg 1.2.3
+                  Only limited versions are supported; currently we are only supporting
+                  the operator version and the previous minor version.
+                type: string
+            required:
+            - googleServiceAccount
+            type: object
+          status:
+            description: ConfigConnectorContextStatus defines the observed state of
+              ConfigConnectorContext
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnectors.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ConfigConnector
+    listKind: ConfigConnectorList
+    plural: configconnectors
+    singular: configconnector
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'true' the most recent reconcile of the ConfigConnector object
+        succeeded
+      jsonPath: .status.healthy
+      name: Healthy
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ConfigConnector is the Schema for the configconnectors API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            anyOf:
+            - oneOf:
+              - not:
+                  required:
+                  - googleServiceAccount
+                required:
+                - credentialSecretName
+              - not:
+                  required:
+                  - credentialSecretName
+                required:
+                - googleServiceAccount
+              properties:
+                mode:
+                  enum:
+                  - cluster
+            - not:
+                anyOf:
+                - required:
+                  - googleServiceAccount
+                - required:
+                  - credentialSecretName
+              properties:
+                mode:
+                  enum:
+                  - namespaced
+            description: ConfigConnectorSpec defines the desired state of ConfigConnector
+            properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                  If Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.
+                  If CCC doesn't define a value but ConfigConnector (CC) does, we defer to that value. Otherwise,
+                  the default is 'Reconciling' where resources get actuated.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
+              credentialSecretName:
+                description: |-
+                  The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.
+                  It's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.
+                  This field cannot be specified together with `googleServiceAccount`.
+                type: string
+              experiments:
+                description: ConfigConnector specific experiments
+                properties:
+                  multiClusterLease:
+                    description: MultiClusterLease defines configuration specific
+                      to multi-cluster leader election.
+                    properties:
+                      clusterCandidateIdentity:
+                        description: |-
+                          The identity of the cluster candidate for the KCC components, hared by all KCC replicas
+                          and workloads across all clusters that are part of the same election.
+                           This name must be unique across all the clusters that you are configuring the multi cluster set up for.
+                        type: string
+                      leaseName:
+                        description: The name of the MultiClusterLease object that
+                          KCC will create.
+                        type: string
+                      namespace:
+                        description: The namespace where the MultiClusterLease object
+                          will be created.
+                        type: string
+                      resourceReplicationMode:
+                        default: Status
+                        description: |-
+                          ResourceReplicationMode specifies how the resources will be synced to the passive clusters.
+                          Can be either 'Status', 'Full', or 'Disabled'.
+                          'Status' (default) means only the status field (and occasionally essential fields like spec.resourceID) are synced.
+                          'Full' means both the spec and status are synced.
+                          'Disabled' means resource replication is completely turned off for this lease.
+                        enum:
+                        - Status
+                        - Full
+                        - Disabled
+                        type: string
+                    required:
+                    - clusterCandidateIdentity
+                    - leaseName
+                    - namespace
+                    type: object
+                  resourceSettings:
+                    description: ResourceSettings allows specifying which resources
+                      to enable or disable.
+                    properties:
+                      mode:
+                        description: |-
+                          Mode controls whether the resources are included or excluded.
+                          Defaults to "exclude" (Exclusion mode).
+                        type: string
+                      resources:
+                        description: Resources is the list of resources to include
+                          or exclude.
+                        items:
+                          properties:
+                            group:
+                              description: Group is the API group of the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                          required:
+                          - group
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              googleServiceAccount:
+                description: |-
+                  The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.
+                  See Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.
+                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.
+                type: string
+              mode:
+                description: |-
+                  The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.
+                  Cluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.
+                  You must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.
+                  Namespaced mode allows you to use different Google service accounts for different Projects.
+                  When in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.
+                enum:
+                - cluster
+                - namespaced
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  If the field is set in both the ConfigConnector object and the
+                  ConfigConnectorContext object is in the namespaced mode, then the value
+                  in the ConfigConnectorContext object will be used.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
+                type: string
+            type: object
+          status:
+            description: ConfigConnectorStatus defines the observed state of ConfigConnector
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: controllerreconcilers.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ControllerReconciler
+    listKind: ControllerReconcilerList
+    plural: controllerreconcilers
+    singular: controllerreconciler
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in cluster mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerReconcilerSpec is the specification of ControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector controller manager in cluster mode.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: ControllerReconcilerStatus defines the observed state of
+              ControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in cluster mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerReconcilerSpec is the specification of ControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector controller manager in cluster mode.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: ControllerReconcilerStatus defines the observed state of
+              ControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: controllerresources.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ControllerResource
+    listKind: ControllerResourceList
+    plural: controllerresources
+    singular: controllerresource
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ControllerResource is the Schema for resource customization API
+          for config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                - cnrm-deletiondefender
+                - cnrm-unmanaged-detector
+                - cnrm-webhook-manager
+                - cnrm-resource-stats-recorder
+                type: string
+            type: object
+          spec:
+            anyOf:
+            - required:
+              - containers
+            - required:
+              - replicas
+            - required:
+              - verticalPodAutoscalerMode
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              metadataHost:
+                description: |-
+                  MetadataHost overrides the GCP metadata server hostname (injected as GCE_METADATA_HOST).
+                  Useful for IPv6-only clusters where the default 169.254.169.254 is unreachable.
+                type: string
+              replicas:
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                format: int64
+                type: integer
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: ControllerResourceStatus defines the observed state of ControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ControllerResource is the Schema for resource customization API
+          for config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                - cnrm-deletiondefender
+                - cnrm-unmanaged-detector
+                - cnrm-webhook-manager
+                - cnrm-resource-stats-recorder
+                type: string
+            type: object
+          spec:
+            anyOf:
+            - required:
+              - containers
+            - required:
+              - replicas
+            - required:
+              - verticalPodAutoscalerMode
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              metadataHost:
+                description: |-
+                  MetadataHost overrides the GCP metadata server hostname (injected as GCE_METADATA_HOST).
+                  Useful for IPv6-only clusters where the default 169.254.169.254 is unreachable.
+                type: string
+              replicas:
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                format: int64
+                type: integer
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: ControllerResourceStatus defines the observed state of ControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: MutatingWebhookConfigurationCustomization
+    listKind: MutatingWebhookConfigurationCustomizationList
+    plural: mutatingwebhookconfigurationcustomizations
+    singular: mutatingwebhookconfigurationcustomization
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - mutating-webhook
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - mutating-webhook
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: namespacedcontrollerreconcilers.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: NamespacedControllerReconciler
+    listKind: NamespacedControllerReconcilerList
+    plural: namespacedcontrollerreconcilers
+    singular: namespacedcontrollerreconciler
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespacedControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in namespaced mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector namespaced controller manager.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: NamespacedControllerReconcilerStatus defines the observed
+              state of NamespacedControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespacedControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in namespaced mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector namespaced controller manager.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: NamespacedControllerReconcilerStatus defines the observed
+              state of NamespacedControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: namespacedcontrollerresources.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: NamespacedControllerResource
+    listKind: NamespacedControllerResourceList
+    plural: namespacedcontrollerresources
+    singular: namespacedcontrollerresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NamespacedControllerResource is the Schema for resource customization
+          API for namespaced config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                type: string
+            type: object
+          spec:
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: NamespacedControllerResourceStatus defines the observed state
+              of NamespacedControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: NamespacedControllerResource is the Schema for resource customization
+          API for namespaced config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                type: string
+            type: object
+          spec:
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: NamespacedControllerResourceStatus defines the observed state
+              of NamespacedControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ValidatingWebhookConfigurationCustomization
+    listKind: ValidatingWebhookConfigurationCustomizationList
+    plural: validatingwebhookconfigurationcustomizations
+    singular: validatingwebhookconfigurationcustomization
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - validating-webhook
+                - abandon-on-uninstall
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - validating-webhook
+                - abandon-on-uninstall
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    cnrm.cloud.google.com/version: 1.125.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+    cnrm.cloud.google.com/system: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: configconnector-operator-cnrm-viewer
+rules:
+- apiGroups:
+  - accesscontextmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aiplatform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aistreams.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alloydb.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - analytics.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigateway.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigee.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigeeregistry.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apihub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apikeys.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apphub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appoptimize.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - artifactregistry.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - asset.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - assuredworkloads.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - automl.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - backupdr.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - beyondcorp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquery.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryanalyticshub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerybiglake.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryconnection.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerydatapolicy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerydatatransfer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerymigration.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryreservation.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigtable.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - billing.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - billingbudgets.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - binaryauthorization.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - blockchainnodeengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificatemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ces.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudasset.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudbuild.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - clouddeploy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - clouddms.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudfunctions.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudfunctions2.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudidentity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudids.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudiot.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudquota.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudscheduler.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudsecuritycompliance.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudtasks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - colab.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - composer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - compute.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configcontroller.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configdelivery.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - connectors.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - contactcenterinsights.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - container.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - containeranalysis.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - containerattached.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - contentwarehouse.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datacatalog.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataflow.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datafusion.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datalabeling.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datalineage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datamigration.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataplex.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataproc.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datastore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datastream.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - deploymentmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - developerconnect.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devicestreaming.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dialogflow.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dialogflowcx.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discoveryengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dlp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dns.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - documentai.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - edgecontainer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - edgenetwork.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - essentialcontacts.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - eventarc.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - filestore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebase.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasedatabase.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasehosting.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasestorage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firestore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - geminidataanalytics.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gkebackup.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gkehub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - healthcare.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iam.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iap.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - identityplatform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kms.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - logging.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - managedkafka.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - memcache.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - memorystore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metastore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - migrationcenter.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - mlengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - modelarmor.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - netapp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkconnectivity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkmanagement.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networksecurity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkservices.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - notebooks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - orgpolicy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - osconfig.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - oslogin.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - parametermanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - privateca.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - privilegedaccessmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pubsub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pubsublite.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - recaptchaenterprise.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - redis.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resourcemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - run.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - saasservicemgmt.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - secretmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - securesourcemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - securitycenter.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicedirectory.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicenetworking.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serviceusage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sourcerepo.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - spanner.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - speech.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sql.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sqladmin.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storagetransfer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tags.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - testing.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tpu.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vectorsearch.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vertexai.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - videostitcher.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vmwareengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vpcaccess.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workflowexecutions.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workflows.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workstations.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - events
+  - namespaces
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors
+  - configconnectorcontexts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors/status
+  - configconnectorcontexts/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - customize.core.cnrm.cloud.google.com
+  resources:
+  - controllerresources
+  - namespacedcontrollerresources
+  - validatingwebhookconfigurationcustomizations
+  - mutatingwebhookconfigurationcustomizations
+  - namespacedcontrollerreconcilers
+  - controllerreconcilers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - customize.core.cnrm.cloud.google.com
+  resources:
+  - controllerresources/status
+  - namespacedcontrollerresources/status
+  - validatingwebhookconfigurationcustomizations/status
+  - mutatingwebhookconfigurationcustomizations/status
+  - namespacedcontrollerreconcilers/status
+  - controllerreconcilers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - cnrm-admin
+  - cnrm-manager-cluster-role
+  - cnrm-manager-ns-role
+  - cnrm-recorder-role
+  - cnrm-webhook-role
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-cnrm-viewer-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configconnector-operator-cnrm-viewer
+subjects:
+- kind: ServiceAccount
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configconnector-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-service
+  namespace: configconnector-operator-system
+spec:
+  ports:
+  - name: controller-manager
+    port: 443
+  selector:
+    cnrm.cloud.google.com/component: configconnector-operator
+    cnrm.cloud.google.com/operator-system: "true"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/component: configconnector-operator
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: configconnector-operator
+      cnrm.cloud.google.com/operator-system: "true"
+  serviceName: configconnector-operator-service
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/operator-version: 1.154.0
+      labels:
+        cnrm.cloud.google.com/component: configconnector-operator
+        cnrm.cloud.google.com/operator-system: "true"
+    spec:
+      containers:
+      - args:
+        - --local-repo=/configconnector-operator/autopilot-channels
+        command:
+        - /configconnector-operator/manager
+        image: gcr.io/gke-release/cnrm/operator:1.154.0
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: configconnector-operator
+      terminationGracePeriodSeconds: 10

--- a/config/installbundle/release-manifests/standard/configconnector-operator.yaml
+++ b/config/installbundle/release-manifests/standard/configconnector-operator.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/config/installbundle/release-manifests/standard/configconnector-operator.yaml
+++ b/config/installbundle/release-manifests/standard/configconnector-operator.yaml
@@ -1,0 +1,3386 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnectorcontexts.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ConfigConnectorContext
+    listKind: ConfigConnectorContextList
+    plural: configconnectorcontexts
+    singular: configconnectorcontext
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'true' the most recent reconcile of the ConfigConnectorContext
+        object succeeded
+      jsonPath: .status.healthy
+      name: Healthy
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ConfigConnectorContext is the Schema for the ConfigConnectorContexts
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigConnectorContextSpec defines the desired state of ConfigConnectorContext
+            properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'. The default is 'Reconciling' where resources get actuated.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
+              billingProject:
+                description: |-
+                  Specifies the project to use for preconditions, quota and billing.
+                  Should only be used when requestProjectPolicy is set to BILLING_PROJECT.
+                type: string
+              experiments:
+                properties:
+                  controllerOverrides:
+                    additionalProperties:
+                      description: ReconcilerType describes the type of reconciler
+                        (controller) being used
+                      type: string
+                    description: |-
+                      ControllerOverrides allows specifying which controller to use for a given
+                      resource kind within this namespace, overriding the system default.
+                      The format for the entries should follow the format as Kind.group :
+                      e.g. BigQueryDataset.bigquery.cnrm.cloud.google.com: direct
+                    type: object
+                  resourceSettings:
+                    description: |-
+                      ResourceSettings allows specifying which resources to enable or disable in this namespace.
+                      Validation likely enforces uniqueness, but if duplicates exist, behavior is undefined.
+                    properties:
+                      mode:
+                        description: |-
+                          Mode controls whether the resources are included or excluded.
+                          Defaults to "exclude" (Exclusion mode).
+                        type: string
+                      resources:
+                        description: Resources is the list of resources to include
+                          or exclude.
+                        items:
+                          properties:
+                            group:
+                              description: Group is the API group of the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                          required:
+                          - group
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              googleServiceAccount:
+                description: |-
+                  The Google Service Account to be used by Config Connector to
+                  authenticate with Google Cloud APIs in the associated namespace.
+                type: string
+              managerNamespace:
+                description: |-
+                  ManagerNamespace instructs Config Connector to deploy
+                  controller managers and related resources in the namespace
+                  specified as 'ManagerNamespace' instead of standard 'cnrm-system'
+                  The specified manager namespace may exist before the corresponding
+                  ConfigConnectorContext is created.
+                  If the specified namespace does not exist then it will be created
+                  by Config Connector. The field is immutable.
+                type: string
+                x-kubernetes-validations:
+                - message: ManagerNamespace field is immutable
+                  rule: self == oldSelf
+              requestProjectPolicy:
+                description: |-
+                  Specifies which project to use for preconditions, quota, and billing for
+                  requests made to Google Cloud APIs for resources in the associated
+                  namespace. Must be one of 'SERVICE_ACCOUNT_PROJECT',
+                  'RESOURCE_PROJECT', or 'BILLING_PROJECT. Defaults to 'SERVICE_ACCOUNT_PROJECT'. If set to
+                  'SERVICE_ACCOUNT_PROJECT', uses the project that the Google Service
+                  Account belongs to. If set to 'RESOURCE_PROJECT', uses the project that
+                  the resource belongs to. If set to 'BILLING_PROJECT', uses the project specified by spec.billingProject.
+                enum:
+                - SERVICE_ACCOUNT_PROJECT
+                - RESOURCE_PROJECT
+                - BILLING_PROJECT
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
+                type: string
+              version:
+                description: |-
+                  Version specifies the exact addon version to be deployed, eg 1.2.3
+                  Only limited versions are supported; currently we are only supporting
+                  the operator version and the previous minor version.
+                type: string
+            required:
+            - googleServiceAccount
+            type: object
+          status:
+            description: ConfigConnectorContextStatus defines the observed state of
+              ConfigConnectorContext
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnectors.core.cnrm.cloud.google.com
+spec:
+  group: core.cnrm.cloud.google.com
+  names:
+    kind: ConfigConnector
+    listKind: ConfigConnectorList
+    plural: configconnectors
+    singular: configconnector
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: When 'true' the most recent reconcile of the ConfigConnector object
+        succeeded
+      jsonPath: .status.healthy
+      name: Healthy
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ConfigConnector is the Schema for the configconnectors API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            anyOf:
+            - oneOf:
+              - not:
+                  required:
+                  - googleServiceAccount
+                required:
+                - credentialSecretName
+              - not:
+                  required:
+                  - credentialSecretName
+                required:
+                - googleServiceAccount
+              properties:
+                mode:
+                  enum:
+                  - cluster
+            - not:
+                anyOf:
+                - required:
+                  - googleServiceAccount
+                - required:
+                  - credentialSecretName
+              properties:
+                mode:
+                  enum:
+                  - namespaced
+            description: ConfigConnectorSpec defines the desired state of ConfigConnector
+            properties:
+              actuationMode:
+                description: |-
+                  The actuation mode of Config Connector controls how resources are actuated onto the cloud provider.
+                  This can be either 'Reconciling' or 'Paused'.
+                  In 'Paused', k8s resources are still reconciled with the api server but not actuated onto the cloud provider.
+                  If Config Connector is running in 'namespaced' mode, then the value in ConfigConnectorContext (CCC) takes precedence.
+                  If CCC doesn't define a value but ConfigConnector (CC) does, we defer to that value. Otherwise,
+                  the default is 'Reconciling' where resources get actuated.
+                enum:
+                - Reconciling
+                - Paused
+                type: string
+              credentialSecretName:
+                description: |-
+                  The Kubernetes secret that contains the Google Service Account Key's credentials to be used by ConfigConnector to authenticate with Google Cloud APIs. This field is used only when in cluster mode.
+                  It's recommended to use `googleServiceAccount` when running ConfigConnector in Google Kubernetes Engine (GKE) clusters with Workload Identity enabled.
+                  This field cannot be specified together with `googleServiceAccount`.
+                type: string
+              experiments:
+                description: ConfigConnector specific experiments
+                properties:
+                  multiClusterLease:
+                    description: MultiClusterLease defines configuration specific
+                      to multi-cluster leader election.
+                    properties:
+                      clusterCandidateIdentity:
+                        description: |-
+                          The identity of the cluster candidate for the KCC components, hared by all KCC replicas
+                          and workloads across all clusters that are part of the same election.
+                           This name must be unique across all the clusters that you are configuring the multi cluster set up for.
+                        type: string
+                      leaseName:
+                        description: The name of the MultiClusterLease object that
+                          KCC will create.
+                        type: string
+                      namespace:
+                        description: The namespace where the MultiClusterLease object
+                          will be created.
+                        type: string
+                      resourceReplicationMode:
+                        default: Status
+                        description: |-
+                          ResourceReplicationMode specifies how the resources will be synced to the passive clusters.
+                          Can be either 'Status', 'Full', or 'Disabled'.
+                          'Status' (default) means only the status field (and occasionally essential fields like spec.resourceID) are synced.
+                          'Full' means both the spec and status are synced.
+                          'Disabled' means resource replication is completely turned off for this lease.
+                        enum:
+                        - Status
+                        - Full
+                        - Disabled
+                        type: string
+                    required:
+                    - clusterCandidateIdentity
+                    - leaseName
+                    - namespace
+                    type: object
+                  resourceSettings:
+                    description: ResourceSettings allows specifying which resources
+                      to enable or disable.
+                    properties:
+                      mode:
+                        description: |-
+                          Mode controls whether the resources are included or excluded.
+                          Defaults to "exclude" (Exclusion mode).
+                        type: string
+                      resources:
+                        description: Resources is the list of resources to include
+                          or exclude.
+                        items:
+                          properties:
+                            group:
+                              description: Group is the API group of the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                          required:
+                          - group
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              googleServiceAccount:
+                description: |-
+                  The Google Service Account to be used by Config Connector to authenticate with Google Cloud APIs. This field is used only when running in cluster mode with Workload Identity enabled.
+                  See Google Kubernetes Engine (GKE) workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for details. This field cannot be specified together with `credentialSecretName`.
+                  For namespaced mode, use `googleServiceAccount` in ConfigConnectorContext CRD to specify the Google Service Account to be used to authenticate with Google Cloud APIs per namespace.
+                type: string
+              mode:
+                description: |-
+                  The mode that Config Connector will run in. This can be either 'cluster' or 'namespaced'. The default is 'namespaced'.
+                  Cluster mode uses a single Google Service Account to create and manage resources, even if you are using Config Connector to manage multiple Projects.
+                  You must specify either `credentialSecretName` or `googleServiceAccount` when in cluster mode, but not both.
+                  Namespaced mode allows you to use different Google service accounts for different Projects.
+                  When in namespaced mode, you must create a ConfigConnectorContext object per namespace that you want to enable Config Connector in, and each must set `googleServiceAccount` to specify the Google Service Account to be used to authenticate with Google Cloud APIs for the namespace.
+                enum:
+                - cluster
+                - namespaced
+                type: string
+              stateIntoSpec:
+                description: |-
+                  StateIntoSpec is the user override of the default value for the
+                  'cnrm.cloud.google.com/state-into-spec' annotation if the annotation is
+                  unset for a resource.
+                  If the field is set in both the ConfigConnector object and the
+                  ConfigConnectorContext object is in the namespaced mode, then the value
+                  in the ConfigConnectorContext object will be used.
+                  'Absent' means that unspecified fields in the resource spec stay
+                  unspecified after successful reconciliation.
+                  'Merge' means that unspecified fields in the resource spec are populated
+                  after a successful reconciliation if those unspecified fields are
+                  computed/defaulted by the API. It is only applicable to resources
+                  supporting the 'Merge' option.
+                enum:
+                - Absent
+                - Merge
+                type: string
+            type: object
+          status:
+            description: ConfigConnectorStatus defines the observed state of ConfigConnector
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: controllerreconcilers.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ControllerReconciler
+    listKind: ControllerReconcilerList
+    plural: controllerreconcilers
+    singular: controllerreconciler
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in cluster mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerReconcilerSpec is the specification of ControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector controller manager in cluster mode.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: ControllerReconcilerStatus defines the observed state of
+              ControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in cluster mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerReconcilerSpec is the specification of ControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector controller manager in cluster mode.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: ControllerReconcilerStatus defines the observed state of
+              ControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: controllerresources.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ControllerResource
+    listKind: ControllerResourceList
+    plural: controllerresources
+    singular: controllerresource
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ControllerResource is the Schema for resource customization API
+          for config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                - cnrm-deletiondefender
+                - cnrm-unmanaged-detector
+                - cnrm-webhook-manager
+                - cnrm-resource-stats-recorder
+                type: string
+            type: object
+          spec:
+            anyOf:
+            - required:
+              - containers
+            - required:
+              - replicas
+            - required:
+              - verticalPodAutoscalerMode
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              metadataHost:
+                description: |-
+                  MetadataHost overrides the GCP metadata server hostname (injected as GCE_METADATA_HOST).
+                  Useful for IPv6-only clusters where the default 169.254.169.254 is unreachable.
+                type: string
+              replicas:
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                format: int64
+                type: integer
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: ControllerResourceStatus defines the observed state of ControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ControllerResource is the Schema for resource customization API
+          for config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                - cnrm-deletiondefender
+                - cnrm-unmanaged-detector
+                - cnrm-webhook-manager
+                - cnrm-resource-stats-recorder
+                type: string
+            type: object
+          spec:
+            anyOf:
+            - required:
+              - containers
+            - required:
+              - replicas
+            - required:
+              - verticalPodAutoscalerMode
+            description: |-
+              ControllerResourceSpec is the specification of the resource customization for containers of
+              a config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              metadataHost:
+                description: |-
+                  MetadataHost overrides the GCP metadata server hostname (injected as GCE_METADATA_HOST).
+                  Useful for IPv6-only clusters where the default 169.254.169.254 is unreachable.
+                type: string
+              replicas:
+                description: |-
+                  The number of desired replicas of the config connector controller.
+                  This field takes effect only if the controller name is "cnrm-webhook-manager".
+                format: int64
+                type: integer
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: ControllerResourceStatus defines the observed state of ControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: mutatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: MutatingWebhookConfigurationCustomization
+    listKind: MutatingWebhookConfigurationCustomizationList
+    plural: mutatingwebhookconfigurationcustomizations
+    singular: mutatingwebhookconfigurationcustomization
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - mutating-webhook
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MutatingWebhookConfigurationCustomization is the Schema for customizing the mutating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - mutating-webhook
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: namespacedcontrollerreconcilers.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: NamespacedControllerReconciler
+    listKind: NamespacedControllerReconcilerList
+    plural: namespacedcontrollerreconcilers
+    singular: namespacedcontrollerreconciler
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespacedControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in namespaced mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector namespaced controller manager.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: NamespacedControllerReconcilerStatus defines the observed
+              state of NamespacedControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NamespacedControllerReconciler is the Schema for reconciliation related customization for
+          config connector controllers in namespaced mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespacedControllerReconciler is the specification of NamespacedControllerReconciler.
+            properties:
+              pprof:
+                description: Configures the debug endpoint on the service.
+                properties:
+                  port:
+                    description: The port that the pprof server binds to if enabled
+                    type: integer
+                  support:
+                    description: Control if pprof should be turned on and which types
+                      should be enabled.
+                    enum:
+                    - none
+                    - all
+                    type: string
+                type: object
+              rateLimit:
+                description: |-
+                  RateLimit configures the token bucket rate limit to the kubernetes client used
+                  by the manager container of the config connector namespaced controller manager.
+                  Please note this rate limit is shared among all the Config Connector resources' requests.
+                  If not specified, the default will be Token Bucket with qps 20, burst 30.
+                properties:
+                  burst:
+                    description: The burst of the token bucket rate limit for all
+                      the requests to the kubernetes client.
+                    type: integer
+                  qps:
+                    description: The QPS of the token bucket rate limit for all the
+                      requests to the kubernetes client.
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: NamespacedControllerReconcilerStatus defines the observed
+              state of NamespacedControllerReconciler.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - rule: self.metadata.name == 'cnrm-controller-manager'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: namespacedcontrollerresources.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: NamespacedControllerResource
+    listKind: NamespacedControllerResourceList
+    plural: namespacedcontrollerresources
+    singular: namespacedcontrollerresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NamespacedControllerResource is the Schema for resource customization
+          API for namespaced config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                type: string
+            type: object
+          spec:
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: NamespacedControllerResourceStatus defines the observed state
+              of NamespacedControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: NamespacedControllerResource is the Schema for resource customization
+          API for namespaced config connector controllers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - cnrm-controller-manager
+                type: string
+            type: object
+          spec:
+            description: |-
+              NamespacedControllerResourceSpec is the specification of the resource customization for containers of
+              a namespaced config connector controller.
+            properties:
+              containers:
+                description: The list of containers whose resource requirements to
+                  be customized.
+                items:
+                  description: |-
+                    ContainerResourceSpec is the specification of the resource customization for a container of
+                    a config connector controller.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the container whose resource requirements will be customized.
+                        Required
+                      enum:
+                      - manager
+                      - webhook
+                      - deletiondefender
+                      - prom-to-sd
+                      - recorder
+                      - unmanageddetector
+                      type: string
+                    resources:
+                      description: |-
+                        Resources specifies the resource customization of this container.
+                        Required
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              verticalPodAutoscalerMode:
+                default: Disabled
+                description: VerticalPodAutoscalerMode indicates the mode of Vertical
+                  Pod Autoscaler for the controller.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: VerticalPodAutoscalerMode cannot be Enabled when Containers
+                are specified
+              rule: '!has(self.verticalPodAutoscalerMode) || self.verticalPodAutoscalerMode
+                == ''Disabled'' || !has(self.containers) || size(self.containers)
+                == 0'
+          status:
+            description: NamespacedControllerResourceStatus defines the observed state
+              of NamespacedControllerResource.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: validatingwebhookconfigurationcustomizations.customize.core.cnrm.cloud.google.com
+spec:
+  group: customize.core.cnrm.cloud.google.com
+  names:
+    kind: ValidatingWebhookConfigurationCustomization
+    listKind: ValidatingWebhookConfigurationCustomizationList
+    plural: validatingwebhookconfigurationcustomizations
+    singular: validatingwebhookconfigurationcustomization
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - validating-webhook
+                - abandon-on-uninstall
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ValidatingWebhookConfigurationCustomization is the Schema for customizing the validating webhook
+          configurations in config connector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - validating-webhook
+                - abandon-on-uninstall
+                type: string
+            type: object
+          spec:
+            description: |-
+              WebhookConfigurationCustomizationSpec is the specification for customizing the webhooks of a config
+              connector webhook configuration.
+            properties:
+              webhooks:
+                description: |-
+                  The list of webhooks whose configuration to be customized.
+                  Required
+                items:
+                  description: WebhookCustomizationSpec is the specification for customizing
+                    for a specific webhook in config connector.
+                  properties:
+                    name:
+                      description: |-
+                        The name of the webhook. Do not include the `.cnrm.cloud.google.com` suffix.
+                        Required
+                      enum:
+                      - abandon-on-uninstall
+                      - deny-immutable-field-updates
+                      - deny-unknown-fields
+                      - iam-validation
+                      - resource-validation
+                      - container-annotation-handler
+                      - generic-defaulter
+                      - iam-defaulter
+                      - management-conflict-annotation-defaulter
+                      type: string
+                    timeoutSeconds:
+                      description: |-
+                        TimeoutSeconds customizes the timeout of the webhook.
+                        The timeout value must be between 1 and 30 seconds.
+                        The default timeout in Kubernetes is 10 seconds.
+                        Required
+                      format: int32
+                      maximum: 30
+                      minimum: 1
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - webhooks
+            type: object
+          status:
+            description: |-
+              WebhookConfigurationCustomizationStatus defines the observed state of ValidatingWebhookConfigurationCustomization and
+              MutatingWebhookConfigurationCustomization.
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              observedGeneration:
+                default: 0
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - healthy
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+    cnrm.cloud.google.com/version: 1.125.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+    cnrm.cloud.google.com/system: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: configconnector-operator-cnrm-viewer
+rules:
+- apiGroups:
+  - accesscontextmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aiplatform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aistreams.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - alloydb.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - analytics.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigateway.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigee.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apigeeregistry.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apihub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apikeys.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apphub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appoptimize.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - artifactregistry.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - asset.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - assuredworkloads.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - automl.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - backupdr.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - beyondcorp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquery.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryanalyticshub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerybiglake.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryconnection.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerydatapolicy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerydatatransfer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigquerymigration.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigqueryreservation.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bigtable.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - billing.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - billingbudgets.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - binaryauthorization.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - blockchainnodeengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificatemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ces.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudasset.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudbuild.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - clouddeploy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - clouddms.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudfunctions.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudfunctions2.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudidentity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudids.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudiot.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudquota.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudscheduler.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudsecuritycompliance.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudtasks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - colab.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - composer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - compute.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configcontroller.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configdelivery.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - connectors.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - contactcenterinsights.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - container.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - containeranalysis.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - containerattached.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - contentwarehouse.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datacatalog.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataflow.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datafusion.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datalabeling.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datalineage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datamigration.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataplex.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dataproc.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datastore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datastream.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - deploymentmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - developerconnect.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devicestreaming.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dialogflow.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dialogflowcx.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discoveryengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dlp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dns.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - documentai.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - edgecontainer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - edgenetwork.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - essentialcontacts.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - eventarc.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - filestore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebase.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasedatabase.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasehosting.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firebasestorage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - firestore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - geminidataanalytics.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gkebackup.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gkehub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - healthcare.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iam.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iap.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - identityplatform.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kms.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - logging.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - managedkafka.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - memcache.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - memorystore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metastore.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - migrationcenter.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - mlengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - modelarmor.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - netapp.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkconnectivity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkmanagement.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networksecurity.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networkservices.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - notebooks.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - orgpolicy.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - osconfig.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - oslogin.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - parametermanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - privateca.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - privilegedaccessmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pubsub.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pubsublite.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - recaptchaenterprise.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - redis.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resourcemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - run.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - saasservicemgmt.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - secretmanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - securesourcemanager.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - securitycenter.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicedirectory.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicenetworking.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serviceusage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sourcerepo.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - spanner.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - speech.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sql.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sqladmin.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storagetransfer.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tags.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - testing.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tpu.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vectorsearch.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vertexai.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - videostitcher.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vmwareengine.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vpcaccess.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workflowexecutions.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workflows.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workstations.cnrm.cloud.google.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  creationTimestamp: null
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - events
+  - namespaces
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - deletecollection
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors
+  - configconnectorcontexts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors/status
+  - configconnectorcontexts/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - core.cnrm.cloud.google.com
+  resources:
+  - configconnectors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - customize.core.cnrm.cloud.google.com
+  resources:
+  - controllerresources
+  - namespacedcontrollerresources
+  - validatingwebhookconfigurationcustomizations
+  - mutatingwebhookconfigurationcustomizations
+  - namespacedcontrollerreconcilers
+  - controllerreconcilers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - customize.core.cnrm.cloud.google.com
+  resources:
+  - controllerresources/status
+  - namespacedcontrollerresources/status
+  - validatingwebhookconfigurationcustomizations/status
+  - mutatingwebhookconfigurationcustomizations/status
+  - namespacedcontrollerreconcilers/status
+  - controllerreconcilers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - cnrm-admin
+  - cnrm-manager-cluster-role
+  - cnrm-manager-ns-role
+  - cnrm-recorder-role
+  - cnrm-webhook-role
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-cnrm-viewer-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configconnector-operator-cnrm-viewer
+subjects:
+- kind: ServiceAccount
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configconnector-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator-service
+  namespace: configconnector-operator-system
+spec:
+  ports:
+  - name: controller-manager
+    port: 443
+  selector:
+    cnrm.cloud.google.com/component: configconnector-operator
+    cnrm.cloud.google.com/operator-system: "true"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/operator-version: 1.154.0
+  labels:
+    cnrm.cloud.google.com/component: configconnector-operator
+    cnrm.cloud.google.com/operator-system: "true"
+  name: configconnector-operator
+  namespace: configconnector-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: configconnector-operator
+      cnrm.cloud.google.com/operator-system: "true"
+  serviceName: configconnector-operator-service
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/operator-version: 1.154.0
+      labels:
+        cnrm.cloud.google.com/component: configconnector-operator
+        cnrm.cloud.google.com/operator-system: "true"
+    spec:
+      containers:
+      - args:
+        - --local-repo=/configconnector-operator/channels
+        command:
+        - /configconnector-operator/manager
+        env:
+        - name: GOMEMLIMIT
+          value: 900MiB
+        image: gcr.io/gke-release/cnrm/operator:1.154.0
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: configconnector-operator
+      terminationGracePeriodSeconds: 10

--- a/docs/guides/gitops-argocd.md
+++ b/docs/guides/gitops-argocd.md
@@ -25,9 +25,8 @@ Before setting up ArgoCD applications for Config Connector, ensure you meet the 
 ### Key considerations
 
 > [!NOTE]
-> **Raw upstream repository vs. rendered manifests**  
-> The raw source repository path (`operator/config/default`) contains release patch templates (`manager_image_patch_template.yaml`) that require build-time rendering. Attempting to point ArgoCD directly at raw upstream source paths without generating `manager_image_patch.yaml` results in Kustomize build errors.  
-> **Solution**: Use official published release bundles from Google Cloud Storage, or render the Kustomize targets using `./dev/tasks/build-release-bundle` in your CI pipeline before committing manifests to your GitOps repository.
+> **Direct upstream repository sync support**  
+> The open-source repository maintains committed default patch manifests and pre-rendered operator manifests in `config/installbundle/release-manifests/standard` (and `operator/config/default`). ArgoCD can point directly at these upstream repository paths without requiring local pre-rendering build steps. Alternatively, official release tarballs from Google Cloud Storage can be used.
 
 > [!IMPORTANT]
 > **Mandatory Server-Side Apply for CRDs**  

--- a/docs/guides/gitops-argocd.md
+++ b/docs/guides/gitops-argocd.md
@@ -1,68 +1,83 @@
 # Managing Config Connector with GitOps (ArgoCD)
 
-This guide provides a production-tested workflow for installing, managing, and upgrading Config Connector (KCC) using GitOps tooling like **ArgoCD** or **Flux**.
+This guide provides a production-tested workflow for installing, managing, and upgrading Config Connector (KCC) using GitOps tools such as **ArgoCD** or **Flux**.
 
 ---
 
-## Architecture & Deployment Options
+## Architecture and deployment options
 
 Config Connector can be deployed and managed via GitOps using two primary patterns:
 
-1. **Operator-Based GitOps (Recommended)**: ArgoCD deploys the Config Connector Operator via pre-rendered release bundles. The Operator then manages CRD lifecycle and controller deployments automatically based on declarative `ConfigConnector` custom resources.
-2. **Pre-Rendered Manifest GitOps**: ArgoCD directly manages the rendered release bundle manifests (`0-cnrm-system.yaml` and resource CRDs) rendered from Kustomize templates.
+1. **Operator-based GitOps (Recommended)**: ArgoCD deploys the Config Connector Operator via pre-rendered release bundles. The Operator then manages CRD lifecycle and controller deployments automatically based on declarative `ConfigConnector` custom resources.
+2. **Pre-rendered manifest GitOps**: ArgoCD directly manages the rendered release bundle manifests (`0-cnrm-system.yaml` and resource CRDs) rendered from Kustomize templates.
 
 ---
 
-## Important Gotchas & Prerequisites
+## Prerequisites and key considerations
 
-Before setting up ArgoCD applications for KCC, note the following critical requirements:
+Before setting up ArgoCD applications for Config Connector, ensure you meet the following prerequisites and review key operational constraints:
 
-### 1. Raw Upstream Repo vs. Rendered Manifests
-The raw source repository (`operator/config/default`) contains release patch templates (`manager_image_patch_template.yaml`) that require build-time rendering. Attempting to point ArgoCD directly at raw upstream source paths without generating `manager_image_patch.yaml` will result in Kustomize build errors.
+### Prerequisites
+* A running Kubernetes cluster (e.g., GKE Standard or GKE Autopilot) with Workload Identity enabled.
+* ArgoCD installed and running in your cluster.
+* A Google Cloud IAM Service Account created with the required GCP roles for the resources you intend to manage.
 
-* **Solution**: Use official published release bundles (downloadable from Google Cloud Storage), or render the Kustomize targets using `dev/tasks/build-release-bundle` in your CI pipeline before committing the manifests to your GitOps repository.
+### Key considerations
 
-### 2. Mandatory Server-Side Apply for CRDs
-KCC includes over 250 CRDs with extensive OpenAPI schemas. Standard client-side `kubectl apply` will fail on large CRD bundles due to Kubernetes' 262KB `kubectl.kubernetes.io/last-applied-configuration` annotation limit in etcd (`metadata.annotations: Too long`).
+> [!NOTE]
+> **Raw upstream repository vs. rendered manifests**  
+> The raw source repository path (`operator/config/default`) contains release patch templates (`manager_image_patch_template.yaml`) that require build-time rendering. Attempting to point ArgoCD directly at raw upstream source paths without generating `manager_image_patch.yaml` results in Kustomize build errors.  
+> **Solution**: Use official published release bundles from Google Cloud Storage, or render the Kustomize targets using `./dev/tasks/build-release-bundle` in your CI pipeline before committing manifests to your GitOps repository.
 
-* **Solution**: You **MUST enable Server-Side Apply** in your ArgoCD Application sync options (`ServerSideApply=true`).
+> [!IMPORTANT]
+> **Mandatory Server-Side Apply for CRDs**  
+> Config Connector includes over 250 CRDs with extensive OpenAPI validation schemas. Standard client-side `kubectl apply` fails on large CRD bundles due to Kubernetes' 262KB `kubectl.kubernetes.io/last-applied-configuration` etcd annotation size limit.  
+> **Solution**: You **must enable Server-Side Apply** in your ArgoCD Application sync options (`ServerSideApply=true`).
 
-### 3. CRD Upgrades & Safety Rules
-* **In-Place Upgrades**: CRDs update **in-place** when applying new versions. etcd object creation timestamps and live GCP resources remain untouched.
-* ⚠️ **NEVER DELETE CRDs**: Running `kubectl delete crd` cascade-deletes all Custom Resource (CR) instances across all namespaces. Because KCC resources have finalizers attached by default, deleting CR instances will instruct KCC to **delete the underlying production GCP infrastructure** in Google Cloud.
+> [!CAUTION]
+> **CRD upgrades and safety rules**  
+> * **In-place updates**: CRDs update **in-place** when applying new versions. etcd object creation timestamps and live GCP resources remain untouched.  
+> * **Never delete CRDs**: Running `kubectl delete crd` cascade-deletes all Custom Resource (CR) instances across all namespaces. Because Config Connector resources have finalizers attached by default, deleting CR instances instructs Config Connector to **delete the underlying production GCP infrastructure** in Google Cloud.
 
 ---
 
-## Step-by-Step Installation Guide
+## Step-by-step installation guide
 
-### Step 1: Obtain or Render the Installation Manifests
+### Step 1: Obtain or render the installation manifests
 
-You can obtain the required pre-rendered KCC installation manifests using either of the following sources:
+Obtain the required pre-rendered Config Connector installation manifests using either of the following methods:
 
-#### **Method A: Official Google Cloud Published Release Bundles (Recommended)**
-If you are installing KCC without building from source, download the latest official release bundle tarball from Google Cloud Storage:
+#### **Method A: Official Google Cloud published release bundles (Recommended)**
+If you are installing Config Connector without building from source, download the latest official release bundle tarball from Google Cloud Storage:
+
 ```bash
-# Download the official release bundle
+# Download the official published release bundle
 curl -O https://storage.googleapis.com/config-connector-operator/latest/release-bundle.tar.gz
+
+# Extract the release bundle files
 tar -xvf release-bundle.tar.gz
 ```
+
 This tarball contains pre-rendered, production-ready manifests:
 * `0-cnrm-system.yaml`: Contains the Operator deployment, RBAC roles, ServiceAccounts, and `configconnector-operator-system` namespace.
-* `crds.yaml`: Contains the complete set of KCC CustomResourceDefinitions.
+* `crds.yaml`: Contains the complete set of Config Connector CustomResourceDefinitions.
 
-#### **Method B: Building from GitHub Repository Source**
+#### **Method B: Building from GitHub repository source**
 If you are tracking the open-source GitHub repository source code:
+
 ```bash
+# Clone the upstream repository
 git clone https://github.com/GoogleCloudPlatform/k8s-config-connector.git
 cd k8s-config-connector
 
-# Render standard cluster bundle
+# Render standard cluster bundle manifests
 ./dev/tasks/build-release-bundle
 ```
 This populates rendered manifests in `config/installbundle/releases/` ready for GitOps use.
 
-#### **Recommended GitOps Repository Structure**
-Organize your team's GitOps repository (e.g., `https://github.com/<your-org>/kcc-gitops.git`) as follows:
+#### **Recommended GitOps repository structure**
+Organize your team's GitOps repository (for example, `https://github.com/<your-org>/kcc-gitops.git`) as follows:
+
 ```text
 kcc-gitops/
 ├── operator/
@@ -75,7 +90,7 @@ kcc-gitops/
 
 ### Step 2: Configure ArgoCD Application for KCC Operator
 
-Create an ArgoCD `Application` targeting your rendered KCC manifests directory in your GitOps repository. Be sure to include `ServerSideApply=true` in `syncOptions`:
+Create an ArgoCD `Application` targeting your rendered Config Connector manifests directory in your GitOps repository. Ensure `ServerSideApply=true` is set under `syncOptions`:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -88,7 +103,7 @@ spec:
   source:
     repoURL: 'https://github.com/<your-org>/kcc-gitops.git'
     targetRevision: main
-    path: operator
+    path: operator                     # Path to 0-cnrm-system.yaml and crds.yaml
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: configconnector-operator-system
@@ -98,44 +113,44 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true   # CRITICAL: Bypasses 262KB annotation limit on CRDs
+      - ServerSideApply=true           # CRITICAL: Bypasses 262KB annotation limit on CRDs
 ```
 
 ---
 
-### Step 3: Declaratively Configure Config Connector
+### Step 3: Declaratively configure Config Connector
 
-Once the Operator is deployed by ArgoCD, declaratively configure Config Connector by committing a `ConfigConnector` custom resource to your GitOps repository.
+Once ArgoCD deploys the Operator, declaratively configure Config Connector by committing a `ConfigConnector` custom resource to your GitOps repository.
 
-> 💡 **Prerequisite**: Ensure the specified Google Service Account (`googleServiceAccount`) has been created in GCP IAM and bound to the KCC ServiceAccount via Workload Identity.
+#### **Cluster mode configuration**:
+Use `mode: cluster` when managing GCP resources across the entire cluster using a single Google Service Account:
 
-#### **Cluster Mode Configuration**:
 ```yaml
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnector
 metadata:
   name: configconnector.core.cnrm.cloud.google.com
 spec:
-  mode: cluster
+  mode: cluster                         # Cluster-wide reconciliation mode
   googleServiceAccount: "kcc-system@<YOUR_PROJECT_ID>.iam.gserviceaccount.com"
 ```
 
-#### **Namespace Mode Configuration**:
-For namespace mode, deploy a `ConfigConnectorContext` resource in each managed namespace to bind dedicated GCP Service Accounts per namespace:
+#### **Namespace mode configuration**:
+Use `mode: namespaced` and deploy a `ConfigConnectorContext` resource in each managed namespace to bind dedicated GCP Service Accounts per namespace:
 
 ```yaml
 apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext
 metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
-  namespace: config-control
+  namespace: config-control             # Target namespace to enable
 spec:
   googleServiceAccount: "kcc-namespace-sa@<YOUR_PROJECT_ID>.iam.gserviceaccount.com"
 ```
 
 ---
 
-## Safe Upgrade Workflow
+## Safe upgrade workflow
 
 When upgrading Config Connector to a newer release:
 
@@ -145,4 +160,4 @@ When upgrading Config Connector to a newer release:
 4. **Verification**:
    - Verify CRDs updated in-place: `kubectl get crd containerclusters.container.cnrm.cloud.google.com` (creation timestamp should remain unchanged).
    - Check operator status: `kubectl get configconnector -o yaml`.
-   - Existing GCP resources and running workloads will remain completely uninterrupted.
+   - Existing GCP resources and running workloads remain completely uninterrupted.

--- a/docs/guides/gitops-argocd.md
+++ b/docs/guides/gitops-argocd.md
@@ -1,0 +1,148 @@
+# Managing Config Connector with GitOps (ArgoCD)
+
+This guide provides a production-tested workflow for installing, managing, and upgrading Config Connector (KCC) using GitOps tooling like **ArgoCD** or **Flux**.
+
+---
+
+## Architecture & Deployment Options
+
+Config Connector can be deployed and managed via GitOps using two primary patterns:
+
+1. **Operator-Based GitOps (Recommended)**: ArgoCD deploys the Config Connector Operator via pre-rendered release bundles. The Operator then manages CRD lifecycle and controller deployments automatically based on declarative `ConfigConnector` custom resources.
+2. **Pre-Rendered Manifest GitOps**: ArgoCD directly manages the rendered release bundle manifests (`0-cnrm-system.yaml` and resource CRDs) rendered from Kustomize templates.
+
+---
+
+## Important Gotchas & Prerequisites
+
+Before setting up ArgoCD applications for KCC, note the following critical requirements:
+
+### 1. Raw Upstream Repo vs. Rendered Manifests
+The raw source repository (`operator/config/default`) contains release patch templates (`manager_image_patch_template.yaml`) that require build-time rendering. Attempting to point ArgoCD directly at raw upstream source paths without generating `manager_image_patch.yaml` will result in Kustomize build errors.
+
+* **Solution**: Use official published release bundles (downloadable from Google Cloud Storage), or render the Kustomize targets using `dev/tasks/build-release-bundle` in your CI pipeline before committing the manifests to your GitOps repository.
+
+### 2. Mandatory Server-Side Apply for CRDs
+KCC includes over 250 CRDs with extensive OpenAPI schemas. Standard client-side `kubectl apply` will fail on large CRD bundles due to Kubernetes' 262KB `kubectl.kubernetes.io/last-applied-configuration` annotation limit in etcd (`metadata.annotations: Too long`).
+
+* **Solution**: You **MUST enable Server-Side Apply** in your ArgoCD Application sync options (`ServerSideApply=true`).
+
+### 3. CRD Upgrades & Safety Rules
+* **In-Place Upgrades**: CRDs update **in-place** when applying new versions. etcd object creation timestamps and live GCP resources remain untouched.
+* ⚠️ **NEVER DELETE CRDs**: Running `kubectl delete crd` cascade-deletes all Custom Resource (CR) instances across all namespaces. Because KCC resources have finalizers attached by default, deleting CR instances will instruct KCC to **delete the underlying production GCP infrastructure** in Google Cloud.
+
+---
+
+## Step-by-Step Installation Guide
+
+### Step 1: Obtain or Render the Installation Manifests
+
+You can obtain the required pre-rendered KCC installation manifests using either of the following sources:
+
+#### **Method A: Official Google Cloud Published Release Bundles (Recommended)**
+If you are installing KCC without building from source, download the latest official release bundle tarball from Google Cloud Storage:
+```bash
+# Download the official release bundle
+curl -O https://storage.googleapis.com/config-connector-operator/latest/release-bundle.tar.gz
+tar -xvf release-bundle.tar.gz
+```
+This tarball contains pre-rendered, production-ready manifests:
+* `0-cnrm-system.yaml`: Contains the Operator deployment, RBAC roles, ServiceAccounts, and `configconnector-operator-system` namespace.
+* `crds.yaml`: Contains the complete set of KCC CustomResourceDefinitions.
+
+#### **Method B: Building from GitHub Repository Source**
+If you are tracking the open-source GitHub repository source code:
+```bash
+git clone https://github.com/GoogleCloudPlatform/k8s-config-connector.git
+cd k8s-config-connector
+
+# Render standard cluster bundle
+./dev/tasks/build-release-bundle
+```
+This populates rendered manifests in `config/installbundle/releases/` ready for GitOps use.
+
+#### **Recommended GitOps Repository Structure**
+Organize your team's GitOps repository (e.g., `https://github.com/<your-org>/kcc-gitops.git`) as follows:
+```text
+kcc-gitops/
+├── operator/
+│   └── 0-cnrm-system.yaml    # Operator deployment & RBAC
+└── crds/
+    └── crds.yaml              # Complete KCC CRD bundle
+```
+
+---
+
+### Step 2: Configure ArgoCD Application for KCC Operator
+
+Create an ArgoCD `Application` targeting your rendered KCC manifests directory in your GitOps repository. Be sure to include `ServerSideApply=true` in `syncOptions`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: config-connector-operator
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/<your-org>/kcc-gitops.git'
+    targetRevision: main
+    path: operator
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: configconnector-operator-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true   # CRITICAL: Bypasses 262KB annotation limit on CRDs
+```
+
+---
+
+### Step 3: Declaratively Configure Config Connector
+
+Once the Operator is deployed by ArgoCD, declaratively configure Config Connector by committing a `ConfigConnector` custom resource to your GitOps repository.
+
+> 💡 **Prerequisite**: Ensure the specified Google Service Account (`googleServiceAccount`) has been created in GCP IAM and bound to the KCC ServiceAccount via Workload Identity.
+
+#### **Cluster Mode Configuration**:
+```yaml
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnector
+metadata:
+  name: configconnector.core.cnrm.cloud.google.com
+spec:
+  mode: cluster
+  googleServiceAccount: "kcc-system@<YOUR_PROJECT_ID>.iam.gserviceaccount.com"
+```
+
+#### **Namespace Mode Configuration**:
+For namespace mode, deploy a `ConfigConnectorContext` resource in each managed namespace to bind dedicated GCP Service Accounts per namespace:
+
+```yaml
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: config-control
+spec:
+  googleServiceAccount: "kcc-namespace-sa@<YOUR_PROJECT_ID>.iam.gserviceaccount.com"
+```
+
+---
+
+## Safe Upgrade Workflow
+
+When upgrading Config Connector to a newer release:
+
+1. **Update Manifests**: Download the new release tarball (Method A) or pull upstream updates and re-run `./dev/tasks/build-release-bundle` (Method B).
+2. **Commit to GitOps Repo**: Push the updated `crds.yaml` and `0-cnrm-system.yaml` to your GitOps repository branch.
+3. **ArgoCD In-Place Sync**: ArgoCD applies the updated CRD OpenAPI schemas via Server-Side Apply.
+4. **Verification**:
+   - Verify CRDs updated in-place: `kubectl get crd containerclusters.container.cnrm.cloud.google.com` (creation timestamp should remain unchanged).
+   - Check operator status: `kubectl get configconnector -o yaml`.
+   - Existing GCP resources and running workloads will remain completely uninterrupted.

--- a/operator/config/autopilot-manager/manager_image_patch.yaml
+++ b/operator/config/autopilot-manager/manager_image_patch.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: configconnector-operator
+spec:
+  template:
+    spec:
+      containers:
+      # Change the value of image field below to your controller image URL
+      - image: gcr.io/gke-release/cnrm/operator:1.154.0
+        name: manager

--- a/operator/config/manager/manager_image_patch.yaml
+++ b/operator/config/manager/manager_image_patch.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: configconnector-operator
+spec:
+  template:
+    spec:
+      containers:
+      # Change the value of image field below to your controller image URL
+      - image: gcr.io/gke-release/cnrm/operator:1.154.0
+        name: manager


### PR DESCRIPTION
### Summary & Rationale
Currently, GitOps tools (like ArgoCD or Flux) cannot target upstream repository paths directly because `operator/config/manager/manager_image_patch.yaml` and `operator/config/autopilot-manager/manager_image_patch.yaml` were generated dynamically at build time and excluded via `.gitignore`. Running `kustomize build operator/config/default` or `kustomize build config/installbundle/release-manifests/standard` directly from git source fails with `manager_image_patch.yaml: no such file or directory`.

This PR:
1. Adds committed default `manager_image_patch.yaml` files for standard and autopilot operator configs pointing to the canonical release operator image.
2. Unignores `manager_image_patch.yaml` in `.gitignore`.
3. Adds pre-rendered, unbundled operator manifests (`configconnector-operator.yaml` and `autopilot-configconnector-operator.yaml`) under `config/installbundle/release-manifests/` for direct GitOps deployment.
4. Updates `docs/guides/gitops-argocd.md` to document direct repository path sync for ArgoCD and Flux.

Fixes #11757.
Relates to #11689.