### PR TITLE
fix: make the manager's built-in metrics server bind address configurable

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	// Ensure built-in types are registered.
 	_ "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/controller/direct/register"
@@ -63,6 +64,7 @@ func main() {
 		leaderElectionMode  string
 		skipNameValidation  bool
 		syncingMode         string
+		metricsBindAddress  string
 	)
 	// metricsOptions controls standard controller-runtime metrics versus OpenCensus/Default metrics.
 	// This is configured via the METRICS_VERSION=v2 environment variable.
@@ -70,6 +72,7 @@ func main() {
 	metricsOptions.ServeControllerRuntimeMetrics = (os.Getenv("METRICS_VERSION") == "v2")
 
 	flag.StringVar(&metricsOptions.Addr, "prometheus-scrape-endpoint", ":8888", "configure the Prometheus scrape endpoint; :8888 as default")
+	flag.StringVar(&metricsBindAddress, "metrics-bind-address", metricsserver.DefaultBindAddress, "address the controller-runtime manager's built-in metrics server binds to; \"0\" disables it, which is safe when controller-runtime metrics are already served on --prometheus-scrape-endpoint")
 	flag.BoolVar(&controllermetrics.ResourceNameLabel, "resource-name-label", false, "option to enable the resource name label on some Prometheus metrics; false by default")
 	flag.BoolVar(&userProjectOverride, "user-project-override", false, "option to use the resource project for preconditions, quota, and billing, instead of the project the credentials belong to; false by default")
 	flag.StringVar(&billingProject, "billing-project", "", "project to use for preconditions, quota, and billing if --user-project-override is enabled; empty by default; if this is left empty but --user-project-override is enabled, the resource's project will be used")
@@ -139,7 +142,7 @@ func main() {
 	// Set client site rate limiter to optimize the configconnector re-reconciliation performance.
 	ratelimiter.SetMasterRateLimiter(restCfg, rateLimitQps, rateLimitBurst)
 	logger.Info("Creating the manager")
-	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection, skipNameValidation, enableSyncing)
+	mgr, err := newManager(ctx, restCfg, scopedNamespace, userProjectOverride, billingProject, multiClusterElection, skipNameValidation, enableSyncing, metricsBindAddress)
 	if err != nil {
 		logging.Fatal(err, "error creating the manager")
 	}
@@ -195,10 +198,12 @@ func main() {
 	logging.ExitInfo("main.go finished execution; exiting ...")
 }
 
-func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool, skipNameValidation bool, enableSyncing bool) (manager.Manager, error) {
+func newManager(ctx context.Context, restCfg *rest.Config, scopedNamespace string, userProjectOverride bool, billingProject string, multiclusterlease bool, skipNameValidation bool, enableSyncing bool, metricsBindAddress string) (manager.Manager, error) {
 	krmtotf.SetUserAgentForTerraformProvider()
 
-	opts := manager.Options{}
+	opts := manager.Options{
+		Metrics: metricsserver.Options{BindAddress: metricsBindAddress},
+	}
 	if scopedNamespace != "" {
 		opts.Cache = cache.Options{
 			DefaultNamespaces: map[string]cache.Config{


### PR DESCRIPTION
### BRIEF Change description

Adds a `--metrics-bind-address` flag to `cmd/manager`, wired into `manager.Options.Metrics.BindAddress`.

Fixes #12113

#### WHY do we need this change?

`cmd/manager` builds `manager.Options{}` without setting `Metrics`, so controller-runtime defaults `BindAddress` to `":8080"` and starts a metrics server there on every run, alongside the Prometheus scrape endpoint on `--prometheus-scrape-endpoint`.

That server is redundant — `RegisterPrometheusExporter` already exposes the same `crmetrics.Registry` at `/metrics.v2` on the main endpoint when `METRICS_VERSION=v2` — and a failure to bind is fatal rather than degraded:

```
error during manager execution. | failed to start metrics server: failed to create listener: listen tcp :8080: bind: address already in use
```

With no flag to move or disable it, any deployment where `:8080` is occupied on the node cannot start the manager. We hit this on shared-network hosts: pods landing where `:8080` was free logged `Serving metrics server bindAddress=:8080` and came up, pods landing where it was taken crashed, which surfaced as erratic host-dependent rollout failures.

#### Special notes for your reviewer:

The default is `metricsserver.DefaultBindAddress` rather than a hardcoded `":8080"`, so **existing behaviour is unchanged** and the default tracks controller-runtime if it ever moves. Operators who already scrape `--prometheus-scrape-endpoint` can pass `--metrics-bind-address=0`, controller-runtime's documented sentinel for disabling the server.

One thing I deliberately did **not** do, and would like your opinion on: it would be reasonable to default this to `"0"` when `metricsOptions.ServeControllerRuntimeMetrics` is true, since the `:8080` server is then strictly redundant with `/metrics.v2`. That is a behaviour change for anyone currently scraping `:8080`, so it felt like your call rather than mine. Happy to add it if you want it in the same PR.

#### Does this PR add something which needs to be `release noted`?

```release-note
Added a --metrics-bind-address flag to the controller manager, controlling the address controller-runtime's built-in metrics server binds to. Defaults to :8080, matching previous behavior. Set it to "0" to disable that server, or to another address to avoid a port conflict that would otherwise prevent the manager from starting.
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:

```docs

```

#### Intended Milestone

Deferring to the reviewer to tag.

### Tests you have done

- [x] `CGO_ENABLED=0 go build ./cmd/manager` — passes.
- [x] `go vet ./cmd/manager` — passes.
- [x] `gofmt` — clean.
- [x] Verified against `controller-runtime v0.20.4` that `DefaultBindAddress` is `":8080"` (`pkg/metrics/server/server.go:45`) and that `"0"` is the disable sentinel (`server.go:120`), so the default preserves current behaviour and the documented opt-out works.
- [x] Confirmed `newManager` has no other callers, so the signature change is contained to this file.
- [ ] Full `make ready-pr` — `lint`, `lint-custom`, `manifests` and `ensure` were not run.
- [ ] E2E. The equivalent change has been running in our internal build since early July and resolved the crash-on-startup there, but that build is not vanilla upstream, so I am not claiming it as an upstream E2E result.