### PR TITLE
operator: set observedGeneration on ControllerReconciler status

### DIFF
--- a/operator/pkg/controllers/configconnector/configconnector_controller.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller.go
@@ -945,16 +945,18 @@ func (r *Reconciler) applyControllerReconcilerCR(ctx context.Context, cr *custom
 
 func (r *Reconciler) handleApplyControllerReconcilerSucceeded(ctx context.Context, cr *customizev1beta1.ControllerReconciler) error {
 	cr.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: true,
-		Errors:  []string{},
+		Healthy:            true,
+		Errors:             []string{},
+		ObservedGeneration: cr.Generation,
 	})
 	return r.updateControllerReconcilerStatus(ctx, cr)
 }
 
 func (r *Reconciler) handleApplyControllerReconcilerFailed(ctx context.Context, cr *customizev1beta1.ControllerReconciler, errMsg string) error {
 	cr.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: false,
-		Errors:  []string{errMsg},
+		Healthy:            false,
+		Errors:             []string{errMsg},
+		ObservedGeneration: cr.Generation,
 	})
 	return r.updateControllerReconcilerStatus(ctx, cr)
 }

--- a/operator/pkg/controllers/configconnector/configconnector_controller_test.go
+++ b/operator/pkg/controllers/configconnector/configconnector_controller_test.go
@@ -1616,7 +1616,8 @@ func TestApplyRateLimitCustomizations(t *testing.T) {
 			expectedManifests:      testcontroller.ClusterModeComponentsWithRatLimitCustomization,
 			expectedCRStatus: customizev1beta1.ControllerReconcilerStatus{
 				CommonStatus: addonv1alpha1.CommonStatus{
-					Healthy: true,
+					Healthy:            true,
+					ObservedGeneration: 1,
 				},
 			},
 		},

--- a/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
+++ b/operator/pkg/controllers/configconnectorcontext/configconnectorcontext_controller.go
@@ -711,8 +711,9 @@ func (r *Reconciler) handleApplyNamespacedControllerReconcilerFailed(ctx context
 		return err
 	}
 	cr.Status.CommonStatus = v1alpha1.CommonStatus{
-		Healthy: false,
-		Errors:  []string{msg},
+		Healthy:            false,
+		Errors:             []string{msg},
+		ObservedGeneration: cr.Generation,
 	}
 	return r.updateNamespacedControllerReconcilerStatus(ctx, cr)
 }
@@ -728,8 +729,9 @@ func (r *Reconciler) handleApplyNamespacedControllerReconcilerSucceeded(ctx cont
 		return err
 	}
 	cr.SetCommonStatus(v1alpha1.CommonStatus{
-		Healthy: true,
-		Errors:  []string{},
+		Healthy:            true,
+		Errors:             []string{},
+		ObservedGeneration: cr.Generation,
 	})
 	return r.updateNamespacedControllerReconcilerStatus(ctx, cr)
 }


### PR DESCRIPTION
The ControllerReconciler and NamespacedControllerReconciler status handlers set `Healthy` and `Errors` but never set `observedGeneration`, so it stays 0. Tools that gate on it (e.g. Helm 4) then treat the resource as never reconciled and block sync. The ConfigConnector and ConfigConnectorContext handlers already set it; this does the same for the reconciler customizations.

Updated the existing rate-limit test to expect the generation.

Fixes #7317.