### PR TITLE
ci: pin GitHub Action references in migration-tracker workflows to SHAs

### DIFF
--- a/.github/workflows/migration-tracker.yaml
+++ b/.github/workflows/migration-tracker.yaml
@@ -29,12 +29,12 @@ jobs:
       pull-requests: write  # Crucial to allow the bot to create PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: master  # Ensure we run on master
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/pages-migration-tracker.yaml
+++ b/.github/workflows/pages-migration-tracker.yaml
@@ -38,10 +38,10 @@ jobs:
       id-token: write   # Required for OIDC authentication with Pages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Prepare site directory structure
         run: |
@@ -60,10 +60,10 @@ jobs:
           EOF
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: './_site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## Summary
Pin action references in `.github/workflows/migration-tracker.yaml` and `.github/workflows/pages-migration-tracker.yaml` to explicit commit SHAs to pass `zizmor` mandatory security audit checks (`zizmor/unpinned-uses`).

## Changes
- Pin `actions/checkout` to `d23441a48e516b6c34aea4fa41551a30e30af803` (`# v6`)
- Pin `actions/setup-python` to `5fda3b95a4ea91299a34e894583c3862153e4b97` (`# v7`)
- Pin `actions/configure-pages` to `45bfe0192ca1faeb007ade9deae92b16b8254a0d` (`# v6`)
- Pin `actions/upload-pages-artifact` to `fc324d3547104276b827a68afc52ff2a11cc49c9` (`# v5`)
- Pin `actions/deploy-pages` to `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` (`# v5`)