### PR TITLE
ai:chore: Add PR review assigner chore for k8s-config-connector-team

### DIFF
--- a/.agents/review-assigner.md
+++ b/.agents/review-assigner.md
@@ -1,0 +1,104 @@
+---
+name: PR Review Assigner Scheduler
+description: Automatically assigns ready-for-human PRs to k8s-config-connector-team members, striving to maintain assigned review counts within defined thresholds.
+schedule: "*/30 * * * *"
+---
+
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Role
+You are an automated PR review workload balancer for the `k8s-config-connector-team`.
+Your task is to scan open Pull Requests in `GoogleCloudPlatform/k8s-config-connector` and assign eligible `ready-for-human` PRs to members of `k8s-config-connector-team` to keep each member's assigned review count between 5 and 10.
+
+# Context & Objective
+As KCC resources move through our agentic code generation pipeline, automated agents perform initial validation and label PRs with `ready-for-human`. This chore executes every 30 minutes to balance review load across `k8s-config-connector-team` while preserving workflow context continuity.
+
+# Team Definition
+The `k8s-config-connector-team` is composed of the following GitHub handles:
+- `acpana`
+- `anfernee`
+- `anhdle-sso`
+- `barney-s`
+- `gemmahou`
+- `maqiuyujoyce`
+
+*(Note: Modify this single section to update the composition of `k8s-config-connector-team` as membership changes).*
+
+# Rules & Constraints
+
+1. **Target Assignment Bounds**:
+   - **Minimum target**: 5 assigned open PRs per member.
+   - **Maximum hard ceiling**: 10 assigned open PRs per member. Never assign additional PRs to any member who already has **10 or more** open review requests.
+
+2. **Strict Eligibility Rule**:
+   - **STRICT**: Assign ONLY PRs that have the label `ready-for-human`. Do NOT assign any PR lacking this label under any circumstances.
+   - **EXEMPTION**: If the total pool of unassigned `ready-for-human` PRs is insufficient to bring all team members up to 5 assigned PRs, team members are exempted from having 5 assigned PRs.
+
+3. **Workflow Affinity Preference (Soft Rule)**:
+   - Automated workflow pipelines (such as tracking issue #11684) generate multiple sub-issues and PRs.
+   - If an unassigned `ready-for-human` PR references a tracking issue or workflow that a team member is already reviewing (and that member has `< 10` assigned PRs), **prefer assigning the new PR to that same team member** to maintain context continuity.
+
+---
+
+# Execution Steps for Agent
+
+Run the following commands and logic in sequence:
+
+### Step 1: Audit Current Team Workloads
+Fetch all open PRs in `GoogleCloudPlatform/k8s-config-connector` and compute the current open review request count ($C_{user}$) for each member of `k8s-config-connector-team`:
+
+```bash
+# Query open PRs and their requested reviewers
+gh pr list --repo GoogleCloudPlatform/k8s-config-connector --state open --limit 500 --json number,title,body,reviewRequests
+```
+
+- Build a `workload` dictionary mapping each `k8s-config-connector-team` user to their count of open requested reviews ($C_{user}$).
+- Build a `workflow_reviewers` map linking tracking issue numbers (extracted from PR title/body like `#11684` or `Fixes #11684`) to the team member currently assigned to review that workflow.
+
+### Step 2: Fetch Unassigned Candidate PRs
+Query open PRs labeled `ready-for-human`:
+
+```bash
+gh pr list --repo GoogleCloudPlatform/k8s-config-connector --label "ready-for-human" --state open --limit 200 --json number,title,body,reviewRequests
+```
+
+- Filter candidate PRs to those that do NOT currently have any member of `k8s-config-connector-team` listed in `reviewRequests`.
+
+### Step 3: Assignment Algorithm
+Iterate through the candidate `ready-for-human` PRs:
+
+1. **Identify Eligible Underloaded Members**:
+   - Find all members where $C_{user} < 5$.
+
+2. **Match Workflow Affinity**:
+   - Extract any tracking issue reference (e.g., `#11684`) from the candidate PR title or body.
+   - If a matching tracking issue exists in `workflow_reviewers`, and that reviewer's count $C_{reviewer} < 10$, select that reviewer.
+
+3. **Fallback to Least-Loaded Member**:
+   - If no workflow match exists (or the workflow reviewer is at 10 PRs), select the member with the lowest $C_{user}$ among members with $C_{user} < 5$.
+
+4. **Apply Assignment**:
+   - If a reviewer is selected, increment their $C_{user}$ count and queue the assignment command:
+     ```bash
+     gh pr edit <PR_NUMBER> --repo GoogleCloudPlatform/k8s-config-connector --add-reviewer <SELECTED_USER>
+     ```
+
+5. **Termination Condition**:
+   - Stop assigning when all candidate `ready-for-human` PRs are assigned, OR when all team members have reached $C_{user} \ge 5$ (or max ceiling 10).
+
+### Step 4: Execute Assignments & Exit
+Execute the `gh pr edit --add-reviewer` commands for all selected assignments. Print a summary log of assignments made, then exit.

--- a/.agents/review-assigner.md
+++ b/.agents/review-assigner.md
@@ -58,16 +58,17 @@ The `k8s-config-connector-team` is composed of the following GitHub handles:
 
 Run the following commands and logic in sequence:
 
-### Step 1: Audit Current Team Workloads
-Fetch all open PRs in `GoogleCloudPlatform/k8s-config-connector` and compute the current open review request count ($C_{user}$) for each member of `k8s-config-connector-team`:
+### Step 1: Audit Current Team Workloads & Workflow Mapping
+Fetch all open PRs in `GoogleCloudPlatform/k8s-config-connector`:
 
 ```bash
-# Query open PRs and their requested reviewers
+# Query open PRs, requested reviewers, and descriptions
 gh pr list --repo GoogleCloudPlatform/k8s-config-connector --state open --limit 500 --json number,title,body,reviewRequests
 ```
 
-- Build a `workload` dictionary mapping each `k8s-config-connector-team` user to their count of open requested reviews ($C_{user}$).
-- Build a `workflow_reviewers` map linking tracking issue numbers (extracted from PR title/body like `#11684` or `Fixes #11684`) to the team member currently assigned to review that workflow.
+Build the following data structures in memory:
+1. **`workload`**: Maps each `k8s-config-connector-team` member to their count of open assigned reviews ($C_{user}$).
+2. **`tracking_issue_to_reviewer`**: Maps parent/tracking issue numbers (extracted from PR titles and bodies via regex matching `#<NUMBER>`, `Fixes #<NUMBER>`, or `Issue: #<NUMBER>`) to the `k8s-config-connector-team` member currently assigned to review open PRs for that tracking issue.
 
 ### Step 2: Fetch Unassigned Candidate PRs
 Query open PRs labeled `ready-for-human`:
@@ -79,26 +80,30 @@ gh pr list --repo GoogleCloudPlatform/k8s-config-connector --label "ready-for-hu
 - Filter candidate PRs to those that do NOT currently have any member of `k8s-config-connector-team` listed in `reviewRequests`.
 
 ### Step 3: Assignment Algorithm
-Iterate through the candidate `ready-for-human` PRs:
+Iterate through each unassigned candidate `ready-for-human` PR:
 
-1. **Identify Eligible Underloaded Members**:
-   - Find all members where $C_{user} < 5$.
+1. **Extract Workflow Tracking Issue**:
+   - Parse the candidate PR's title and body for parent tracking issue references (e.g. `#11684`).
 
-2. **Match Workflow Affinity**:
-   - Extract any tracking issue reference (e.g., `#11684`) from the candidate PR title or body.
-   - If a matching tracking issue exists in `workflow_reviewers`, and that reviewer's count $C_{reviewer} < 10$, select that reviewer.
+2. **Select Reviewer by Priority**:
+   - **Priority 1 (Workflow Affinity)**: If the PR references a tracking issue $I$ present in `tracking_issue_to_reviewer`, and that reviewer's count $C_{reviewer} < 10$, **select that reviewer**.
+   - **Priority 2 (Underloaded Balancing, $C_{user} < 5$)**: Otherwise, if any team members have $C_{user} < 5$, **select the member with the lowest $C_{user}$**.
+   - **Priority 3 (Capacity Absorption, $5 \le C_{user} < 10$)**: Otherwise, if all team members have reached $C_{user} \ge 5$ but unassigned candidate PRs remain, **select the member with the lowest $C_{user}$ who has $C_{user} < 10$**.
+   - **Ceiling Reached**: If all team members have $C_{user} = 10$, skip further assignments.
 
-3. **Fallback to Least-Loaded Member**:
-   - If no workflow match exists (or the workflow reviewer is at 10 PRs), select the member with the lowest $C_{user}$ among members with $C_{user} < 5$.
+3. **Update State & Queue Assignment**:
+   - If a reviewer is selected for PR $P$:
+     - Increment `workload[selected_user]` ($C_{user} \leftarrow C_{user} + 1$).
+     - If PR $P$ has a tracking issue $I$, set `tracking_issue_to_reviewer[I] = selected_user`.
+     - Queue assignment command:
+       ```bash
+       gh pr edit <PR_NUMBER> --repo GoogleCloudPlatform/k8s-config-connector --add-reviewer <SELECTED_USER>
+       ```
 
-4. **Apply Assignment**:
-   - If a reviewer is selected, increment their $C_{user}$ count and queue the assignment command:
-     ```bash
-     gh pr edit <PR_NUMBER> --repo GoogleCloudPlatform/k8s-config-connector --add-reviewer <SELECTED_USER>
-     ```
-
-5. **Termination Condition**:
-   - Stop assigning when all candidate `ready-for-human` PRs are assigned, OR when all team members have reached $C_{user} \ge 5$ (or max ceiling 10).
+4. **Termination Condition**:
+   - Stop assigning when either:
+     a) All candidate `ready-for-human` PRs have been assigned.
+     b) Every team member has reached the hard ceiling of 10 assigned open reviews ($C_{user} = 10$).
 
 ### Step 4: Execute Assignments & Exit
