### PR TITLE
fix(export): allow exporting sets containing nested resource references

### DIFF
--- a/pkg/krmtotf/tftokrm.go
+++ b/pkg/krmtotf/tftokrm.go
@@ -745,9 +745,14 @@ func convertTFReferenceToKCCReference(tfField, specKey string, state map[string]
 // convertTFSetToKCCSet converts a set object in Terraform to a KCC set object
 func convertTFSetToKCCSet(stateVal, prevSpecVal interface{}, schema *tfschema.Schema, rc *corekccv1alpha1.ResourceConfig, prefix string, ignoreOutputOnlySpecFields bool) interface{} {
 	if containsReferenceField(prefix, rc) {
-		// TODO(kcc-eng): Support the case where the hashing function depends on resolved values from
-		//  resource references. For the time being, fall back to the declared state.
-		return prevSpecVal
+		if prevSpecVal != nil {
+			// TODO(kcc-eng): Support the case where the hashing function depends on resolved values from
+			//  resource references. For the time being, fall back to the declared state.
+			return prevSpecVal
+		}
+		// If prevSpecVal is nil (e.g. during a config-connector export or import), we do not have a
+		// previous spec to preserve or fall back to. In this case, we proceed to convert and output the
+		// live state elements directly as external references.
 	}
 	list := stateVal.([]interface{})
 	if len(list) == 0 {

--- a/pkg/krmtotf/tftokrm_test.go
+++ b/pkg/krmtotf/tftokrm_test.go
@@ -314,6 +314,59 @@ func TestConvertTFObjToKCCObj(t *testing.T) {
 			},
 		},
 		{
+			name: "set containing nested reference with nil prevSpec (export scenario)",
+			schemaOverride: map[string]*tfschema.Schema{
+				"set_of_objects_key": {
+					Type:     tfschema.TypeSet,
+					Optional: true,
+					Elem: &tfschema.Resource{
+						Schema: map[string]*tfschema.Schema{
+							"group": {
+								Type:     tfschema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			rc: &corekccv1alpha1.ResourceConfig{
+				ResourceReferences: []corekccv1alpha1.ReferenceConfig{
+					{
+						TFField: "set_of_objects_key.group",
+						Types: []corekccv1alpha1.TypeConfig{
+							{
+								Key: "instanceGroupRef",
+								GVK: k8sschema.GroupVersionKind{
+									Group:   "test1.cnrm.cloud.google.com",
+									Version: "v1alpha1",
+									Kind:    "Test1Bar",
+								},
+							},
+						},
+					},
+				},
+			},
+			state: map[string]interface{}{
+				"set_of_objects_key": []interface{}{
+					map[string]interface{}{
+						"group": "ref-val-1",
+					},
+				},
+			},
+			prevSpec: nil,
+			expected: map[string]interface{}{
+				"setOfObjectsKey": []interface{}{
+					map[string]interface{}{
+						"group": map[string]interface{}{
+							"instanceGroupRef": map[string]interface{}{
+								"external": "ref-val-1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "spec-defined values are preserved",
 			state: map[string]interface{}{
 				"string_key": "fully-expanded-string-value",


### PR DESCRIPTION
### BRIEF Change description

<!--
Describe what this pull request does.

* If your pull request is to address an open issue, indicate it by specifying the
issue number: 
* If your pull request fixes an issue which has not been filed, please file the
issue and put the number here.

For example: "Fixes #858"
-->
Generated by GeminiCLI.

Fixes a bug in `convertTFSetToKCCSet` where any set field containing nested resource references (such as `backend` field in `ComputeBackendService`) was completely omitted from the exported YAML output.

During normal reconciliation, the converter falls back to the user's declared KRM spec (`prevSpecVal`) for sets containing reference fields. This is necessary because set-hashing of unresolved local references (which use a local resource `name`) will never match the resolved GCP URLs (which use full resource links) from the live state. This hash mismatch would otherwise cause the converter to assume the elements are different, clobbering the user's local references and causing infinite diff reconciliation loops.

However, during a `config-connector export` or `import` command, there is no previous specification available (`prevSpecVal` is `nil`). Falling back unconditionally to `prevSpecVal` in this case discarded the live state elements, resulting in a missing set field in the final exported YAML.

- Modified `convertTFSetToKCCSet` in `pkg/krmtotf/tftokrm.go` to only apply the reference fallback safeguard if `prevSpecVal != nil`.
- Added a comprehensive unit test in `pkg/krmtotf/tftokrm_test.go` that specifically simulates an export scenario (`prevSpec == nil`) of a set containing nested reference fields, verifying correct live state conversion.

Fixes #8672 

#### WHY do we need this change?

#### Special notes for your reviewer:

#### Does this PR add something which needs to be 'release noted'?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ComputeBackendService: Fix config-connector export tool to export `backend` field.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

<!--
This section can be blank if this pull request does not require any additional documentation.

When adding links which point to resources within git repositories, like
usage documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

Before:
```
config-connector export //compute.googleapis.com/v1/projects/cnrm-yuhou/global/backendServices/computebackendservice-test
---
apiVersion: compute.cnrm.cloud.google.com/v1beta1
kind: ComputeBackendService
metadata:
  annotations:
    cnrm.cloud.google.com/project-id: cnrm-yuhou
  name: computebackendservice-test
spec:
  connectionDrainingTimeoutSec: 300
  healthChecks:
  - healthCheckRef:
      external: https://www.googleapis.com/compute/v1/projects/cnrm-yuhou/global/httpHealthChecks/computehttphealthcheck-test
  loadBalancingScheme: EXTERNAL
  location: global
  portName: http
  protocol: HTTP
  resourceID: computebackendservice-test
  sessionAffinity: NONE
  timeoutSec: 10
```
After
```
go run github.com/GoogleCloudPlatform/k8s-config-connector/cmd/config-connector export //compute.googleapis.com/v1/projects/cnrm-yuhou/global/backendServices/computebackendservice-test
apiVersion: compute.cnrm.cloud.google.com/v1beta1
kind: ComputeBackendService
metadata:
  annotations:
    cnrm.cloud.google.com/project-id: cnrm-yuhou
  name: computebackendservice-test
spec:
  backend:
  - balancingMode: UTILIZATION
    capacityScaler: 1
    group:
      instanceGroupRef:
        external: https://www.googleapis.com/compute/v1/projects/cnrm-yuhou/zones/us-central1-a/instanceGroups/computeinstancegroup-test
  connectionDrainingTimeoutSec: 300
  healthChecks:
  - healthCheckRef:
      external: https://www.googleapis.com/compute/v1/projects/cnrm-yuhou/global/httpHealthChecks/computehttphealthcheck-test
  loadBalancingScheme: EXTERNAL
  location: global
  portName: http
  protocol: HTTP
  resourceID: computebackendservice-test
  sessionAffinity: NONE
  timeoutSec: 10
```

`backend` field is populated correctly.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
