### PR TITLE
feat(container): add inTransitEncryptionConfig support to ContainerCluster

### DIFF
--- a/apis/container/v1beta1/containercluster_types.go
+++ b/apis/container/v1beta1/containercluster_types.go
@@ -1475,6 +1475,11 @@ type ContainerClusterSpec struct {
 	// +kcc:proto:field=google.container.v1.Cluster.initial_node_count
 	InitialNodeCount *int `json:"initialNodeCount,omitempty"`
 
+	/* In-transit encryption options for the cluster.*/
+	// +kcc:proto:field=google.container.v1.Cluster.network_config.in_transit_encryption_config
+	// +kubebuilder:validation:Enum=IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED;IN_TRANSIT_ENCRYPTION_DISABLED;IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT
+	InTransitEncryptionConfig *string `json:"inTransitEncryptionConfig,omitempty"`
+
 	/* Immutable. Configuration of cluster IP allocation for VPC-native clusters. Adding this block enables IP aliasing, making the cluster VPC-native instead of routes-based. */
 	// +kcc:proto:field=google.container.v1.Cluster.ip_allocation_policy
 	IPAllocationPolicy *IPAllocationPolicy `json:"ipAllocationPolicy,omitempty"`

--- a/apis/container/v1beta1/containercluster_types.go
+++ b/apis/container/v1beta1/containercluster_types.go
@@ -1475,9 +1475,8 @@ type ContainerClusterSpec struct {
 	// +kcc:proto:field=google.container.v1.Cluster.initial_node_count
 	InitialNodeCount *int `json:"initialNodeCount,omitempty"`
 
-	/* In-transit encryption options for the cluster.*/
+	/* In-transit encryption options for the cluster. Possible values are IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED, IN_TRANSIT_ENCRYPTION_DISABLED, IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT*/
 	// +kcc:proto:field=google.container.v1.Cluster.network_config.in_transit_encryption_config
-	// +kubebuilder:validation:Enum=IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED;IN_TRANSIT_ENCRYPTION_DISABLED;IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT
 	InTransitEncryptionConfig *string `json:"inTransitEncryptionConfig,omitempty"`
 
 	/* Immutable. Configuration of cluster IP allocation for VPC-native clusters. Adding this block enables IP aliasing, making the cluster VPC-native instead of routes-based. */

--- a/apis/container/v1beta1/zz_generated.deepcopy.go
+++ b/apis/container/v1beta1/zz_generated.deepcopy.go
@@ -849,6 +849,11 @@ func (in *ContainerClusterSpec) DeepCopyInto(out *ContainerClusterSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.InTransitEncryptionConfig != nil {
+		in, out := &in.InTransitEncryptionConfig, &out.InTransitEncryptionConfig
+		*out = new(string)
+		**out = **in
+	}
 	if in.IPAllocationPolicy != nil {
 		in, out := &in.IPAllocationPolicy, &out.IPAllocationPolicy
 		*out = new(IPAllocationPolicy)

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
@@ -667,6 +667,13 @@ spec:
                     description: Whether to enable the Identity Service component.
                     type: boolean
                 type: object
+              inTransitEncryptionConfig:
+                description: In-transit encryption options for the cluster.
+                enum:
+                - IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED
+                - IN_TRANSIT_ENCRYPTION_DISABLED
+                - IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT
+                type: string
               initialNodeCount:
                 description: Immutable. The number of nodes to create in this cluster's
                   default node pool. In regional or multi-zonal clusters, this is

--- a/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
+++ b/config/crds/resources/apiextensions.k8s.io_v1_customresourcedefinition_containerclusters.container.cnrm.cloud.google.com.yaml
@@ -668,11 +668,9 @@ spec:
                     type: boolean
                 type: object
               inTransitEncryptionConfig:
-                description: In-transit encryption options for the cluster.
-                enum:
-                - IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED
-                - IN_TRANSIT_ENCRYPTION_DISABLED
-                - IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT
+                description: In-transit encryption options for the cluster. Possible
+                  values are IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED, IN_TRANSIT_ENCRYPTION_DISABLED,
+                  IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT
                 type: string
               initialNodeCount:
                 description: Immutable. The number of nodes to create in this cluster's

--- a/config/samples/resources/containercluster/in-transit-encryption-container-cluster/container_v1beta1_containercluster.yaml
+++ b/config/samples/resources/containercluster/in-transit-encryption-container-cluster/container_v1beta1_containercluster.yaml
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  labels:
+    availability: dev
+    target-audience: development
+  name: containercluster-sample-intransit
+spec:
+  description: Minimal VPC-Native cluster with Dataplane V2 and In-Transit Encryption.
+  location: us-central1-a
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /20
+    servicesIpv4CidrBlock: /20
+  datapathProvider: ADVANCED_DATAPATH
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED

--- a/config/samples/resources/containercluster/in-transit-encryption-container-cluster/container_v1beta1_containercluster.yaml
+++ b/config/samples/resources/containercluster/in-transit-encryption-container-cluster/container_v1beta1_containercluster.yaml
@@ -28,4 +28,4 @@ spec:
     clusterIpv4CidrBlock: /20
     servicesIpv4CidrBlock: /20
   datapathProvider: ADVANCED_DATAPATH
-  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT # or IN_TRANSIT_ENCRYPTION_DISABLED to disable

--- a/mockgcp/mockcontainer/cluster.go
+++ b/mockgcp/mockcontainer/cluster.go
@@ -378,6 +378,14 @@ func (s *ClusterManagerV1) UpdateCluster(ctx context.Context, req *pb.UpdateClus
 		update.DesiredDisableL4LbFirewallReconciliation = nil
 	}
 
+	if update.DesiredInTransitEncryptionConfig != nil {
+		if obj.NetworkConfig == nil {
+			obj.NetworkConfig = &pb.NetworkConfig{}
+		}
+		obj.NetworkConfig.InTransitEncryptionConfig = update.DesiredInTransitEncryptionConfig
+		update.DesiredInTransitEncryptionConfig = nil
+	}
+
 	if update.DesiredAdditionalIpRangesConfig != nil {
 		if obj.IpAllocationPolicy == nil {
 			obj.IpAllocationPolicy = &pb.IPAllocationPolicy{}

--- a/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
+++ b/pkg/clients/generated/apis/container/v1beta1/containercluster_types.go
@@ -1242,6 +1242,10 @@ type ContainerClusterSpec struct {
 	// +optional
 	IdentityServiceConfig *ClusterIdentityServiceConfig `json:"identityServiceConfig,omitempty"`
 
+	/* In-transit encryption options for the cluster. Options are IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED, IN_TRANSIT_ENCRYPTION_DISABLED, IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT */
+	// +optional
+	InTransitEncryptionConfig *string `json:"inTransitEncryptionConfig,omitempty"`
+
 	/* Immutable. The number of nodes to create in this cluster's default node pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Must be set if node_pool is not set. If you're using google_container_node_pool objects with no default node pool, you'll need to set this to a value of at least 1, alongside setting remove_default_node_pool to true. */
 	// +optional
 	InitialNodeCount *int64 `json:"initialNodeCount,omitempty"`

--- a/pkg/clients/generated/apis/container/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/clients/generated/apis/container/v1beta1/zz_generated.deepcopy.go
@@ -2857,6 +2857,11 @@ func (in *ContainerClusterSpec) DeepCopyInto(out *ContainerClusterSpec) {
 		*out = new(ClusterIdentityServiceConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.InTransitEncryptionConfig != nil {
+		in, out := &in.InTransitEncryptionConfig, &out.InTransitEncryptionConfig
+		*out = new(string)
+		**out = **in
+	}
 	if in.InitialNodeCount != nil {
 		in, out := &in.InitialNodeCount, &out.InitialNodeCount
 		*out = new(int64)

--- a/pkg/controller/direct/container/mapper_manual.go
+++ b/pkg/controller/direct/container/mapper_manual.go
@@ -70,6 +70,10 @@ func NetworkConfig_InTransitEncryptionConfig_ToProto(mapCtx *direct.MapContext, 
 	return &v
 }
 
+func NetworkConfig_InTransitEncryptionConfig_FromProto(mapCtx *direct.MapContext, in pb.InTransitEncryptionConfig) *string {
+	return direct.Enum_FromProto[pb.InTransitEncryptionConfig](mapCtx, in)
+}
+
 func NetworkConfig_ClusterNetworkPerformanceConfig_TotalEgressBandwidthTier_ToProto(mapCtx *direct.MapContext, in *string) *pb.NetworkConfig_ClusterNetworkPerformanceConfig_Tier {
 	if in == nil {
 		return nil
@@ -431,6 +435,7 @@ func ContainerClusterSpec_FromProto(mapCtx *direct.MapContext, in *pb.Cluster) *
 		out.EnableFQDNNetworkPolicy = direct.LazyPtr(nc.GetEnableFqdnNetworkPolicy())
 		out.EnableMultiNetworking = direct.LazyPtr(nc.GetEnableMultiNetworking())
 		out.DatapathProvider = direct.Enum_FromProto[pb.DatapathProvider](mapCtx, nc.GetDatapathProvider())
+		out.InTransitEncryptionConfig = NetworkConfig_InTransitEncryptionConfig_FromProto(mapCtx, nc.GetInTransitEncryptionConfig())
 	}
 
 	return out
@@ -496,7 +501,7 @@ func ContainerClusterSpec_ToProto(mapCtx *direct.MapContext, in *krm.ContainerCl
 	if in.DefaultMaxPodsPerNode != nil {
 		out.DefaultMaxPodsConstraint = &pb.MaxPodsConstraint{MaxPodsPerNode: int64(direct.ValueOf(in.DefaultMaxPodsPerNode))}
 	}
-	if in.EnableL4ILBSubsetting != nil || in.EnableIntranodeVisibility != nil || in.EnableCiliumClusterwideNetworkPolicy != nil || in.EnableFQDNNetworkPolicy != nil || in.EnableMultiNetworking != nil || in.DatapathProvider != nil {
+	if in.EnableL4ILBSubsetting != nil || in.EnableIntranodeVisibility != nil || in.EnableCiliumClusterwideNetworkPolicy != nil || in.EnableFQDNNetworkPolicy != nil || in.EnableMultiNetworking != nil || in.DatapathProvider != nil || in.InTransitEncryptionConfig != nil {
 		out.NetworkConfig = &pb.NetworkConfig{}
 		out.NetworkConfig.EnableL4IlbSubsetting = direct.ValueOf(in.EnableL4ILBSubsetting)
 		out.NetworkConfig.EnableIntraNodeVisibility = direct.ValueOf(in.EnableIntranodeVisibility)
@@ -504,6 +509,7 @@ func ContainerClusterSpec_ToProto(mapCtx *direct.MapContext, in *krm.ContainerCl
 		out.NetworkConfig.EnableFqdnNetworkPolicy = in.EnableFQDNNetworkPolicy
 		out.NetworkConfig.EnableMultiNetworking = direct.ValueOf(in.EnableMultiNetworking)
 		out.NetworkConfig.DatapathProvider = direct.Enum_ToProto[pb.DatapathProvider](mapCtx, in.DatapathProvider)
+		out.NetworkConfig.InTransitEncryptionConfig = NetworkConfig_InTransitEncryptionConfig_ToProto(mapCtx, in.InTransitEncryptionConfig)
 	}
 
 	return out

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_generated_object_containercluster-intransitencryption.golden.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_generated_object_containercluster-intransitencryption.golden.yaml
@@ -1,0 +1,49 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/mutable-but-unreadable-fields: '{}'
+    cnrm.cloud.google.com/observed-secret-versions: (removed)
+    cnrm.cloud.google.com/project-id: ${projectId}
+    cnrm.cloud.google.com/state-into-spec: absent
+  finalizers:
+  - cnrm.cloud.google.com/finalizer
+  - cnrm.cloud.google.com/deletion-defender
+  generation: 3
+  labels:
+    cnrm-test: "true"
+  name: containercluster-${uniqueId}
+  namespace: ${uniqueId}
+spec:
+  datapathProvider: ADVANCED_DATAPATH
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED
+  initialNodeCount: 1
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /20
+    servicesIpv4CidrBlock: /20
+  location: us-central1-a
+  networkingMode: VPC_NATIVE
+  resourceID: containercluster-${uniqueId}
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: The resource is up to date
+    reason: UpToDate
+    status: "True"
+    type: Ready
+  endpoint: 1.23.456.78
+  labelFingerprint: abcdef0123A=
+  masterVersion: 1.30.5-gke.1014001
+  observedGeneration: 3
+  observedState:
+    controlPlaneEndpointsConfig:
+      dnsEndpointConfig:
+        endpoint: gke-12345trewq-${projectNumber}.us-central1-a.gke.goog
+    masterAuth:
+      clusterCaCertificate: 1234567890abcdefghijklmn
+    privateClusterConfig:
+      privateEndpoint: 10.128.0.2
+      publicEndpoint: 8.8.8.8
+  selfLink: https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}
+  servicesIpv4Cidr: 34.118.224.0/20

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http.log
@@ -1,0 +1,3687 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}.",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "cluster": {
+    "autopilot": {
+      "enabled": false
+    },
+    "autoscaling": {
+      "enableNodeAutoprovisioning": false
+    },
+    "binaryAuthorization": {
+      "enabled": false
+    },
+    "controlPlaneEndpointsConfig": {
+      "dnsEndpointConfig": {
+        "allowExternalTraffic": false,
+        "enableK8sTokensViaDns": false
+      },
+      "ipEndpointsConfig": {
+        "authorizedNetworksConfig": {},
+        "enablePublicEndpoint": true,
+        "enabled": true,
+        "globalAccess": false,
+        "privateEndpointSubnetwork": ""
+      }
+    },
+    "initialNodeCount": 1,
+    "ipAllocationPolicy": {
+      "clusterIpv4CidrBlock": "/20",
+      "servicesIpv4CidrBlock": "/20",
+      "stackType": "IPV4",
+      "useIpAliases": true
+    },
+    "legacyAbac": {
+      "enabled": false
+    },
+    "maintenancePolicy": {
+      "window": {}
+    },
+    "name": "containercluster-${uniqueId}",
+    "network": "projects/${projectId}/global/networks/default",
+    "networkConfig": {
+      "datapathProvider": "ADVANCED_DATAPATH",
+      "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT"
+    },
+    "networkPolicy": {},
+    "nodeConfig": {
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ]
+    },
+    "notificationConfig": {
+      "pubsub": {}
+    },
+    "resourceLabels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "shieldedNodes": {
+      "enabled": true
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "progress": {
+    "metrics": [
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING"
+      },
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING_TOTAL"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING_TOTAL"
+      },
+      {
+        "intValue": "1",
+        "name": "CLUSTER_HEALTHCHECKING"
+      },
+      {
+        "intValue": "2",
+        "name": "CLUSTER_HEALTHCHECKING_TOTAL"
+      }
+    ]
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+PUT https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+{
+  "update": {
+    "desiredInTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "UPDATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "UPDATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "abandoning": 0,
+    "creating": 0,
+    "creatingWithoutRetries": 0,
+    "deleting": 0,
+    "none": 1,
+    "recreating": 0,
+    "refreshing": 0,
+    "restarting": 0,
+    "resuming": 0,
+    "starting": 0,
+    "stopping": 0,
+    "suspending": 0,
+    "verifying": 0
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES",
+    "onFailedHealthCheck": "DEFAULT_ACTION"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "kind": "compute#instanceGroupManager",
+  "listManagedInstancesResults": "PAGINATED",
+  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "satisfiesPzs": true,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
+  "standbyPolicy": {
+    "mode": "MANUAL"
+  },
+  "status": {
+    "allInstancesConfig": {
+      "effective": true
+    },
+    "isStable": true,
+    "stateful": {
+      "hasStatefulConfig": false,
+      "isStateful": false,
+      "perInstanceConfigs": {
+        "allEffective": true
+      }
+    },
+    "versionTarget": {
+      "isReached": true
+    }
+  },
+  "targetSize": 1,
+  "targetSizePolicy": {
+    "mode": "INDIVIDUAL"
+  },
+  "targetStoppedSize": 0,
+  "targetSuspendedSize": 0,
+  "updatePolicy": {
+    "maxSurge": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "calculated": 1,
+      "fixed": 1
+    },
+    "minReadySec": 0,
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "versions": [
+    {
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "targetSize": {
+        "calculated": 1
+      }
+    }
+  ],
+  "zone": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "dnsCacheConfig": {
+      "enabled": true
+    },
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    },
+    "nodeReadinessConfig": {}
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "LIMITED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEgress": {
+    "mode": "VIA_CONTROL_PLANE"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sCertsViaDns": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.35.6-gke.1049000",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
+    "defaultPodIpv4RangeUtilization": 0.0625,
+    "networkTierConfig": {
+      "networkTier": "NETWORK_TIER_DEFAULT"
+    },
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "34.118.224.0/20",
+    "servicesIpv4CidrBlock": "34.118.224.0/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "master": {},
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM",
+        "JOBSET"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "defaultSnatStatus": {},
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "nodeImageConfig": {
+      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "imageProject": "gke-node-images"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodeCreationConfig": {
+    "nodeCreationMode": "VIA_KUBELET"
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "nodeImageConfig": {
+          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "imageProject": "gke-node-images"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+      ],
+      "kubeletCertInfo": {
+        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+      },
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "networkTierConfig": {
+          "networkTier": "NETWORK_TIER_DEFAULT"
+        },
+        "podIpv4CidrBlock": "10.2.176.0/20",
+        "podIpv4RangeUtilization": 0.0625,
+        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}/nodePools/default-pool",
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.35.6-gke.1049000"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateCluster": true,
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+DELETE https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "DELETE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "DELETE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http.log
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http.log
@@ -149,11 +149,11 @@ X-Xss-Protection: 0
         "name": "CLUSTER_CONFIGURING_TOTAL"
       },
       {
-        "intValue": "12",
+        "intValue": "10",
         "name": "CLUSTER_DEPLOYING"
       },
       {
-        "intValue": "12",
+        "intValue": "10",
         "name": "CLUSTER_DEPLOYING_TOTAL"
       },
       {
@@ -240,7 +240,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -253,9 +253,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -269,16 +269,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -309,7 +308,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -364,7 +363,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -424,7 +423,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -444,13 +443,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -467,9 +466,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -479,7 +477,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -527,7 +525,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -541,7 +539,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -560,18 +558,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -614,7 +612,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -690,7 +688,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -703,9 +701,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -719,16 +717,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -759,7 +756,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -814,7 +811,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -874,7 +871,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -894,13 +891,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -917,9 +914,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -929,7 +925,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -977,7 +973,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -991,7 +987,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -1010,18 +1006,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -1064,7 +1060,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -1140,7 +1136,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -1153,9 +1149,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -1169,16 +1165,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -1209,7 +1204,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -1264,7 +1259,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -1324,7 +1319,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -1344,13 +1339,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -1367,9 +1362,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -1379,7 +1373,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -1427,7 +1421,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -1441,7 +1435,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -1460,18 +1454,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -1514,7 +1508,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -1590,7 +1584,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -1603,9 +1597,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -1619,16 +1613,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -1659,7 +1652,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -1714,7 +1707,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -1774,7 +1767,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -1794,13 +1787,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -1817,9 +1810,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -1829,7 +1821,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -2000,7 +1992,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -2013,9 +2005,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -2029,16 +2021,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -2069,7 +2060,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -2124,7 +2115,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -2184,7 +2175,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -2204,13 +2195,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -2227,9 +2218,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -2239,7 +2229,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -2287,7 +2277,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -2301,7 +2291,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -2320,18 +2310,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -2374,7 +2364,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -2450,7 +2440,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -2463,9 +2453,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -2479,16 +2469,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -2519,7 +2508,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -2574,7 +2563,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -2634,7 +2623,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -2654,13 +2643,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -2677,9 +2666,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -2689,7 +2677,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -2737,7 +2725,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -2751,7 +2739,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -2770,18 +2758,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -2824,7 +2812,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -2900,7 +2888,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -2913,9 +2901,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -2929,16 +2917,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -2969,7 +2956,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -3024,7 +3011,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -3084,7 +3071,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -3104,13 +3091,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -3127,9 +3114,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -3139,7 +3125,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {
@@ -3187,7 +3173,7 @@ X-Xss-Protection: 0
 
 ---
 
-GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp?alt=json&prettyPrint=false
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp?alt=json&prettyPrint=false
 User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion}
 
 200 OK
@@ -3201,7 +3187,7 @@ X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0
 
 {
-  "baseInstanceName": "gke-containercluster-hgb-default-pool-0013ff0c",
+  "baseInstanceName": "gke-containercluster-da4-default-pool-76327978",
   "creationTimestamp": "2024-04-01T12:34:56.123456Z",
   "currentActions": {
     "abandoning": 0,
@@ -3220,18 +3206,18 @@ X-Xss-Protection: 0
   },
   "fingerprint": "abcdef0123A=",
   "id": "000000000000000000000",
-  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "instanceGroup": "https://www.googleapis.com/compute/beta/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-da4-default-pool-76327978-grp",
   "instanceLifecyclePolicy": {
     "defaultActionOnFailure": "REPAIR",
     "forceUpdateOnRepair": "YES",
     "onFailedHealthCheck": "DEFAULT_ACTION"
   },
-  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+  "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
   "kind": "compute#instanceGroupManager",
   "listManagedInstancesResults": "PAGINATED",
-  "name": "gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "name": "gke-containercluster-da4-default-pool-76327978-grp",
   "satisfiesPzs": true,
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp",
   "serviceAccount": "service-${projectNumber}@container-engine-robot.iam.gserviceaccount.com",
   "standbyPolicy": {
     "mode": "MANUAL"
@@ -3274,7 +3260,7 @@ X-Xss-Protection: 0
   },
   "versions": [
     {
-      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-hgb-default-pool-0013ff0c",
+      "instanceTemplate": "https://www.googleapis.com/compute/beta/projects/${projectId}/regions/us-central1/instanceTemplates/gke-containercluster-da4-default-pool-76327978",
       "targetSize": {
         "calculated": 1
       }
@@ -3350,7 +3336,7 @@ X-Xss-Protection: 0
       "allowExternalTraffic": false,
       "enableK8sCertsViaDns": false,
       "enableK8sTokensViaDns": false,
-      "endpoint": "gke-856c90ad385e4874bf9d5febefdffc13fc6c-${projectNumber}.us-central1-a.gke.goog"
+      "endpoint": "gke-688a7161399d406bb46fa699dc59032f95b3-${projectNumber}.us-central1-a.gke.goog"
     },
     "ipEndpointsConfig": {
       "authorizedNetworksConfig": {
@@ -3363,9 +3349,9 @@ X-Xss-Protection: 0
     }
   },
   "createTime": "2024-04-01T12:34:56.123456Z",
-  "currentMasterVersion": "1.35.6-gke.1049000",
+  "currentMasterVersion": "1.35.6-gke.1127000",
   "currentNodeCount": 1,
-  "currentNodeVersion": "1.35.6-gke.1049000",
+  "currentNodeVersion": "1.35.6-gke.1127000",
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"
@@ -3379,16 +3365,15 @@ X-Xss-Protection: 0
   },
   "etag": "abcdef0123A=",
   "id": "000000000000000000000",
-  "initialClusterVersion": "1.35.6-gke.1049000",
+  "initialClusterVersion": "1.35.6-gke.1127000",
   "initialNodeCount": 1,
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "10.112.0.0/14",
     "clusterIpv4CidrBlock": "10.112.0.0/14",
-    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-856c90ad",
-    "defaultPodIpv4RangeUtilization": 0.0625,
+    "clusterSecondaryRangeName": "gke-containercluster-${uniqueId}-pods-688a7161",
     "networkTierConfig": {
       "networkTier": "NETWORK_TIER_DEFAULT"
     },
@@ -3419,7 +3404,7 @@ X-Xss-Protection: 0
   "master": {},
   "masterAuth": {
     "clientCertificateConfig": {},
-    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBPYVQvekxIeEVMQkJvNnZaTlh5WWd3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1ptSTFPVFUxTWpNdFpqQTFPUzAwWVRneUxUazFaRGt0TnpFMVlUQTFObVZoTWpJeQpNQ0FYRFRJMk1EY3lOREUyTXprek1Gb1lEekl3TlRZd056RTJNVGN6T1RNd1dqQXZNUzB3S3dZRFZRUURFeVJtCllqVTVOVFV5TXkxbU1EVTVMVFJoT0RJdE9UVmtPUzAzTVRWaE1EVTJaV0V5TWpJd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDN1RXNmZ1aHR5ZU5NdmF3QitDMTAzeks2UFNlQ2tpSTJhM0UrcgpQT1JYTFBEWUFvVW9RRFVvK1ZGVndkYmQyTmVvUWVtK3I1YmxldVAzWE9ocWw3TWJuZDJQVUdhanprMXBheFVSCmltVHp3eGNyWmF3VVJ6Q1VNaGNrTWJlOVRlWVR1OTBGVXNFVm85UnovU21IeHNNNEZkc0s3cWZycDI2eDh4ZUsKdndmczRVRnJPbzhrRU8vRTArVTNWUjdtN1NGYmdhN1ZqVHlXeGFKQmErWEtxM0hTTmViMHhYd011U0p0RmZWZwpLMFdKb1dibUFrSXF3NVB0VTlRSVZtbkdaTGg1c3htVHFsWmNyNEJSa1FTSnZhUzQrUmY0T2xGTHdGcW9yMm9sClhaaUwyQ1A1S2Y4YWc3SUtmUmg5UEc2MlFZYWdYMjRqK1pUL21WVGVUOXRYQ2Y4dVdyR2FPNTg2VnNzVzJycnkKN2tDblgzMWdGNW91RVRIL2dPaXlYamM3V1JzU2ZXdHlYcDIzR3FmUWM1S1p1dVltU213L00yaklEWDdBQmNheQpQWmIrTXZNZFEvQUd2OUFsS294b0lZZXl2djU4TVdzbFhHNkwzV28zK0dYUTREalF1ai83NkhXd2JLVlZmdlVXCjJvWEYzcU1xcTRMblFwSzV3ekc0WU1kTTNPTUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGQTFnRHNmWlpyTlNDNitXRmlPUFJCTkFENFFITUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVZobGp4cU5CUVNuV2RDR2E2ZkZ3ZmZBYkZDWEp5TE00alZwelFTNUVZCjVSMU5ka1YwamhPYnRLalRwcGR4N3g4RWpEdDFmYUxtdCtiTmRnVm5oMTlRekQybDN6aDdBR3BqZXRUY1owTHIKY2VCZCtidlB3L2dUdDlBTHFMNVp2VVUrOU5ydDk3U3ZmVUpnUDlWOEtYaXEzVmZuMUdXWkQ0OVVtMmllQlRlUwp4SlhrcGhxdmtnQ0daM2hkc1I0aGZDNkUxd2JUVXJoL3g0aVM0SWhuajAyNzkrMnVtblJhQ3VBZXlSTUZpOEMyCjFrNUQwMWVsUUU3dVdMRkl3WHFIZ2RaSlFjSTNRTVliYTgxK1d5YTlGa2dCWWZVcmxkeVNkdEhldjlITWpaR3YKV2lWOTg4SGVab1NNTXUxT1k0T3J4ajdIVmdWWFJJL3BHS1A0QUtvYWtWK1dQZ1JiVmgrVlJ5enoxNWEyb3hGcwpZM0ZyZXVoOFhTdkF5ZWdlSktKdCtFSGEzNzMxNEZHckYyWDV6MWR3YU04endpUENTSUh3dTNESEJ2K2hhYTdoCjdnUC81WjZwMU9OSkZXcHNFMCt6eFllaDQzNVY4ZWkzVGluOXlhRnUzV2ZjNTI2VGlMUVNtYUdYQU1OcUdEVEkKejVCdk9mQXhBVWdUZjlBZjl6WHpYVkk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+    "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRV3hQWTNsUnhsVFJOOEp1OEFlVzR0REFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbVpqSm1NV0ZrTkMweFpEazRMVFEwTldNdE9XUmlaaTAwWldVMU1EUTRObU15TVRJdwpJQmNOTWpZd056STNNVGcxTXpRd1doZ1BNakExTmpBM01Ua3hPVFV6TkRCYU1DOHhMVEFyQmdOVkJBTVRKR1ptCk1tWXhZV1EwTFRGa09UZ3RORFExWXkwNVpHSm1MVFJsWlRVd05EZzJZekl4TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU9TcjJ3UTJ4aVRVTHNwM2ZLOS9uai9zTDczVGNaU1VPelVKM3FUZwo5K25ySDhsdDBGWGRjK0ZKaFdsRWFnZTg5Rkpmd2lESGRkSW9MZXNTOXNOTHFONzBVQmlmRlJVdWt4dmREMkVRCkNOOEFDNE9zV1ArejhjaDl2KzlNTTdEMHF0V0luWmlOQ1JnUGVJZzl5MktXcTBPQXArbzJkc2FYYm13Q2djUFUKanZzaUVxN0ZnOFI0OFg0enlWTUdsSzEyTmxNOStUOXlHcmV6OEtzT2pidnF2blRHalNjU2t3SGRTZ29iYytneApaVXZ0MTJSQ29sS0xrZXh1VW12WlpvTUthNFhVVTM4WVNUeHhOL0t4RU92emw1WEdPUGJJUHlveXhxcCtsbDhWCm9XRzVmY3VwelRlQVl4S1JNdTN3Y2NuWC92RUNwbHl2cTRmaytSb2RCaGxlYVduSVVQVVI1Ky9Ia3VwUUFicUEKNnFxcFpLQWpsNnEyWXB3b2MxaEVFMlpmRmI3V0RCd3JLVUZ5TG1MNmM5VmFJTisya1hIN2N2SmdVR3Rsb0NMdApTdG91b2dDNDdENkdmL3ROYkpOOGVRRGJDYnlFMmZhOU9JckdodFNWREpRR1hub2Q5RDFBUmFkUjRNNW12V3NqCjdYM0lKTmRJQ3Z0eGV5dENDVTY2QmV4RmtRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwZzhYeklSWjM1aHk0NlZKL0gzWDltcHBlRWt3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFONkJsWVA2TkJDV0VCb3E1Z0ZqdFFPNms5RW5RZVMrY3VqN3FCTnBoOVE4CklIY010dGdTVEcwQTJaSDREakRxL0diUlNnZFRRWVg5NjhXclBGM1gyMzNWNG0vUlFvc1lxVE5TVUVvZ3lqSXAKSlY5MWtvdkNPcjZJY0VFbjVLZU1JaTR2YjhEcmJIN2xLblZ1c2tiUmVMQXRjeStFMjlveG5mcmtmOUd1MjJIRApFMUpGZWZoUEF1Y0xIVkhJUnV6SjgyWHdPUlJDbUtLMnB2OFd1ZVpHNWVWcnhUOU5BamVWWW5xQVNmTzE0REpaCjYzaHAxdW5jbXNoQ1FVVG05Rmgrajk1ME05bUlvNVhvN1pVVWVrdzhXUXV0YWwra0NicHErUUh2b1JLSThvWXoKdmUwU0FwNnpsU1QzaTd2dTRUTk14OUpVWnhVRkdMYVlrTTlUaERiRGZSdWsxaURYdFRSTXJ5SXBJdG5xaHhtOApDclE5TW8wMlRBbnpORDVOanA5a3dWYUp4VDMwWlJKcitpcFhDVWZOUWRIRVNoenc0dFoyMk9zTnpVeGtaRzUrCkVmTEpHNFlsZDU3OHFPUnl5N3Q2RXgvYkpKTk5jQVdFR1B6eEVEN1daQnlZcFVYYnBXZ05nTVZubG41QTNIUFQKaFZTdFdGL2h0ZmppUVF6WHl2amw4dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
   },
   "masterAuthorizedNetworksConfig": {
     "gcpPublicCidrsAccessEnabled": true
@@ -3474,7 +3459,7 @@ X-Xss-Protection: 0
       "disable-legacy-endpoints": "true"
     },
     "nodeImageConfig": {
-      "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+      "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
       "imageProject": "gke-node-images"
     },
     "oauthScopes": [
@@ -3534,7 +3519,7 @@ X-Xss-Protection: 0
           "disable-legacy-endpoints": "true"
         },
         "nodeImageConfig": {
-          "image": "gke-1356-gke1049000-cos-125-19216-395-109-c-pre",
+          "image": "gke-1356-gke1127000-cos-125-19216-395-109-c-pre",
           "imageProject": "gke-node-images"
         },
         "oauthScopes": [
@@ -3554,13 +3539,13 @@ X-Xss-Protection: 0
         },
         "windowsNodeConfig": {}
       },
-      "etag": "ade6f176-9fcc-4f09-8484-6c0e4ac2fa99",
+      "etag": "4f01d15d-f91e-425d-9c38-4156f88fce6c",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-hgb-default-pool-0013ff0c-grp"
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-da4-default-pool-76327978-grp"
       ],
       "kubeletCertInfo": {
-        "tpmBootstrapCertExpireTime": "2031-07-23T17:40:45Z"
+        "tpmBootstrapCertExpireTime": "2031-07-26T19:54:58Z"
       },
       "locations": [
         "us-central1-a"
@@ -3577,9 +3562,8 @@ X-Xss-Protection: 0
         "networkTierConfig": {
           "networkTier": "NETWORK_TIER_DEFAULT"
         },
-        "podIpv4CidrBlock": "10.2.176.0/20",
-        "podIpv4RangeUtilization": 0.0625,
-        "podRange": "gke-containercluster-${uniqueId}-pods-856c90ad",
+        "podIpv4CidrBlock": "10.3.128.0/20",
+        "podRange": "gke-containercluster-${uniqueId}-pods-688a7161",
         "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
       },
       "podIpv4CidrSize": 24,
@@ -3589,7 +3573,7 @@ X-Xss-Protection: 0
         "maxSurge": 1,
         "strategy": "SURGE"
       },
-      "version": "1.35.6-gke.1049000"
+      "version": "1.35.6-gke.1127000"
     }
   ],
   "notificationConfig": {

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http_mock.log
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_http_mock.log
@@ -1,0 +1,2759 @@
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+404 Not Found
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}.",
+        "reason": "notFound"
+      }
+    ],
+    "message": "Not found: projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}.",
+    "status": "NOT_FOUND"
+  }
+}
+
+---
+
+POST https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+{
+  "cluster": {
+    "autopilot": {
+      "enabled": false
+    },
+    "autoscaling": {
+      "enableNodeAutoprovisioning": false
+    },
+    "binaryAuthorization": {
+      "enabled": false
+    },
+    "controlPlaneEndpointsConfig": {
+      "dnsEndpointConfig": {
+        "allowExternalTraffic": false,
+        "enableK8sTokensViaDns": false
+      },
+      "ipEndpointsConfig": {
+        "authorizedNetworksConfig": {},
+        "enablePublicEndpoint": true,
+        "enabled": true,
+        "globalAccess": false,
+        "privateEndpointSubnetwork": ""
+      }
+    },
+    "initialNodeCount": 1,
+    "ipAllocationPolicy": {
+      "clusterIpv4CidrBlock": "/20",
+      "servicesIpv4CidrBlock": "/20",
+      "stackType": "IPV4",
+      "useIpAliases": true
+    },
+    "legacyAbac": {
+      "enabled": false
+    },
+    "maintenancePolicy": {
+      "window": {}
+    },
+    "name": "containercluster-${uniqueId}",
+    "network": "projects/${projectId}/global/networks/default",
+    "networkConfig": {
+      "datapathProvider": "ADVANCED_DATAPATH",
+      "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT"
+    },
+    "networkPolicy": {},
+    "nodeConfig": {
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ]
+    },
+    "notificationConfig": {
+      "pubsub": {}
+    },
+    "resourceLabels": {
+      "cnrm-test": "true",
+      "managed-by-cnrm": "true"
+    },
+    "shieldedNodes": {
+      "enabled": true
+    }
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "CREATE_CLUSTER",
+  "progress": {
+    "metrics": [
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING"
+      },
+      {
+        "intValue": "8",
+        "name": "CLUSTER_CONFIGURING_TOTAL"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING"
+      },
+      {
+        "intValue": "12",
+        "name": "CLUSTER_DEPLOYING_TOTAL"
+      },
+      {
+        "intValue": "1",
+        "name": "CLUSTER_HEALTHCHECKING"
+      },
+      {
+        "intValue": "2",
+        "name": "CLUSTER_HEALTHCHECKING_TOTAL"
+      }
+    ]
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-abcdef-default-pool",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "none": 1
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-abcdef-default-pool-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/global/instanceTemplates/gke-containercluster-abcdef-default-pool",
+  "kind": "compute#instanceGroupManager",
+  "name": "gke-containercluster-abcdef-default-pool-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp",
+  "status": {
+    "isStable": true
+  },
+  "targetSize": 1,
+  "updatePolicy": {
+    "maxSurge": {
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "fixed": 1
+    },
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-abcdef-default-pool",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "none": 1
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-abcdef-default-pool-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/global/instanceTemplates/gke-containercluster-abcdef-default-pool",
+  "kind": "compute#instanceGroupManager",
+  "name": "gke-containercluster-abcdef-default-pool-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp",
+  "status": {
+    "isStable": true
+  },
+  "targetSize": 1,
+  "updatePolicy": {
+    "maxSurge": {
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "fixed": 1
+    },
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-abcdef-default-pool",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "none": 1
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-abcdef-default-pool-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/global/instanceTemplates/gke-containercluster-abcdef-default-pool",
+  "kind": "compute#instanceGroupManager",
+  "name": "gke-containercluster-abcdef-default-pool-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp",
+  "status": {
+    "isStable": true
+  },
+  "targetSize": 1,
+  "updatePolicy": {
+    "maxSurge": {
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "fixed": 1
+    },
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+PUT https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+Content-Type: application/json
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+{
+  "update": {
+    "desiredInTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED"
+  }
+}
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "UPDATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "UPDATE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-abcdef-default-pool",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "none": 1
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-abcdef-default-pool-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/global/instanceTemplates/gke-containercluster-abcdef-default-pool",
+  "kind": "compute#instanceGroupManager",
+  "name": "gke-containercluster-abcdef-default-pool-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp",
+  "status": {
+    "isStable": true
+  },
+  "targetSize": 1,
+  "updatePolicy": {
+    "maxSurge": {
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "fixed": 1
+    },
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://compute.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "baseInstanceName": "gke-containercluster-abcdef-default-pool",
+  "creationTimestamp": "2024-04-01T12:34:56.123456Z",
+  "currentActions": {
+    "none": 1
+  },
+  "fingerprint": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "instanceGroup": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a/instanceGroups/gke-containercluster-abcdef-default-pool-grp",
+  "instanceLifecyclePolicy": {
+    "defaultActionOnFailure": "REPAIR",
+    "forceUpdateOnRepair": "YES"
+  },
+  "instanceTemplate": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/global/instanceTemplates/gke-containercluster-abcdef-default-pool",
+  "kind": "compute#instanceGroupManager",
+  "name": "gke-containercluster-abcdef-default-pool-grp",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp",
+  "status": {
+    "isStable": true
+  },
+  "targetSize": 1,
+  "updatePolicy": {
+    "maxSurge": {
+      "fixed": 1
+    },
+    "maxUnavailable": {
+      "fixed": 1
+    },
+    "minimalAction": "REPLACE",
+    "replacementMethod": "SUBSTITUTE",
+    "type": "OPPORTUNISTIC"
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta1/projects/${projectId}/zones/us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "addonsConfig": {
+    "gcePersistentDiskCsiDriverConfig": {
+      "enabled": true
+    },
+    "kubernetesDashboard": {
+      "disabled": true
+    },
+    "networkPolicyConfig": {
+      "disabled": true
+    }
+  },
+  "anonymousAuthenticationConfig": {
+    "mode": "ENABLED"
+  },
+  "autopilot": {},
+  "autoscaling": {
+    "autoprovisioningNodePoolDefaults": {
+      "imageType": "COS_CONTAINERD",
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "oauthScopes": [
+        "https://www.googleapis.com/auth/devstorage.read_only",
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring",
+        "https://www.googleapis.com/auth/service.management.readonly",
+        "https://www.googleapis.com/auth/servicecontrol",
+        "https://www.googleapis.com/auth/trace.append"
+      ],
+      "serviceAccount": "default"
+    },
+    "autoscalingProfile": "BALANCED"
+  },
+  "binaryAuthorization": {},
+  "clusterIpv4Cidr": "10.112.0.0/14",
+  "clusterTelemetry": {
+    "type": "ENABLED"
+  },
+  "controlPlaneEndpointsConfig": {
+    "dnsEndpointConfig": {
+      "allowExternalTraffic": false,
+      "enableK8sTokensViaDns": false,
+      "endpoint": "gke-12345trewq-${projectNumber}.us-central1-a.gke.goog"
+    },
+    "ipEndpointsConfig": {
+      "authorizedNetworksConfig": {
+        "gcpPublicCidrsAccessEnabled": true
+      },
+      "enablePublicEndpoint": true,
+      "enabled": true,
+      "globalAccess": false,
+      "privateEndpoint": "${privateEndpointIPV4}",
+      "publicEndpoint": "${publicEndpointIPV4}"
+    }
+  },
+  "createTime": "2024-04-01T12:34:56.123456Z",
+  "currentMasterVersion": "1.30.5-gke.1014001",
+  "currentNodeCount": 1,
+  "currentNodeVersion": "1.30.5-gke.1014001",
+  "databaseEncryption": {
+    "currentState": "CURRENT_STATE_DECRYPTED",
+    "state": "DECRYPTED"
+  },
+  "defaultMaxPodsConstraint": {
+    "maxPodsPerNode": "110"
+  },
+  "endpoint": "${publicEndpointIPV4}",
+  "enterpriseConfig": {
+    "clusterTier": "STANDARD"
+  },
+  "etag": "abcdef0123A=",
+  "id": "000000000000000000000",
+  "initialClusterVersion": "1.30.5-gke.1014001",
+  "initialNodeCount": 1,
+  "instanceGroupUrls": [
+    "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef"
+  ],
+  "ipAllocationPolicy": {
+    "clusterIpv4Cidr": "10.112.0.0/14",
+    "clusterIpv4CidrBlock": "10.112.0.0/14",
+    "podCidrOverprovisionConfig": {},
+    "servicesIpv4Cidr": "/20",
+    "servicesIpv4CidrBlock": "/20",
+    "stackType": "IPV4",
+    "useIpAliases": true
+  },
+  "labelFingerprint": "abcdef0123A=",
+  "legacyAbac": {},
+  "location": "us-central1-a",
+  "locations": [
+    "us-central1-a"
+  ],
+  "loggingConfig": {
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "WORKLOADS"
+      ]
+    }
+  },
+  "loggingService": "logging.googleapis.com/kubernetes",
+  "maintenancePolicy": {
+    "resourceVersion": "abcd1234"
+  },
+  "masterAuth": {
+    "clientCertificateConfig": {},
+    "clusterCaCertificate": "1234567890abcdefghijklmn"
+  },
+  "masterAuthorizedNetworksConfig": {
+    "gcpPublicCidrsAccessEnabled": true
+  },
+  "monitoringConfig": {
+    "advancedDatapathObservabilityConfig": {},
+    "componentConfig": {
+      "enableComponents": [
+        "SYSTEM_COMPONENTS",
+        "DAEMONSET",
+        "DEPLOYMENT",
+        "STATEFULSET",
+        "JOBSET",
+        "STORAGE",
+        "HPA",
+        "POD",
+        "CADVISOR",
+        "KUBELET",
+        "DCGM"
+      ]
+    },
+    "managedPrometheusConfig": {
+      "enabled": true
+    }
+  },
+  "monitoringService": "monitoring.googleapis.com/kubernetes",
+  "name": "containercluster-${uniqueId}",
+  "network": "default",
+  "networkConfig": {
+    "datapathProvider": "ADVANCED_DATAPATH",
+    "inTransitEncryptionConfig": "IN_TRANSIT_ENCRYPTION_DISABLED",
+    "network": "projects/${projectId}/global/networks/default",
+    "serviceExternalIpsConfig": {},
+    "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+  },
+  "nodeConfig": {
+    "bootDisk": {
+      "diskType": "pd-balanced",
+      "sizeGb": "100"
+    },
+    "diskSizeGb": 100,
+    "diskType": "pd-balanced",
+    "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+    "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false,
+      "maxParallelImagePulls": 2
+    },
+    "machineType": "e2-medium",
+    "metadata": {
+      "disable-legacy-endpoints": "true"
+    },
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ],
+    "resourceLabels": {
+      "goog-gke-node-pool-provisioning-model": "on-demand"
+    },
+    "serviceAccount": "default",
+    "shieldedInstanceConfig": {
+      "enableIntegrityMonitoring": true
+    },
+    "windowsNodeConfig": {}
+  },
+  "nodePoolAutoConfig": {
+    "nodeKubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    }
+  },
+  "nodePoolDefaults": {
+    "nodeConfigDefaults": {
+      "loggingConfig": {
+        "variantConfig": {
+          "variant": "DEFAULT"
+        }
+      },
+      "nodeKubeletConfig": {
+        "insecureKubeletReadonlyPortEnabled": false
+      }
+    }
+  },
+  "nodePools": [
+    {
+      "config": {
+        "bootDisk": {
+          "diskType": "pd-balanced",
+          "sizeGb": "100"
+        },
+        "diskSizeGb": 100,
+        "diskType": "pd-balanced",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
+        "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": false,
+          "maxParallelImagePulls": 2
+        },
+        "machineType": "e2-medium",
+        "metadata": {
+          "disable-legacy-endpoints": "true"
+        },
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/trace.append"
+        ],
+        "resourceLabels": {
+          "goog-gke-node-pool-provisioning-model": "on-demand"
+        },
+        "serviceAccount": "default",
+        "shieldedInstanceConfig": {
+          "enableIntegrityMonitoring": true
+        },
+        "windowsNodeConfig": {}
+      },
+      "initialNodeCount": 1,
+      "instanceGroupUrls": [
+        "https://www.googleapis.com/compute/v1/projects/${projectId}/zones/us-central1-a/instanceGroupManagers/gke-containercluster-abcdef-default-pool-grp"
+      ],
+      "locations": [
+        "us-central1-a"
+      ],
+      "management": {
+        "autoRepair": true,
+        "autoUpgrade": true
+      },
+      "maxPodsConstraint": {
+        "maxPodsPerNode": "110"
+      },
+      "name": "default-pool",
+      "networkConfig": {
+        "podIpv4CidrBlock": "10.92.0.0/14",
+        "podIpv4RangeUtilization": 0.001,
+        "podRange": "default-pool-pods-12345678",
+        "subnetwork": "projects/${projectId}/regions/us-central1/subnetworks/default"
+      },
+      "podIpv4CidrSize": 24,
+      "status": "RUNNING",
+      "upgradeSettings": {
+        "maxSurge": 1,
+        "strategy": "SURGE"
+      },
+      "version": "1.30.5-gke.1014001"
+    }
+  ],
+  "notificationConfig": {
+    "pubsub": {}
+  },
+  "podAutoscaling": {
+    "hpaProfile": "PERFORMANCE"
+  },
+  "privateClusterConfig": {
+    "privateEndpoint": "${privateEndpointIPV4}",
+    "publicEndpoint": "${publicEndpointIPV4}"
+  },
+  "protectConfig": {
+    "workloadConfig": {
+      "auditMode": "BASIC"
+    },
+    "workloadVulnerabilityMode": "WORKLOAD_VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "rbacBindingConfig": {
+    "enableInsecureBindingSystemAuthenticated": true,
+    "enableInsecureBindingSystemUnauthenticated": true
+  },
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
+  "resourceLabels": {
+    "cnrm-test": "true",
+    "managed-by-cnrm": "true"
+  },
+  "securityPostureConfig": {
+    "mode": "BASIC",
+    "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
+  },
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectId}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "servicesIpv4Cidr": "34.118.224.0/20",
+  "shieldedNodes": {
+    "enabled": true
+  },
+  "status": "RUNNING",
+  "subnetwork": "default",
+  "userManagedKeysConfig": {},
+  "zone": "us-central1-a"
+}
+
+---
+
+DELETE https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/clusters/containercluster-${uniqueId}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "name": "${operationID}",
+  "operationType": "DELETE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "RUNNING",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}
+
+---
+
+GET https://container.googleapis.com/v1beta1/projects/${projectId}/locations/us-central1-a/operations/${operationID}?alt=json&prettyPrint=false
+User-Agent: google-api-go-client/0.5 kcc/${kccVersion} (+https://github.com/GoogleCloudPlatform/k8s-config-connector) kcc/controller-manager/${kccVersion} (mockgcp)
+
+200 OK
+Content-Type: application/json; charset=UTF-8
+Server: ESF
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Xss-Protection: 0
+
+{
+  "endTime": "2024-04-01T12:34:56.123456Z",
+  "name": "${operationID}",
+  "operationType": "DELETE_CLUSTER",
+  "selfLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/operations/${operationID}",
+  "startTime": "2024-04-01T12:34:56.123456Z",
+  "status": "DONE",
+  "targetLink": "https://container.googleapis.com/v1beta1/projects/${projectNumber}/zones/us-central1-a/clusters/containercluster-${uniqueId}",
+  "zone": "us-central1-a"
+}

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_identities.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/_identities.yaml
@@ -1,0 +1,7 @@
+- caisURL: unknown
+  error: not yet supported
+  group: container.cnrm.cloud.google.com
+  kind: ContainerCluster
+  name: containercluster-${uniqueId}
+  namespace: ${uniqueId}
+  version: v1beta1

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/create.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/create.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: containercluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /20
+    servicesIpv4CidrBlock: /20
+  datapathProvider: ADVANCED_DATAPATH
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT

--- a/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/update.yaml
+++ b/pkg/test/resourcefixture/testdata/basic/container/v1beta1/containercluster/containercluster-intransitencryption/update.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: containercluster-${uniqueId}
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /20
+    servicesIpv4CidrBlock: /20
+  datapathProvider: ADVANCED_DATAPATH
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -207,6 +207,7 @@ gatewayApiConfig:
   channel: string
 identityServiceConfig:
   enabled: boolean
+inTransitEncryptionConfig: string
 initialNodeCount: integer
 ipAllocationPolicy:
   additionalIpRangesConfigs:
@@ -1699,6 +1700,16 @@ A duration in seconds with up to nine fractional digits, ending with 's'. Exampl
         <td>
             <p><code class="apitype">boolean</code></p>
             <p>Whether to enable the Identity Service component.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p><code>inTransitEncryptionConfig</code></p>
+            <p><i>Optional</i></p>
+        </td>
+        <td>
+            <p><code class="apitype">string</code></p>
+            <p>In-transit encryption options for the cluster.</p>
         </td>
     </tr>
     <tr>
@@ -4374,6 +4385,27 @@ spec:
   location: us-west1
   releaseChannel:
     channel: REGULAR
+```
+
+### In Transit Encryption Container Cluster
+```yaml
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  labels:
+    availability: dev
+    target-audience: development
+  name: containercluster-sample-intransit
+spec:
+  description: Minimal VPC-Native cluster with Dataplane V2 and In-Transit Encryption.
+  location: us-central1-a
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /20
+    servicesIpv4CidrBlock: /20
+  datapathProvider: ADVANCED_DATAPATH
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED
 ```
 
 ### Routes Based Container Cluster

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -1709,7 +1709,7 @@ A duration in seconds with up to nine fractional digits, ending with 's'. Exampl
         </td>
         <td>
             <p><code class="apitype">string</code></p>
-            <p>In-transit encryption options for the cluster.</p>
+            <p>In-transit encryption options for the cluster. Possible values are IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED, IN_TRANSIT_ENCRYPTION_DISABLED, IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT</p>
         </td>
     </tr>
     <tr>

--- a/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
+++ b/scripts/generate-google3-docs/resource-reference/generated/resource-docs/container/containercluster.md
@@ -4405,7 +4405,7 @@ spec:
     clusterIpv4CidrBlock: /20
     servicesIpv4CidrBlock: /20
   datapathProvider: ADVANCED_DATAPATH
-  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_DISABLED
+  inTransitEncryptionConfig: IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT # or IN_TRANSIT_ENCRYPTION_DISABLED to disable
 ```
 
 ### Routes Based Container Cluster

--- a/tests/apichecks/testdata/exceptions/missingfields.txt
+++ b/tests/apichecks/testdata/exceptions/missingfields.txt
@@ -1286,7 +1286,6 @@
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.monitoringConfig.advancedDatapathObservabilityConfig[].relayMode" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPolicy.enabled" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkPolicy.provider" is not set in unstructured objects
-[missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.networkingMode" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.advancedMachineFeatures.threadsPerCore" is not set in unstructured objects
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.bootDiskKMSCryptoKeyRef" is not set; neither 'external' nor 'name' are set
 [missing_field] crd=containerclusters.container.cnrm.cloud.google.com version=v1beta1: field ".spec.nodeConfig.diskSizeGb" is not set in unstructured objects

--- a/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_cluster.go
+++ b/third_party/github.com/hashicorp/terraform-provider-google-beta/google-beta/services/container/resource_container_cluster.go
@@ -2135,6 +2135,12 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"in_transit_encryption_config": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  `Defines the config of in-transit encryption`,
+				ValidateFunc: validation.StringInSlice([]string{"IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED", "IN_TRANSIT_ENCRYPTION_DISABLED", "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT"}, false),
+			},
 		},
 	}
 }
@@ -2261,6 +2267,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			DefaultSnatStatus:                    expandDefaultSnatStatus(d.Get("default_snat_status")),
 			DatapathProvider:                     d.Get("datapath_provider").(string),
 			PrivateIpv6GoogleAccess:              d.Get("private_ipv6_google_access").(string),
+			InTransitEncryptionConfig:            d.Get("in_transit_encryption_config").(string),
 			EnableL4ilbSubsetting:                d.Get("enable_l4_ilb_subsetting").(bool),
 			DisableL4LbFirewallReconciliation:    d.Get("disable_l4_lb_firewall_reconciliation").(bool),
 			DnsConfig:                            expandDnsConfig(d.Get("dns_config")),
@@ -2817,6 +2824,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("private_ipv6_google_access", cluster.NetworkConfig.PrivateIpv6GoogleAccess); err != nil {
 		return fmt.Errorf("Error setting private_ipv6_google_access: %s", err)
 	}
+	if err := d.Set("in_transit_encryption_config", cluster.NetworkConfig.InTransitEncryptionConfig); err != nil {
+		return fmt.Errorf("Error setting in_transit_encryption_config: %s", err)
+	}
 	if err := d.Set("disable_l4_lb_firewall_reconciliation", cluster.NetworkConfig.DisableL4LbFirewallReconciliation); err != nil {
 		return fmt.Errorf("Error setting disable_l4_lb_firewall_reconciliation: %s", err)
 	}
@@ -3282,6 +3292,40 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s Cilium Clusterwide Network Policy has been updated to %v", d.Id(), enabled)
 	}
 