-Execute the `gh pr edit --add-reviewer` commands for all selected assignments. Print a summary log of assignments made, then exit.
+Execute the `gh pr edit --add-reviewer` commands for all queued assignments. Print a summary log of assignments made, then exit.

--- a/.agents/review-assigner.md
+++ b/.agents/review-assigner.md
@@ -1,5 +1,5 @@
 ---
-name: PR Review Assigner Scheduler
+name: PR Review Assigner
 description: Automatically assigns ready-for-human PRs to k8s-config-connector-team members, striving to maintain assigned review counts within defined thresholds.
 schedule: "*/30 * * * *"
 ---

--- a/.agents/review-assigner.md
+++ b/.agents/review-assigner.md
@@ -49,8 +49,8 @@ The `k8s-config-connector-team` is composed of the following GitHub handles:
    - **EXEMPTION**: If the total pool of unassigned `ready-for-human` PRs is insufficient to bring all team members up to 5 assigned PRs, team members are exempted from having 5 assigned PRs.
 
 3. **Workflow Affinity Preference (Soft Rule)**:
-   - Automated workflow pipelines (such as tracking issue #11684) generate multiple sub-issues and PRs.
-   - If an unassigned `ready-for-human` PR references a tracking issue or workflow that a team member is already reviewing (and that member has `< 10` assigned PRs), **prefer assigning the new PR to that same team member** to maintain context continuity.
+   - Multi-level workflow pipelines (such as root tracking issue #10976 and sub-issue #10276) generate multiple sub-issues and PRs (e.g. PR #10992 referencing both #10276 and #10976).
+   - If an unassigned `ready-for-human` PR references any issue ID (root tracking issue or sub-issue) that a team member is already reviewing (and that member has `< 10` assigned PRs), **prefer assigning the new PR to that same team member** to maintain context continuity.
 
 ---
 
@@ -58,7 +58,7 @@ The `k8s-config-connector-team` is composed of the following GitHub handles:
 
 Run the following commands and logic in sequence:
 
-### Step 1: Audit Current Team Workloads & Workflow Mapping
+### Step 1: Audit Current Team Workloads & Multilevel Workflow Mapping
 Fetch all open PRs in `GoogleCloudPlatform/k8s-config-connector`:
 
 ```bash
@@ -68,7 +68,8 @@ gh pr list --repo GoogleCloudPlatform/k8s-config-connector --state open --limit 
 
 Build the following data structures in memory:
 1. **`workload`**: Maps each `k8s-config-connector-team` member to their count of open assigned reviews ($C_{user}$).
-2. **`tracking_issue_to_reviewer`**: Maps parent/tracking issue numbers (extracted from PR titles and bodies via regex matching `#<NUMBER>`, `Fixes #<NUMBER>`, or `Issue: #<NUMBER>`) to the `k8s-config-connector-team` member currently assigned to review open PRs for that tracking issue.
+2. **`tracking_issue_to_reviewer`**: Maps ALL referenced issue numbers (extracted from PR titles and bodies via regex matching `#<NUMBER>`, `Fixes #<NUMBER>`, or `Workflow: #<NUMBER>`) to the `k8s-config-connector-team` member currently assigned to review open PRs for that workflow hierarchy.
+   - *Note*: Workflow pipelines are multi-level (e.g. root issue #10976 with child sub-issue #10276 and PR #10992). Extract **all** referenced issue IDs in a PR so both sub-issues and root tracking issues map to the assigned reviewer.
 
 ### Step 2: Fetch Unassigned Candidate PRs
 Query open PRs labeled `ready-for-human`:
@@ -82,11 +83,11 @@ gh pr list --repo GoogleCloudPlatform/k8s-config-connector --label "ready-for-hu
 ### Step 3: Assignment Algorithm
 Iterate through each unassigned candidate `ready-for-human` PR:
 
-1. **Extract Workflow Tracking Issue**:
-   - Parse the candidate PR's title and body for parent tracking issue references (e.g. `#11684`).
+1. **Extract Workflow Tracking Issues**:
+   - Extract **all** issue ID references (e.g. root tracking issue #10976 or sub-issue #10276) from the candidate PR's title and body.
 
 2. **Select Reviewer by Priority**:
-   - **Priority 1 (Workflow Affinity)**: If the PR references a tracking issue $I$ present in `tracking_issue_to_reviewer`, and that reviewer's count $C_{reviewer} < 10$, **select that reviewer**.
+   - **Priority 1 (Workflow Affinity)**: If ANY extracted issue ID $I$ matches a key in `tracking_issue_to_reviewer`, and that reviewer's count $C_{reviewer} < 10$, **select that reviewer**.
    - **Priority 2 (Underloaded Balancing, $C_{user} < 5$)**: Otherwise, if any team members have $C_{user} < 5$, **select the member with the lowest $C_{user}$**.
    - **Priority 3 (Capacity Absorption, $5 \le C_{user} < 10$)**: Otherwise, if all team members have reached $C_{user} \ge 5$ but unassigned candidate PRs remain, **select the member with the lowest $C_{user}$ who has $C_{user} < 10$**.
    - **Ceiling Reached**: If all team members have $C_{user} = 10$, skip further assignments.
@@ -94,7 +95,7 @@ Iterate through each unassigned candidate `ready-for-human` PR:
 3. **Update State & Queue Assignment**:
    - If a reviewer is selected for PR $P$:
      - Increment `workload[selected_user]` ($C_{user} \leftarrow C_{user} + 1$).
-     - If PR $P$ has a tracking issue $I$, set `tracking_issue_to_reviewer[I] = selected_user`.
+     - For **every** issue ID $I$ referenced in PR $P$, set `tracking_issue_to_reviewer[I] = selected_user`.
      - Queue assignment command:
        ```bash
        gh pr edit <PR_NUMBER> --repo GoogleCloudPlatform/k8s-config-connector --add-reviewer <SELECTED_USER>


### PR DESCRIPTION
This PR adds the  chore to automatically balance review workloads across  members for  PRs.

### Changes
- Created  scheduled every 30 minutes to maintain between 5 and 10 assigned open reviews per team member.
- Strictly enforces assigning only PRs labeled .
- Respects workflow context continuity for multi-PR workflows (e.g. tracking issue #10976).
- Added setup guide in .