### PR TITLE
mockgcp: use protoResolver in httptogrpc gRPC mux

### DIFF
--- a/mockgcp/common/httptogrpc/dynamicgrpcgateway.go
+++ b/mockgcp/common/httptogrpc/dynamicgrpcgateway.go
@@ -224,6 +224,7 @@ func (m *grpcMux) serveHTTPMethod(w http.ResponseWriter, r *http.Request, method
 			if len(body) != 0 {
 				unmarshalOptions := protojson.UnmarshalOptions{
 					DiscardUnknown: true,
+					Resolver:       &protoResolver{},
 				}
 
 				dest := protoMessage

--- a/mockgcp/common/httptogrpc/methodcall.go
+++ b/mockgcp/common/httptogrpc/methodcall.go
@@ -111,7 +111,9 @@ func (c *httpMethodCall) SendResponse(response proto.Message, responseOptions Re
 
 	c.parent.addGCPHeaders(ctx, c.w, response)
 
-	marshalOptions := protojson.MarshalOptions{}
+	marshalOptions := protojson.MarshalOptions{
+		Resolver: &protoResolver{},
+	}
 	responseOptions.populateMarshalOptions(&marshalOptions)
 
 	if c.grpcMethod != nil {

--- a/mockgcp/common/httptogrpc/proto_resolver.go
+++ b/mockgcp/common/httptogrpc/proto_resolver.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httptogrpc
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+type protoResolver struct {
+}
+
+var _ protoregistry.ExtensionTypeResolver = &protoResolver{}
+
+func (r *protoResolver) FindExtensionByName(message protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	return protoregistry.GlobalTypes.FindExtensionByName(r.remapName(message))
+}
+
+func (r *protoResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	return protoregistry.GlobalTypes.FindExtensionByNumber(r.remapName(message), field)
+}
+
+var _ protoregistry.MessageTypeResolver = &protoResolver{}
+
+func (r *protoResolver) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	return protoregistry.GlobalTypes.FindMessageByName(r.remapName(message))
+}
+
+func (r *protoResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	if suffix, ok := strings.CutPrefix(url, "type.googleapis.com/google."); ok {
+		s := "type.googleapis.com/mockgcp." + suffix
+		mt, err := protoregistry.GlobalTypes.FindMessageByURL(s)
+		if err == nil {
+			return mt, nil
+		}
+	}
+	return protoregistry.GlobalTypes.FindMessageByURL(url)
+}
+
+func (r *protoResolver) remapName(name protoreflect.FullName) protoreflect.FullName {
+	s := string(name)
+	if strings.HasPrefix(s, "google.") {
+		s = "mockgcp." + strings.TrimPrefix(s, "google.")
+		return protoreflect.FullName(s)
+	}
+	return name
+}


### PR DESCRIPTION
## Summary
Use `protoResolver` in `httptogrpc` gRPC mux marshal and unmarshal options to properly map `google.` to `mockgcp.` protobuf message names and URLs.

## Changes
- Add `mockgcp/common/httptogrpc/proto_resolver.go` implementing `protoregistry.ExtensionTypeResolver` and `protoregistry.MessageTypeResolver`.
- Set `Resolver: &protoResolver{}` in `protojson.UnmarshalOptions` in `mockgcp/common/httptogrpc/dynamicgrpcgateway.go`.
- Set `Resolver: &protoResolver{}` in `protojson.MarshalOptions` in `mockgcp/common/httptogrpc/methodcall.go`.