### PR TITLE
Pin actions in migration-tracker workflow

### DIFF
--- a/.github/workflows/migration-tracker.yaml
+++ b/.github/workflows/migration-tracker.yaml
@@ -29,12 +29,12 @@ jobs:
       pull-requests: write  # Crucial to allow the bot to create PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: master  # Ensure we run on master
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@c8764032d8478d1033621415053e1a8a25c6c641 # v7.0.0
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
This PR pins actions/checkout and actions/setup-python to their full commit hashes in migration-tracker workflow to satisfy the security lint policy.