### PR TITLE
fix: SQLUser CLOUD_IAM_GROUP users on MySQL never converge (cherry-pick upstream v6.1.0 read fix)

### DIFF
--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/sql/resource_sql_user.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/sql/resource_sql_user.go
@@ -346,11 +346,14 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for _, currentUser := range users.Items {
-		if !strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") {
-			name = strings.Split(name, "@")[0]
+		var username string
+		if !(strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") || currentUser.Type == "CLOUD_IAM_GROUP") {
+			username = strings.Split(name, "@")[0]
+		} else {
+			username = name
 		}
 
-		if currentUser.Name == name {
+		if currentUser.Name == username {
 			// Host can only be empty for postgres instances,
 			// so don't compare the host if the API host is empty.
 			if host == "" || currentUser.Host == host {


### PR DESCRIPTION
Fixes #11862

## Problem

A `SQLUser` of `spec.type: CLOUD_IAM_GROUP` on a MySQL instance never converges: the account is created successfully in Cloud SQL (and works — members can log in), but `resourceSqlUserRead` strips the domain from the desired username unconditionally on MySQL, while the Admin API returns group users under their **full email**. The comparison never matches, every reconcile concludes the user is gone, re-issues the INSERT and collides:

```
Error 400: Database user 'tech-backend-team' cannot be created because a user exists with the same name.
```

The resource stays `UpdateFailed` permanently; acquiring a pre-existing group account fails the same way. Reproduced on Config Connector 1.145.0 and 1.153.0 with MySQL 8.0/8.4; Postgres is unaffected.

The stripping also mutates the loop-outer `name` variable, so behavior additionally depends on iteration order of unrelated users on the instance.

## Fix

Cherry-pick of the upstream provider fix shipped in **v6.1.0** (GoogleCloudPlatform/magic-modules#11466, closing hashicorp/terraform-provider-google#17040 / b/321524487): use a per-iteration `username` variable and skip domain-stripping for `CLOUD_IAM_GROUP` users, so they are compared by full email on both engines.

```go
for _, currentUser := range users.Items {
    var username string
    if !(strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") || currentUser.Type == "CLOUD_IAM_GROUP") {
        username = strings.Split(name, "@")[0]
    } else {
        username = name
    }
    if currentUser.Name == username {
```

## Verification

- Live-reproduced the failure and confirmed the exact mismatch against the raw Admin API (`users.list` returns `"name": "tech-backend-team@neon-free.ch", "host": "%"` while the read compares `tech-backend-team`).
- The host comparison is already safe for this case: the desired host is empty for IAM group users (the API rejects a host on insert), and the existing `host == ""` guard skips the comparison.
- `gofmt` clean; change is byte-identical in intent to the upstream fix that has been in the released provider since Aug 2024.
