### PR TITLE
fix(test): verify KUBEBUILDER_ASSETS directory exists in setup-envtest

### DIFF
--- a/dev/tasks/setup-envtest
+++ b/dev/tasks/setup-envtest
@@ -20,7 +20,7 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
-if [[ -z "${KUBEBUILDER_ASSETS:-}" ]]; then
+if [[ -z "${KUBEBUILDER_ASSETS:-}" ]] || [[ ! -d "${KUBEBUILDER_ASSETS}" ]]; then
   echo "Downloading envtest assets..."
   export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 use -p path)
 fi


### PR DESCRIPTION
### Summary
This PR updates `dev/tasks/setup-envtest` to verify that the directory specified in `KUBEBUILDER_ASSETS` actually exists before relying on it:

```bash
if [[ -z "${KUBEBUILDER_ASSETS:-}" ]] || [[ ! -d "${KUBEBUILDER_ASSETS}" ]]; then
```

### Root Cause / Motivation
In containerized sandbox development environments and automated agent pipelines (such as AI Factory), `KUBEBUILDER_ASSETS` may be pre-configured in the shell environment to a default path (e.g., `/root/.local/share/kubebuilder-envtest/k8s/1.36.0-linux-amd64`). 
When patch releases of kubebuilder-envtest are updated (e.g. to `1.36.2-linux-amd64`), the old directory no longer exists. Previously, because `KUBEBUILDER_ASSETS` was non-empty, `setup-envtest` skipped running `setup-envtest use -p path`, causing presubmit unit tests and git pre-push hooks to crash on missing control plane binaries (`etcd: no such file or directory`).

This fix ensures that whenever `KUBEBUILDER_ASSETS` points to a non-existent directory, `setup-envtest` automatically re-runs and locates or downloads valid test binaries.