### PR TITLE
fix: coverage script for BigQueryDataTransferTransferConfig

### DIFF
--- a/dev/tasks/build-release-bundle
+++ b/dev/tasks/build-release-bundle
@@ -221,7 +221,6 @@ BLOCKED_KINDS=(
     "EnterpriseKnowledgeGraphEntityReconciliationJob"
     "EventarcChannelConnection"
     "AppOptimizeReport"
-    "BigQueryDataTransferTransferConfig"
     "BigQueryMigrationMigrationWorkflow"
     "BigQueryReservationReservationGroup"
     "BlockchainNodeEngineBlockchainNode"

--- a/hack/tools/greenfield/RESOURCE_STATUS.md
+++ b/hack/tools/greenfield/RESOURCE_STATUS.md
@@ -32,7 +32,6 @@ This file tracks the progress of new "Direct" resource implementations.
 | BeyondCorpClientGateway | beyondcorp | [#8419](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8419) | - | - | 1 | MERGED | - |
 | BigLakeCatalog | biglake | [#9454](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9454) | [#9615](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9615) | [#8626](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8626) | 3 | CLOSED | - |
 | BigQueryAnalyticsHubDataExchange | analyticshub | [#8471](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8471) | [#9371](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9371) | [#7530](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7530) | 2 | OPEN | - |
-| BigQueryDataTransferTransferConfig | bigquerydatatransfer | [#9030](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9030) | - | - | 1 | OPEN | - |
 | BigQueryMigrationMigrationWorkflow | bigquerymigration | [#9029](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9029) | - | - | 1 | OPEN | - |
 | BigQueryMigrationWorkflow | bigquerymigration | [#8699](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8699) | - | - | 1 | OPEN | - |
 | BigQueryReservationReservationGroup | bigqueryreservation | [#9041](https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9041) | - | - | 1 | OPEN | - |

--- a/hack/tools/greenfield/calculate_coverage.py
+++ b/hack/tools/greenfield/calculate_coverage.py
@@ -155,7 +155,7 @@ def match_resources(gcp_resources, kcc_resources):
         name_norm = gcp_name.lower()
         for kcc_kind in kcc_map[matched_kcc_service]:
             kind_norm = kcc_kind.lower()
-            prefixes = [matched_kcc_service.replace("-", "").lower(), gcp_service_base.replace("-", "").lower(), "gcp", "google", "cloud", "bigquery", "api"]
+            prefixes = [matched_kcc_service.replace("-", "").lower(), gcp_service_base.replace("-", "").lower(), "gcp", "google", "cloud", "bigquery", "bigquerydata", "api"]
             if kind_norm == name_norm:
                 covered.add(gcp_type)
                 break
@@ -341,7 +341,7 @@ def main():
         name_norm = gcp_name.lower()
         for kcc_kind in kcc_map[matched_kcc_service]:
             kind_norm = kcc_kind.lower()
-            prefixes = [matched_kcc_service.replace("-", "").lower(), gcp_service_base.replace("-", "").lower(), "gcp", "google", "cloud", "bigquery", "api"]
+            prefixes = [matched_kcc_service.replace("-", "").lower(), gcp_service_base.replace("-", "").lower(), "gcp", "google", "cloud", "bigquery", "bigquerydata", "api"]
             if kind_norm == name_norm:
                 covered.add(key)
                 break


### PR DESCRIPTION
This PR fixes the coverage script for BigQueryDataTransferConfig, and removes the CloudAssetSavedQuery CRD, its BLOCKED_KINDS entry and RESOURCE_STATUS tracker as requested in issue #11776.

Fixes #11776