+	if d.HasChange("in_transit_encryption_config") {
+		inTransitConfig := d.Get("in_transit_encryption_config").(string)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredInTransitEncryptionConfig: inTransitConfig,
+				ForceSendFields:                  []string{"DesiredInTransitEncryptionConfig"},
+			},
+		}
+		updateF := func() error {
+			log.Println("[DEBUG] updating in_transit_encryption_config")
+			name := containerClusterFullName(project, location, clusterName)
+			clusterUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.Update(name, req)
+			if config.UserProjectOverride {
+				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+			}
+			op, err := clusterUpdateCall.Do()
+			if err != nil {
+				return err
+			}
+
+			// Wait until it's updated
+			err = ContainerOperationWait(config, op, project, location, "updating In-Transit Encryption Config", userAgent, d.Timeout(schema.TimeoutUpdate))
+			log.Println("[DEBUG] done updating in_transit_encryption_config")
+			return err
+		}
+
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s In-Transit Encryption Config has been updated to %v", d.Id(), inTransitConfig)
+	}
+
 	if d.HasChange("enable_fqdn_network_policy") {
 		enabled := d.Get("enable_fqdn_network_policy").(bool)
 		req := &container.UpdateClusterRequest{
@@ -3734,7 +3778,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		if d.HasChange("node_config.0.resource_manager_tags") {
 			rmtags := d.Get("node_config.0.resource_manager_tags")
 			req := &container.UpdateNodePoolRequest{
-				Name: "default-pool",
+				Name:                "default-pool",
 				ResourceManagerTags: expandResourceManagerTags(rmtags),
 			}
 			if req.ResourceManagerTags == nil {


### PR DESCRIPTION

### BRIEF Change description

Adds support for inTransitEncryptionConfig in ContainerCluster, including:
- CRD schema and API type definitions
- Terraform provider mapping and serial update handling
- Direct controller manual mapper support
- MockGCP DesiredInTransitEncryptionConfig handling
- Zonal E2E test fixture (containercluster-intransitencryption)

Fixes #11785 
https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/11785

#### WHY do we need this change?

Users of GKE that want intransitencryption can now enable/disable it using KCC


#### Does this PR add something which needs to be 'release noted'?
NONE

#### Intended Milestone

Please indicate the intended milestone. 
- [ ] Reviewer tagged PR with the actual milestone.

- [x] Run `make ready-pr` to ensure this PR is ready for review.
- [x] Perform necessary E2E testing for changed resources.
