### PR TITLE
Fix spelling in pause docs and GCP tracker

### DIFF
--- a/docs/features/pause.md
+++ b/docs/features/pause.md
@@ -2,7 +2,7 @@
 
 > `Feature State`: `alpha` as of version v1.114
 
-KCC can be configured to pause actuation of resouces on the cloud provider
+KCC can be configured to pause actuation of resources on the cloud provider
 (GCP). K8s objects continue to be reconciled with the api server but any
 interaction with the cloud provider should be paused. This can be helpful for
 debugging purposes or to have a hot standby.
@@ -46,4 +46,3 @@ NOTE: you can avoid any pausing in actuation by first changing the
 
 *   [Config Connector Operational Modes](config-connector-mode.md) for general configuration options (Identity, Billing, etc.).
 *   [Controller Implementation Overrides](controller-configuration.md) for details on choosing between Direct, Terraform, and DCL controllers.
- 

--- a/pkg/gcpwatch/tracker.go
+++ b/pkg/gcpwatch/tracker.go
@@ -34,7 +34,7 @@ const (
 type DependencyTracker struct {
 	fetcher Fetcher
 
-	gcpResources map[gcpResouceKey]*dependenciesByResource
+	gcpResources map[gcpResourceKey]*dependenciesByResource
 
 	controllersMutex sync.Mutex
 	controllers      map[string]*ControllerRegistration
@@ -65,7 +65,7 @@ func (t *DependencyTracker) RegisterController(key string, queue chan event.Gene
 	return registration
 }
 
-type gcpResouceKey struct {
+type gcpResourceKey struct {
 	Kind     string
 	External string
 }
@@ -96,7 +96,7 @@ func NewDependencyTracker(fetcher Fetcher) *DependencyTracker {
 	tracker := &DependencyTracker{
 		fetcher:      fetcher,
 		controllers:  make(map[string]*ControllerRegistration),
-		gcpResources: make(map[gcpResouceKey]*dependenciesByResource),
+		gcpResources: make(map[gcpResourceKey]*dependenciesByResource),
 	}
 
 	return tracker
@@ -130,18 +130,18 @@ func (t *DependencyTracker) PollForever(ctx context.Context, pc *PollConfig) {
 	}
 }
 
-func (t *DependencyTracker) copyKeysUnderLock() []gcpResouceKey {
+func (t *DependencyTracker) copyKeysUnderLock() []gcpResourceKey {
 	t.controllersMutex.Lock()
 	defer t.controllersMutex.Unlock()
 
-	keys := make([]gcpResouceKey, 0, len(t.gcpResources))
+	keys := make([]gcpResourceKey, 0, len(t.gcpResources))
 	for key := range t.gcpResources {
 		keys = append(keys, key)
 	}
 	return keys
 }
 
-func (t *DependencyTracker) getGCPResourcesUnderLock(key gcpResouceKey) *dependenciesByResource {
+func (t *DependencyTracker) getGCPResourcesUnderLock(key gcpResourceKey) *dependenciesByResource {
 	t.controllersMutex.Lock()
 	defer t.controllersMutex.Unlock()
 
@@ -172,7 +172,7 @@ func (t *DependencyTracker) pollOnce(ctx context.Context) error {
 	return nil
 }
 
-func maybeNotifyDependenciesUnderLock(ctx context.Context, gcpResource *dependenciesByResource, key gcpResouceKey, latest *ResourceInfo) {
+func maybeNotifyDependenciesUnderLock(ctx context.Context, gcpResource *dependenciesByResource, key gcpResourceKey, latest *ResourceInfo) {
 	log := klog.FromContext(ctx)
 
 	gcpResource.dependenciesMutex.Lock()
@@ -255,7 +255,7 @@ func (t *DependencyTracker) getTarget(kind string, external string) *dependencie
 	t.controllersMutex.Lock()
 	defer t.controllersMutex.Unlock()
 
-	key := gcpResouceKey{
+	key := gcpResourceKey{
 		Kind:     kind,
 		External: external,
 	}


### PR DESCRIPTION
### BRIEF Change description

Fixes #9218

Corrects `resouces` in the pause documentation and consistently renames the internal `gcpResouceKey` type to `gcpResourceKey`.

#### WHY do we need this change?

The misspellings reduce documentation clarity and make the internal tracker type harder to search and understand.

#### Special notes for your reviewer:

The type is unexported and all references are updated in the same file.

#### Does this PR add something which needs to be release noted?
```release-note
NONE
```

- [ ] Reviewer reviewed release note.

#### Additional documentation e.g., references, usage docs, etc.:
```docs
[Issue]: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9218
```

#### Intended Milestone

- [ ] Reviewer tagged PR with the actual milestone.

### Tests you have done

- `GOWORK=off go test ./pkg/gcpwatch`
- Verified the old misspellings no longer occur in the affected files.
- `git diff --check`

- [ ] Run `make ready-pr` to ensure this PR is ready for review.
- [ ] Perform necessary E2E testing for changed resources.